### PR TITLE
[msbuild/tests] add test for custom framework setup via NuGet package.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2879,6 +2879,40 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 				}
 			}
 		}
+
+		[Test]
+		public void AdditionalFrameworkBuild ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				TargetFrameworkVersion = "v9.0",
+				UseLatestPlatformSdk = false,
+			};
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("int count = 1;", "public class Foo : Java.Util.Vector, Java.Util.IList { void Java.Util.IList.Sort (Java.Util.IComparator comparator) { } } \n\t\tint count = 1;");
+			proj.Packages.Add (new Package () {
+				Id = "xamarin.android.dim",
+				Version = "0.1.8",
+				TargetFramework = "MonoAndroid90",
+				References = {}
+			});
+			proj.ImportsPrepended.Add (new Import ("..\\packages\\xamarin.android.dim.0.1.8\\build\\xamarin.android.dim.props"));
+			proj.ImportsPrepended.Add (new Import ("..\\packages\\xamarin.android.csc.dim.0.1.2\\build\\xamarin.android.csc.dim.props"));
+			proj.Packages.Add (new Package () {
+				Id = "xamarin.android.csc.dim",
+				Version = "0.1.2",
+				TargetFramework = "MonoAndroid10",
+				References = {}
+			});
+			proj.SetProperty ("LangVersion", "latest");
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", nameof (AdditionalFrameworkBuild)), false, false)) {
+				builder.RequiresMSBuild = true;
+				builder.Target = "Restore";
+				Assert.IsTrue (builder.Build (proj), "Restore should have succeeded.");
+				builder.Target = "Build";
+				Assert.True (builder.Build (proj), "Build should have succeeded");
+			}
+		}
+
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
@@ -75,8 +75,10 @@ namespace Xamarin.ProjectTools
 		public override ProjectRootElement Construct ()
 		{
 			var root = base.Construct ();
+			foreach (var import in ImportsPrepended)
+				root.AddImport (import.Project ());
 			root.AddImport (XamarinAndroidLanguage.NormalProjectImport);
-			foreach (var import in Imports)
+			foreach (var import in ImportsAppended)
 				root.AddImport (import.Project ());
 			return root;
 		}


### PR DESCRIPTION
It proves incomplete but kind of working solution for https://github.com/xamarin/xamarin-android/issues/1880 .

The original idea (and what once worked) was to only extend an MSBuild
property for ResolveSdks task. But after a couple of changes it does not
work anymore, as there had been a handful of SDK resolution changes.

Since it's not really safe to depend on those properties, we should rather
provide a complete set of framework assemblies (which means, packages
containing both v1.0 and latest) to get app still build.