### PR TITLE
[.NET] Stop .aar files being picked up from sub projects.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -18,6 +18,9 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 
   <PropertyGroup>
     <_DefaultJavaSourceJarPattern>**\*-source.jar;**\*-sources.jar;**\*-src.jar</_DefaultJavaSourceJarPattern>
+    <!-- Ignore Resources and files in SubDirectories -->
+    <_DefaultLibraryItemExcludes Condition=" '$(Configuration)' == 'Debug' " >$(DefaultItemExcludes);**/bin/Release/**;**/obj/Release/**</_DefaultLibraryItemExcludes>
+    <_DefaultLibraryItemExcludes Condition=" '$(Configuration)' == 'Release' ">$(DefaultItemExcludes);**/bin/Debug/**;**/obj/Debug/**</_DefaultLibraryItemExcludes>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
@@ -45,7 +48,7 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
     <TransformFile Include="Transforms\**\*.xml" />
     <!-- Default Java or native libraries -->
     <AndroidLibrary       Include="**\*.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(_DefaultJavaSourceJarPattern)" />
-    <AndroidLibrary       Include="**\*.aar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <AndroidLibrary       Include="**\*.aar" Exclude="$(_DefaultLibraryItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <AndroidNativeLibrary Include="**\*.so"  Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <JavaSourceJar        Include="$(_DefaultJavaSourceJarPattern)"   Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -24,16 +24,21 @@ projects.
       <_AarSearchDirectory   Include="@(_ReferenceDependencyPaths->'%(RootDir)%(Directory)')" />
       <_AarDistinctDirectory Include="@(_AarSearchDirectory->Distinct())" />
       <_AarFromLibraries     Include="%(_AarDistinctDirectory.Identity)*.aar" />
+      <!--
+        We have to use the FullPath for the AndroidAarLibrary items as the previous step
+        produces items with a FullPath. @(AndroidAarLibrary) items are generally relative
+        so they never get excluded.
+      -->
+      <_AarFromLibraries     Remove="%(AndroidAarLibrary.FullPath)" />
     </ItemGroup>
-    <ItemGroup Condition=" '@(_AarFromLibraries->Count())' != '0' ">
+    <ItemGroup Condition=" '@(_AarFromLibraries->Distinct()->Count())' != '0' ">
       <!--
         NOTE:
         * set %(Pack) to false for located .aar files, we should not repackage into NuGets
         * %(AndroidSkipResourceProcessing) is required for located .aar's; there could be custom views.
       -->
       <AndroidAarLibrary
-          Include="@(_AarFromLibraries)"
-          Exclude="@(AndroidAarLibrary)"
+          Include="@(_AarFromLibraries->Distinct())"
           Pack="false"
           AndroidSkipResourceProcessing="false"
       />


### PR DESCRIPTION
PR #6485 reworked the HelloWorld samples example to fix the following
issue.

```
error APT2144: invalid file path '/Users/.../Documents/Sandbox/Xamarin/designerrewrite/samples/HelloWorld/obj/Debug/net6.0-android/lp/1.stamp'
```

This was occurring because when we built the `HelloWorld` app it would
automatically pickup various aar files in the `HelloWorldLibrary` project.
This project was  in a sub directory of the `HelloWorld` app.

What we would end up with is the app would end up including both
`Debug` and `Release` .aar files from the sub directory (if both were built).
But in addition it would also run a search for other `.aar` files which
would then be added with the `AndroidSkipResourceProcessing` metadata
set to `false`. So we would end up with data such as

```
AndroidAarLibrary=HelloWorldLibrary/bin/Debug/HelloWorldLibrary.aar
            AndroidSkipResourceProcessing=true
            Pack=true
AndroidAarLibrary=HelloWorldLibrary/bin/Release/HelloWorldLibrary.aar
            AndroidSkipResourceProcessing=true
            Pack=true
AndroidAarLibrary=/Users/foo/path/to/xa/samples/HelloWorldLibrary/bin/Debug/HelloWorldLibrary.aar
            AndroidSkipResourceProcessing=false
            Pack=false
```

These are ALL the same library and they should only be included once.
So we have a few fixes for this. The first is to alter the `AutoImport`
code to ignore sub directories depending on the build `$(Configuration)`.
This is so when building `Debug` we do NOT include `Release` in the
`AutoImport`.

Next is to alter the `_ResolveAars` target to exclude the auto imported
items from the `.aar` libraries we find during the search. This has to
be done using the `FullPath` metadata as the search will result in paths
which are full paths, but auto import produces relative ones. This is why
the old `Exclude` code was not working as expected.