### PR TITLE
[ci] Update checkout path for nightly build

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -55,6 +55,7 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
+      path: s/xamarin-android
 
     - template: /build-tools/automation/yaml-templates/commercial-build.yaml
       parameters:


### PR DESCRIPTION
The main build scripts prefer a checkout path of `s/xamarin-android`,
and the nightly job should do the same (at least for now).