### PR TITLE
Bump to NDK r27

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "26d";
-		public const string AndroidNdkPkgRevision = "26.3.11579264";
+		public const string AndroidNdkVersion = "27-beta2";
+		public const string AndroidNdkPkgRevision = "27.0.11902837-rc1";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 21;
 

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "27-beta2";
-		public const string AndroidNdkPkgRevision = "27.0.11902837-rc1";
+		public const string AndroidNdkVersion = "27";
+		public const string AndroidNdkPkgRevision = "27.0.12077973";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 21;
 

--- a/src-ThirdParty/llvm/verbose_abort.cpp
+++ b/src-ThirdParty/llvm/verbose_abort.cpp
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <__config>
+#include <__verbose_abort>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+
+#ifdef __BIONIC__
+#  include <android/api-level.h>
+#  if __ANDROID_API__ >= 21
+#    include <syslog.h>
+extern "C" void android_set_abort_message(const char* msg);
+#  else
+#    include <assert.h>
+#  endif // __ANDROID_API__ >= 21
+#endif   // __BIONIC__
+
+#if defined(__APPLE__) && __has_include(<CrashReporterClient.h>)
+#  include <CrashReporterClient.h>
+#endif
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+_LIBCPP_WEAK void __libcpp_verbose_abort(char const* format, ...) {
+  // Write message to stderr. We do this before formatting into a
+  // buffer so that we still get some information out if that fails.
+  {
+    va_list list;
+    va_start(list, format);
+    std::vfprintf(stderr, format, list);
+    va_end(list);
+  }
+
+  // Format the arguments into an allocated buffer for CrashReport & friends.
+  // We leak the buffer on purpose, since we're about to abort() anyway.
+  char* buffer;
+  (void)buffer;
+  va_list list;
+  va_start(list, format);
+
+#if defined(__APPLE__) && __has_include(<CrashReporterClient.h>)
+  // Note that we should technically synchronize accesses here (by e.g. taking a lock),
+  // however concretely we're only setting a pointer, so the likelihood of a race here
+  // is low.
+  vasprintf(&buffer, format, list);
+  CRSetCrashLogMessage(buffer);
+#elif defined(__BIONIC__)
+  vasprintf(&buffer, format, list);
+
+#  if __ANDROID_API__ >= 21
+  // Show error in tombstone.
+  android_set_abort_message(buffer);
+
+  // Show error in logcat.
+  openlog("libc++", 0, 0);
+  syslog(LOG_CRIT, "%s", buffer);
+  closelog();
+#  else
+  // The good error reporting wasn't available in Android until L. Since we're
+  // about to abort anyway, just call __assert2, which will log _somewhere_
+  // (tombstone and/or logcat) in older releases.
+  __assert2(__FILE__, __LINE__, __func__, buffer);
+#  endif // __ANDROID_API__ >= 21
+#endif
+  va_end(list);
+
+  std::abort();
+}
+
+_LIBCPP_END_NAMESPACE_STD

--- a/src/native/CMakePresets.json.in
+++ b/src/native/CMakePresets.json.in
@@ -18,6 +18,7 @@
             "cacheVariables": {
                 "ANDROID_NDK": "@AndroidNdkDirectory@",
                 "ANDROID_TOOLCHAIN": "clang",
+                "ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES": "ON",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "CMAKE_MAKE_PROGRAM": "@NinjaPath@",
                 "OUTPUT_PATH": "@OutputPath@",

--- a/src/native/monodroid/CMakeLists.txt
+++ b/src/native/monodroid/CMakeLists.txt
@@ -133,6 +133,7 @@ target_compile_options(
   ${XAMARIN_MONO_ANDROID_LIB}
   PRIVATE
   ${XA_DEFAULT_SYMBOL_VISIBILITY}
+  ${XA_COMMON_CXX_ARGS}
 )
 
 target_include_directories(

--- a/src/native/monodroid/embedded-assemblies.hh
+++ b/src/native/monodroid/embedded-assemblies.hh
@@ -389,7 +389,7 @@ namespace xamarin::android::internal {
 		bool                   need_to_scan_more_apks = true;
 
 		AssemblyStoreIndexEntry *assembly_store_hashes;
-		std::mutex             assembly_decompress_mutex;
+		xamarin::android::mutex  assembly_decompress_mutex;
 	};
 }
 

--- a/src/native/monodroid/monodroid-glue-internal.hh
+++ b/src/native/monodroid/monodroid-glue-internal.hh
@@ -346,7 +346,7 @@ namespace xamarin::android::internal
 		jnienv_register_jni_natives_fn jnienv_register_jni_natives = nullptr;
 		MonoAssemblyLoadContextGCHandle default_alc = nullptr;
 
-		static std::mutex             pinvoke_map_write_lock;
+		static xamarin::android::mutex             pinvoke_map_write_lock;
 		static pinvoke_library_map    other_pinvoke_map;
 		static MonoCoreRuntimeProperties monovm_core_properties;
 		MonovmRuntimeConfigArguments  runtime_config_args;
@@ -354,7 +354,7 @@ namespace xamarin::android::internal
 		static void *system_native_library_handle;
 		static void *system_security_cryptography_native_android_library_handle;
 		static void *system_io_compression_native_library_handle;
-		static std::mutex   dso_handle_write_lock;
+		static xamarin::android::mutex   dso_handle_write_lock;
 	};
 }
 #endif

