### PR TITLE
Bump LibZipSharp to 3.3.0

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@c6aae9e5a154cfbf2c3a94e046fa2c747c3b82e2
+xamarin/monodroid:main@e11d9a5af8f00a88d15bd87c777608f17c4ece78

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
 
   <!-- Common <PackageReference/> versions -->
   <PropertyGroup>
-    <LibZipSharpVersion>3.1.1</LibZipSharpVersion>
+    <LibZipSharpVersion>3.3.0</LibZipSharpVersion>
     <MicroBuildCoreVersion>1.0.0</MicroBuildCoreVersion>
     <MonoCecilVersion>0.11.4</MonoCecilVersion>
     <NewtonsoftJsonPackageVersion>13.0.3</NewtonsoftJsonPackageVersion>


### PR DESCRIPTION
Changes: https://github.com/dotnet/android-libzipsharp/compare/3.1.1...3.3.0

  * https://github.com/dotnet/android-libzipsharp/commit/de57dcc: Add xml comments. Centralize the dotnet target framework (https://github.com/dotnet/android-libzipsharp/pull/143)
  * https://github.com/dotnet/android-libzipsharp/commit/b541b87: Fix the elusive invalid zip archive issue that has been a problem for ages! (https://github.com/dotnet/android-libzipsharp/pull/142)
  * https://github.com/dotnet/android-libzipsharp/commit/c2ae332: Update OneLocBuildToken (https://github.com/dotnet/android-libzipsharp/pull/141)
  * https://github.com/dotnet/android-libzipsharp/commit/4fef46a: Bump library versions for the latest upstream releases (https://github.com/dotnet/android-libzipsharp/pull/140)
  * https://github.com/dotnet/android-libzipsharp/commit/14f591c: Remove LZMA (XZ) support (https://github.com/dotnet/android-libzipsharp/pull/139)
  * https://github.com/dotnet/android-libzipsharp/commit/336a86f: [ci] Use managed identity for API Scan (https://github.com/dotnet/android-libzipsharp/pull/138)
  * https://github.com/dotnet/android-libzipsharp/commit/8bc799c: [ci] Add API Scan job (https://github.com/dotnet/android-libzipsharp/pull/132)
  * https://github.com/dotnet/android-libzipsharp/commit/afef4b2: [ci] Improve binskim scan performance (https://github.com/dotnet/android-libzipsharp/pull/137)
  * https://github.com/dotnet/android-libzipsharp/commit/577147e: [ci] Migrate to the 1ES template (https://github.com/dotnet/android-libzipsharp/pull/135)