### PR TITLE
[Xamarin.Android,Build.Tasks] Library .aar includes $(AndroidManifest) (#8273)

### DIFF
--- a/Documentation/docs-mobile/TOC.yml
+++ b/Documentation/docs-mobile/TOC.yml
@@ -316,6 +316,8 @@
         href: messages/xa4313.md
       - name: XA4314
         href: messages/xa4314.md
+      - name: XA4315
+        href: messages/xa4315.md
     - name: "XA5xxx: GCC and toolchain"
       items:
       - name: "XA5xxx: GCC and toolchain"

--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -215,6 +215,7 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 + [XA4312](xa4312.md): Referencing an Android Wear application project from an Android application project is deprecated.
 + [XA4313](xa4313.md): Framework assembly has been deprecated.
 + [XA4314](xa4314.md): `$(Property)` is empty. A value for `$(Property)` should be provided.
++ [XA4315](xa4315.md): Ignoring {file}. Manifest does not have the required 'package' attribute on the manifest element.
 
 ## XA5xxx: GCC and toolchain
 

--- a/Documentation/docs-mobile/messages/xa4315.md
+++ b/Documentation/docs-mobile/messages/xa4315.md
@@ -1,0 +1,32 @@
+---
+title: .NET for Android error XA4315
+description: XA4315 warning code
+ms.date: 09/12/2024
+---
+# .NET for Android warning XA4315
+
+## Example messages
+
+```
+warning XA4315: Ignoring {file}. Manifest does not have the required 'package' attribute on the manifest element.
+```
+
+## Issue
+
+The specified `$(file)` does not have a `package` attribute on its `manifest` element.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>
+```
+
+## Solution
+
+Add the missing attribute to the manifest.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package='com.microsoft.hellolibrary'>
+</manifest>
+```

--- a/samples/HelloWorld/HelloLibrary/AndroidManifest.xml
+++ b/samples/HelloWorld/HelloLibrary/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package='com.microsoft.hellolibrary'>
   <queries>
     <package android:name="com.companyname.someappid" />
   </queries>

--- a/samples/HelloWorld/HelloLibrary/AndroidManifest.xml
+++ b/samples/HelloWorld/HelloLibrary/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <queries>
+    <package android:name="com.companyname.someappid" />
+  </queries>
+</manifest>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -47,6 +47,7 @@ projects.
       <_CreateAarInputs Include="@(_AndroidResourceDest)" />
       <_CreateAarInputs Include="@(AndroidEnvironment)" />
       <_CreateAarInputs Include="@(AndroidJavaLibrary)" />
+      <_CreateAarInputs Include="$(AndroidManifest)" />
       <_CreateAarInputs Include="@(EmbeddedJar)" />
       <_CreateAarInputs Include="@(EmbeddedNativeLibrary)" />
       <_CreateAarInputs Include="@(ProguardConfiguration)" />
@@ -79,6 +80,7 @@ projects.
         AndroidAssets="@(AndroidAsset)"
         AndroidResources="@(_AndroidResourceDest)"
         AndroidEnvironment="@(AndroidEnvironment)"
+        AndroidManifest="$(AndroidManifest)"
         JarFiles="@(AndroidJavaLibrary);@(EmbeddedJar)"
         NativeLibraries="@(EmbeddedNativeLibrary)"
         ProguardConfigurationFiles="@(ProguardConfiguration)"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -88,8 +88,6 @@
     <!-- Prefer $(RuntimeIdentifiers) plural -->
     <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android-arm64;android-x64</RuntimeIdentifiers>
     <RuntimeIdentifier  Condition=" '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' " />
-    <AndroidManifest Condition=" '$(AndroidManifest)' == '' and Exists ('Properties\AndroidManifest.xml') and !Exists ('AndroidManifest.xml') ">Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidManifest Condition=" '$(AndroidManifest)' == '' ">AndroidManifest.xml</AndroidManifest>
     <GenerateApplicationManifest Condition=" '$(GenerateApplicationManifest)' == '' ">true</GenerateApplicationManifest>
     <!-- Default to AOT in Release mode -->
     <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' and '$(AotAssemblies)' == '' and '$(Configuration)' == 'Release' ">true</RunAOTCompilation>
@@ -136,6 +134,10 @@
     <ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">1</ApplicationVersion>
     <Version Condition=" $([System.Version]::TryParse ('$(ApplicationDisplayVersion)', $([System.Version]::Parse('1.0')))) ">$(ApplicationDisplayVersion)</Version>
     <ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AndroidManifest Condition=" '$(AndroidManifest)' == '' and Exists ('Properties\AndroidManifest.xml') and !Exists ('AndroidManifest.xml') ">Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidManifest Condition=" '$(AndroidManifest)' == '' And Exists ('AndroidManifest.xml') ">AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1557,6 +1557,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Ignoring {0}. Manifest does not have the required 'package' attribute on the manifest element.
+        /// </summary>
+        public static string XA4315 {
+            get {
+                return ResourceManager.GetString("XA4315", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Missing Android NDK toolchains directory &apos;{0}&apos;. Please install the Android NDK..
         /// </summary>
         public static string XA5101 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -828,6 +828,11 @@ Remove the '{0}' reference from your project and add the '{1}' NuGet package ins
     <comment>{0} - The MSBuildProperty which contains a value.
 </comment>
   </data>
+  <data name="XA4315" xml:space="preserve">
+    <value>Ignoring `{0}`. Manifest does not have the required 'package' attribute on the manifest element.</value>
+    <comment>{0} - The path the the file.
+</comment>
+  </data>
   <data name="XA5101" xml:space="preserve">
     <value>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</value>
     <comment>{0} - The path of the missing directory</comment>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Xamarin.Android.Tools;
 using Xamarin.Tools.Zip;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
@@ -115,9 +115,8 @@ namespace Xamarin.Android.Tasks
 					aar.AddEntry ("proguard.txt", sb.ToString (), Files.UTF8withoutBOM);
 				}
 				if (AndroidManifest != null && File.Exists (AndroidManifest.ItemSpec)) {
-					var sb = new StringBuilder ();
-					sb.AppendLine (File.ReadAllText (AndroidManifest.ItemSpec));
-					aar.AddEntry ("AndroidManifest.xml", sb.ToString (), Files.UTF8withoutBOM);
+					var manifest = File.ReadAllText (AndroidManifest.ItemSpec);
+					aar.AddEntry ("AndroidManifest.xml", manifest, Files.UTF8withoutBOM);
 				}
 				foreach (var entry in existingEntries) {
 					Log.LogDebugMessage ($"Removing {entry} as it is not longer required.");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
@@ -19,6 +19,8 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem [] AndroidEnvironment { get; set; }
 
+		public ITaskItem AndroidManifest { get; set; }
+
 		public ITaskItem [] JarFiles { get; set; }
 
 		public ITaskItem [] NativeLibraries { get; set; }
@@ -111,6 +113,11 @@ namespace Xamarin.Android.Tasks
 						sb.AppendLine (File.ReadAllText (file.ItemSpec));
 					}
 					aar.AddEntry ("proguard.txt", sb.ToString (), Files.UTF8withoutBOM);
+				}
+				if (AndroidManifest != null && File.Exists (AndroidManifest.ItemSpec)) {
+					var sb = new StringBuilder ();
+					sb.AppendLine (File.ReadAllText (AndroidManifest.ItemSpec));
+					aar.AddEntry ("AndroidManifest.xml", sb.ToString (), Files.UTF8withoutBOM);
 				}
 				foreach (var entry in existingEntries) {
 					Log.LogDebugMessage ($"Removing {entry} as it is not longer required.");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
@@ -116,7 +116,12 @@ namespace Xamarin.Android.Tasks
 				}
 				if (AndroidManifest != null && File.Exists (AndroidManifest.ItemSpec)) {
 					var manifest = File.ReadAllText (AndroidManifest.ItemSpec);
-					aar.AddEntry ("AndroidManifest.xml", manifest, Files.UTF8withoutBOM);
+					var doc = XDocument.Parse(manifest);
+					if (!string.IsNullOrEmpty (doc.Element ("manifest")?.Attribute ("package")?.Value ?? string.Empty)) {
+						aar.AddEntry ("AndroidManifest.xml", manifest, Files.UTF8withoutBOM);
+					} else {
+						Log.LogDebugMessage ($"Skipping {AndroidManifest.ItemSpec}. The `manifest` does not have a `package` attribute.");
+					}
 				}
 				foreach (var entry in existingEntries) {
 					Log.LogDebugMessage ($"Removing {entry} as it is not longer required.");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLibraryResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLibraryResources.cs
@@ -71,6 +71,10 @@ namespace Xamarin.Android.Tasks
 
 				var manifest = AndroidAppManifest.Load (Path.GetFullPath (manifestFile), MonoAndroidHelper.SupportedVersions);
 				var packageName = manifest.PackageName;
+				if (string.IsNullOrEmpty (packageName)) {
+					LogDebugMessage ($"Skipping, AndroidManifest.xml does not have a packageName: {manifestFile}");
+					continue;
+				}
 				if (!libraries.TryGetValue (packageName, out Package library)) {
 					libraries.Add (packageName, library = new Package {
 						Name = packageName,

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -58,7 +58,6 @@ namespace Xamarin.Android.Tasks
 						var doc = XDocument.Load(file);
 						if (string.IsNullOrEmpty (doc.Element ("manifest")?.Attribute ("package")?.Value ?? string.Empty)) {
 							Log.LogCodedWarning ("XA4315", file, 0, Properties.Resources.XA4315, file);
-							//Log.LogCodedWarning ("", $"Ignoring {file}. Manifest does not have the required 'package' attribute on the manifest.");
 							continue;
 						}
 						manifestDocuments.Add (new TaskItem (file));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -55,8 +55,8 @@ namespace Xamarin.Android.Tasks
 						var directory = Path.GetFileName (Path.GetDirectoryName (file));
 						if (IgnoredManifestDirectories.Contains (directory))
 							continue;
-						var doc = new  ManifestDocument(file);
-						if (string.IsNullOrEmpty (doc.PackageName)) {
+						var doc = XDocument.Load(file);
+						if (string.IsNullOrEmpty (doc.Element ("manifest")?.Attribute ("package")?.Value ?? string.Empty)) {
 							Log.LogCodedWarning ("XA4315", file, 0, Properties.Resources.XA4315, file);
 							//Log.LogCodedWarning ("", $"Ignoring {file}. Manifest does not have the required 'package' attribute on the manifest.");
 							continue;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -55,6 +55,12 @@ namespace Xamarin.Android.Tasks
 						var directory = Path.GetFileName (Path.GetDirectoryName (file));
 						if (IgnoredManifestDirectories.Contains (directory))
 							continue;
+						var doc = new  ManifestDocument(file);
+						if (string.IsNullOrEmpty (doc.PackageName)) {
+							Log.LogCodedWarning ("XA4315", file, 0, Properties.Resources.XA4315, file);
+							//Log.LogCodedWarning ("", $"Ignoring {file}. Manifest does not have the required 'package' attribute on the manifest.");
+							continue;
+						}
 						manifestDocuments.Add (new TaskItem (file));
 					}
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 using Microsoft.Android.Build.Tasks;
 using Mono.Cecil;
 using NUnit.Framework;
@@ -77,7 +78,7 @@ namespace Xamarin.Android.Build.Tests
 			});
 			libC.OtherBuildItems.Add (new BuildItem ("None", "AndroidManifest.xml") {
 				TextContent = () => @"<?xml version='1.0' encoding='utf-8'?>
-<manifest xmlns:android='http://schemas.android.com/apk/res/android'>
+<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.microsoft.libc'>
   <queries>
     <package android:name='com.companyname.someappid' />
   </queries>
@@ -250,6 +251,11 @@ namespace Xamarin.Android.Build.Tests
 			className = "Lcom/soundcloud/android/crop/Crop;"; // from android-crop-1.0.1.aar
 			Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 
+			// Check AndroidManifest
+			var androidManifest = Path.Combine (intermediate, "android", "AndroidManifest.xml");
+			FileAssert.Exists (androidManifest);
+			var doc = XDocument.Load (androidManifest);
+			Assert.AreEqual(1, doc.Element ("manifest").Elements ("queries").Count (), "There should be 1 query.");
 			// Check environment variable
 			var environmentFiles = EnvironmentHelper.GatherEnvironmentFiles (intermediate, "x86_64", required: true);
 			var environmentVariables = EnvironmentHelper.ReadEnvironmentVariables (environmentFiles);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -75,6 +75,14 @@ namespace Xamarin.Android.Build.Tests
 			libC.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("Assets\\bar\\bar.txt") {
 				BinaryContent = () => Array.Empty<byte> (),
 			});
+			libC.OtherBuildItems.Add (new BuildItem ("None", "AndroidManifest.xml") {
+				TextContent = () => @"<?xml version='1.0' encoding='utf-8'?>
+<manifest xmlns:android='http://schemas.android.com/apk/res/android'>
+  <queries>
+    <package android:name='com.companyname.someappid' />
+  </queries>
+</manifest>",
+			});
 			libC.SetProperty ("AndroidUseDesignerAssembly", useDesignerAssembly.ToString ());
 			var activity = libC.Sources.FirstOrDefault (s => s.Include () == "MainActivity.cs");
 			if (activity != null)
@@ -87,6 +95,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var aar = ZipHelper.OpenZip (aarPath)) {
 				aar.AssertContainsEntry (aarPath, "assets/bar/bar.txt");
 				aar.AssertEntryEquals (aarPath, "proguard.txt", "# LibraryC");
+				aar.AssertContainsEntry (aarPath, "AndroidManifest.xml");
 			}
 
 			var libB = new XamarinAndroidLibraryProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -88,7 +88,7 @@ namespace Xamarin.Android.Build.Tests
 			var activity = libC.Sources.FirstOrDefault (s => s.Include () == "MainActivity.cs");
 			if (activity != null)
 				libC.Sources.Remove (activity);
-			var libCBuilder = CreateDllBuilder (Path.Combine ("temp", libC.ProjectName));
+			var libCBuilder = CreateDllBuilder (Path.Combine (path, libC.ProjectName));
 			Assert.IsTrue (libCBuilder.Build (libC), $"{libC.ProjectName} should succeed");
 
 			var aarPath = Path.Combine (Root, libCBuilder.ProjectDirectory, libC.OutputPath, $"{libC.ProjectName}.aar");
@@ -171,7 +171,7 @@ namespace Xamarin.Android.Build.Tests
 			activity = libB.Sources.FirstOrDefault (s => s.Include () == "MainActivity.cs");
 			if (activity != null)
 				libB.Sources.Remove (activity);
-			var libBBuilder = CreateDllBuilder (Path.Combine ("temp", libB.ProjectName));
+			var libBBuilder = CreateDllBuilder (Path.Combine (path, libB.ProjectName));
 			Assert.IsTrue (libBBuilder.Build (libB), $"{libB.ProjectName} should succeed");
 
 			var projectJarHash = Files.HashString (Path.Combine (libB.IntermediateOutputPath,
@@ -221,7 +221,7 @@ namespace Xamarin.Android.Build.Tests
 				appA.OtherBuildItems.Add (new AndroidItem.AndroidLibrary (aarPath));
 			}
 			appA.SetProperty ("AndroidUseDesignerAssembly", useDesignerAssembly.ToString ());
-			var appBuilder = CreateApkBuilder (Path.Combine ("temp", appA.ProjectName));
+			var appBuilder = CreateApkBuilder (Path.Combine (path, appA.ProjectName));
 			Assert.IsTrue (appBuilder.Build (appA), $"{appA.ProjectName} should succeed");
 
 			// Check .apk/.aab for assets, res, and native libraries
@@ -255,7 +255,7 @@ namespace Xamarin.Android.Build.Tests
 			var androidManifest = Path.Combine (intermediate, "android", "AndroidManifest.xml");
 			FileAssert.Exists (androidManifest);
 			var doc = XDocument.Load (androidManifest);
-			Assert.AreEqual(1, doc.Element ("manifest").Elements ("queries").Count (), "There should be 1 query.");
+			Assert.IsNotNull(doc.Element ("manifest")?.Element ("queries")?.Element ("package"), $"There should be 1 package in the queries in {androidManifest}.");
 			// Check environment variable
 			var environmentFiles = EnvironmentHelper.GatherEnvironmentFiles (intermediate, "x86_64", required: true);
 			var environmentVariables = EnvironmentHelper.ReadEnvironmentVariables (environmentFiles);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8262

Context: https://developer.android.com/studio/projects/android-library#aar-contents
Context: fcd7cf8f4200ccae92e333c920613bfec260973b

In fcd7cf8f, we stopped using `@(EmbeddedResource)` within assemblies
to contain Android Resource, Assets, Libraries, etc., and instead
began a `.aar` file.

One of the things never supported in the Classic system was to allow
Library projects to contain `AndroidManifest.xml` files, and package
`AndroidManifest.xml` files into the library `.aar` file for inclusion
in NuGet packages.

Add `$(AndroidManifest)` to `@(_CreateAarInputs)`, so that Library
projects can now specify an `AndroidManifest.xml` file for inclusion
in the library `.aar` file (which in turn should be included in NuGet
packages).

This allows NuGet authors to e.g. set default permissions if need be
by simply adding `AndroidManifest.xml` to the library project dir.

Also, fix an issue in `<GenerateLibraryResources/>` when a manifest
file does NOT have a package name.  Such files should be ignored.