### PR TITLE
First Pass on Dynamic Asset Features

### DIFF
--- a/Documentation/guides/DynamicFeatures.md
+++ b/Documentation/guides/DynamicFeatures.md
@@ -1,0 +1,461 @@
+# Android Dynamic Feature Delivery
+
+_NOTE: This document is very likely to change, as the the implementation
+of Dynamic Features matures._
+
+Android Dynamic Features are a way of splitting up your application
+into smaller parts which users can download on-demand. This can be
+useful in scenarios such as Games or apps with low usage parts.
+An example would be a Support module which does not get used very
+often, rather than including this code in the main app it could be
+a dynamic feature which is downloaded when the user requests support.
+Alternatively think of Game levels in a game. On first install only
+the first few levels are installed to save download size. But later
+the additional levels can be downloaded while the user is not playing
+the game.
+
+Dynamic Features can ONLY be used when targeting the Google Play
+Store and using `PackageFormat` set to `aab`. Using `apk` will
+NOT work.
+
+## Xamarin Dynamic Asset/Feature Delivery
+
+The Xamarin implementation of this will start by focusing on asset
+delivery. This is where the `AndroidAsset` items can be split out
+into a separate module for downloading later.
+
+_NOTE: In the future we plan to support feature or code delivery
+however there are significant challenges to supporting that in our
+runtime. So this will be done after the initial rollout of asset
+delivery._
+
+The new Dynamic Feature Module will be based around a normal
+Xamarin Android class library. The kind you get when calling
+
+```
+dotnet new androidlib
+```
+
+Although we plan to provide a template. The new Module will generally
+be nothing different from a normal class library project. The
+current restrictions are that it only contains `AndroidAsset` items.
+No `AndroidResource` items can be included and any C# code in the
+library will NOT end up in the application.
+
+The one additional file is a special `AndroidManifest.xml` file which
+will be generated as part of the module build process. This manifest
+file needs a few special elements which need to be provided by
+the following MSBuild properties.
+
+* FeatureSplitName: (string) The name of the feature. You will use this in code to
+    install the feature. Defaults to `ProjectName`.
+* IsFeatureSplit: (bool) Defines if this feature is a "feature split". Defaults to `true`.
+* FeatureDeliveryType: (Enum) The type of delivery mechanism to use. Valid values are
+    OnDemand or InstallTime. Defaults to InstallTime.
+* FeatureType: (Enum) The type of feature this is. Valid values are
+    Feature or AssetPack. Defaults to Feature.
+* FeatureTitleResource: (string) This MUST be a valid @string which is present in your
+    application strings.xml file. For example `@strings/assetsfeature`.
+    Note the actual value of the resource can be 50 characters long and can be localized.
+    It is this resource which is used to let the users know which feature is being
+    downloaded. So it should be descriptive.
+    This Item does NOT have default and will need to be provided.
+
+These properties will have default values based on things like the Project name.
+
+Here is a example of an Asset Feature Module for .net 6.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-android</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
+    <FeatureSplitName>assetsfeature</FeatureSplitName>
+    <FeatureType>Asset</FeatureType>
+    <IsFeatureSplit>true</IsFeatureSplit>
+    <FeatureDeliveryType>OnDemand</FeatureDeliveryType>
+  </PropertyGroup>
+</Project>
+```
+
+This is defining an OnDemand Asset Delivery package.
+The follow code is defining a Dynamic Feature Module.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-android</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
+    <FeatureSplitName>examplefeature</FeatureSplitName>
+    <FeatureType>Feature</FeatureType>
+    <IsFeatureSplit>true</IsFeatureSplit>
+    <FeatureDeliveryType>OnDemand</FeatureDeliveryType>
+    <FeatureTitleResource>@strings/examplefeature</FeatureTitleResource>
+  </PropertyGroup>
+</Project>
+```
+
+In order to reference a feature you can use a normal `ProjectReference` MSBuild
+Item. We will detect the use of `FeatureSplitName` in each project and will
+remove that project from the normal build process.
+
+Features will then build later in the build process, after the main app
+has built its base resource package but before the linker runs.
+
+As part of the build system all `Features` will include a `Reference` to
+the main application `Assembly`. So there is no need to add any `PackageReference`
+items to any NuGet which is already being used by main app as they will be
+automatically referenced when we build the feature.
+
+## Downloading a Dynamic Feature at runtime
+
+In order to download features you need to reference the
+`Xamarin.Google.Android.Play.Core` Nuget Package from your main application.
+You can do this by adding the following Package References.
+
+```xml
+    <PackageReference Include="Xamarin.GooglePlayServices.Base" Version="117.6.0" />
+    <PackageReference Include="Xamarin.Google.Android.Play.Core" Version="1.10.2" />
+```
+
+Note that `Xamarin.GooglePlayServices.Base` is also required. The `Version` numbers
+here will change as new versions are being released all the time. The minimum
+required `Xamarin.Google.Android.Play.Core` is `1.10.2`.
+
+This is because some of the classes we need to use in the `Play.Core` API use Java
+Generics. The Xamarin Android Binding system has a problem with these types of
+classes. So some of the API will either be missing or will produce build errors.
+In `Xamarin.Google.Android.Play.Core` `1.10.2` we added a set of `Wrapper` classes
+which expose a non Generic API in C# which will allow users to use the required
+`Listener` classes.
+
+### Installing Asset Packs
+
+If you have created an `InstallTime` asset pack, there is no additional work to do.
+The pack will be installed at the same time the app is installed. As a result the
+`Assets` will be available via the normal `AssetManager` API.
+
+If you create an `OnDemand` asset pack, you will need to manually start the installation
+and monitor its progress. To do this you need to use the `IAssetPackManager`. This can
+be created using
+
+```csharp
+IAssetPackManager manager = AssetPackManagerFactory.GetInstance (this);
+```
+
+You can then use the following code to check if the Asset Pack was installed. If it was
+not, then you can start the installation with the `IAssetPackManager.Fetch` method.
+
+```csharp
+var location = assetPackManager.GetPackLocation ("assetsfeature");
+if (location == null)
+{
+    assetPackManager.Fetch(new string[] { "assetsfeature" });
+}
+```
+
+Note the argument passed in there is the same as the `FeatureSplitName` MSbuild property.
+In order to monitor the progress of the download google provided a `AssetPackStateUpdateListener`
+class. However this class uses Generics and if you use it directly it will result in
+java build errors. So the `Xamarin.Google.Android.Play.Core` version `1.10.2` Nuget provides
+a `AssetPackStateUpdateListenerWrapper` class which exposes a C# event based API to make
+things easier.
+
+```csharp
+listener = new AssetPackStateUpdateListenerWrapper();
+listener.StateUpdate += (s, e) => {
+   var status = e.State.Status();
+   switch (status)
+   {
+      case AssetPackStatus.Pending:
+         break;
+     // more case statements here
+   }
+};
+```
+
+The `StateUpdate` event will allow you to get the download status if any Asset Packs which
+are being downloaded.
+In order for this listener to work we need to register it with the `IAssetPackManager` we
+created earlier. We do this in the `OnResume` and `OnPause` methods in the activity.
+
+To get the `manager` object to use this listener we need to call the `RegisterListener` method.
+We also need to call the `UnregisterListener` as well when we are finish or if the app is paused.
+Because we are using a wrapper class we cannot just pass our `listener` to the `RegisterListener`
+method directly. This is because it is expecting a `AssetPackStateUpdateListener` type.
+But we do provide a property on the `AssetPackStateUpdateListenerWrapper` which will give
+you access to the underlying `AssetPackStateUpdateListener` class. So to register you can
+use the following code.
+
+```csharp
+protected override void OnResume()
+{
+	// regsiter our Listener Wrapper with the IAssetPackManager so we get feedback.
+	manager.RegisterListener(listener.Listener);
+	base.OnResume();
+}
+
+protected override void OnPause()
+{
+	manager.UnregisterListener(listener.Listener);
+	base.OnPause();
+}
+```
+
+With the `listener` registered you will now get status updates during a download.
+Here is a sample activity.
+
+```csharp
+using Android.App;
+using Android.OS;
+using Android.Runtime;
+using Android.Widget;
+using Java.Lang;
+using Xamarin.Google.Android.Play.Core.AssetPacks;
+using Xamarin.Google.Android.Play.Core.AssetPacks.Model;
+using Android.Content;
+
+namespace DynamicAssetsExample
+{
+    [Activity(Label = "@string/app_name", MainLauncher = true)]
+    public class MainActivity : Activity
+    {
+        IAssetPackManager manager;
+        AssetPackStateUpdateListenerWrapper listener;
+        protected override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+
+            // Set our view from the "main" layout resource
+            SetContentView(Resource.Layout.activity_main);
+            var button = FindViewById<Button>(Resource.Id.installButton);
+            // create the IAssetPackManager instance.
+            manager = AssetPackManagerFactory.GetInstance (this);
+            // Setup the State Update Listener.
+            listener = new AssetPackStateUpdateListenerWrapper ();
+            listener.StateUpdate += (s, e) => {
+                var status = e.State.Status ();
+                System.Console.WriteLine (status);
+            };
+            // Setup to install the asset pack on a button click.
+            button.Click += (s, e) => {
+                var location = assetPackManager.GetPackLocation ("assetsfeature");
+                if (location == null)
+                {
+                    assetPackManager.Fetch(new string[] { "assetsfeature" });
+                }
+            };
+        }
+
+        protected override void OnResume ()
+        {
+            // Register our listener
+            manager.RegisterListener (listener.Listener);
+            base.OnResume ();
+        }
+
+        protected override void OnPause()
+        {
+            // Unregister our listener. We don't want notifications
+            // when the app is not running.
+            manager.UnregisterListener (listener.Listener);
+            base.OnPause();
+        }
+    }
+}
+```
+
+### Installing Features
+
+To use Dynamic Features you need to add a custom `Application` class which
+derives from `SplitCompatApplication`. This is so the underlying application
+will include all the support code provided by a `SplitCompatApplication`.
+
+```csharp
+using System;
+using Android.App;
+using Android.Runtime;
+using Xamarin.Google.Android.Play.Core.SplitCompat;
+
+namespace DynamicFeatureExample
+{
+	[Application]
+	public class DynamicApplication : SplitCompatApplication
+	{
+		public DynamicApplication(IntPtr handle, JniHandleOwnership jniHandle)
+			: base(handle, jniHandle)
+		{
+		}
+
+		public override void OnCreate()
+		{
+			base.OnCreate();
+		}
+	}
+}
+```
+
+In order to download a feature we need to create an instance of a class implementing
+`ISplitInstallManager`. There are two of these available. The first is for your
+live application and can be created using the `SplitInstallManagerFactory`
+The second is for local testing and should be created using the `FakeSplitInstallManagerFactory`.
+You can use a `#if DEBUG` conditional compilation block to change which one you use.
+
+```csharp
+ISplitInstallManager manager;
+#if DEBUG
+var fakeManager = FakeSplitInstallManagerFactory.Create(this);
+manager = fakeManager;
+#else
+manager = SplitInstallManagerFactory.Create (this);
+#endif
+```
+
+Once you have an instance of the `ISplitInstallManager` the process of requesting
+the install of a feature is quite straight forward. You create an instance of a
+`SplitInstallRequest` via the `SplitInstallRequest.NewBuilder` method. Call
+`builder.AddModule("foo")` to add all the modules you want to install. Finally call
+`Build()` on that `request` and pass the result `manager.StartInstall` method.
+Here is some sample code.
+
+```csharp
+var builder = SplitInstallRequest.NewBuilder ();
+builder.AddModule ("assetsfeature");
+manager.StartInstall (builder.Build ());
+```
+
+This will start the installation of the `assetsfeature`. Note that the string passed
+in here is the same value as we defined for `FeatureSplitName` earlier in our
+Feature.
+
+Most of the Google samples use the `SplitInstallStateUpdatedListener` class to
+track the progress of the installation. This is where the problems start.
+`SplitInstallStateUpdatedListener` is one of those Java Generic classes which cause
+a build error if you try to use it. So what we have done is created a wrapper class
+in the `Xamarin.Google.Android.Play.Core` version `1.10.2` Nuget Package which you
+can use instead and still get the same functionality.
+
+To use this listener first create an instance of the `SplitInstallStateUpdatedListenerWrapper`.
+You can then add an `EventHander` for the `StatusUpdate` event to keep track of the
+download and install progress.
+
+```csharp
+listener = new SplitInstallStateUpdatedListenerWrapper ();
+listener.StateUpdate += (s, e) => {
+    var state = e.State.;
+    System.Console.WriteLine (state.Status());
+};
+```
+
+To get the `manager` object to use this listener we need to call the `RegisterListener` method.
+We also need to call the `UnregisterListener` as well when we are finish or if the app is paused.
+Because we are using a wrapper class we cannot just pass our `listener` to the `RegisterListener`
+method directly. This is because it is expecting a `SplitInstallStateUpdatedListener` type.
+But we do provide a property on the `SplitInstallStateUpdatedListenerWrapper` which will give
+you access to the underlying `SplitInstallStateUpdatedListener` class. So to register you can
+use the following code.
+
+```csharp
+manager.RegisterListener (listener.Listener);
+```
+
+To Unregsiter use this code.
+
+```csharp
+manager.UnregisterListener (listener.Listener);
+```
+
+With our listener registered we can now keep track of the download and install progress of our
+feature. Here is a full sample `Activity` which shows at a basic level how to install a feature
+based on a button click.
+
+
+```csharp
+using Android.App;
+using Android.OS;
+using Android.Runtime;
+using Android.Widget;
+using Java.Lang;
+using Xamarin.Google.Android.Play.Core.SplitInstall;
+using Xamarin.Google.Android.Play.Core.SplitInstall.Model;
+using Xamarin.Google.Android.Play.Core.SplitInstall.Testing;
+using Android.Content;
+
+namespace DynamicAssetsExample
+{
+    [Activity(Label = "@string/app_name", MainLauncher = true)]
+    public class MainActivity : Activity
+    {
+        ISplitInstallManager manager;
+        SplitInstallStateUpdatedListenerWrapper listener;
+        protected override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+
+            // Set our view from the "main" layout resource
+            SetContentView(Resource.Layout.activity_main);
+            var button = FindViewById<Button>(Resource.Id.installButton);
+            // create the ISplitInstallManager instances.
+#if DEBUG
+            var fakeManager = FakeSplitInstallManagerFactory.Create(this);
+            manager = fakeManager;
+#else
+            manager = SplitInstallManagerFactory.Create (this);
+#endif
+            // Setup the Install State Update Listener.
+            listener = new SplitInstallStateUpdatedListenerWrapper ();
+            listener.StateUpdate += (s, e) => {
+                var status = e.State.Status ();
+                System.Console.WriteLine (status);
+            };
+            // Setup to install the feature on a button click.
+            button.Click += (s, e) => {
+                var builder = SplitInstallRequest.NewBuilder ();
+                builder.AddModule ("assetsfeature");
+                var installTask = manager.StartInstall (builder.Build ());
+            };
+        }
+
+        protected override void OnResume ()
+        {
+            // Register our listener
+            manager.RegisterListener (listener.Listener);
+            base.OnResume ();
+        }
+
+        protected override void OnPause()
+        {
+            // Unregister our listener. We don't want notifications
+            // when the app is not running.
+            manager.UnregisterListener (listener.Listener);
+            base.OnPause();
+        }
+    }
+}
+```
+
+## Testing a Dynamic Feature Locally
+
+In order to test Dynamic features on a local device you need to provide some additional
+arguments to `bundletool` during the build. The `--local-testing` argument will inject
+some additional metadata into the `aab` file which will cause your `features` to be
+deployed to a holding area on the device.
+
+Then when the `FakeSplitInstallManagerFactory` manager tries to install these features
+it will get them from this holding area.
+
+If you are developing using dynamic features this is the recommended arguments you need
+
+```xml
+<AndroidPackageFormat>aab</AndroidPackageFormat>
+<EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+<AndroidBundleToolExtraArgs Condition=" '$(Configuration)' == 'Debug' ">--local-testing</AndroidBundleToolExtraArgs>
+```
+
+This will force you to always use `aab` files and embed the .net assemblies into the
+package. While this is not ideal it is currently the only way to debug dynamic features.
+The `AndroidBundleToolExtraArgs` will allow you to test downloading features on demand.
+
+

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -133,6 +133,7 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)System.Collections.Immutable.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)System.Buffers.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)System.IO.Hashing.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Assets.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Aapt2.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Analysis.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Application.targets" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -139,6 +139,7 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Bindings.ClassParse.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Bindings.Core.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Bindings.Maven.targets" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.DynamicFeature.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Build.Tasks.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Build.Tasks.pdb" />
     <_MSBuildFiles Include="@(_LocalizationLanguages->'$(MicrosoftAndroidSdkOutDir)%(Identity)\Microsoft.Android.Build.BaseTasks.resources.dll')" />

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -19,6 +19,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Compile" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Link" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Convert" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.CreateDynamicFeatureManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
 <PropertyGroup>
   <Aapt2DaemonMaxInstanceCount Condition=" '$(Aapt2DaemonMaxInstanceCount)' == '' " >0</Aapt2DaemonMaxInstanceCount>
