### PR TITLE
[ci] Fix android source path for MAUI test job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -340,7 +340,7 @@ extends:
 
         - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
           parameters:
-            xaSourcePath: $(Build.SourcesDirectory)/xamarin-android
+            xaSourcePath: $(Build.SourcesDirectory)/android
             androidSdkPlatforms: $(DefaultTestSdkPlatforms)
             dotnetVersion: 9.0
             dotnetQuality: preview
@@ -383,7 +383,7 @@ extends:
         - task: DotNetCoreCLI@2
           displayName: Update Android SDK band in Workloads.csproj
           inputs:
-            projects: $(Build.SourcesDirectory)/xamarin-android/Xamarin.Android.sln
+            projects: $(Build.SourcesDirectory)/android/Xamarin.Android.sln
             arguments: -t:UpdateMauiWorkloadsProj -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/update-maui-workloadsproj.binlog
 
         - pwsh: ./build.ps1 --target=dotnet --configuration="$(XA.Build.Configuration)" --nugetsource="$(Build.StagingDirectory)\android-packs" --verbosity=diagnostic
@@ -399,14 +399,14 @@ extends:
           displayName: Install MAUI workload packs
           retryCountOnTaskFailure: 3
           inputs:
-            projects: $(Build.SourcesDirectory)/xamarin-android/Xamarin.Android.sln
+            projects: $(Build.SourcesDirectory)/android/Xamarin.Android.sln
             arguments: -t:InstallMaui -p:MauiUseLocalPacks=true -p:MauiWorkloadToInstall=maui -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/install-maui.binlog
 
         - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
           parameters:
             command: new
             arguments: maui -o $(Build.StagingDirectory)/MauiTestProj
-            xaSourcePath: $(Build.SourcesDirectory)/xamarin-android
+            xaSourcePath: $(Build.SourcesDirectory)/android
             displayName: Create MAUI template
             continueOnError: false
 
@@ -425,7 +425,7 @@ extends:
               -f $(DotNetTargetFramework)-android -c Debug
               --configfile $(Build.SourcesDirectory)/maui/NuGet.config
               -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Debug.binlog
-            xaSourcePath: $(Build.SourcesDirectory)/xamarin-android
+            xaSourcePath: $(Build.SourcesDirectory)/android
             displayName: Build MAUI template - Debug
 
         - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
@@ -435,7 +435,7 @@ extends:
               -f $(DotNetTargetFramework)-android -c Release
               --configfile $(Build.SourcesDirectory)/maui/NuGet.config
               -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Release.binlog
-            xaSourcePath: $(Build.SourcesDirectory)/xamarin-android
+            xaSourcePath: $(Build.SourcesDirectory)/android
             displayName: Build MAUI template - Release
 
         - task: CopyFiles@2


### PR DESCRIPTION
Other test jobs use `s/` or `s/xamarin-android` as a checkout path. 