--- a/src/native/monodroid/monodroid-glue.cc
+++ b/src/native/monodroid/monodroid-glue.cc
@@ -77,7 +77,7 @@ using namespace microsoft::java_interop;
 using namespace xamarin::android;
 using namespace xamarin::android::internal;
 
-std::mutex MonodroidRuntime::pinvoke_map_write_lock;
+xamarin::android::mutex MonodroidRuntime::pinvoke_map_write_lock;
 
 MonoCoreRuntimeProperties MonodroidRuntime::monovm_core_properties = {
 	.trusted_platform_assemblies = nullptr,
@@ -86,7 +86,7 @@ MonoCoreRuntimeProperties MonodroidRuntime::monovm_core_properties = {
 	.pinvoke_override = &MonodroidRuntime::monodroid_pinvoke_override
 };
 
-std::mutex MonodroidRuntime::dso_handle_write_lock;
+xamarin::android::mutex MonodroidRuntime::dso_handle_write_lock;
 bool MonodroidRuntime::startup_in_progress = true;
 
 void

--- a/src/native/monodroid/monodroid-tracing.cc
+++ b/src/native/monodroid/monodroid-tracing.cc
@@ -15,7 +15,7 @@ namespace {
 	decltype(xa_get_java_backtrace)* _xa_get_java_backtrace;
 	decltype(xa_get_interesting_signal_handlers)* _xa_get_interesting_signal_handlers;
 	bool tracing_init_done;
-	std::mutex tracing_init_lock {};
+	xamarin::android::mutex tracing_init_lock {};
 }
 
 void

--- a/src/native/monodroid/startup-aware-lock.hh
+++ b/src/native/monodroid/startup-aware-lock.hh
@@ -8,7 +8,7 @@ namespace xamarin::android::internal
 	class StartupAwareLock final
 	{
 	public:
-		explicit StartupAwareLock (std::mutex &m)
+		explicit StartupAwareLock (xamarin::android::mutex &m)
 			: lock (m)
 		{
 			if (MonodroidRuntime::is_startup_in_progress ()) {
@@ -34,7 +34,7 @@ namespace xamarin::android::internal
 		StartupAwareLock& operator= (StartupAwareLock const&) = delete;
 
 	private:
-		std::mutex& lock;
+		xamarin::android::mutex& lock;
 	};
 }
 #endif

--- a/src/native/monodroid/timing-internal.hh
+++ b/src/native/monodroid/timing-internal.hh
@@ -440,7 +440,7 @@ namespace xamarin::android::internal
 
 	private:
 		std::atomic_size_t next_event_index = 0;
-		std::mutex event_vector_realloc_mutex;
+		xamarin::android::mutex event_vector_realloc_mutex;
 		std::vector<TimingEvent> events;
 
 		static TimingEvent init_time;

--- a/src/native/monodroid/timing.hh
+++ b/src/native/monodroid/timing.hh
@@ -106,7 +106,7 @@ namespace xamarin::android
 
 		managed_timing_sequence* get_available_sequence () noexcept
 		{
-			std::lock_guard<std::mutex> lock (sequence_lock);
+			lock_guard<xamarin::android::mutex> lock (sequence_lock);
 
 			managed_timing_sequence *ret;
 			for (size_t i = 0; i < sequence_pool_size; i++) {
@@ -132,7 +132,7 @@ namespace xamarin::android
 			if (sequence == nullptr)
 				return;
 
-			std::lock_guard<std::mutex> lock (sequence_lock);
+			lock_guard<xamarin::android::mutex> lock (sequence_lock);
 			if (sequence->dynamic) {
 				sequence->period.reset ();
 				delete sequence;
@@ -145,7 +145,7 @@ namespace xamarin::android
 	private:
 		managed_timing_sequence  *sequence_pool;
 		size_t                    sequence_pool_size;
-		std::mutex                sequence_lock;
+		xamarin::android::mutex   sequence_lock;
 	};
 
 	// This is a hack to avoid having to allocate memory when rendering messages that use additional

--- a/src/native/monodroid/xamarin_getifaddrs.cc
+++ b/src/native/monodroid/xamarin_getifaddrs.cc
@@ -279,7 +279,7 @@ typedef void (*freeifaddrs_impl_fptr)(struct _monodroid_ifaddrs *ifa);
 static getifaddrs_impl_fptr getifaddrs_impl = NULL;
 static freeifaddrs_impl_fptr freeifaddrs_impl = NULL;
 static bool initialized;
-static std::mutex init_lock;
+static xamarin::android::mutex init_lock;
 
 void
 _monodroid_getifaddrs_init ()
@@ -291,7 +291,7 @@ int
 _monodroid_getifaddrs (struct _monodroid_ifaddrs **ifap)
 {
 	if (!initialized) {
-		std::lock_guard<std::mutex> lock (init_lock);
+		std::lock_guard<xamarin::android::mutex> lock (init_lock);
 		if (!initialized) {
 			_monodroid_getifaddrs_init ();
 			initialized = true;

--- a/src/native/shared/CMakeLists.txt
+++ b/src/native/shared/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIB_ALIAS_NO_ABI ${LIB_ALIAS}-no-abi)
 set(XA_SHARED_CXX_ABI_SOURCES
   cxx-abi/string.cc
   cxx-abi/terminate.cc
+  ${REPO_ROOT_DIR}/src-ThirdParty/llvm/verbose_abort.cpp
 )
 
 set(XA_SHARED_SOURCES

--- a/src/native/shared/cppcompat.hh
+++ b/src/native/shared/cppcompat.hh
@@ -16,7 +16,7 @@
 //
 // When/if we have any STL implementation available on standard Android
 // we can remove this file.
-namespace std
+namespace xamarin::android
 {
 	template<typename TMutex>
 	class lock_guard

--- a/src/native/tracing/native-tracing.cc
+++ b/src/native/tracing/native-tracing.cc
@@ -26,7 +26,7 @@ static jmethodID java_lang_Thread_getStackTrace;
 static jclass java_lang_StackTraceElement;
 static jmethodID java_lang_StackTraceElement_toString;
 
-static std::mutex java_init_lock;
+static xamarin::android::mutex java_init_lock;
 
 const char* xa_get_managed_backtrace () noexcept
 {
@@ -291,7 +291,7 @@ void init_jni (JNIEnv *env) noexcept
 		return;
 	}
 
-	std::lock_guard lock (java_init_lock);
+	xamarin::android::lock_guard lock (java_init_lock);
 
 	java_lang_Thread = to_gref (env, env->FindClass ("java/lang/Thread"));
 	java_lang_Thread_currentThread = env->GetStaticMethodID (java_lang_Thread, "currentThread", "()Ljava/lang/Thread;");


### PR DESCRIPTION
Changes: https://github.com/android/ndk/wiki/Changelog-r27

NDK r27 has been released.  The most important change affecting us is that we should start building
all our native libraries with [16k page alignment](https://github.com/android/ndk/wiki/Changelog-r27#announcements),
support for which is already in `main` and will be refined once #9075 is merged.

Notable changes:

  * NDK switched to LLVM 18.0.1 as its toolchain
  * A RISC-V sysroot (AKA riscv64, or rv64) has been added. It is not supported. It is present to aid bringup for
    OS vendors, but it's not yet a supported Android ABI. It will not be built by default.
  * Added APP_SUPPORT_FLEXIBLE_PAGE_SIZES for ndk-build and ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES for CMake. 
  * The unsupported libclang, libclang-cpp, libLLVM, and libLTO libraries were removed to save space.