### PR TITLE
[Xamarin.Android.Build.Tasks] honour `minSdkVersion` from library `uses-sdk` Manifest Files.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -90,6 +90,8 @@ namespace Xamarin.Android.Tasks
 
 		public string SupportedOSPlatformVersion { get; set; }
 
+		public string LibraryMinSdk { get; set; } = string.Empty;
+
 		public ITaskItem[] Environments { get; set; }
 
 		[Output]
@@ -345,6 +347,7 @@ namespace Xamarin.Android.Tasks
 				SdkDir = AndroidSdkDir,
 				TargetSdkVersion = AndroidSdkPlatform,
 				MinSdkVersion = minSdkVersion,
+				LibraryMinSdkVersion = LibraryMinSdk,
 				Debug = Debug,
 				MultiDex = MultiDex,
 				NeedsInternet = NeedsInternet,

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadImportedLibrariesCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadImportedLibrariesCache.cs
@@ -1,21 +1,21 @@
-// 
+//
 // ReadImportedLibrariesCache.cs
-//  
+//
 // Author:
 //       Dean Ellis <dean.ellis@xamarin.com>
-// 
+//
 // Copyright (c) 2013 Xamarin Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -39,7 +39,7 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "RIL";
 
 		[Required]
-		public string CacheFile { get; set;} 
+		public string CacheFile { get; set;}
 
 		[Output]
 		public ITaskItem [] Jars { get; set; }
@@ -49,6 +49,9 @@ namespace Xamarin.Android.Tasks
 
 		[Output]
 		public ITaskItem [] ManifestDocuments { get; set; }
+
+		[Output]
+		public string LibraryMinSdk { get; set; }
 
 		public override bool RunTask ()
 		{
@@ -60,10 +63,11 @@ namespace Xamarin.Android.Tasks
 			Jars = doc.GetPathsAsTaskItems ("Jars", "Jar");
 			NativeLibraries = doc.GetPathsAsTaskItems ("NativeLibraries", "NativeLibrary");
 			ManifestDocuments = doc.GetPathsAsTaskItems ("ManifestDocuments", "ManifestDocument");
-
-			Log.LogDebugTaskItems ("  NativeLibraries: ", NativeLibraries);
-			Log.LogDebugTaskItems ("  Jars: ", Jars);
-			Log.LogDebugTaskItems ("  ManifestDocuments: ", ManifestDocuments);
+			var minSdk = doc.Element ("Paths")?.Element ("ManifestDocuments")?.Attribute ("libraryMinSdk");
+			LibraryMinSdk = string.Empty;
+			if (minSdk != null)
+				if (int.TryParse (minSdk.Value, out int minSDK))
+					LibraryMinSdk = minSdk.Value;
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -707,7 +707,7 @@ namespace Bug12935
 				var usesSdk = doc.Element ("manifest")?.Element ("uses-sdk");
 				Assert.IsNotNull (usesSdk, "Should have found a uses-sdk element.");
 				var expected = addReference ? "23" : "19";
-				Assert.AreEqual (expected, usesSdk.Attribute ("minSdkVersion")?.Value, $"minSdkVersion should have been '{expected}' but was '{usesSdk.Attribute ("minSdkVersion")?.Value}'");
+				Assert.AreEqual (expected, usesSdk.Attribute (ns + "minSdkVersion")?.Value, $"minSdkVersion should have been '{expected}' but was '{usesSdk.Attribute ("minSdkVersion")?.Value}'");
 
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -328,6 +328,16 @@ namespace Xamarin.ProjectTools
 				}
 			}
 		};
+		public static Package AndroidXSecurityCrypto = new Package {
+			Id = "Xamarin.AndroidX.Security.SecurityCrypto",
+			Version = "1.0.0.9",
+			TargetFramework = "MonoAndroid90",
+			References = {
+				new BuildItem.Reference("Xamarin.AndroidX.Security.SecurityCrypto") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.Security.SecurityCrypto.1.0.0.9\\lib\\MonoAndroid90\\Xamarin.AndroidX.Security.SecurityCrypto.dll"
+				}
+			}
+		};
 		public static Package XamarinGoogleAndroidMaterial = new Package {
 			Id = "Xamarin.Google.Android.Material",
 			Version = "1.0.0.1",

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1545,6 +1545,7 @@ because xbuild doesn't support framework reference assemblies.
       LinkingEnabled="$(_LinkingEnabled)"
       HaveMultipleRIDs="$(_HaveMultipleRIDs)"
       IntermediateOutputDirectory="$(IntermediateOutputPath)"
+      LibraryMinSdk="$(_LibraryMinSdk)"
       Environments="@(AndroidEnvironment);@(LibraryEnvironments)">
     <Output TaskParameter="GeneratedBinaryTypeMaps" ItemName="_AndroidTypeMapping" Condition=" '$(_InstantRunEnabled)' == 'True' " />
   </GenerateJavaStubs>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -102,6 +102,7 @@ This file is used by all project types, including binding projects.
       <Output TaskParameter="NativeLibraries"   ItemName="ExtractedNativeLibraryImports" />
       <Output TaskParameter="NativeLibraries"   ItemName="AndroidNativeLibrary" />
       <Output TaskParameter="ManifestDocuments" ItemName="ExtractedManifestDocuments" />
+      <Output TaskParameter="LibraryMinSdk"     PropertyName="_LibraryMinSdk" />
     </ReadImportedLibrariesCache>
   </Target>
 


### PR DESCRIPTION
Fixes https://i.azdo.io/1720987

When users add an empty `uses-sdk` element to their AndroidManifest.xml  file they can introduce the following error.

```
Error	AMM0000	
uses-sdk:minSdkVersion 19 cannot be smaller than version 21 declared in library C:…\obj\Debug\net7.0-android\lp\130\jl\AndroidManifest.xml as the library might be using APIs not available in 19
Suggestion: use a compatible library with a minSdk of at most 19,
or increase this project’s minSdk version to at least 21,
or use tools:overrideLibrary=“androidx.security” to force usage (may lead to runtime failures)
Directory ‘obj\Debug\net7.0-android\lp\130’ is from ‘androidx.security.security-crypto.aar’.
```

This is because the `minSdk` of libaries was not taken into consideration when genereting the final manifest file.
Currently if the user does NOT specify a `minSdk` in the manifest it will default to `XABuildConfig.NDKMinimumApiAvailable` which is currently set to `19`.  This then causes the conflict. 

What we should do is figure out what the `minSdk` value is from any library projects and then use that if the user does
not provide one. 