### PR TITLE
Support Visual Studio "Build Acceleration"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
@@ -203,7 +203,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
 
   So lets remove it. We MUST remove the item from the @ReferencePathWithRefAssemblies
   ItemGroup BEFORE the CollectResolvedCompilationReferencesDesignTime target runs.
-  This is because that target uses the Returns funtionality. It turns out you cannot
+  This is because that target uses the Returns functionality. It turns out you cannot
   modify the ItemGroup that is being returned via a Returns on a target.
 -->
 <Target Name="_RemoveResourceDesignerFromResolvedComilationReferences" BeforeTargets="CollectResolvedCompilationReferencesDesignTime" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
@@ -206,9 +206,14 @@ Copyright (C) 2016 Xamarin. All rights reserved.
   This is because that target uses the Returns functionality. It turns out you cannot
   modify the ItemGroup that is being returned via a Returns on a target.
 -->
-<Target Name="_RemoveResourceDesignerFromResolvedComilationReferences" BeforeTargets="CollectResolvedCompilationReferencesDesignTime" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+<Target Name="_RemoveResourceDesignerFromResolvedComilationReferences"
+      BeforeTargets="CollectResolvedCompilationReferencesDesignTime"
+      Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'"
+>
   <ItemGroup>
-    <_ResourceDesignerFiles Include="%(ReferencePathWithRefAssemblies.Identity)" Condition="'%(ReferencePathWithRefAssemblies.OriginalPath)' == '$(_GenerateResourceDesignerAssemblyOutput)'" />
+    <_ResourceDesignerFiles Include="%(ReferencePathWithRefAssemblies.Identity)"
+        Condition="'%(ReferencePathWithRefAssemblies.OriginalPath)' == '$(_GenerateResourceDesignerAssemblyOutput)'"
+    />
     <ReferencePathWithRefAssemblies Remove="@(_ResourceDesignerFiles)" />
   </ItemGroup>
 </Target>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
@@ -196,6 +196,23 @@ Copyright (C) 2016 Xamarin. All rights reserved.
   </ItemGroup>
 </Target>
 
+<!--
+  The Visual Studio FastUpdate check flags the Resource Designer assembly as
+  newer than the output assembly (which it is). But it causes it to incorrectly
+  think the build is out of date. 
+
+  So lets remove it. We MUST remove the item from the @ReferencePathWithRefAssemblies
+  ItemGroup BEFORE the CollectResolvedCompilationReferencesDesignTime target runs.
+  This is because that target uses the Returns funtionality. It turns out you cannot
+  modify the ItemGroup that is being returned via a Returns on a target.
+-->
+<Target Name="_RemoveResourceDesignerFromResolvedComilationReferences" BeforeTargets="CollectResolvedCompilationReferencesDesignTime" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+  <ItemGroup>
+    <_ResourceDesignerFiles Include="%(ReferencePathWithRefAssemblies.Identity)" Condition="'%(ReferencePathWithRefAssemblies.OriginalPath)' == '$(_GenerateResourceDesignerAssemblyOutput)'" />
+    <ReferencePathWithRefAssemblies Remove="@(_ResourceDesignerFiles)" />
+  </ItemGroup>
+</Target>
+
 <Target Name="_BuildResourceDesigner"
     Condition=" '$(AndroidUseDesignerAssembly)' == 'True' "
     DependsOnTargets="$(_BuildResourceDesignerDependsOn)" />


### PR DESCRIPTION
Fixes #8581
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2051915
 
Context
* https://github.com/dotnet/project-system/blob/dd9431b535a6158060d7ab64597276eb2c354aab/docs/design-time-builds.md#targets-that-run-during-design-time-builds
* https://github.com/dotnet/project-system/blob/dd9431b535a6158060d7ab64597276eb2c354aab/docs/up-to-date-check.md#default-inputs-and-outputs
* https://github.com/dotnet/project-system/blob/dd9431b535a6158060d7ab64597276eb2c354aab/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L448-L449



The Visual Studio FastUpdate check flags the Resource Designer assembly as
newer than the output assembly (which it is). But it causes it to incorrectly
think the build is out of date.

```
WARNING: Potential build performance issue in 'Foo.csproj'.
The project does not appear up-to-date after a successful build:
Input ResolvedCompilationReference item 'obj\Debug\net8.0-android\_Microsoft.Android.Resource.Designer.dll' (2023-12-11 11:34:12.546) has been modified since the last successful build started
```

So lets remove it. We MUST remove the item from the @ReferencePathWithRefAssemblies
ItemGroup BEFORE the CollectResolvedCompilationReferencesDesignTime target runs.
This is because that target uses the Returns functionality. It turns out you cannot
modify the ItemGroup that is being returned via a Returns on a target.

Unfortunately there isn't a way to unit test this since the Fast Update check
ONLY runs in Visual Studio. The targets do not even exist on the command line.