@@ -163,6 +165,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
       OutputFile="$(ResgenTemporaryDirectory)\resources.apk"
       PackageName="$(_AndroidPackage)"
+      PackageId="$(FeaturePackageId)"
       JavaPlatformJarPath="$(JavaPlatformJarPath)"
       JavaDesignerOutputDirectory="$(ResgenTemporaryDirectory)"
       CompiledResourceFlatFiles="@(_CompiledFlatFiles)"
@@ -224,7 +227,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       AdditionalAndroidResourcePaths="@(_LibraryResourceDirectories)"
       YieldDuringToolExecution="$(YieldDuringToolExecution)"
       PackageName="$(_AndroidPackage)"
+      PackageId="$(FeaturePackageId)"
       JavaPlatformJarPath="$(JavaPlatformJarPath)"
+      AdditionalApksToLink="@(_AdditionalApksToLink)"
       VersionCodePattern="$(AndroidVersionCodePattern)"
       VersionCodeProperties="$(AndroidVersionCodeProperties)"
       SupportedAbis="@(_BuildTargetAbis)"
@@ -245,6 +250,128 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <ProguardConfiguration Include="$(_Aapt2ProguardRules)" />
     <FileWrites Include="$(_Aapt2ProguardRules)" />
     <FileWrites Include="$(IntermediateOutputPath)android\*\aapt_rules.txt" />
+  </ItemGroup>
+</Target>
+
+<!-- Dynamic Feature Section -->
+
+<Target Name="_GenerateDynamicFeatureManifest"
+    Inputs="$(MSBuildProjectFile)"
+    Outputs="$(IntermediateOutputPath)AndroidManifest.xml">
+  <PropertyGroup>
+    <AndroidManifest Condition=" '$(AndroidManifest)' == '' ">$(IntermediateOutputPath)AndroidManifest.xml</AndroidManifest>
+    <FeatureSplitName Condition=" '$(FeatureSplitName)' == '' " >$(ProjectName)</FeatureSplitName>
+    <!-- FeatureDeliveryType : Valid Values are InstallTime, OnDemand -->
+    <FeatureDeliveryType Condition=" '$(FeatureDeliveryType)' == '' " >InstallTime</FeatureDeliveryType>
+    <IsFeatureSplit Condition=" '$(IsFeatureSplit)' == '' " >True</IsFeatureSplit>
+    <!-- FeatureType : Valid Values are Feature, AssetPack -->
+    <FeatureType Condition=" '$(FeatureType)' == '' ">Feature</FeatureType>
+  </PropertyGroup>
+  <MakeDir Directories="$(IntermediateOutputPath)android\bin" Condition="!Exists('$(IntermediateOutputPath)android\bin')" />
+  <CreateDynamicFeatureManifest
+    FeatureSplitName="$(FeatureSplitName)"
+    FeatureDeliveryType="$(FeatureDeliveryType)"
+    IsFeatureSplit="$(IsFeatureSplit)"
+    FeatureTitleResource="$(FeatureTitleResource)"
+    FeatureType="$(FeatureType)"
+    PackageName="$(PackageName)"
+    OutputFile="$(AndroidManifest)"
+    MinSdkVersion="$(_MinSdkVersion)"
+    TargetSdkVersion="$(_TargetSdkVersion)"
+  />
+  <ItemGroup>
+    <FileWrites Include="$(AndroidManifest)" />
+  </ItemGroup>
+</Target>
+
+<Target Name="_ConvertAppPackageForFeatureCompilation"
+    Condition=" '@(_AndroidDynamicFeature->Count())' != '0' "
+    Inputs="$(_PackagedResources)"
+    Outputs="$(_PackagedResources).ap_">
+  <Aapt2Convert
+    DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+    DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
+    OutputArchive="$(_PackagedResources).ap_"
+    Files="$(_PackagedResources)"
+    OutputFormat="binary"
+    ToolPath="$(Aapt2ToolPath)"
+    ToolExe="$(Aapt2ToolExe)"
+  />
+  <ItemGroup>
+    <FileWrites Include="$(_PackagedResources).ap_" />
+  </ItemGroup>
+</Target>
+
+<Target Name="_ConvertFeaturePackage">
+  <Aapt2Convert
+      DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+      DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
+      OutputArchive="$(_FeaturePackage)"
+      Files="$(_PackagedResources)"
+      OutputFormat="proto"
+      ToolPath="$(Aapt2ToolPath)"
+      ToolExe="$(Aapt2ToolExe)"
+  />
+  <ItemGroup>
+    <FileWrites Include="$(_FeaturePackage)" />
+  </ItemGroup>
+</Target>
+
+<Target Name="_CreateFeaturePackageWithAapt2"
+    DependsOnTargets="UpdateAndroidAssets"
+    Condition=" '$(FeatureType)' == 'AssetPack' "
+    Inputs="$(AndroidManifest);@(AndroidAsset);$(_AppPackagedResources)"
+    Outputs="$(_FeaturePackage)"
+  >
+  <PropertyGroup>
+    <_AndroidIntermediateAapt2OutputDirectory>$(IntermediateOutputPath)aapt2output</_AndroidIntermediateAapt2OutputDirectory>
+  </PropertyGroup>
+  <MakeDir Directories="$(_AndroidIntermediateDexOutputDirectory);$(_AndroidIntermediateAapt2OutputDirectory)" />
+  <Aapt2Link
+      AndroidManifestFile="$(AndroidManifest)"
+      CompiledResourceFlatFiles="@(_CompiledFlatFiles)"
+      DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+      DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
+      ResourceDirectories="$(MonoAndroidResDirIntermediate)"
+      AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
+      ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
+      OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
+      OutputFile="$(_AndroidIntermediateAapt2OutputDirectory)"
+      OutputToDirectory="True"
+      YieldDuringToolExecution="$(YieldDuringToolExecution)"
+      PackageName="$(FeaturePackageName)"
+      PackageId="$(FeaturePackageId)"
+      JavaPlatformJarPath="$(JavaPlatformJarPath)"
+      AdditionalApksToLink="@(_AdditionalApksToLink)"
+      VersionCodePattern="$(AndroidVersionCodePattern)"
+      VersionCodeProperties="$(AndroidVersionCodeProperties)"
+      SupportedAbis="@(_BuildTargetAbis)"
+      CreatePackagePerAbi="$(AndroidCreatePackagePerAbi)"
+      AssetsDirectory="$(MonoAndroidAssetsDirIntermediate)"
+      AdditionalAndroidAssetPaths="@(LibraryAssetDirectories)"
+      AndroidSdkPlatform="$(_AndroidApiLevel)"
+      JavaDesignerOutputDirectory="$(AaptTemporaryDirectory)"
+      ManifestFiles="$(AndroidManifest)"
+      ProtobufFormat="False"
+      ExtraArgs="$(AndroidAapt2LinkExtraArgs)"
+      ToolPath="$(Aapt2ToolPath)"
+      ToolExe="$(Aapt2ToolExe)"
+      UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
+  />
+  <!-- We don't need this file for asset packs. In fact bundle-tool will error if it is present. -->
+  <Delete
+      Files="$(_AndroidIntermediateAapt2OutputDirectory)\resources.arsc"
+      Condition=" '$(FeatureType)' == 'AssetPack' And Exists ('$(_AndroidIntermediateAapt2OutputDirectory)\resources.arsc') "
+  />
+
+  <ZipDirectory
+      SourceDirectory="$(_AndroidIntermediateAapt2OutputDirectory)"
+      DestinationFile="$(_PackagedResources)"
+      Overwrite="true"
+  />
+  <ItemGroup>
+    <FileWrites Include="$(_PackagedResources)" />
+    <FileWrites Include="$(_AndroidIntermediateAapt2OutputDirectory)\**\*.*" />
   </ItemGroup>
 </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -19,6 +19,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Compile" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Link" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.Aapt2LinkAssetPack" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Convert" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CreateDynamicFeatureManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
