### PR TITLE
Fix places still pointing to xamarin/xamarin-android

### DIFF
--- a/build-tools/create-packs/License.targets
+++ b/build-tools/create-packs/License.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <PackageProjectUrl>https://github.com/xamarin/xamarin-android</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/dotnet/android</PackageProjectUrl>
     <NuGetLicense Condition="Exists('$(XamarinAndroidSourcePath)external\monodroid\tools\scripts\License.txt')">$(XamarinAndroidSourcePath)external\monodroid\tools\scripts\License.txt</NuGetLicense>
     <NuGetLicense Condition=" '$(NuGetLicense)' == '' or '$(PackageId)' != 'Microsoft.Android.Sdk.$(HostOS)' ">$(XamarinAndroidSourcePath)LICENSE.TXT</NuGetLicense>
     <PackageLicenseFile>LICENSE.TXT</PackageLicenseFile>

--- a/build-tools/debian-metadata/control
+++ b/build-tools/debian-metadata/control
@@ -5,8 +5,8 @@ Maintainer: Xamarin <hello@xamarin.com>
 Build-Depends: debhelper (>=9), cli-common-dev (>= 0.9~)
 Standards-Version: 3.9.6
 Homepage: https://www.xamarin.com/platform
-Vcs-Git: https://github.com/xamarin/xamarin-android.git
-Vcs-Browser: https://github.com/xamarin/xamarin-android
+Vcs-Git: https://github.com/dotnet/android.git
+Vcs-Browser: https://github.com/dotnet/android
 
 Package: xamarin.android-oss
 Architecture: amd64

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -75,7 +75,7 @@
       <Output TaskParameter="Branch"                  PropertyName="XAVersionBranch"        Condition=" '$(XAVersionBranch)' == '' " />
     </GitBranch>
     <PropertyGroup>
-      <XARepositoryName Condition=" '$(XARepositoryName)' == '' ">xamarin-android</XARepositoryName>
+      <XARepositoryName Condition=" '$(XARepositoryName)' == '' ">dotnet/android</XARepositoryName>
       <!-- See Azure Pipelines predefined variables. -->
       <_AndroidPackLabel Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">ci.pr.gh$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackBranch>$([System.Text.RegularExpressions.Regex]::Replace('$(XAVersionBranch)', '[^a-zA-Z0-9-]', '-'))</_AndroidPackBranch>

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedSourceLinkJsonFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedSourceLinkJsonFile.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Android.Prepare
 
 				json.AppendLine ($"    \"{localPath}/*\": \"{contentUri.Uri}/*\",");
 			}
-			json.AppendLine ($"    \"{BuildPaths.XamarinAndroidSourceRoot}/*\": \"https://raw.githubusercontent.com/xamarin/xamarin-android/{xaCommit}/*\"");
+			json.AppendLine ($"    \"{BuildPaths.XamarinAndroidSourceRoot}/*\": \"https://raw.githubusercontent.com/dotnet/android/{xaCommit}/*\"");
 			json.AppendLine ("  }");
 			json.AppendLine ("}");
 

--- a/tools/relnote-gen/App.cs
+++ b/tools/relnote-gen/App.cs
@@ -15,9 +15,9 @@ enum State {
 
 static class App {
 
-	const string XamarinAndroidCommitBase   = "http://github.com/xamarin/xamarin-android/commit/";
-	const string XamarinAndroidPullBase     = "http://github.com/xamarin/xamarin-android/pull/";
-	const string XamarinAndroidIssuesBase   = "http://github.com/xamarin/xamarin-android/issues/";
+	const string XamarinAndroidCommitBase   = "https://github.com/dotnet/android/commit/";
+	const string XamarinAndroidPullBase     = "https://github.com/dotnet/android/pull/";
+	const string XamarinAndroidIssuesBase   = "https://github.com/dotnet/android/issues/";
 
 	static readonly Regex SummaryParser = new Regex (
 		@"^\s*(\[(?<component>[^]]+)\]\s+)?" +

--- a/tools/relnote-gen/README.md
+++ b/tools/relnote-gen/README.md
@@ -34,8 +34,8 @@ Then the output of `renote-gen` will be:
 
   - Summary
     ([#NUMBER](URL/NUMBER),
-    [PR #PR](http://github.com/xamarin/xamarin-android/pull/PR),
-    [Commit COMMIT](http://github.com/xamarin/xamarin-android/commit/COMMIT))
+    [PR #PR](https://github.com/dotnet/android/pull/PR),
+    [Commit COMMIT](https://github.com/dotnet/android/commit/COMMIT))
 ```
 
 # API Diffs?


### PR DESCRIPTION
I tried to fix places that would show up in user-facing places like the `Version.commit`, SourceLink, etc. Or places that make web requests using this URL.

There are still many links in `.md` files or code comments, but those should redirect appropriately.