### PR TITLE
[ci] Update sdk-insertions trigger

### DIFF
--- a/.github/workflows/sdk-insertion-bump.yml
+++ b/.github/workflows/sdk-insertion-bump.yml
@@ -1,11 +1,12 @@
 name: Notify release branch change
 
 on:
+  workflow_dispatch:
   # trigger for main and release branches.
-  push:
-    branches:
-      - main
-      - 'release/**'
+  #push:
+  #  branches:
+  #    - main
+  #    - 'release/**'
 
 jobs:
   pingRemote:
@@ -30,6 +31,6 @@ jobs:
           token: ${{ secrets.SERVICEACCOUNT_PAT }}
           event-type: 'sdk_insertion' 
           repository: 'xamarin/sdk-insertions'
-          client-payload: '{"repository": "xamarin/xamarin-android", "branch": "${{ github.ref_name }}", "commit": "${{ github.sha }}", "commit_message": ${{ steps.commit_title.outputs.COMMIT_TITLE }} }'
+          client-payload: '{"repository": "dotnet/android", "branch": "${{ github.ref_name }}", "commit": "${{ github.sha }}", "commit_message": ${{ steps.commit_title.outputs.COMMIT_TITLE }} }'
 
 


### PR DESCRIPTION
Fixes the sdk-insertion-bump workflow to pass updated repo information.
The trigger has also been disabled for now, though it can still be ran
manually via the workflow_dispatch event. 