### PR TITLE
Try a project with a space in Name

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -179,7 +179,7 @@ namespace Xamarin.Android.Tasks
 				if (!string.IsNullOrEmpty (EnumMetadataDirectory))
 					WriteLine (sw, $"--enummetadata=\"{EnumMetadataDirectory}\"");
 				if (!string.IsNullOrEmpty (AssemblyName))
-					WriteLine (sw, $"--assembly={AssemblyName}");
+					WriteLine (sw, $"\"--assembly={AssemblyName}\"");
 
 				if (!NoStdlib) {
 					string fxpath = MonoAndroidFrameworkDirectories.Split (';').First (p => new DirectoryInfo (p).GetFiles ("mscorlib.dll").Any ());

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -179,7 +179,7 @@ namespace Xamarin.Android.Tasks
 				if (!string.IsNullOrEmpty (EnumMetadataDirectory))
 					WriteLine (sw, $"--enummetadata=\"{EnumMetadataDirectory}\"");
 				if (!string.IsNullOrEmpty (AssemblyName))
-					WriteLine (sw, $"\"--assembly={AssemblyName}\"");
+					WriteLine (sw, $"--assembly=\"{AssemblyName}\"");
 
 				if (!NoStdlib) {
 					string fxpath = MonoAndroidFrameworkDirectories.Split (';').First (p => new DirectoryInfo (p).GetFiles ("mscorlib.dll").Any ());

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -30,6 +30,8 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
+				ProjectName = "Test Me",
+				RootNamespace = "Test.Me",
 				EnableDefaultItems = true,
 				ExtraNuGetConfigSources = {
 					// Microsoft.AspNetCore.Components.WebView is not in dotnet-public

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -101,11 +101,18 @@ Console.WriteLine ($""{DateTime.UtcNow.AddHours(-30).Humanize(culture:c)}"");
 
 		[Test]
 		[Category ("SmokeTests")]
-		public void CheckProjectWithSpaceInNameWorks ()
+		[TestCase ("Test Me")]
+		// testing characters as per https://www.compart.com/en/unicode/category/Zs
+		[TestCase ("TestUnicodeSpace2000\u2000Me")]
+		[TestCase ("TestUnicodeSpace0020\u0020Me")]
+		[TestCase ("TestUnicodeSpace2009\u2009Me")]
+		[TestCase ("TestUnicodeSpace2002\u2002Me")]
+		[TestCase ("TestUnicodeSpace2007\u2007Me")]
+		public void CheckProjectWithSpaceInNameWorks (string projectName)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
-				ProjectName = "Test Me",
+				ProjectName = projectName,
 				RootNamespace = "Test.Me",
 			};
 			using (var b = CreateApkBuilder ()) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -100,6 +100,19 @@ Console.WriteLine ($""{DateTime.UtcNow.AddHours(-30).Humanize(culture:c)}"");
 		}
 
 		[Test]
+		public void CheckProjectWithSpaceInNameWorks ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				ProjectName = "Test Me",
+				RootNamespace = "Test.Me",
+			};
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "build failed");
+			}
+		}
+
+		[Test]
 		public void CheckClassesDexIsIncluded ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -103,11 +103,12 @@ Console.WriteLine ($""{DateTime.UtcNow.AddHours(-30).Humanize(culture:c)}"");
 		[Category ("SmokeTests")]
 		[TestCase ("Test Me")]
 		// testing characters as per https://www.compart.com/en/unicode/category/Zs
-		[TestCase ("TestUnicodeSpace2000\u2000Me")]
 		[TestCase ("TestUnicodeSpace0020\u0020Me")]
-		[TestCase ("TestUnicodeSpace2009\u2009Me")]
-		[TestCase ("TestUnicodeSpace2002\u2002Me")]
-		[TestCase ("TestUnicodeSpace2007\u2007Me")]
+		// TODO these break with AOT error on windows
+		//[TestCase ("TestUnicodeSpace2000\u2000Me")]
+		//[TestCase ("TestUnicodeSpace2009\u2009Me")]
+		//[TestCase ("TestUnicodeSpace2002\u2002Me")]
+		//[TestCase ("TestUnicodeSpace2007\u2007Me")]
 		public void CheckProjectWithSpaceInNameWorks (string projectName)
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -100,6 +100,7 @@ Console.WriteLine ($""{DateTime.UtcNow.AddHours(-30).Humanize(culture:c)}"");
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void CheckProjectWithSpaceInNameWorks ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -182,8 +182,8 @@ namespace Xamarin.ProjectTools
 				psi.SetEnvironmentVariable ("DOTNETSDK_WORKLOAD_PACK_ROOTS", TestEnvironment.WorkloadPackOverridePath);
 			}
 
