### PR TITLE
[ci] Use static pool for MSBuild emulator test jobs

### DIFF
--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -4,7 +4,7 @@ parameters:
   stageName: msbuilddevice_tests
   job_name: 'mac_dotnetdevice_tests'
   dependsOn: mac_build
-  agent_count: 8
+  agent_count: 6
   stageCondition: succeeded()
   stagePrefix: ''
   xaSourcePath: $(System.DefaultWorkingDirectory)
@@ -25,12 +25,16 @@ stages:
       parallel: ${{ parameters.agent_count }}
     displayName: "macOS > Tests > MSBuild+Emulator"
     pool:
-      vmImage: $(HostedMacImage)
-    timeoutInMinutes: 90
-    cancelTimeoutInMinutes: 5
+      name: VSEng-VSMac-Xamarin-Shared
+      demands:
+      - macOS.Name -equals Ventura
+      - macOS.Architecture -equals arm64
+    timeoutInMinutes: 120
     workspace:
       clean: all
     steps:
+    - template: agent-cleanser/v1.yml@yaml-templates
+
     - template: setup-test-environment.yaml
       parameters:
         installTestSlicer: true
@@ -77,8 +81,7 @@ stages:
 
   - job: wear_tests
     displayName: macOS > Tests > WearOS 
-    timeoutInMinutes: 180
-    cancelTimeoutInMinutes: 2
+    timeoutInMinutes: 120
     strategy:
       parallel: 1
     variables:
@@ -88,10 +91,15 @@ stages:
       deviceName: wear_square
       androidSdkPlatforms: 33
     pool:
-      vmImage: $(HostedMacImage)
+      name: VSEng-VSMac-Xamarin-Shared
+      demands:
+      - macOS.Name -equals Ventura
+      - macOS.Architecture -equals arm64
     workspace:
       clean: all
     steps:
+    - template: agent-cleanser/v1.yml@yaml-templates
+
     - template: setup-test-environment.yaml
       parameters:
         installTestSlicer: true

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -106,6 +106,7 @@
       <_WLExtractedFiles Include="$(_SdkManifestsFolder)temp\LICENSE" />
       <_WLExtractedFiles Include="$(_SdkManifestsFolder)temp\data\*" />
     </ItemGroup>
+    <Touch Files="@(_WLExtractedFiles)" />
     <Move SourceFiles="@(_WLExtractedFiles)" DestinationFolder="$(_SdkManifestsFolder)microsoft.net.sdk.android" />
     <RemoveDir Directories="$(_SdkManifestsFolder)temp\" />
 
@@ -140,6 +141,10 @@
         WorkingDirectory="$(_TempDirectory)"
     />
     <RemoveDir Directories="$(_TempDirectory)" />
+    <ItemGroup>
+      <_ExtractedPackContent Include="$(DotNetPreviewPath)packs\Microsoft.Android*\**" />
+    </ItemGroup>
+    <Touch Files="@(_ExtractedPackContent)" />
   </Target>
 
   <Target Name="DeleteExtractedWorkloadPacks" >

--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.NET.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.NET.csproj
@@ -26,6 +26,8 @@
     <GenerateDocumentation>True</GenerateDocumentation>
   </PropertyGroup>
 
+  <Import Project="..\..\Configuration.props" />
+
   <ItemGroup>
     <Compile Include="..\..\src-ThirdParty\NUnitLite\**\*.cs" />
   </ItemGroup>

--- a/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/HttpClientTest.cs
+++ b/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/HttpClientTest.cs
@@ -11,7 +11,7 @@ public class HttpClientTest
 		{
 			var client = new HttpClient ();
 			var data = new StringContent ("{\"foo\": \"bar\" }", Encoding.UTF8, "application/json");
-			var response = client.PostAsync ("https://httpbin.org/post", data).Result;
+			var response = client.PostAsync ("https://webhook.site/c8e3ec94-673c-45dd-a660-a44779c9ac69/post", data).Result;
 			response.EnsureSuccessStatusCode ();
 			var json = response.Content.ReadAsStringAsync ().Result;
 			return $"[PASS] {nameof (HttpClientTest)}.{nameof (Post)}";

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 				AotAssemblies = false,
 			};
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			
 			if (Builder.UseDotNet) {
 				// TODO: only needed in .NET 6+

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 			};
 			if (isRelease || !CommercialBuildAvailable) {
-				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+				proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			}
 			proj.SetDefaultTargetDevice ();
 			if (Builder.UseDotNet && isRelease) {
@@ -91,7 +91,7 @@ namespace Xamarin.Android.Build.Tests
 				ProjectName = "MyApp",
 			};
 			if (!CommercialBuildAvailable) {
-				app.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+				app.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			}
 			app.SetDefaultTargetDevice ();
 			app.SetProperty ("AndroidEnablePreloadAssemblies", preloadAssemblies.ToString ());
@@ -192,7 +192,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = false,
 				AndroidFastDeploymentType = fastDevType,
 			};
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			proj.SetProperty ("EmbedAssembliesIntoApk", embedAssemblies.ToString ());
 			proj.SetProperty ("AndroidPackageFormat", packageFormat);
 			proj.SetDefaultTargetDevice ();
