### PR TITLE
Remove Preserve attribute from IntentService ctor

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -852,11 +852,6 @@
   <remove-node path="/api/package[@name='junit.framework']/class[@name='TestSuite']/method[parameter[@type='java.lang.Class']]" api-since="16" />
      -->
 
-  <!-- Preserve Mono.Android.App.IntentService::.ctor if the
-       type is used anywhere. -->
-
-  <attr path="/api/package[@name='mono.android.app']/class[@name='IntentService']/constructor[count(parameter) = 0]" name="customAttributes">[Preserve(Conditional = true)]</attr>
-
   <!--    Asyncification    -->
 
   <!-- Interfaces -->


### PR DESCRIPTION
It shouldn't be needed as the service based on `IntentService` should
have the constructor without parameters and thus it would preserve its
base constructor.

In case someone declares Android service without public default
parameterless constructor, the build fails with:

    error XA4213: The type 'MyService' must provide a public default constructor

Context: The constructor is called when the service is created by
Android and it uses the parameterless constructor.