@@ -302,7 +303,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   </ItemGroup>
 </Target>
 
-<Target Name="_ConvertFeaturePackage">
+<Target Name="_ConvertFeaturePackage" Condition=" '$(FeatureType)' != 'AssetPack' ">
   <Aapt2Convert
       DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
       DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
@@ -323,55 +324,19 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     Inputs="$(AndroidManifest);@(AndroidAsset);$(_AppPackagedResources)"
     Outputs="$(_FeaturePackage)"
   >
-  <PropertyGroup>
-    <_AndroidIntermediateAapt2OutputDirectory>$(IntermediateOutputPath)aapt2output</_AndroidIntermediateAapt2OutputDirectory>
-  </PropertyGroup>
-  <MakeDir Directories="$(_AndroidIntermediateDexOutputDirectory);$(_AndroidIntermediateAapt2OutputDirectory)" />
-  <Aapt2Link
-      AndroidManifestFile="$(AndroidManifest)"
-      CompiledResourceFlatFiles="@(_CompiledFlatFiles)"
+  <Aapt2LinkAssetPack
       DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
       DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
-      ResourceDirectories="$(MonoAndroidResDirIntermediate)"
-      AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
-      ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
-      OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
-      OutputFile="$(_AndroidIntermediateAapt2OutputDirectory)"
-      OutputToDirectory="True"
-      YieldDuringToolExecution="$(YieldDuringToolExecution)"
+      OutputArchive="$(_FeaturePackage)"
+      AssetDirectory="$(MonoAndroidAssetsDirIntermediate)"
+      Manifest="$(AndroidManifest)"
       PackageName="$(FeaturePackageName)"
-      PackageId="$(FeaturePackageId)"
-      JavaPlatformJarPath="$(JavaPlatformJarPath)"
-      AdditionalApksToLink="@(_AdditionalApksToLink)"
-      VersionCodePattern="$(AndroidVersionCodePattern)"
-      VersionCodeProperties="$(AndroidVersionCodeProperties)"
-      SupportedAbis="@(_BuildTargetAbis)"
-      CreatePackagePerAbi="$(AndroidCreatePackagePerAbi)"
-      AssetsDirectory="$(MonoAndroidAssetsDirIntermediate)"
-      AdditionalAndroidAssetPaths="@(LibraryAssetDirectories)"
-      AndroidSdkPlatform="$(_AndroidApiLevel)"
-      JavaDesignerOutputDirectory="$(AaptTemporaryDirectory)"
-      ManifestFiles="$(AndroidManifest)"
-      ProtobufFormat="False"
-      ExtraArgs="$(AndroidAapt2LinkExtraArgs)"
       ToolPath="$(Aapt2ToolPath)"
       ToolExe="$(Aapt2ToolExe)"
-      UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
-  />
-  <!-- We don't need this file for asset packs. In fact bundle-tool will error if it is present. -->
-  <Delete
-      Files="$(_AndroidIntermediateAapt2OutputDirectory)\resources.arsc"
-      Condition=" '$(FeatureType)' == 'AssetPack' And Exists ('$(_AndroidIntermediateAapt2OutputDirectory)\resources.arsc') "
-  />
-
-  <ZipDirectory
-      SourceDirectory="$(_AndroidIntermediateAapt2OutputDirectory)"
-      DestinationFile="$(_PackagedResources)"
-      Overwrite="true"
-  />
+  />  
   <ItemGroup>
-    <FileWrites Include="$(_PackagedResources)" />
-    <FileWrites Include="$(_AndroidIntermediateAapt2OutputDirectory)\**\*.*" />
+    <FileWrites Include="$(_FeaturePackage)" />
   </ItemGroup>
 </Target>
+
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
@@ -1,0 +1,120 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Assets.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+Copyright (C) 2010-2011 Novell. All rights reserved.
+Copyright (C) 2011-2012 Xamarin. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+<UsingTask TaskName="Xamarin.Android.Tasks.AndroidComputeResPaths" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.Aapt2LinkAssetPack" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.GetAssetPacks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.RemoveUnknownFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.CreateDynamicFeatureManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+
+<!-- Assets build properties -->
+<PropertyGroup>
+    <MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
+    <MonoAndroidAssetPacksDirIntermediate>$(IntermediateOutputPath)assetpacks\packs</MonoAndroidAssetPacksDirIntermediate>
+    <MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
+</PropertyGroup>
+
+<!-- Assets Build -->
+
+<Target Name="UpdateAndroidAssets"
+	DependsOnTargets="$(CoreResolveReferencesDependsOn);_ComputeAndroidAssetsPaths;_GenerateAndroidAssetsDir" />
+
+<Target Name="_ComputeAndroidAssetsPaths">
+	<AndroidComputeResPaths
+            ResourceFiles="@(AndroidAsset)"
+            IntermediateDir="$(MonoAndroidAssetsDirIntermediate)"
+            AssetPackIntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)"
+            Prefixes="$(MonoAndroidAssetsPrefix)"
+            ProjectDir="$(ProjectDir)"
+        >
+		<Output ItemName="_AndroidAssetsDest" TaskParameter="IntermediateFiles" />
+		<Output ItemName="_AndroidResolvedAssets" TaskParameter="ResolvedResourceFiles" />
+	</AndroidComputeResPaths>
+</Target>
+
+<Target Name="_GenerateAndroidAssetsDir"
+	Inputs="@(_AndroidMSBuildAllProjects);@(_AndroidResolvedAssets)"
+	Outputs="@(_AndroidAssetsDest)">
+	<MakeDir Directories="$(MonoAndroidAssetsDirIntermediate);$(MonoAndroidAssetPacksDirIntermediate)" />
+	<Copy SourceFiles="@(_AndroidResolvedAssets)" DestinationFiles="@(_AndroidAssetsDest)" SkipUnchangedFiles="true" />
+	<RemoveUnknownFiles Files="@(_AndroidAssetsDest)" Directory="$(MonoAndroidAssetsDirIntermediate)" RemoveDirectories="true" />
+	<Touch Files="@(_AndroidAssetsDest)" />
+  <ItemGroup>
+    <FileWrites Include="@(_AndroidAssetsDest)" />
+  </ItemGroup>
+</Target>
+
+<Target Name="_CalculateAssetPacks"
+    Condition=" '$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true' "
+  >
+  <!-- Enumerate the assetpacks directory and build a pack per top level directory -->
+  <GetAssetPacks Assets="@(AndroidAsset)">
+    <Output ItemName="_AndroidAsset" TaskParameter="AssetPacks" />
+  </GetAssetPacks>
+  <ItemGroup>
+    <_AssetPacks Include="@(_AndroidAsset)">
+      <AssetPackOutput>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack).zip</AssetPackOutput>
+      <ManifestFile>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack)\AndroidManifest.xml</ManifestFile>
+      <DeliveryType Condition=" '%(_AndroidAsset.DeliveryType)' == '' ">InstallTime</DeliveryType>
+    </_AssetPacks>
+  </ItemGroup>
+</Target>
+
+<Target Name="_CreateAssetPackManifests"
+    Condition=" '$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true' "
+    DependsOnTargets="UpdateAndroidAssets;_CalculateAssetPacks"
+    Inputs="@(_AssetPacks)"
+    Outputs="@(_AssetPacks->'%(ManifestFile)')">
+
+    <CreateDynamicFeatureManifest
+      FeatureSplitName="%(_AssetPacks.AssetPack)"
+      FeatureDeliveryType="%(_AssetPacks.DeliveryType)"
+      FeatureType="AssetPack"
+      PackageName="$(_AndroidPackage).%(_AssetPacks.AssetPack)"
+      OutputFile="%(_AssetPacks.ManifestFile)"
+    />
+  <ItemGroup>
+    <FileWrites Include="%(_AssetPacks.ManifestFile)" />
+  </ItemGroup>
+</Target>
+
+<Target Name="_BuildAssetPacks"
+      AfterTargets="_CreateBaseApk"
+      DependsOnTargets="_CreateAssetPackManifests"
+      Condition=" '$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true' "
+      Inputs="@(_AssetPacks)"
+      Outputs="@(_AssetPacks->'%(AssetPackOutput)')">
+
+  <Aapt2LinkAssetPack
+      DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+      DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
+      OutputArchive="%(_AssetPacks.AssetPackOutput)"
+      AssetDirectory="$(MonoAndroidAssetPacksDirIntermediate)\%(_AssetPacks.AssetPack)\assets"
+      Manifest="%(_AssetPacks.ManifestFile)"
+      PackageName="$(_AndroidPackage).%(_AssetPacks.AssetPack)"
+      ToolPath="$(Aapt2ToolPath)"
+      ToolExe="$(Aapt2ToolExe)"
+  />    
+  <ItemGroup>
+    <AndroidAppBundleModules Include="%(_AssetPacks.AssetPackOutput)" />
+    <FileWrites Include="$%(_AssetPacks.AssetPackOutput)" />
+  </ItemGroup>
+</Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DynamicFeature.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DynamicFeature.targets
@@ -4,6 +4,9 @@
 <!-- Andorid Feature Build System-->
 <PropertyGroup>
   <_BuildDynamicFeaturesInParallel>False</_BuildDynamicFeaturesInParallel>
+  <DynamicFeatureResDirIntermediate>$(IntermediateOutputPath)assetpacks\g</DynamicFeatureResDirIntermediate>
+  <DynamicFeatureResDirIntermediateStampFile>$(DynamicFeatureResDirIntermediate)\assetpacks.stamp</DynamicFeatureResDirIntermediateStampFile>
+  <_DynamicFeatureResourceFile>$(DynamicFeatureResDirIntermediate)\res\values\ms_asset_pack_strings.xml</_DynamicFeatureResourceFile>
 </PropertyGroup>
 <Target Name="_CheckIsDynamicFeature"
       Returns="@(_DynamicFeaetureProjectMetadata)" Condition=" '$(FeatureSplitName)' != '' Or '$(FeatureType)' != '' ">