-			args.AppendFormat ("\"{0}\" /t:{1} {2}",
-					Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution), target, logger);
+			args.AppendFormat ("{0} /t:{1} {2}",
+					QuoteFileName (Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
 
 			if (!AutomaticNuGetRestore) {
 				args.Append (" --no-restore");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -182,8 +182,8 @@ namespace Xamarin.ProjectTools
 				psi.SetEnvironmentVariable ("DOTNETSDK_WORKLOAD_PACK_ROOTS", TestEnvironment.WorkloadPackOverridePath);
 			}
 
-			args.AppendFormat ("{0} /t:{1} {2}",
-					QuoteFileName (Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
+			args.AppendFormat ("\"{0}\" /t:{1} {2}",
+					Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution), target, logger);
 
 			if (!AutomaticNuGetRestore) {
 				args.Append (" --no-restore");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStore.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStore.cs
@@ -110,7 +110,7 @@ namespace Xamarin.Android.Tasks
 			uint localEntryCount = 0;
 			var localAssemblies = new List<AssemblyStoreIndexEntry> ();
 
-			manifestWriter.WriteLine ("Hash 32     Hash 64             Blob ID  Blob idx  Name");
+			manifestWriter.WriteLine ("Hash 32\tHash 64\tBlob ID\tBlob idx\tName");
 
 			var seenHashes32 = new HashSet<ulong> ();
 			var seenHashes64 = new HashSet<ulong> ();
@@ -126,7 +126,7 @@ namespace Xamarin.Android.Tasks
 					haveDuplicates = true;
 				}
 
-				manifestWriter.WriteLine ($"0x{assembly.NameHash32:x08}  0x{assembly.NameHash64:x016}  {assembly.StoreID:d03}      {assembly.LocalBlobIndex:d04}      {assembly.Name}");
+				manifestWriter.WriteLine ($"0x{assembly.NameHash32:x08}\t0x{assembly.NameHash64:x016}\t{assembly.StoreID:d03}\t{assembly.LocalBlobIndex:d04}\t{assembly.Name}");
 			}
 
 			if (haveDuplicates) {
@@ -243,7 +243,6 @@ namespace Xamarin.Android.Tasks
 						assemblyName = $"{archivePath}/{assemblyName}";
 					}
 				}
-
 				AssemblyStoreIndexEntry entry = WriteAssembly (writer, assembly, assemblyName, (uint)localAssemblies.Count);
 				if (addToGlobalIndex) {
 					globalIndex.Add (entry);

--- a/tools/assembly-store-reader/AssemblyStoreManifestEntry.cs
+++ b/tools/assembly-store-reader/AssemblyStoreManifestEntry.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Android.AssemblyStore
 		public AssemblyStoreManifestEntry (string[] fields)
 		{
 			if (fields.Length != NumberOfFields) {
-				throw new ArgumentOutOfRangeException (nameof (fields), "Invalid number of fields");
+				throw new ArgumentOutOfRangeException (nameof (fields), $"Invalid number of fields. Expected {NumberOfFields} found {fields.Length}");
 			}
 
 			Hash32 = GetUInt32 (fields[Hash32FieldIndex]);

--- a/tools/assembly-store-reader/AssemblyStoreManifestReader.cs
+++ b/tools/assembly-store-reader/AssemblyStoreManifestReader.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.AssemblyStore
 {
 	class AssemblyStoreManifestReader
 	{
-		static readonly char[] fieldSplit = new char[] { ' ' };
+		static readonly char[] fieldSplit = new char[] { '\t' };
 
 		public List<AssemblyStoreManifestEntry> Entries                      { get; } = new List<AssemblyStoreManifestEntry> ();
 		public Dictionary<uint, AssemblyStoreManifestEntry> EntriesByHash32  { get; } = new Dictionary<uint, AssemblyStoreManifestEntry> ();


### PR DESCRIPTION
We have on occasion had reports of users using a space in their "Project Name". We already have a test which checks for spaces in the path, but not in the project name. This commit adds this test and fixes up a few area's where this caused a problem. 

It should be noted that certain unicode based characters still cause issues with the .net Aot compiler. These unit test cases have been commented out for now. 