### PR TITLE
[runtime] Explicitly align application shared library to page size

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
@@ -129,6 +129,7 @@ namespace Xamarin.Android.Tasks
 				"-soname libxamarin-app.so " +
 				"-z relro " +
 				"-z noexecstack " +
+				"-z max-page-size=4096 " +
 				"--enable-new-dtags " +
 				"--build-id " +
 				"--warn-shared-textrel " +


### PR DESCRIPTION
This is just for parity with what `clang` uses, it will align the `libxamarin-app.so` 
library to a more natural boundary of 4k bytes (size of a memory page on Android)

Without the flag, the shared library is aligned to 64k bytes, which is wasteful with
regards to consumed memory (not much, but still) and may also make memory access slightly
slower than necessary.