@@ -71,6 +74,27 @@
       Condition="'@(_AndroidDynamicFeatureProjects.Count())' != '0' "
       DependsOnTargets="_CollectDynamicFeatures">
     <MSBuild Projects="@(_AndroidDynamicFeatureProjects)" BuildInParallel="$(_BuildDynamicFeaturesInParallel)" Targets="Clean" RebaseOutputs="true" Properties="Configuration=$(Configuration)" />
+</Target>
+
+<Target Name="_CreateAssetPackTitleResources"
+    Condition=" '$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true' ">
+  <!--
+    Create the values.xml entires for the asset packs.
+    This needs to be done BEFORE we call aapt2 compile and aapt2 link so that the values are
+    in the main package.
+  -->
+  <MakeDir Directories="$(DynamicFeatureResDirIntermediate)\res\values" />
+  <CreateAssetPackTitleResources
+    Assets="@(_AndroidDynamicFeature)"
+    OutputFile="$(_DynamicFeatureResourceFile)"
+  />
+  <Touch Files="$(DynamicFeatureResDirIntermediateStampFile)" AlwaysCreate="True" />
+  <ItemGroup>
+    <LibraryResourceDirectories Include="$(DynamicFeatureResDirIntermediate)\res">
+      <StampFile>$(DynamicFeatureResDirIntermediateStampFile)</StampFile>
+    </LibraryResourceDirectories>
+    <FileWrites Include="$(_DynamicFeatureResourceFile)" />
+  </ItemGroup>
 </Target>
 <!-- Feature Specific Targets. -->
 

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DynamicFeature.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DynamicFeature.targets
@@ -1,0 +1,121 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+<UsingTask TaskName="Xamarin.Android.Tasks.CalculatePackageIdsForFeatures" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<!-- Andorid Feature Build System-->
+<PropertyGroup>
+  <_BuildDynamicFeaturesInParallel>False</_BuildDynamicFeaturesInParallel>
+</PropertyGroup>
+<Target Name="_CheckIsDynamicFeature"
+      Returns="@(_DynamicFeaetureProjectMetadata)" Condition=" '$(FeatureSplitName)' != '' Or '$(FeatureType)' != '' ">
+    <ItemGroup>
+      <_DynamicFeaetureProjectMetadata Include="$(MSBuildProjectFullPath)">
+        <IsDynamicFeature>true</IsDynamicFeature>
+        <FeaturePackage>$(MSBuildProjectDirectory)\$(_FeaturePackage)</FeaturePackage>
+        <FeatureType>$(FeatureType)</FeatureType>
+        <_BaseZipIntermediate>$(IntermediateOutputPath)\$(MSBuildProjectName).zip</_BaseZipIntermediate>
+      </_DynamicFeaetureProjectMetadata>
+    </ItemGroup>
+</Target>
+<Target Name="_ResolveAndroidDynamicFeatureProjects" BeforeTargets="AssignProjectConfiguration" Condition=" '$(AndroidApplication)' == 'true' ">
+    <MSBuild
+      Projects="@(ProjectReference)"
+      Targets="_CheckIsDynamicFeature"
+      BuildInParallel="$(_BuildDynamicFeaturesInParallel)"
+      SkipNonexistentTargets="true"
+      RebaseOutputs="true"
+    >
+      <Output TaskParameter="TargetOutputs" ItemName="_AndroidDynamicFeatureProjects" />
+    </MSBuild>
+    <ItemGroup>
+      <ProjectReference Remove="%(_AndroidDynamicFeatureProjects.OriginalItemSpec)" />
+    </ItemGroup>
+  </Target>
+<Target Name="_GetDynamicFeatureOutputs" DependsOnTargets="_ResolveAndroidDynamicFeatureProjects">
+    <CalculatePackageIdsForFeatures
+      FeatureProjects="@(_AndroidDynamicFeatureProjects)"
+    >
+        <Output TaskParameter="Output" ItemName="_AndroidDynamicFeature" />
+    </CalculatePackageIdsForFeatures>
+</Target>
+<Target Name="_BuildDynamicFeatures"
+      AfterTargets="_CreateBaseApk"
+      DependsOnTargets="_GetDynamicFeatureOutputs;_ConvertAppPackageForFeatureCompilation"
+      Condition=" '$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true' "
+      Inputs="@(_AndroidDynamicFeature)"
+      Outputs="@(_AndroidDynamicFeatureProjects->'%(FeaturePackage)')">
+    <PropertyGroup>
+      <_BuildArguments>
+      Configuration=$(Configuration);
+      BuildingFeature=True;
+      PackageName=$(_AndroidPackage);
+      AndroidPackageFormat=aab;
+      JavaPlatformJarPath=$(JavaPlatformJarPath);
+      Aapt2ToolPath=$(Aapt2ToolPath);Aapt2ToolExe=$(Aapt2ToolExe);
+      _TargetSdkVersion=$(_TargetSdkVersion);
+      _MinSdkVersion=$(_MinSdkVersion);
+      _AndroidIncludeRuntime=False;
+      _AppPackagedResources=$(MSBuildProjectDirectory)\$(_PackagedResources).ap_;
+      _AppAssemblyDirectory=$(MSBuildProjectDirectory)\$(MonoAndroidIntermediateAssemblyDir);
+      </_BuildArguments>
+    </PropertyGroup>
+    <MSBuild Projects="@(_AndroidDynamicFeature)" BuildInParallel="$(_BuildDynamicFeaturesInParallel)" Targets="Restore;BuildDynamicFeature" RebaseOutputs="true"
+      Properties="$(_BuildArguments)">
+        <Output TaskParameter="TargetOutputs" ItemName="_FeatureAssemblies" />
+    </MSBuild>
+    <ItemGroup>
+        <AndroidAppBundleModules Include="%(_AndroidDynamicFeatureProjects.FeaturePackage)" />
+    </ItemGroup>
+</Target>
+
+<Target Name="_CleanDynamicFeatures"
+      Condition="'@(_AndroidDynamicFeatureProjects.Count())' != '0' "
+      DependsOnTargets="_CollectDynamicFeatures">
+    <MSBuild Projects="@(_AndroidDynamicFeatureProjects)" BuildInParallel="$(_BuildDynamicFeaturesInParallel)" Targets="Clean" RebaseOutputs="true" Properties="Configuration=$(Configuration)" />
+</Target>
+<!-- Feature Specific Targets. -->
+
+<PropertyGroup>
+    <_FeaturePackage>$(OutputPath)$(MSBuildProjectName).zip</_FeaturePackage>
+    <_FeaturePackageTemp>$(IntermediateOutputPath)$(MSBuildProjectName).zip</_FeaturePackageTemp>
+</PropertyGroup>
+
+<Target Name="_SetupFeature">
+  <PropertyGroup>
+    <FeaturePackageName Condition=" '$(FeaturePackageName)' == '' " >$(_AndroidPackage).$(MSBuildProjectName)</FeaturePackageName>
+  </PropertyGroup>
+  <ItemGroup>
+    <_AdditionalApksToLink Include="$(_AppPackagedResources)" />
+    <Reference Include="$(_AppAssemblyDirectory)*.dll" AndroidSkipResourceExtraction="True" AndroidSkipAddToPackage="True" />
+    <_AppAssemblies Include="$(_AppAssemblyDirectory)*.dll" />
+    <ResolvedAssemblies Include="%(_AppAssemblies.Identity)" AndroidSkipResourceExtraction="True" AndroidSkipAddToPackage="True">
+      <DestinationSubPath>%(_AppAssemblies.Filename)</DestinationSubPath>
+    </ResolvedAssemblies>
+  </ItemGroup>
+</Target>
+<PropertyGroup>
+  <BeforeBuildDynamicFeatureDependsOnTargets>
+    _SetupFeature;
+    _SetupDesignTimeBuildForBuild;
+    _GenerateDynamicFeatureManifest;
+  </BeforeBuildDynamicFeatureDependsOnTargets>
+  <AfterBuildDynamicFeatureDependsOnTargets>
+    ;_ConvertFeaturePackage
+  </AfterBuildDynamicFeatureDependsOnTargets>
+  <CleanDependsOn>
+      $(CleanDependsOn);
+      _CleanDynamicFeatures;
+  </CleanDependsOn>
+</PropertyGroup>
+<Target Name="BuildDynamicFeature"
+        Inputs="$(_AndroidManifestAbs);@(AndroidAsset);$(_AppPackagedResources)"
+        Outputs="$(_FeaturePackage)">
+
+        <PropertyGroup>
+          <_FeatureTargets>$(BeforeBuildDynamicFeatureDependsOnTargets)</_FeatureTargets>
+          <_FeatureTargets Condition="'$(FeatureType)' == 'Feature' And '@(Compile.Count())' != '0'" >$(_FeatureTargets);PackageForAndroid</_FeatureTargets>
+          <_FeatureTargets Condition="'$(FeatureType)' == 'AssetPack' " >$(_FeatureTargets);_CreateFeaturePackageWithAapt2</_FeatureTargets>
+          <_FeatureTargets>$(_FeatureTargets);$(AfterBuildDynamicFeatureDependsOnTargets)</_FeatureTargets>
+        </PropertyGroup>
+        <CallTarget Targets="$(_FeatureTargets)" />
+</Target>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -59,6 +59,7 @@ properties that determine build ordering.
       _ResolveSatellitePaths;
       _CreatePackageWorkspace;
       _CreateBaseApk;
+      _BuildAssetPacks;
       _BuildDynamicFeatures;
       _LinkAssemblies;
       _GenerateJavaStubs;
@@ -128,9 +129,14 @@ properties that determine build ordering.
       $(DesignTimeResolveAssemblyReferencesDependsOn);
       _BuildResourceDesigner;
     </DesignTimeResolveAssemblyReferencesDependsOn>
+    <_PrepareAssetPackDependsOnTargets>
+      _CalculateAssetPacks;
+      $(_PrepareAssetPackDependsOnTargets);
+    </_PrepareAssetPackDependsOnTargets>
     <_UpdateAndroidResourcesDependsOn>
       $(CoreResolveReferencesDependsOn);
       _CreatePropertiesCache;
+      $(_PrepareAssetPackDependsOnTargets);
       _CheckForDeletedResourceFile;
       _ComputeAndroidResourcePaths;
       _UpdateAndroidResgen;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -58,6 +58,8 @@ properties that determine build ordering.
       _ResolveAssemblies;
       _ResolveSatellitePaths;
       _CreatePackageWorkspace;
+      _CreateBaseApk;
+      _BuildDynamicFeatures;
       _LinkAssemblies;
       _GenerateJavaStubs;
       _ManifestMerger;
@@ -69,7 +71,6 @@ properties that determine build ordering.
       _CreateApplicationSharedLibraries;
       _CompileDex;
       $(_AfterCompileDex);
