### PR TITLE
Keep all .NET runtime classes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
@@ -26,7 +26,7 @@
 -keepclassmembers class md52ce486a14f4bcd95899665e9d932190b.** { *; <init>(...); }
 
 # .NET 8 runtime
--keep class net.dot.android.crypto.DotnetProxyTrustManager { *; <init>(...); }
+-keep class net.dot.android.crypto.** { *; <init>(...); }
 
 # Android's template misses fluent setters...
 -keepclassmembers class * extends android.view.View {

--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
@@ -25,7 +25,7 @@
 -keep class md52ce486a14f4bcd95899665e9d932190b.** { *; <init>(...); }
 -keepclassmembers class md52ce486a14f4bcd95899665e9d932190b.** { *; <init>(...); }
 
-# .NET 8 runtime
+# .NET runtime
 -keep class net.dot.android.crypto.** { *; <init>(...); }
 
 # Android's template misses fluent setters...


### PR DESCRIPTION
In dotnet/runtime we are adding a few more Java classes to assist with .NET crypto. One was added in https://github.com/dotnet/runtime/pull/103016, and another may be added in https://github.com/dotnet/runtime/pull/103337.

This PR changes ProGuard to keep all of the classes in this package rather than individually adding them. If we prefer to keep them individually, I can change the PR to do that, too.

/cc @simonrozsival 