### PR TITLE
[WIP] [Xamarin.Android.Build.Tasks] use hashes as `Inputs` for `_GenerateJavaStubs`

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/AssemblyResolverCoda.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/AssemblyResolverCoda.cs
@@ -1,0 +1,12 @@
+using Mono.Cecil;
+using System.IO;
+
+namespace Java.Interop.Tools.Cecil;
+
+public static class AssemblyResolverCoda
+{
+	public static AssemblyDefinition GetAssembly (this IAssemblyResolver resolver, string fileName)
+	{
+		return resolver.Resolve (AssemblyNameReference.Parse (Path.GetFileNameWithoutExtension (fileName)));
+	}
+}

--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -1,14 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\external\java.interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\external\java.interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems')" />
   <PropertyGroup>
     <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
-    <DefineConstants>ILLINK</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>ILLINK;HAVE_CECIL</DefineConstants>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(MicrosoftAndroidSdkOutDir)</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.ILLink" Version="$(MicrosoftNETILLinkTasksPackageVersion)" />
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj" />
+    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Localization\Java.Interop.Localization.csproj" />
+    <ProjectReference Include="..\..\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\Microsoft.Android.Build.BaseTasks.csproj" />
     <ProjectReference Include="..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj" ReferenceOutputAssembly="False" />
 
     <Compile Include="..\Xamarin.Android.Build.Tasks\obj\$(Configuration)\Profile.g.cs" Link="Profile.g.cs" />
@@ -45,6 +49,13 @@
     <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\MethodDefinitionRocks.cs" Link="Java.Interop\MethodDefinitionRocks.cs" />
     <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\TypeDefinitionCache.cs" Link="Java.Interop\TypeDefinitionCache.cs" />
     <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\TypeDefinitionRocks.cs" Link="Java.Interop\TypeDefinitionRocks.cs" />
+    <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics\Diagnostic.cs" Link="Java.Interop.Tools.Diagnostics\Diagnostic.cs" />
+    <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics\XamarinAndroidException.cs" Link="Java.Interop.Tools.Diagnostics\XamarinAndroidException.cs" />
+    <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64Helper.cs" Link="Java.Interop.Tools.JavaCallableWrappers\Crc64Helper.cs" />
+    <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64.Table.cs" Link="Java.Interop.Tools.JavaCallableWrappers\Crc64.Table.cs" />
+    <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\JavaTypeScanner.cs" Link="Java.Interop.Tools.JavaCallableWrappers\JavaTypeScanner.cs" />
+    <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\JavaCallableWrapperGenerator.cs" Link="Java.Interop.Tools.JavaCallableWrappers\JavaCallableWrapperGenerator.cs" />
+    <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings\JavaNativeTypeManager.cs" Link="Java.Interop.Tools.TypeNameMappings\JavaNativeTypeManager.cs" />
     <Compile Include="..\Xamarin.Android.Build.Tasks\Utilities\MonoAndroidHelper.Linker.cs" Link="Utilities\MonoAndroidHelper.Linker.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/CalculateJavaStubHashStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/CalculateJavaStubHashStep.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Java.Interop.Tools.JavaCallableWrappers;
