### PR TITLE
[Mono.Android] Handle "No authentication challenges found" on HTTP 401

### DIFF
--- a/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -1047,6 +1047,24 @@ namespace Xamarin.Android.NetTests {
 			}
 		}
 #endif
+		// Verifies the handler always returns a response on 401, regardless of the
+		// presence of a WWW-Authenticate header in the HTTP response. (Pre API 19,
+		// HttpURLConnectionImpl would throw an Java.IO.IOException in this scenario).
+		[Test]
+		public void ShouldHandle401WithoutWWWAuthenticateHeader() 
+		{
+			var listener = CreateListener(l => {
+				var response = l.Response;
+				response.StatusCode = 401;
+			});
+
+			using (listener)
+			using (var httpClient = new HttpClient(CreateHandler(), true)) {
+				var response = httpClient.GetAsync(LocalServer).Result;
+
+				Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+			}
+		}
 
 		HttpListener CreateListener (Action<HttpListenerContext> contextAssert)
 		{

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -306,7 +306,7 @@ namespace Xamarin.Android.Net
 					}
 					// Accessing the ResponseCode will throw an IOException if the code is 401
 					// and the server has not returned a WWW-Authenticate header on < API 19
-					catch (IOException ex) when (ex.Message.Contains("authentication challenges")) {
+					catch (Java.IO.IOException ex) when (ex.Message?.Contains("authentication challenges") ?? false) {
 						// Will return 401 as the connection's internal state is now correct
 						return (HttpStatusCode)httpConnection.ResponseCode;
 					}


### PR DESCRIPTION
Pre-KitKat (< API 19), when accessing `Java.Net.HttpURLConnection.ResponseCode` for a 401 response without a `WWW-Authenticate` header, `Java.IO.IOException: No authentication challenges found` is thrown.

This commit catches the exception, ensuring a 401 is returned by `AndroidClientHandler`.

Android libcore sources:
- [Source of exception <= API 18](https://android.googlesource.com/platform/libcore/+/459a682c55c93c554ad4e822260569a204572dda/luni/src/main/java/libcore/net/http/HttpURLConnectionImpl.java#438)
- [Switch to okhttp API 19+](https://android.googlesource.com/platform/libcore/+/2503556d17b28c7b4e6e514540a77df1627857d0)