### PR TITLE
[debugger] Removing usage of mono_unhandled_exception

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -237,18 +237,10 @@ namespace Android.Runtime {
 			GC.SuppressFinalize (obj);
 		}
 
-		static Action<Exception> mono_unhandled_exception = null!;
 		static Action<AppDomain, UnhandledExceptionEventArgs> AppDomain_DoUnhandledException = null!;
 
 		static void Initialize ()
 		{
-			if (mono_unhandled_exception == null) {
-				var mono_UnhandledException = typeof (System.Diagnostics.Debugger)
-					.GetMethod ("Mono_UnhandledException", BindingFlags.NonPublic | BindingFlags.Static);
-				if (mono_UnhandledException != null)
-					mono_unhandled_exception = (Action<Exception>) Delegate.CreateDelegate (typeof(Action<Exception>), mono_UnhandledException);
-			}
-
 			if (AppDomain_DoUnhandledException == null) {
 				var ad_due = typeof (AppDomain)
 					.GetMethod ("DoUnhandledException",
@@ -275,10 +267,6 @@ namespace Android.Runtime {
 			}
 
 			var javaException = JavaObject.GetObject<Java.Lang.Throwable> (env, javaExceptionPtr, JniHandleOwnership.DoNotTransfer)!;
-
-			// Disabled until Linker error surfaced in https://github.com/xamarin/xamarin-android/pull/4302#issuecomment-596400025 is resolved
-			//System.Diagnostics.Debugger.Mono_UnhandledException (javaException);
-			mono_unhandled_exception?.Invoke (javaException);
 
 			try {
 				var jltp = javaException as JavaProxyThrowable;

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
@@ -7,7 +7,6 @@ using System.Threading;
 namespace Android.Runtime {
 	public static class JNINativeWrapper {
 
-		static MethodInfo? mono_unhandled_exception_method;
 		static MethodInfo? exception_handler_method;
 		static MethodInfo? wait_for_bridge_processing_method;
 
@@ -15,12 +14,6 @@ namespace Android.Runtime {
 		{
 			if (exception_handler_method != null)
 				return;
-#if MONOANDROID1_0
-			mono_unhandled_exception_method = typeof (System.Diagnostics.Debugger).GetMethod (
-				"Mono_UnhandledException", BindingFlags.NonPublic | BindingFlags.Static);
-			if (mono_unhandled_exception_method == null)
-				AndroidEnvironment.FailFast ("Cannot find System.Diagnostics.Debugger.Mono_UnhandledException");
-#endif
 			exception_handler_method = typeof (AndroidEnvironment).GetMethod (
 				"UnhandledException", BindingFlags.NonPublic | BindingFlags.Static);
 			if (exception_handler_method == null)
@@ -70,15 +63,8 @@ namespace Android.Runtime {
 			ig.Emit (OpCodes.Leave, label);
 
 			bool  filter = Debugger.IsAttached || !JNIEnv.PropagateExceptions;
-			if (filter && mono_unhandled_exception_method != null) {
-				ig.BeginExceptFilterBlock ();
 
-				ig.Emit (OpCodes.Call, mono_unhandled_exception_method);
-				ig.Emit (OpCodes.Ldc_I4_1);
-				ig.BeginCatchBlock (null!);
-			} else {
-				ig.BeginCatchBlock (typeof (Exception));
-			}
+			ig.BeginCatchBlock (typeof (Exception));
 
 			ig.Emit (OpCodes.Dup);
 			ig.Emit (OpCodes.Call, exception_handler_method!);

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
@@ -62,8 +62,6 @@ namespace Android.Runtime {
 
 			ig.Emit (OpCodes.Leave, label);
 
-			bool  filter = Debugger.IsAttached || !JNIEnv.PropagateExceptions;
-
 			ig.BeginCatchBlock (typeof (Exception));
 
 			ig.Emit (OpCodes.Dup);

--- a/src/Mono.Android/Android.Runtime/UncaughtExceptionHandler.cs
+++ b/src/Mono.Android/Android.Runtime/UncaughtExceptionHandler.cs
@@ -7,8 +7,6 @@ namespace Android.Runtime {
 
 	sealed class UncaughtExceptionHandler : Java.Lang.Object, Java.Lang.Thread.IUncaughtExceptionHandler {
 
-		Action<Exception>? mono_unhandled_exception;
-
 		Action<AppDomain, UnhandledExceptionEventArgs>?      AppDomain_DoUnhandledException;
 
 		Java.Lang.Thread.IUncaughtExceptionHandler defaultHandler;
@@ -30,7 +28,6 @@ namespace Android.Runtime {
 				Android.Runtime.AndroidEnvironment.FailFast ($"Unable to initialize UncaughtExceptionHandler. Nested exception caught: {e}");
 			}
 
-			mono_unhandled_exception! (ex);
 			if (AppDomain_DoUnhandledException != null) {
 				try {
 					var jltp = ex as JavaProxyThrowable;
@@ -48,11 +45,6 @@ namespace Android.Runtime {
 
 		void Initialize ()
 		{
-			if (mono_unhandled_exception == null) {
-				var mono_UnhandledException = typeof (System.Diagnostics.Debugger)
-					.GetMethod ("Mono_UnhandledException", BindingFlags.NonPublic | BindingFlags.Static);
-				mono_unhandled_exception = (Action<Exception>) Delegate.CreateDelegate (typeof(Action<Exception>), mono_UnhandledException);
-			}
 
 			if (AppDomain_DoUnhandledException == null) {
 				var ad_due = typeof (AppDomain)


### PR DESCRIPTION
We don't need to call mono_unhandled_exception the runtime will handle with it.

Relates to https://github.com/mono/mono/pull/20314.
We don't need to wait for mono/mono PR to be merged, mono PR only removes the unhandled_exception function.