### PR TITLE
Use AsyncTask from xamarin-android-tools

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:dev/pjc/at-asynctask@ddb73d1550baecd59bc1ef41b2299e4c2d496716
+xamarin/monodroid:dev/pjc/at-asynctask@7bde2820c821471210d31d744a019994f59c0ef4

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@ae876c994e5902f429e0e5cf04e5918c82ecc762
+xamarin/monodroid:dev/pjc/at-asynctask@ddb73d1550baecd59bc1ef41b2299e4c2d496716

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@93ab95e18077d56d9d55ce7b4069a534e2dea35e
+xamarin/monodroid:main@ae876c994e5902f429e0e5cf04e5918c82ecc762

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:dev/pjc/at-asynctask@7bde2820c821471210d31d744a019994f59c0ef4
+xamarin/monodroid:dev/pjc/at-asynctask@a6789e0e94dc327cf2a336be156b3a9930f57868

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@e11d9a5af8f00a88d15bd87c777608f17c4ece78
+xamarin/monodroid:main@038240c52a7dc2e66b9ad2ddb20b9886836eaec9

--- a/Documentation/guides/MSBuildBestPractices.md
+++ b/Documentation/guides/MSBuildBestPractices.md
@@ -612,7 +612,7 @@ public class MyTask : AndroidTask
 The benefit here is that if an unhandled exception is thrown, `MyTask`
 will automatically generate proper error codes.
 
