### PR TITLE
[Mono.Android.dll] For .NET 7+, use the API level as the assembly version.

### DIFF
--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -135,7 +135,7 @@
       <_Enums1>--preserve-enums --enumflags=enumflags --enumfields=map.csv --enummethods=methodmap.csv</_Enums1>
       <_Enums2>--enummetadata=$(IntermediateOutputPath)mcw\enummetadata</_Enums2>
       <_Annotations Condition=" '$(_AnnotationsZip)' != '' ">"--annotations=$(_AnnotationsZip)"</_Annotations>
-      <_Assembly>--assembly="Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"</_Assembly>
+      <_Assembly>--assembly="Mono.Android"</_Assembly>
       <_TypeMap>--type-map-report=$(IntermediateOutputPath)mcw\type-mapping.txt</_TypeMap>
       <_Api>$(IntermediateOutputPath)mcw\api-$(AndroidPlatformId).xml</_Api>
       <_Dirs>--enumdir=$(IntermediateOutputPath)mcw</_Dirs>

--- a/src/Mono.Android/Properties/AssemblyInfo.cs.in
+++ b/src/Mono.Android/Properties/AssemblyInfo.cs.in
@@ -22,6 +22,7 @@ using System.Runtime.Versioning;
 #if ANDROID_UNSTABLE
 [assembly: RequiresPreviewFeatures("This is an unstable Android API level. Opt into preview features by adding <EnablePreviewFeatures>True</EnablePreviewFeatures> to your project file.")]
 #endif
+[assembly: AssemblyVersion ("@API_LEVEL@.0.0.0")]
 [assembly: TargetPlatform("Android@API_LEVEL@.0")]
 [assembly: SupportedOSPlatform("Android@MIN_API_LEVEL@.0")]
 

--- a/tests/api-compatibility/api-compat-exclude-attributes.txt
+++ b/tests/api-compatibility/api-compat-exclude-attributes.txt
@@ -1,6 +1,7 @@
 // These attributes should be excluded from api-compat check reference assemblies.
 
 T:Android.Runtime.PreserveAttribute
+T:Android.Runtime.RegisterAttribute
 T:Android.Runtime.StringDefAttribute
 T:Android.Runtime.IntDefAttribute
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6903

Beginning with .NET 7, we are going to version `Mono.Android.dll` with the API Level as the version number (ex: `32.0.0.0`).  This should help prevent a user from using a library assembly that is built against a newer API level than their application supports.

Note both NuGet package logic and project reference logic have checks to prevent this, however referencing a loose assembly has no protection.  (`<Reference Include='My.Library.dll'>`).

For example:
- User binds a library with `net7.0-android33.0`.
- User tries to consume that library as a `<Reference>` in `net7.0-android32.0`

This will produce as error similar to:
```
Cannot resolve assembly Mono.Android.dll with version 33.0.0.0.  Only Mono.Android.dll 32.0.0.0 could be found.
```

![image](https://user-images.githubusercontent.com/179295/168685011-c8d0cd2e-0c7a-4bf6-af6d-cef4194ddbed.png)

Additionally we need to pass the version number to `generator` so it can produce the correct assembly qualified invoker reference for interfaces:

```csharp
[Register ("android/graphics/PostProcessor", "", "Android.Graphics.IPostProcessorInvoker", ApiSince = 28)]
public partial interface IPostProcessor : IJavaObject, IJavaPeerable {
	[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android28.0")]
	[Register ("onPostProcess", "(Landroid/graphics/Canvas;)I", "GetOnPostProcess_Landroid_graphics_Canvas_Handler:Android.Graphics.IPostProcessorInvoker, Mono.Android, Version=32.0.0.0, Culture=neutral, PublicKeyToken=null", ApiSince = 28)]
	int OnPostProcess (Android.Graphics.Canvas canvas);
}
```