+using Microsoft.Android.Build.Tasks;
+using Mono.Cecil;
+using Mono.Linker;
+using Mono.Linker.Steps;
+
+#if ILLINK
+using Microsoft.Android.Sdk.ILLink;
+#endif  // ILLINK
+
+
+namespace MonoDroid.Tuner
+{
+	public class CalculateJavaStubHashStep : BaseStep
+	{
+#if ILLINK
+		protected override void Process ()
+		{
+			logger = (level, message) => Context.LogMessage ($"{level} {message}");
+			cache = Context;
+			scanner = new JavaTypeScanner (logger, Context);
+		}
+#else   // !ILLINK
+		public CalculateJavaStubHashStep (Action<TraceLevel, string> logger, IMetadataResolver cache)
+		{
+			this.logger = logger;
+			this.cache = cache;
+			scanner = new JavaTypeScanner (logger, this.cache);
+		}
+#endif  // !ILLINK
+
+		static readonly Encoding Encoding = Encoding.UTF8;
+
+		Action<TraceLevel, string> logger;
+		IMetadataResolver cache;
+		JavaTypeScanner scanner;
+		string outputDirectory;
+
+		public void Calculate (AssemblyDefinition assembly, string outputDirectory)
+		{
+			this.outputDirectory = outputDirectory;
+			ProcessAssembly (assembly);
+		}
+
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			HashAlgorithm hasher = new Microsoft.Android.Build.Tasks.Crc64 ();
+			foreach (var type in scanner.GetJavaTypes (assembly)) {
+				Hash (hasher, type.FullName);
+
+				foreach (var method in type.Methods) {
+					Hash (hasher, method.Name);
+				}
+			}
+
+			hasher.TransformFinalBlock (Array.Empty<byte> (), 0, 0);
+
+			var assemblyFile = Path.GetFileName (assembly.MainModule.FileName);
+			var hashFile = Path.Combine (outputDirectory, $"{assemblyFile}.hash");
+			if (Files.CopyIfStringChanged (Convert.ToBase64String (hasher.Hash), hashFile)) {
+				logger (TraceLevel.Verbose, $"Saved: {hashFile}");
+			}
+		}
+
+		static void Hash (HashAlgorithm hasher, string value)
+		{
+			int length = Encoding.GetByteCount (value);
+			var bytes = ArrayPool<byte>.Shared.Rent (length);
+			try {
+				Encoding.GetBytes (value, 0, value.Length, bytes, 0);
+				hasher.TransformBlock (bytes, 0, length, null, 0);
+			} finally {
+				ArrayPool<byte>.Shared.Return (bytes);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1496,6 +1496,8 @@ because xbuild doesn't support framework reference assemblies.
       UsingAndroidNETSdk="$(UsingAndroidNETSdk)"
   />
   <ItemGroup>
+    <_AllJavaStubHashFile Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath).hash')" />
+    <_JavaStubHashFile Include="@(_AllJavaStubHashFile)" Condition="Exists('%(_AllJavaStubHashFile.Identity)')" />
     <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)**" />
   </ItemGroup>
 </Target>
@@ -1525,7 +1527,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GenerateJavaStubs"
     DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest)"
-    Inputs="@(_AndroidMSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
+    Inputs="@(_AndroidMSBuildAllProjects);@(_JavaStubHashFile);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
     Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
 
   <PropertyGroup>


### PR DESCRIPTION
One of the slower parts of an incremental Android build is:

    _GenerateJavaStubs = 978 ms

Currently, this happens when any .NET assembly changes: C# change, `.xaml` change, etc.

In theory, we could analyze .NET assemblies during the linker and create a "hash" that represents types & members that would invalidate `_GenerateJavaStubs`'s output. We can then save these hashes in a file to be used as `Inputs` instead of the .NET assemblies themselves.

Example of the hash:

    HashAlgorithm hasher = new Microsoft.Android.Build.Tasks.Crc64 ();
    foreach (var type in scanner.GetJavaTypes (assembly)) {
        Hash (hasher, type.FullName);
        foreach (var method in type.Methods) {
            Hash (hasher, method.Name);
        }
    }

The result is:

    Target Name=_GenerateJavaStubs Project=bar.csproj
    Skipping target "_GenerateJavaStubs" because all output files are up-to-date with respect to the input files.

Improving the incremental build time about about ~1 second in a `dotnet new maui` project. `_LinkAssembliesNoShrink` will be slightly slower, but because it builds partially it will only be creating this hash on a single file most of the time. Currently, this seems to be about ~20ms final numbers TBD.

Things left to do:

* Make sure we are hashing the right things that `_GenerateJavaStubs` cares about.

* Fix `Release` builds, they likely aren't setup right.

* Add several tests around this scenario. We need to validate adding new `Java.Lang.Object` subclasses work as expected.