-      _CreateBaseApk;
       _PrepareAssemblies;
       _ResolveSatellitePaths;
       _CheckApkPerAbiFlag;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Convert.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Convert.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using Xamarin.Android.Tools;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks {
+
+	public class Aapt2Convert : Aapt2 {
+		public override string TaskPrefix => "A2C";
+
+		[Required]
+		public ITaskItem [] Files { get; set; }
+		[Required]
+		public ITaskItem OutputArchive { get; set; }
+		public string OutputFormat { get; set; } = "binary";
+		public string ExtraArgs { get; set; }
+
+		protected override int GetRequiredDaemonInstances ()
+		{
+			return Math.Min (1, DaemonMaxInstanceCount);
+		}
+
+		public async override System.Threading.Tasks.Task RunTaskAsync ()
+		{
+			RunAapt (GenerateCommandLineCommands (Files, OutputArchive), OutputArchive.ItemSpec);
+			ProcessOutput ();
+			if (OutputFormat == "proto" && File.Exists (OutputArchive.ItemSpec)) {
+				// move the manifest to the right place.
+				using (var zip = new ZipArchiveEx (OutputArchive.ItemSpec, File.Exists (OutputArchive.ItemSpec) ? FileMode.Open : FileMode.Create)) {
+					zip.MoveEntry ("AndroidManifest.xml", "manifest/AndroidManifest.xml");
+				}
+			}
+		}
+
+		protected string[] GenerateCommandLineCommands (IEnumerable<ITaskItem> files, ITaskItem output)
+		{
+			List<string> cmd = new List<string> ();
+			cmd.Add ("convert");
+			if (!string.IsNullOrEmpty (ExtraArgs))
+				cmd.Add (ExtraArgs);
+			if (MonoAndroidHelper.LogInternalExceptions)
+				cmd.Add ("-v");
+			if (!string.IsNullOrEmpty (OutputFormat)) {
+				cmd.Add ("--output-format");
+				cmd.Add (OutputFormat);
+			}
+			cmd.Add ($"-o");
+			cmd.Add (GetFullPath (output.ItemSpec));
+			foreach (var file  in files) {
+				cmd.Add (GetFullPath (file.ItemSpec));
+			}
+			return cmd.ToArray ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using Xamarin.Android.Tools;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks {
+
+	public class Aapt2LinkAssetPack : Aapt2 {
+		public override string TaskPrefix => "A2LAP";
+
+        [Required]
+		public ITaskItem Manifest { get; set; }
+
+		[Required]
+		public ITaskItem AssetDirectory { get; set; }
+
+        [Required]
+        public string PackageName { get; set; }
+
+        [Required]
+        public ITaskItem OutputArchive { get; set; }
+
+        public string OutputFormat { get; set; } = "proto";
+
+		protected override int GetRequiredDaemonInstances ()
+		{
+			return Math.Min (1, DaemonMaxInstanceCount);
+		}
+
+		public async override System.Threading.Tasks.Task RunTaskAsync ()
+		{
+			RunAapt (GenerateCommandLineCommands (Manifest, AssetDirectory, OutputArchive), OutputArchive.ItemSpec);
+			ProcessOutput ();
+            if (OutputFormat == "proto" && File.Exists (OutputArchive.ItemSpec)) {
+				// move the manifest to the right place.
+				using (var zip = new ZipArchiveEx (OutputArchive.ItemSpec, File.Exists (OutputArchive.ItemSpec) ? FileMode.Open : FileMode.Create)) {
+					zip.MoveEntry ("AndroidManifest.xml", "manifest/AndroidManifest.xml");
+                    zip.Archive.DeleteEntry ("resources.pb");
+				}
+			}
+		}
+
+		protected string[] GenerateCommandLineCommands (ITaskItem manifest, ITaskItem assetDirectory, ITaskItem output)
+		{
+            //link --manifest AndroidManifest.xml --proto-format --custom-package $(Package) -A $(AssetsDirectory) -o $(_TempOutputFile)
+			List<string> cmd = new List<string> ();
+			cmd.Add ("link");
+			if (MonoAndroidHelper.LogInternalExceptions)
+				cmd.Add ("-v");
+            cmd.Add ("--manifest");
+            cmd.Add (GetFullPath (manifest.ItemSpec));
+			if (OutputFormat == "proto") {
+				cmd.Add ("--proto-format");
+			}
+            cmd.Add ("--custom-package");
+            cmd.Add (PackageName);
+            cmd.Add ("-A");
+            cmd.Add (GetFullPath (assetDirectory.ItemSpec));
+			cmd.Add ($"-o");
+			cmd.Add (GetFullPath (output.ItemSpec));
+			return cmd.ToArray ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -45,6 +45,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string IntermediateDir { get; set; }
 
+		public string AssetPackIntermediateDir { get; set; }
+
 		public string Prefixes { get; set; }
 
 		public bool LowercaseFilenames { get; set; }
@@ -83,6 +85,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				//compute the target path
 				string rel;
+				var pack = item.GetMetadata ("AssetPack");
 				var logicalName = item.GetMetadata ("LogicalName").Replace ('\\', Path.DirectorySeparatorChar);
 				if (item.GetMetadata ("IsWearApplicationResource") == "True") {
 					rel = item.ItemSpec.Substring (IntermediateDir.Length);
@@ -126,6 +129,11 @@ namespace Xamarin.Android.Tasks
 				}
 				string dest = Path.GetFullPath (Path.Combine (IntermediateDir, baseFileName));
 				string intermediateDirFullPath = Path.GetFullPath (IntermediateDir);
+				if (!string.IsNullOrEmpty (pack) && !string.IsNullOrEmpty (AssetPackIntermediateDir)) {
+					dest = Path.GetFullPath (Path.Combine (AssetPackIntermediateDir, pack, "assets", baseFileName));
+					intermediateDirFullPath = Path.GetFullPath (AssetPackIntermediateDir);
+				}
+				
 				// if the path ends up "outside" of our target intermediate directory, just use the filename
 				if (String.Compare (intermediateDirFullPath, 0, dest, 0, intermediateDirFullPath.Length, StringComparison.OrdinalIgnoreCase) != 0) {
 					dest = Path.GetFullPath (Path.Combine (IntermediateDir, Path.GetFileName (baseFileName)));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -91,6 +91,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool IncludeWrapSh { get; set; }
 
+		public bool IncludeRuntime { get; set; } = true;
+
 		public string CheckedBuild { get; set; }
 
 		public string RuntimeConfigBinFilePath { get; set; }
@@ -205,7 +207,8 @@ namespace Xamarin.Android.Tasks
 					apk.Flush ();
 				}
 
-				AddRuntimeLibraries (apk, supportedAbis);
+				if (IncludeRuntime)
+					AddRuntimeLibraries (apk, supportedAbis);
 				apk.Flush();
 				AddNativeLibraries (files, supportedAbis);
 				AddAdditionalNativeLibraries (files, supportedAbis);
@@ -689,14 +692,16 @@ namespace Xamarin.Android.Tasks
 
 		private void AddNativeLibraries (ArchiveFileList files, string [] supportedAbis)
 		{
-			var frameworkLibs = FrameworkNativeLibraries.Select (v => new LibInfo {
-				Path = v.ItemSpec,
-				Link = v.GetMetadata ("Link"),
-				Abi = GetNativeLibraryAbi (v),
-				ArchiveFileName = GetArchiveFileName (v)
-			});
+			if (IncludeRuntime) {
+				var frameworkLibs = FrameworkNativeLibraries.Select (v => new LibInfo {
+					Path = v.ItemSpec,
+					Link = v.GetMetadata ("Link"),
+					Abi = GetNativeLibraryAbi (v),
+					ArchiveFileName = GetArchiveFileName (v)
+				});
 
-			AddNativeLibraries (files, supportedAbis, frameworkLibs);
+				AddNativeLibraries (files, supportedAbis, frameworkLibs);
+			}
 
 			var libs = NativeLibraries.Concat (BundleNativeLibraries ?? Enumerable.Empty<ITaskItem> ())
 				.Where (v => IncludeNativeLibrary (v))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildBaseAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildBaseAppBundle.cs
@@ -33,19 +33,11 @@ namespace Xamarin.Android.Tasks
 		/// </summary>
 		protected override void FixupArchive (ZipArchiveEx zip)
 		{
-			if (!zip.Archive.ContainsEntry ("AndroidManifest.xml")) {
+			if (!zip.MoveEntry ("AndroidManifest.xml", "manifest/AndroidManifest.xml")) {
 				Log.LogDebugMessage ($"No AndroidManifest.xml. Skipping Fixup");
 				return;
 			}
-			var entry = zip.Archive.ReadEntry ("AndroidManifest.xml");
-			Log.LogDebugMessage ($"Fixing up AndroidManifest.xml to be manifest/AndroidManifest.xml.");
-			using (var stream = new MemoryStream ()) {
-				entry.Extract (stream);
-				stream.Position = 0;
-				zip.Archive.AddEntry ("manifest/AndroidManifest.xml", stream);
-				zip.Archive.DeleteEntry (entry);
-				zip.Flush ();
-			}
+			Log.LogDebugMessage ($"Fixed up AndroidManifest.xml to be manifest/AndroidManifest.xml.");
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculatePackageIdsForFeatures.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculatePackageIdsForFeatures.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.Xml.XPath;
+
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+
+using Xamarin.Build;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks
+{
+	public class CalculatePackageIdsForFeatures : AndroidTask
+	{
+		public override string TaskPrefix => "CPI";
+
+		[Required]
+		public ITaskItem[] FeatureProjects { get; set; }
+
+		[Output]
+		public ITaskItem[] Output { get; set; }
+
+		public override bool RunTask ()
+		{
+			List<ITaskItem> output = new List<ITaskItem> ();
+			int packageId = 0x7f; // default package Id for the main app.
+			// we now decrement the package id and will use that for
+			// each "feature". This is so resources do not clash.
+			foreach (var feature in FeatureProjects) {
+				packageId--;
+				var item = new TaskItem (feature.ItemSpec);
+				bool isFeature = feature.GetMetadata("FeatureType") == "Feature";
+				string apkFileIntermediate = feature.GetMetadata ("_BaseZipIntermediate");
+				item.SetMetadata ("AdditionalProperties", $"AndroidApplication={isFeature.ToString ()};_BaseZipIntermediate={apkFileIntermediate};EmbedAssembliesIntoApk=true;FeaturePackageId=0x{packageId.ToString ("X")}");
+				output.Add (item);
+			}
+			Output = output.ToArray ();
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAssetPackTitleResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAssetPackTitleResources.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+
+using Xamarin.Android.Tools;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks
+{
+	public class CreateAssetPackTitleResources : AndroidTask
+	{
+        public override string TaskPrefix => "CAPTR";
+
+        [Required]
+        public ITaskItem[] Assets { get; set; }
+        [Required]
+		public ITaskItem OutputFile { get; set; }
+        public override bool RunTask ()
+		{
+			XDocument doc = new XDocument ();
+            XElement resources = new XElement ("resources");
+            foreach (var asset in Assets) {
+                var pack = asset.GetMetadata ("AssetPack");
+                var title = asset.GetMetadata ("TitleResource");
+                if (string.IsNullOrEmpty (pack))
+                    continue;
+                resources.Add (new XElement ("string",
+                    new XAttribute ("name", title),
+                    pack
+                ));
+            }
+            doc.Add (resources);
+			doc.Save (OutputFile.ItemSpec);
+			return !Log.HasLoggedErrors;
+		}
+    }
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+
+using Xamarin.Android.Tools;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks
+{
+	public class CreateDynamicFeatureManifest : AndroidTask
+	{
+		readonly XNamespace androidNS = "http://schemas.android.com/apk/res/android";
+		readonly XNamespace distNS = "http://schemas.android.com/apk/distribution";
+		readonly XNamespace toolsNS = "http://schemas.android.com/tools";
+
+		public override string TaskPrefix => "CDFM";
+
+		[Required]
+		public string FeatureSplitName { get; set; }
+
+		[Required]
+		public string FeatureDeliveryType { get; set; }
+
+		[Required]
+		public string FeatureType { get; set; }
+
+		[Required]
+		public string PackageName { get; set; }
+
+		[Required]
+		public ITaskItem OutputFile { get; set; }
+
+		public string FeatureTitleResource { get; set; }
+
+		public string MinSdkVersion { get; set; }
+
+		public string TargetSdkVersion { get; set; }
+
+		public bool IsFeatureSplit { get; set; } = false;
+		public bool IsInstant { get; set; } = false;
+		public bool HasCode { get; set; } = false;
+
+		public override bool RunTask ()
+		{
+			XDocument doc = new XDocument ();
+			switch (FeatureType) {
+				case "AssetPack":
+					GenerateAssetPackManifest (doc);
+					break;
+				default:
+					GenerateFeatureManifest (doc);
+					break;
+			}
+			doc.Save (OutputFile.ItemSpec);
+			return !Log.HasLoggedErrors;
+		}
+
+		void GenerateFeatureManifest (XDocument doc) {
+			XAttribute featureTitleResource = null;
+			if (!string.IsNullOrEmpty (FeatureTitleResource))
+				featureTitleResource = new XAttribute (distNS + "title", FeatureTitleResource);
+			XElement usesSdk = new XElement ("uses-sdk");
+			if (!string.IsNullOrEmpty (MinSdkVersion))
+				usesSdk.Add (new XAttribute (androidNS + "minSdkVersion", MinSdkVersion));
+			if (!string.IsNullOrEmpty (MinSdkVersion))
+				usesSdk.Add (new XAttribute (androidNS + "targetSdkVersion", TargetSdkVersion));
+			doc.Add (new XElement ("manifest",
+					new XAttribute(XNamespace.Xmlns + "android", androidNS),
+					new XAttribute(XNamespace.Xmlns + "tools", toolsNS),
+					new XAttribute(XNamespace.Xmlns + "dist", distNS),
+					new XAttribute (androidNS + "versionCode", "1"),
+					new XAttribute (androidNS + "versionName", "1.0"),
+					new XAttribute ("package", PackageName),
+					new XAttribute ("featureSplit", FeatureSplitName),
+					new XAttribute (androidNS + "isFeatureSplit", IsFeatureSplit),
+					new XElement (distNS + "module",
+						featureTitleResource,
+						new XAttribute (distNS + "instant", IsInstant),
+						new XElement (distNS + "delivery",
+							GetDistribution ()
+						),
+						new XElement (distNS + "fusing",
+							new XAttribute (distNS + "include", true)
+						)
+					),
+					usesSdk,
+					new XElement ("application",
+						new XAttribute (androidNS + "hasCode", HasCode),
+						new XAttribute (toolsNS + "replace", "android:hasCode")
+					)
+				)
+			);
+		}
+
+		void GenerateAssetPackManifest (XDocument doc) {
+			doc.Add (new XElement ("manifest",
+					new XAttribute (XNamespace.Xmlns + "android", androidNS),
+					new XAttribute (XNamespace.Xmlns + "tools", toolsNS),
+					new XAttribute (XNamespace.Xmlns + "dist", distNS),
+					new XAttribute ("package", PackageName),
+					new XAttribute ("split", FeatureSplitName),
+					new XElement (distNS + "module",
+						new XAttribute (distNS + "type", "asset-pack"),
+						new XElement (distNS + "delivery",
+							GetDistribution ()
+						),
+						new XElement (distNS + "fusing",
+							new XAttribute (distNS + "include", true)
+						)
+					)
+				)
+			);
+		}
+
+		XElement GetDistribution ()
+		{
+			XElement distribution;
+			switch (FeatureDeliveryType)
+			{
+				case "OnDemand":
+					distribution = new XElement (distNS + "on-demand");
+					break;
+				case "InstallTime":
+				default:
+					distribution = new XElement (distNS + "install-time");
+					break;
+			}
+			return distribution;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
@@ -126,6 +126,9 @@ namespace Xamarin.Android.Tasks
 				case "OnDemand":
 					distribution = new XElement (distNS + "on-demand");
 					break;
+				case "FastFollow":
+					distribution = new XElement (distNS + "fast-follow");
+					break;
 				case "InstallTime":
 				default:
 					distribution = new XElement (distNS + "install-time");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAssetPacks.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAssetPacks.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks
+{
+	// We have a list of files, we want to get the
+	// ones that actually exist on disk.
+	public class GetAssetPacks : AndroidTask
+	{
+		public override string TaskPrefix => "GAP";
+
+		[Required]
+		public ITaskItem[] Assets { get; set; }
+
+        public string[] MetadataToCopy { get; set; } = { "DeliveryType", "IsFeatureSplit"};
+
+		[Output]
+		public ITaskItem[] AssetPacks { get; set; }
+
+		public override bool RunTask ()
+		{
+            Dictionary<string, ITaskItem> assetPacks = new Dictionary<string, ITaskItem> ();
+			foreach (var asset in Assets) {
+                var assetPack = asset.GetMetadata ("AssetPack");
+                if (string.IsNullOrEmpty (assetPack))
+                    continue;
+                if (!assetPacks.ContainsKey (assetPack)) {
+                    assetPacks[assetPack] = new TaskItem (assetPack);
+                    assetPacks[assetPack].SetMetadata ("AssetPack", assetPack);
+                }
+                var item = assetPacks[assetPack];
+                foreach (var metadata in MetadataToCopy)
+                    if (string.IsNullOrEmpty (item.GetMetadata (metadata)))
+                        item.SetMetadata (metadata, asset.GetMetadata (metadata));
+            }
+
+            AssetPacks = assetPacks.Values.ToArray ();
+
+			return true;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
@@ -35,9 +35,7 @@ namespace Xamarin.Android.Tasks
 			// --modules: List of modules to be installed, or "_ALL_" for all modules.
 			// Defaults to modules installed during first install, i.e. not on-demand.
 			// Xamarin.Android won't support on-demand modules yet.
-			if (Modules == null)
-				cmd.AppendSwitchIfNotNull ("--modules ", "_ALL_");
-			else
+			if (Modules != null)
 				cmd.AppendSwitchIfNotNull ("--modules ", $"\"{string.Join ("\",\"", Modules)}\"");
 
 			return cmd;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
@@ -38,11 +38,18 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public bool IsTestOnly { get; set; } = false;
 
+		[Output]
+		public string MinSdkVersion { get; set; }
+
+		[Output]
+		public string TargetSdkVersion { get; set; }
+
 		public override bool RunTask ()
 		{
 			var androidNs = AndroidAppManifest.AndroidXNamespace;
 			var manifest = AndroidAppManifest.Load (ManifestFile, MonoAndroidHelper.SupportedVersions);
 			var app = manifest.Document.Element ("manifest")?.Element ("application");
+			var usesSdk = manifest.Document.Element ("manifest")?.Element ("uses-sdk");
 
 			if (app != null) {
 				string text = app.Attribute (androidNs + "extractNativeLibs")?.Value;
@@ -73,6 +80,10 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 				UsesLibraries = libraries.ToArray ();
+			}
+			if (usesSdk != null) {
+				MinSdkVersion = usesSdk.Attribute (androidNs + "minSdkVersion")?.Value;
+				TargetSdkVersion = usesSdk.Attribute (androidNs + "targetSdkVersion")?.Value;
 			}
 
 			return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DynamicFeatureTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DynamicFeatureTests.cs
@@ -1,0 +1,162 @@
+using NUnit.Framework;
+using System.IO;
+using System.Text;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[Category ("Node-3")]
+	[Parallelizable (ParallelScope.Children)]
+	public class DynamicFeatureTests : BaseTest
+	{
+		[Test]
+		[Category ("SmokeTests")]
+		public void BuildDynamicAssetFeature ([Values (true, false)] bool isRelease) {
+
+			if (!Builder.UseDotNet)
+				Assert.Ignore ("Dynamic Features not supported on Legacy Projects.");
+			var path = Path.Combine ("temp", TestName);
+			var feature1 = new XamarinAndroidLibraryProject () {
+				ProjectName = "Feature1",
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new AndroidItem.AndroidAsset ("Assets\\asset3.txt") {
+						TextContent = () => "Asset3",
+						Encoding = Encoding.ASCII,
+					},
+				}
+			};
+			// we don't need any of this stuff!
+			feature1.Sources.Clear ();
+			feature1.AndroidResources.Clear ();
+			feature1.SetProperty ("FeatureType", "AssetPack");
+			var app = new XamarinAndroidApplicationProject {
+				ProjectName = "MyApp",
+				IsRelease = isRelease,
+			};
+			app.SetProperty ("AndroidPackageFormat", "aab");
+			var reference = new BuildItem ("ProjectReference", $"..\\{feature1.ProjectName}\\{feature1.ProjectName}.csproj");
+			app.References.Add (reference);
+			using (var libBuilder = CreateDllBuilder (Path.Combine (path, feature1.ProjectName))) {
+				libBuilder.Save (feature1);
+				using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+					Assert.IsTrue (appBuilder.Build (app), $"{app.ProjectName} should succeed");
+					// Check the final aab has the required feature files in it.
+					var aab = Path.Combine (Root, appBuilder.ProjectDirectory,
+						app.OutputPath, $"{app.PackageName}.aab");
+					using (var zip = ZipHelper.OpenZip (aab)) {
+						Assert.IsTrue (zip.ContainsEntry ("feature1/assets/asset3.txt"), "aab should contain feature1/assets/asset3.txt");
+						Assert.IsTrue (zip.ContainsEntry ("feature1/assets.pb"), "aab should contain feature1/assets.pb");
+						Assert.IsFalse (zip.ContainsEntry ("feature1/resources.pb"), "aab should not contain feature1/resources.pb");
+					}
+				}
+			}
+		}
+
+		[Test]
+		[Category ("SmokeTests")]
+		public void BuildDynamicActivityFeature ([Values (true, false)] bool isRelease) {
+
+			if (!Builder.UseDotNet)
+				Assert.Ignore ("Dynamic Features not supported on Legacy Projects.");
+			var path = Path.Combine ("temp", TestName);
+			var assetFeature = new XamarinAndroidLibraryProject () {
+				ProjectName = "AssetFeature",
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new AndroidItem.AndroidAsset ("Assets\\asset3.txt") {
+						TextContent = () => "Asset3",
+						Encoding = Encoding.ASCII,
+					},
+				}
+			};
+			// we don't need any of this stuff!
+			assetFeature.Sources.Clear ();
+			assetFeature.AndroidResources.Clear ();
+			assetFeature.SetProperty ("FeatureType", "AssetPack");
+
+			var feature1 = new XamarinAndroidLibraryProject () {
+				ProjectName = "Feature1",
+				IsRelease = isRelease,
+			};
+			feature1.Sources.Clear ();
+			feature1.AndroidResources.Clear ();
+			// Add an activity which the main app can call.
+			feature1.Sources.Add (new BuildItem.Source ("FeatureActivity.cs") {
+				TextContent = () => @"using System;
+using Android.App;
+using Android.Content;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Android.OS;
+
+namespace Feature1
+{
+	[Register (""" + feature1.ProjectName + @".FeatureActivity""), Activity (Label = ""Feature1"", MainLauncher = false, Icon = ""@drawable/icon"")]
+	public class FeatureActivity : Activity {
+		protected override void OnCreate (Bundle bundle)
+		{
+			base.OnCreate (bundle);
+			SetContentView (Resource.Layout.FeatureActivity);
+		}
+	}
+}
+",
+			});
+			feature1.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\Layout\\FeatureActivity.xml") {
+				TextContent = () => @"<?xml version='1.0' encoding='utf-8' ?>
+<LinearLayout xmlns:android='http://schemas.android.com/apk/res/android'
+	android:orientation='vertical'
+	android:layout_width='fill_parent'
+	android:layout_height='fill_parent'>
+	<TextView
+		android:id='@+id/featuretext'
+		android:layout_width='wrap_content'
+		android:layout_height='wrap_content'
+		android:layout_centerInParent='true'
+		android:text='Feature Activity Shown!'
+	/>
+</LinearLayout>
+",
+			});
+			feature1.SetProperty ("FeatureType", "Feature");
+			feature1.SetProperty ("FeatureTitleResource", "@string/feature1");
+			var app = new XamarinAndroidApplicationProject {
+				ProjectName = "MyApp",
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new AndroidItem.AndroidResource (() => "Resources\\values\\string1.xml") {
+						TextContent = () => @"<resources>
+					<string name=""feature1"">Feature1</string>
+				</resources>",
+					},
+				}
+			};
+			app.SetProperty ("AndroidPackageFormat", "aab");
+			var reference = new BuildItem ("ProjectReference", $"..\\{assetFeature.ProjectName}\\{assetFeature.ProjectName}.csproj");
+			app.References.Add (reference);
+			reference = new BuildItem ("ProjectReference", $"..\\{feature1.ProjectName}\\{feature1.ProjectName}.csproj");
+			app.References.Add (reference);
+			using (var libBuilder = CreateDllBuilder (Path.Combine (path, assetFeature.ProjectName))) {
+				libBuilder.Save (assetFeature);
+				using (var libBuilder1 = CreateDllBuilder (Path.Combine (path, feature1.ProjectName))) {
+					libBuilder1.Save (feature1);
+					using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+						Assert.IsTrue (appBuilder.Build (app), $"{app.ProjectName} should succeed");
+						// Check the final aab has the required feature files in it.
+						var aab = Path.Combine (Root, appBuilder.ProjectDirectory,
+							app.OutputPath, $"{app.PackageName}.aab");
+						using (var zip = ZipHelper.OpenZip (aab)) {
+							Assert.IsTrue (zip.ContainsEntry ($"feature1/root/assemblies/{feature1.ProjectName}.dll"), $"aab should contain feature1/root/assemblies/{feature1.ProjectName}.dll");
+							Assert.IsFalse (zip.ContainsEntry ("feature1/root/assemblies/System.dll"), "aab should not contain feature1/root/assemblies/System.dll");
+							Assert.IsFalse (zip.ContainsEntry ("feature1/assets.pb"), "aab should contain feature1/assets.pb");
+							Assert.IsTrue (zip.ContainsEntry ("feature1/resources.pb"), "aab should contain feature1/resources.pb");
+						}
+					}
+				}
+			}
+			Assert.Fail ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DynamicFeatureTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DynamicFeatureTests.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Build.Tests
 	{
 		[Test]
 		[Category ("SmokeTests")]
-		public void BuildApplicationWithDynamicAssetFeature ([Values (true, false)] bool isRelease) {
+		public void BuildApplicationWithAssetPack ([Values (true, false)] bool isRelease) {
 			var path = Path.Combine ("temp", TestName);
 			var app = new XamarinAndroidApplicationProject {
 				ProjectName = "MyApp",
@@ -21,10 +21,25 @@ namespace Xamarin.Android.Build.Tests
 						TextContent = () => "Asset1",
 						Encoding = Encoding.ASCII,
 					},
+					new AndroidItem.AndroidAsset ("Assets\\asset2.txt") {
+						TextContent = () => "Asset2",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack1;DeliveryType=InstallTime",
+					},
 					new AndroidItem.AndroidAsset ("Assets\\asset3.txt") {
 						TextContent = () => "Asset3",
 						Encoding = Encoding.ASCII,
 						MetadataValues="AssetPack=assetpack1",
+					},
+					new AndroidItem.AndroidAsset ("Assets\\asset4.txt") {
+						TextContent = () => "Asset4",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack2;DeliveryType=OnDemand",
+					},
+					new AndroidItem.AndroidAsset ("Assets\\asset5.txt") {
+						TextContent = () => "Asset5",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack3;DeliveryType=FastFollow",
 					},
 				}
 			};
@@ -36,8 +51,13 @@ namespace Xamarin.Android.Build.Tests
 					app.OutputPath, $"{app.PackageName}.aab");
 				using (var zip = ZipHelper.OpenZip (aab)) {
 					Assert.IsTrue (zip.ContainsEntry ("base/assets/asset1.txt"), "aab should contain base/assets/asset1.txt");
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset2.txt"), "aab should not contain base/assets/asset2.txt");
 					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset3.txt"), "aab should not contain base/assets/asset3.txt");
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset4.txt"), "aab should not contain base/assets/asset4.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets/asset2.txt"), "aab should contain assetpack1/assets/asset2.txt");
 					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets/asset3.txt"), "aab should contain assetpack1/assets/asset3.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack2/assets/asset4.txt"), "aab should contain assetpack2/assets/asset4.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack3/assets/asset5.txt"), "aab should contain assetpack3/assets/asset5.txt");
 					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets.pb"), "aab should contain assetpack1/assets.pb");
 					Assert.IsFalse (zip.ContainsEntry ("assetpack1/resources.pb"), "aab should not contain assetpack1/resources.pb");
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CreateDynamicFeatureManifestTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CreateDynamicFeatureManifestTests.cs
@@ -1,0 +1,69 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xamarin.Android.Tasks;
+using Xamarin.Tools.Zip;
+using TaskItem = Microsoft.Build.Utilities.TaskItem;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	[Category ("Node-2")]
+	public class CreateDynamicFeatureManifestTests : BaseTest
+	{
+		[Test]
+		[TestCase ("OnDemand", "", "")]
+		[TestCase ("OnDemand", "21", "")]
+		[TestCase ("OnDemand", "21", "30")]
+		[TestCase ("InstallTime", "", "")]
+		[TestCase ("InstallTime", "21", "")]
+		[TestCase ("InstallTime", "21", "30")]
+		[TestCase ("", "", "")]
+		public void CreateDynamicFeatureManifestIsCreated (string deliveryType, string minSdk, string targetSdk)
+		{
+			string path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory(path);
+			string manifest = Path.Combine(path, "AndroidManifest.xml");
+			var task = new CreateDynamicFeatureManifest {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				FeatureDeliveryType = deliveryType,
+				FeatureSplitName = "MyFeature",
+				FeatureTitleResource = "@strings/myfeature",
+				PackageName = "com.feature.test",
+				OutputFile = new TaskItem (manifest),
+				MinSdkVersion = minSdk,
+				TargetSdkVersion = targetSdk,
+			};
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			XDocument doc = XDocument.Load (manifest);
+			var nsResolver = new XmlNamespaceManager (new NameTable ());
+			nsResolver.AddNamespace ("android", "http://schemas.android.com/apk/res/android");
+			nsResolver.AddNamespace ("dist", "http://schemas.android.com/apk/distribution");
+			bool hasMinSdk = !string.IsNullOrEmpty (minSdk);
+			Assert.AreEqual (hasMinSdk, doc.XPathSelectElements ($"//manifest/uses-sdk[@android:minSdkVersion='{minSdk}']", nsResolver).Any (),
+				$"minSdkVersion should {(hasMinSdk ? "" : "not")} be set.");
+			bool hasTargetSdk = !string.IsNullOrEmpty (targetSdk);
+			Assert.AreEqual (hasMinSdk, doc.XPathSelectElements ($"//manifest/uses-sdk[@android:targetSdkVersion='{targetSdk}']", nsResolver).Any (),
+				$"minSdkVersion should {(hasTargetSdk ? "" : "not")} be set.");
+			string expected = "";
+			switch (deliveryType) {
+				case "OnDemand":
+					expected = "dist:on-demand";
+					break;
+				case "InstallTime":
+				default:
+					expected = "dist:install-time";
+					break;
+			}
+			Assert.IsTrue (doc.XPathSelectElements ($"//manifest/dist:module/dist:delivery/{expected}", nsResolver).Any (), $"Delivery type should be set to {expected}");
+			Directory.Delete (path, recursive: true);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -124,6 +124,22 @@ namespace Xamarin.Android.Tasks
 				zip.DeleteEntry ((ulong)index);
 		}
 
+		public bool MoveEntry (string from, string to)
+		{
+			if (!zip.ContainsEntry (from)) {
+				return false;
+			}
+			var entry = zip.ReadEntry (from);
+			using (var stream = new MemoryStream ()) {
+				entry.Extract (stream);
+				stream.Position = 0;
+				zip.AddEntry (to, stream);
+				zip.DeleteEntry (entry);
+				Flush ();
+			}
+			return true;
+		}
+
 		public void AddDirectory (string folder, string folderInArchive, CompressionMethod method = CompressionMethod.Default)
 		{
 			if (!string.IsNullOrEmpty (folder)) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -114,6 +114,10 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="MSBuild\Xamarin\Android\Xamarin.Android.DynamicFeature.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Xamarin.Android.DynamicFeature.targets</Link>
+    </None>
     <None Include="Xamarin.Android.BuildInfo.txt">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -93,6 +93,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Resource.Designer.targets</Link>
     </None>
+    <None Include="MSBuild\Xamarin\Android\Xamarin.Android.Assets.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Xamarin.Android.Assets.targets</Link>
+    </None>
     <None Include="MSBuild\Xamarin\Android\Xamarin.Android.Aapt2.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Aapt2.targets</Link>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -362,6 +362,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <!-- Assets build properties -->
 <PropertyGroup>
 	<MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
+  <MonoAndroidAssetPacksDirIntermediate>$(IntermediateOutputPath)assetpacks\</MonoAndroidAssetPacksDirIntermediate>
 	<MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
 </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -298,6 +298,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidGenerateJniMarshalMethods Condition=" '$(AndroidGenerateJniMarshalMethods)' == '' ">False</AndroidGenerateJniMarshalMethods>
 	<AndroidMakeBundleKeepTemporaryFiles Condition=" '$(AndroidMakeBundleKeepTemporaryFiles)' == '' ">False</AndroidMakeBundleKeepTemporaryFiles>
 
+	<_AndroidIncludeRuntime Condition=" '$(_AndroidIncludeRuntime)' == '' ">True</_AndroidIncludeRuntime>
 	<!-- If true it will cause all the assemblies in the apk to be preloaded on startup time -->
 	<_AndroidEnablePreloadAssembliesDefault Condition=" '$(UsingAndroidNETSdk)' == 'true' ">False</_AndroidEnablePreloadAssembliesDefault>
 	<_AndroidEnablePreloadAssembliesDefault Condition=" '$(UsingAndroidNETSdk)' != 'true' ">True</_AndroidEnablePreloadAssembliesDefault>
@@ -372,6 +373,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <!-- As we split up/refactor this file, put new imports here -->
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.D8.targets" Condition=" '$(AndroidDexTool)' == 'd8' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DynamicFeature.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DesignTime.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.EmbeddedResource.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Javac.targets" />
@@ -599,8 +601,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Target Name="_ValidateAndroidPackageProperties"
     DependsOnTargets="_GetAndroidPackageName;_GetJavaPlatformJar">
 	<PropertyGroup>
-		<ApkFileIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage).apk</ApkFileIntermediate>
-		<_BaseZipIntermediate>$(IntermediateOutputPath)android\bin\base.zip</_BaseZipIntermediate>
+		<ApkFileIntermediate Condition=" '$(ApkFileIntermediate)' == ''">$(IntermediateOutputPath)android\bin\$(_AndroidPackage).apk</ApkFileIntermediate>
+		<_BaseZipIntermediate Condition=" '$(_BaseZipIntermediate)' == '' ">$(IntermediateOutputPath)android\bin\base.zip</_BaseZipIntermediate>
 		<_AppBundleIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage).aab</_AppBundleIntermediate>
 		<_ApkSetIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage).apks</_ApkSetIntermediate>
 		<_UniversalApkSetIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage)-Universal.apks</_UniversalApkSetIntermediate>
@@ -1600,6 +1602,8 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="UsesLibraries"       ItemName="AndroidExternalJavaLibrary" />
     <Output TaskParameter="UseEmbeddedDex"      PropertyName="_UseEmbeddedDex" />
     <Output TaskParameter="IsTestOnly"          PropertyName="_AndroidIsTestOnlyPackage" />
+    <Output TaskParameter="MinSdkVersion"       PropertyName="_MinSdkVersion" />
+    <Output TaskParameter="TargetSdkVersion"    PropertyName="_TargetSdkVersion" />
   </ReadAndroidManifest>
   <PropertyGroup>
     <AndroidStoreUncompressedFileExtensions Condition=" '$(_EmbeddedDSOsEnabled)' == 'True' ">.so;$(AndroidStoreUncompressedFileExtensions)</AndroidStoreUncompressedFileExtensions>
@@ -2131,10 +2135,18 @@ because xbuild doesn't support framework reference assemblies.
     CheckedBuild="$(_AndroidCheckedBuild)"
     RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
     ExcludeFiles="@(AndroidPackagingOptionsExclude)"
+<<<<<<< HEAD
     IncludeFiles="@(AndroidPackagingOptionsInclude)"
+=======
+<<<<<<< HEAD
+>>>>>>> 3d45abff5 ([Xamarin.Andorid.Build.Tasks] First Pass on Dynamic Asset Features)
     ZipFlushFilesLimit="$(_ZipFlushFilesLimit)"
     ZipFlushSizeLimit="$(_ZipFlushSizeLimit)"
     UseAssemblyStore="$(AndroidUseAssemblyStore)">
+=======
+    UseAssemblyStore="$(AndroidUseAssemblyStore)"
+    IncludeRuntime="$(_AndroidIncludeRuntime)">
+>>>>>>> 10b353371 ([Xamarin.Andorid.Build.Tasks] First Pass on Dynamic Asset Features)
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
   <BuildBaseAppBundle
@@ -2170,11 +2182,12 @@ because xbuild doesn't support framework reference assemblies.
       IncludeFiles="@(AndroidPackagingOptionsInclude)"
       ZipFlushFilesLimit="$(_ZipFlushFilesLimit)"
       ZipFlushSizeLimit="$(_ZipFlushSizeLimit)"
-      UseAssemblyStore="$(AndroidUseAssemblyStore)">
+      UseAssemblyStore="$(AndroidUseAssemblyStore)"
+      IncludeRuntime="$(_AndroidIncludeRuntime)">
     <Output TaskParameter="OutputFiles" ItemName="BaseZipFile" />
   </BuildBaseAppBundle>
   <BuildAppBundle
-      Condition=" '$(AndroidPackageFormat)' == 'aab' "
+      Condition=" '$(AndroidPackageFormat)' == 'aab' And '$(BuildingFeature)' != 'True' "
       ToolPath="$(JavaToolPath)"
       JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
       JavaOptions="$(JavaOptions)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2135,18 +2135,11 @@ because xbuild doesn't support framework reference assemblies.
     CheckedBuild="$(_AndroidCheckedBuild)"
     RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
     ExcludeFiles="@(AndroidPackagingOptionsExclude)"
-<<<<<<< HEAD
     IncludeFiles="@(AndroidPackagingOptionsInclude)"
-=======
-<<<<<<< HEAD
->>>>>>> 3d45abff5 ([Xamarin.Andorid.Build.Tasks] First Pass on Dynamic Asset Features)
     ZipFlushFilesLimit="$(_ZipFlushFilesLimit)"
     ZipFlushSizeLimit="$(_ZipFlushSizeLimit)"
-    UseAssemblyStore="$(AndroidUseAssemblyStore)">
-=======
     UseAssemblyStore="$(AndroidUseAssemblyStore)"
     IncludeRuntime="$(_AndroidIncludeRuntime)">
->>>>>>> 10b353371 ([Xamarin.Andorid.Build.Tasks] First Pass on Dynamic Asset Features)
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
   <BuildBaseAppBundle

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -359,13 +359,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</AllowedReferenceRelatedFileExtensions>
 </PropertyGroup>
 
-<!-- Assets build properties -->
-<PropertyGroup>
-	<MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
-  <MonoAndroidAssetPacksDirIntermediate>$(IntermediateOutputPath)assetpacks\</MonoAndroidAssetPacksDirIntermediate>
-	<MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
-</PropertyGroup>
-
 <!--
 *******************************************
           Imports
@@ -373,6 +366,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 -->
 <!-- As we split up/refactor this file, put new imports here -->
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.D8.targets" Condition=" '$(AndroidDexTool)' == 'd8' " />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Assets.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DynamicFeature.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DesignTime.targets" />
@@ -876,27 +870,6 @@ because xbuild doesn't support framework reference assemblies.
 		ToolExe="$(LintToolExe)"
 		JavaSdkPath="$(_JavaSdkDirectory)"
 	/>
-</Target>
-
-<!-- Assets Build -->
-
-<Target Name="UpdateAndroidAssets"
-	DependsOnTargets="$(CoreResolveReferencesDependsOn);_ComputeAndroidAssetsPaths;_GenerateAndroidAssetsDir" />
-
-<Target Name="_ComputeAndroidAssetsPaths">
-	<AndroidComputeResPaths ResourceFiles="@(AndroidAsset)" IntermediateDir="$(MonoAndroidAssetsDirIntermediate)" Prefixes="$(MonoAndroidAssetsPrefix)" ProjectDir="$(ProjectDir)">
-		<Output ItemName="_AndroidAssetsDest" TaskParameter="IntermediateFiles" />
-		<Output ItemName="_AndroidResolvedAssets" TaskParameter="ResolvedResourceFiles" />
-	</AndroidComputeResPaths>
-</Target>
-
-<Target Name="_GenerateAndroidAssetsDir"
-	Inputs="@(_AndroidMSBuildAllProjects);@(_AndroidResolvedAssets)"
-	Outputs="@(_AndroidAssetsDest)">
-	<MakeDir Directories="$(MonoAndroidAssetsDirIntermediate)" />
-	<Copy SourceFiles="@(_AndroidResolvedAssets)" DestinationFiles="@(_AndroidAssetsDest)" SkipUnchangedFiles="true" />
-	<RemoveUnknownFiles Files="@(_AndroidAssetsDest)" Directory="$(MonoAndroidAssetsDirIntermediate)" RemoveDirectories="true" />
-	<Touch Files="@(_AndroidAssetsDest)" />
 </Target>
 
 <!-- Resource build properties -->
@@ -1815,15 +1788,6 @@ because xbuild doesn't support framework reference assemblies.
       LibraryProjectImportsDirectoryName="$(_LibraryProjectImportsDirectoryName)">
     <Output TaskParameter="ExtraPackages" PropertyName="AaptExtraPackages" />
   </GetExtraPackages>
-
-  <!--
-  For aapt copy the assets into one folder.
-  For aapt2 we will consule the library assets in place.
-  -->
-  <CollectLibraryAssets
-      Condition=" '$(AndroidUseAapt2)' != 'true' "
-      AdditionalAssetDirectories="@(LibraryAssetDirectories)"
-      AssetDirectory="$(MonoAndroidAssetsDirIntermediate)" />
 </Target>
 
 <PropertyGroup>

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -348,7 +348,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			string adb = Path.Combine (task.AdbToolPath, task.AdbToolExe);
 			string cmd = task.GetCommandLineBuilder ().ToString ();
-			Assert.AreEqual ($"install-apks --apks foo.apks --adb \"{adb}\" --device-id emulator-5554 --allow-downgrade --modules _ALL_", cmd);
+			Assert.AreEqual ($"install-apks --apks foo.apks --adb \"{adb}\" --device-id emulator-5554 --allow-downgrade", cmd);
 		}
 	}
 }


### PR DESCRIPTION
Context #4810 

This is the first implementation for supporting building Dynamic Feature Assets modules for Android. 
This idea is to have these "features" as standard android library projects. The `ProjectReference` will 
need to use the following

```xml
<ItemGroup>
    <ProjectReference Include="Features\AssetsFeature\AssetsFeature.csproj">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <AndroidDynamicFeature>true</AndroidDynamicFeature>
    </ProjectReference>
  </ItemGroup>
```

We set `ReferenceOutputAssembly` to `false` to ensure that the assembly for the feature is NOT included
in the final aab file.  The new meta Data `AndroidDynamicFeature` allows the build system to pick up 
project references which are "features".

As part of the final packaging step of the main app we will gather up all the `ProjectRefernce` items which have
`AndroidDynamicFeature` set to `true` (and maybe `ReferenceOutputAssembly` set to `false`). 
This will be done by the `_BuildDynamicFeatures` which will run just after `_CreateBaseApk`. 

It will call `_GetDynamicFeatureOutputs` for each `ProjectReference` which will collect the `output` files
for each feature. It will then call the `BuildDynamicFeature` target via the `MSBuild` task for each
`ProjectReference`.  The `BuildDynamicFeature` is the target responsible for collecting all the assets and 
packaging them using `aapt2` up into a zip. Once all the `BuildDynamicFeature` calls are complete the created
`zip` files will be added to the `AndroidAppBundleModules` and then included in the final `aab` file. 

It might seem odd that the feature projects are built after the main app. However this is required because the 
feature needs to use the `packaged_resources` file as an input to `aapt2` when building the feature. This is 
why the `_BuildDynamicFeatures` happens AFTER `_CreateBaseApk`. It is only at that point that the final 
`packaged_resources` file exists. 

One of the very weird things is that the feature zip needs to be built using the `aapt2` `--static-lib` flag. As a result
we need to call `aapt2 convert` on the final zip. This is because it is in the `apk` `binary` format and needs to be converted over to the `aab` `proto` format. So there is a new `Aapt2Convert` task which handles that job. It also makes sure the 
`AndroidManifest.xml` file is in the right place when converting to `proto` format.

A basic project example using .net 6 for a feature would look like this.

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>net6.0-android</TargetFramework>
  </PropertyGroup>
</Project>
``` 

As you can see it is just a normal library project. At this time is CANNOT contain any `AndroidResource` items such as drawables or layouts. It must only contain `AndroidAsset` items. So we probably should have a new template for a `Dynamic Feature` which just creates the `csproj` and the `Assets` folder. 

One sticking point is probably the `AndroidManifest.xml` file which we need for a `feature`. There is a sample

```xml
<?xml version="1.0" encoding="utf-8"?>
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
        xmlns:tools="http://schemas.android.com/tools"
        xmlns:dist="http://schemas.android.com/apk/distribution"
        android:versionCode="1"
        android:versionName="1.0"
        package="com.companyname.DynamicAssetsExample"
        featureSplit="assetsfeature"
        android:isFeatureSplit="true">
  <dist:module dist:title="@string/assetsfeature" dist:instant="false">
    <dist:delivery>
      <dist:on-demand />
    </dist:delivery>
    <dist:fusing dist:include="false" />
  </dist:module>
  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
  <application android:hasCode="false" tools:replace="android:hasCode" />
</manifest>
```
The interesting parts are all the additional `dist` elements. What we can probably do is auto generate this 
during the `BuildDynamicFeature`. However we need to think carefully about this since if we plan to have 
code and `Activities` in the feature at some point, those will also need to end up in the `AndroidManifest.xml`.