### PR TITLE
[xaprepare] Update Android 10 name (#4011)

### DIFF
--- a/Documentation/release-notes/4011.md
+++ b/Documentation/release-notes/4011.md
@@ -1,0 +1,6 @@
+### Issues fixed
+
+  * [GitHub PR 4011](https://github.com/xamarin/xamarin-android/pull/4011):
+    The old *Q* nickname from the Android 10 preview versions was still being
+    shown for Android 10 in the Visual Studio project property pages and the
+    Android SDK Manager.

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Prepare
 			new AndroidPlatform (apiName: "Oreo",                   apiLevel: 26, platformID: "26",  include: "v8.0",    framework: "v8.0"),
 			new AndroidPlatform (apiName: "Oreo",                   apiLevel: 27, platformID: "27",  include: "v8.1",    framework: "v8.1"),
 			new AndroidPlatform (apiName: "Pie",                    apiLevel: 28, platformID: "28",  include: "v9.0",    framework: "v9.0"),
-			new AndroidPlatform (apiName: "Q",                      apiLevel: 29, platformID: "29",  include: "v10.0",   framework: "v10.0"),
+			new AndroidPlatform (apiName: "",                       apiLevel: 29, platformID: "29",  include: "v10.0",   framework: "v10.0"),
 		};
 
 		public static readonly Dictionary<string, uint> NdkMinimumAPI = new Dictionary<string, uint> {


### PR DESCRIPTION
Context: https://www.blog.google/products/android/evolving-android-brand/

The `AndroidApiInfo.xml` files produced by `xaprepare` during build
preparation includes a *Name* value:

        <AndroidApiInfo>
          <Id>29</Id>
          <Level>29</Level>
          <Name>Q</Name>
          <Version>v10.0</Version>
          <Stable>True</Stable>
        </AndroidApiInfo>

Both the version number and name are shown within various parts of
[the IDEs][0], e.g.

![VS Minimum Android Version](https://i.stack.imgur.com/XGp32.png)

        Android 9.0 (Pie)
        Android 8.1 (Oreo)

The problem is that starting with Android 10, Google is no longer
providing "nicknames" for Android releases.

What should Visual Studio do?

*Currently*, we still emit a Name of "Q" for API-29, thus VS shows:

        Android 10.0 (Q)

We could "clear out" the Name value, but unfortunately VS currently
doesn't special-case this in any way, and thus would show:

        Android 10.0 ()

Which looks "wrong".

Fixing this will require two changes:

 1. We (xamarin-android) will begin clearing out the Name for Android
    releases which lack a nickname, and

 2. The VS team will modify their Target Framework name generation
    logic such that the parenthesis and Name are only used when Name
    is a non-empty value.  This will allow API-29 to have a displayed
    name of `Android 10.0`.

Begin the process: begin emitting an empty Name field for API-29,
allowing the IDE team to begin implementing their side.

[0]: https://stackoverflow.com/questions/55945365/how-can-i-target-android-4-1-in-visual-studio-2019