### PR TITLE
Update WindowsOnArm64.md

### DIFF
--- a/Documentation/guides/WindowsOnArm64.md
+++ b/Documentation/guides/WindowsOnArm64.md
@@ -39,8 +39,7 @@ This downloads the latest files in `C:\Program Files\dotnet\sdk-manifests`.
 
 The Mono workloads from dotnet/runtime need a small fix.
 
-Open `C:\Program Files\dotnet\sdk-manifests\7.0.100\microsoft.net.workload.mono.toolchain\WorkloadManifest.json`
-in your favorite text editor.
+Open each `WorkloadManifest.json` under the folder tree `C:\Program Files\dotnet\sdk-manifests` in your favorite text editor and make the following changes:
 
 Do a `Find/Replace` for:
 


### PR DESCRIPTION
There may be more than one file that needs to be enable the Android workload.