@@ -434,7 +434,7 @@ namespace ${ROOT_NAMESPACE} {
 			app.SetProperty ("AndroidPackageFormat", packageFormat);
 			app.MainPage = app.MainPage.Replace ("InitializeComponent ();", "InitializeComponent (); new Foo ();");
 			app.AddReference (lib);
-			app.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			app.SetAndroidSupportedAbis ("arm64-v8a", "x86", "x86_64");
 			app.SetProperty (KnownProperties._AndroidAllowDeltaInstall, allowDeltaInstall.ToString ());
 			app.SetDefaultTargetDevice ();
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 			};
 			if (isRelease) {
-				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+				proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			}
 			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj));
@@ -67,7 +67,7 @@ namespace Xamarin.Android.Build.Tests
 			if (isRelease) {
 				// Set debuggable=true to allow run-as command usage with a release build
 				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
-				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+				proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			}
 			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj));
@@ -97,7 +97,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject () {
 				PackageName = "com.xamarin.keytest"
 			};
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			using (var builder = CreateApkBuilder ()) {
 				// Use the default debug.keystore XA generates
 				Assert.IsTrue (builder.Install (proj), "first install should succeed.");
@@ -128,7 +128,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			// Set debuggable=true to allow run-as command usage with a release build
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			proj.SetProperty ("AndroidPackageFormat", "apk");
 			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj));
@@ -180,7 +180,7 @@ namespace Xamarin.Android.Build.Tests
 			} else {
 				proj.RemoveProperty (proj.ReleaseProperties, "EmbedAssembliesIntoApk");
 			}
-			var abis = new [] { "armeabi-v7a", "x86", "x86_64" };
+			var abis = new [] { "arm64-v8a", "x86_64" };
 			proj.SetAndroidSupportedAbis (abis);
 			using (var builder = CreateApkBuilder ()) {
 				if (RunAdbCommand ("shell pm list packages Mono.Android.DebugRuntime").Trim ().Length != 0)
@@ -270,7 +270,7 @@ namespace Xamarin.Android.Build.Tests
 
 				//Now toggle FastDev to OFF
 				proj.EmbedAssembliesIntoApk = true;
-				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+				proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 
 				Assert.IsTrue (builder.Install (proj), "Second install should have succeeded.");
 
@@ -302,7 +302,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (proj.ReleaseProperties, "AndroidKeyStore", "True");
 			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningKeyStore", "test.keystore");
 			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningKeyAlias", "mykey");
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			proj.SetProperty (proj.ReleaseProperties, "AndroidPackageFormat", packageFormat);
 			proj.SetProperty ("AndroidUseApkSigner", "true");
 			proj.OtherBuildItems.Add (new BuildItem (BuildActions.None, "test.keystore") {
@@ -338,7 +338,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			// Set debuggable=true to allow run-as command usage with a release build
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 
 			string wantedFile;
 			if (Builder.UseDotNet) {
@@ -438,7 +438,7 @@ namespace Xamarin.Android.Build.Tests
 				proj.SetProperty ("AndroidSigningStorePass", password);
 				proj.SetProperty ("AndroidSigningKeyPass", password);
 			}
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			proj.SetProperty ("AndroidKeyStore", androidKeyStore);
 			proj.SetProperty ("AndroidSigningKeyStore", "test.keystore");
 			proj.SetProperty ("AndroidSigningKeyAlias", "mykey");

--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -104,7 +104,7 @@ namespace UnnamedProject
 			}
 		}
 	}";
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 			proj.SetProperty ("EmbedAssembliesIntoApk", embedAssemblies.ToString ());
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {

--- a/tests/MSBuildDeviceIntegration/Tests/SystemApplicationTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/SystemApplicationTests.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Android.Build.Tests
 				WebContent = "https://github.com/aosp-mirror/platform_build/raw/master/target/product/security/platform.x509.pem"
 			});
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("<manifest ", "<manifest android:sharedUserId=\"android.uid.system\" ");
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			proj.SetAndroidSupportedAbis ("arm64-v8a", "x86_64");
 
 
 			proj.SetDefaultTargetDevice ();

--- a/tests/Mono.Android-Tests/Mono.Android-Test.Library/Mono.Android-Test.Library.NET.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Test.Library/Mono.Android-Test.Library.NET.csproj
@@ -10,6 +10,8 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
 
+  <Import Project="..\..\..\Configuration.props" />
+
   <ItemGroup>
     <AndroidAsset Include="..\LinkedAssets\linked_text2.txt">
       <Link>Assets\linked_text2.txt</Link>

--- a/tests/TestRunner.Core/TestRunner.Core.NET.csproj
+++ b/tests/TestRunner.Core/TestRunner.Core.NET.csproj
@@ -7,4 +7,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <Import Project="..\..\Configuration.props" />
+
 </Project>

--- a/tests/TestRunner.NUnit/TestRunner.NUnit.NET.csproj
+++ b/tests/TestRunner.NUnit/TestRunner.NUnit.NET.csproj
@@ -8,6 +8,8 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <Import Project="..\..\Configuration.props" />
+
   <ItemGroup>
     <ProjectReference Include="..\TestRunner.Core\TestRunner.Core.NET.csproj" />
     <ProjectReference Include="..\..\src\Xamarin.Android.NUnitLite\Xamarin.Android.NUnitLite.NET.csproj" />


### PR DESCRIPTION
Moves MSBuild emulator test jobs to a static machine pool containing
mac minis to try to improve reliability and performance.