-`AndroidAsyncTask` has an additional override for doing work on a
+`AsyncTask` has an additional override for doing work on a
 background thread:
 
 ```csharp

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj" />
-    <ProjectReference Include="..\..\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj" />
+    <ProjectReference Include="..\..\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\Microsoft.Android.Build.BaseTasks.csproj" />
     <ProjectReference Include="..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj" />
   </ItemGroup>
 

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj" />
+    <ProjectReference Include="..\..\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj" />
     <ProjectReference Include="..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj" />
   </ItemGroup>
 

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
@@ -6,8 +6,6 @@ using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
-using Xamarin.Build;
-
 using Tasks = System.Threading.Tasks;
 
 namespace Xamarin.Android.Tools.BootstrapTasks

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Text;
 using System.Diagnostics;
 
+using Microsoft.Android.Build.Tasks;
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 {
 	public class RunParallelCmds : AsyncTask
 	{
+		public override string TaskPrefix => "RPCMD";
+
 		[Required]
 		public ITaskItem[] Commands { get; set; }
 

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -165,8 +165,6 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Tools.AndroidSdk.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Tools.AndroidSdk.pdb" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Tools.Versions.props" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Build.AsyncTask.dll" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Build.AsyncTask.pdb" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)K4os.Compression.LZ4.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)ELFSharp.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)ManifestOverlays\Timing.xml" />

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Sleep.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Sleep.cs
@@ -9,7 +9,7 @@ using TPLTask = System.Threading.Tasks.Task;
 
 namespace Xamarin.Android.BuildTools.PrepTasks
 {
-	public class XASleepInternal : AndroidAsyncTask
+	public class XASleepInternal : AsyncTask
 	{
 		public override string TaskPrefix => "XASI";
 		public int Milliseconds { get; set; }

--- a/src-ThirdParty/android-platform-tools-base/SymbolWriter.cs
+++ b/src-ThirdParty/android-platform-tools-base/SymbolWriter.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Xamarin.Android.Tools;
-using Xamarin.Build;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -17,7 +17,7 @@ using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks
 {
-	public class Aapt : AndroidAsyncTask
+	public class Aapt : AsyncTask
 	{
 		public override string TaskPrefix => "APT";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -13,7 +13,6 @@ using Microsoft.Build.Framework;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using Xamarin.Android.Tools;
-using Xamarin.Build;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -15,7 +15,6 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 using Xamarin.Android.Tools;
 using ThreadingTasks = System.Threading.Tasks;
-using Xamarin.Build;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -19,7 +19,7 @@ using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks {
 
-	public abstract class Aapt2 : AndroidAsyncTask {
+	public abstract class Aapt2 : AsyncTask {
 
 		private const int MAX_PATH = 260;
 		private const int ASCII_MAX_CHAR = 127;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -15,7 +15,7 @@ using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CalculateLayoutCodeBehind : AndroidAsyncTask
+	public class CalculateLayoutCodeBehind : AsyncTask
 	{
 		public override string TaskPrefix => "CLC";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -11,7 +11,6 @@ using System.Xml.XPath;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 
-using Xamarin.Build;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -12,7 +12,7 @@ using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CompileNativeAssembly : AndroidAsyncTask
+	public class CompileNativeAssembly : AsyncTask
 	{
 		public override string TaskPrefix => "CNA";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -8,7 +8,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 using Xamarin.Android.Tools;
-using Xamarin.Build;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Android.Tasks
 {
 	// TODO: add doc comments to the generated properties
 	//
-	public partial class GenerateLayoutBindings : AndroidAsyncTask
+	public partial class GenerateLayoutBindings : AsyncTask
 	{
 		public override string TaskPrefix => "GLB";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
@@ -11,7 +11,6 @@ using System.Xml.XPath;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 
-using Xamarin.Build;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLibraryResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLibraryResources.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// We used to invoke aapt/aapt2 per library (many times!), this task does the work to generate R.java for libraries without calling aapt/aapt2.
 	/// </summary>
-	public partial class GenerateLibraryResources : AndroidAsyncTask
+	public partial class GenerateLibraryResources : AsyncTask
 	{
 		public override string TaskPrefix => "GLR";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLibraryResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLibraryResources.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Xamarin.Android.Tools;
-using Xamarin.Build;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Tasks
 	/// The <Aot/> task subclasses this in "legacy" Xamarin.Android.
 	/// The <GetAotAssemblies/> task subclasses this in .NET 6+.
 	/// </summary>
-	public abstract class GetAotArguments : AndroidAsyncTask
+	public abstract class GetAotArguments : AsyncTask
 	{
 		[Required]
 		public string AndroidApiLevel { get; set; } = "";

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetMicrosoftNuGetPackagesMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetMicrosoftNuGetPackagesMap.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace Xamarin.Android.Tasks;
 
-public class GetMicrosoftNuGetPackagesMap : AndroidAsyncTask
+public class GetMicrosoftNuGetPackagesMap : AsyncTask
 {
 	static readonly HttpClient http_client = new HttpClient ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
@@ -13,7 +13,7 @@ using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks
 {
-	public class LinkApplicationSharedLibraries : AndroidAsyncTask
+	public class LinkApplicationSharedLibraries : AsyncTask
 	{
 		public override string TaskPrefix => "LAS";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
@@ -9,7 +9,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 using Xamarin.Android.Tools;
-using Xamarin.Build;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
@@ -15,7 +15,7 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks;
 
-public class MavenDownload : AndroidAsyncTask
+public class MavenDownload : AsyncTask
 {
 	public override string TaskPrefix => "MDT";
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -313,8 +313,6 @@
   <ItemGroup>
     <_ExtraPackageSource Include="$(PkgXamarin_LibZipSharp)\lib\$(TargetFrameworkNETStandard)\libZipSharp.pdb" />
     <_ExtraPackageTarget Include="$(OutputPath)\libZipSharp.pdb" />
-    <_ExtraPackageSource Include="$(PkgXamarin_Build_AsyncTask)\lib\$(TargetFrameworkNETStandard)\Xamarin.Build.AsyncTask.pdb" />
-    <_ExtraPackageTarget Include="$(OutputPath)\Xamarin.Build.AsyncTask.pdb" />
     <_ExtraPackageSource Include="$(PkgMono_Cecil)\lib\$(TargetFrameworkNETStandard)\Mono.Cecil.pdb" />
     <_ExtraPackageTarget Include="$(OutputPath)\Mono.Cecil.pdb" />
     <_ExtraPackageSource Include="$(PkgMono_Cecil)\lib\$(TargetFrameworkNETStandard)\Mono.Cecil.Mdb.pdb" />


### PR DESCRIPTION
We've decided to move https://github.com/xamarin/Xamarin.Build.AsyncTask
into xamarin-android-tools as part of dotnet org migration efforts.

Changes: https://github.com/dotnet/android-tools/compare/96745904ec3eeb71ccd178eeeab9a14afebfeb80...3debf8e07ce4a9dd4435d52913203eb93cc9df79

Changes: https://github.com/xamarin/monodroid/compare/e11d9a5af8f00a88d15bd87c777608f17c4ece78...038240c52a7dc2e66b9ad2ddb20b9886836eaec9

