### PR TITLE
Bump to dotnet/java-interop/main@7a058c0e

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/dotnet/java-interop
-    branch = dev/jonp/jonp-add-JavaAs
+    branch = main
 [submodule "external/libunwind"]
     path = external/libunwind
     url = https://github.com/libunwind/libunwind.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/dotnet/java-interop
-    branch = main
+    branch = dev/jonp/jonp-add-JavaAs
 [submodule "external/libunwind"]
     path = external/libunwind
     url = https://github.com/libunwind/libunwind.git

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -50,7 +50,7 @@ namespace Android.Runtime
 		internal static IntPtr java_class_loader;
 		internal static JniMethodInfo? mid_Class_forName;
 
-		static AndroidRuntime? androidRuntime;
+		internal static AndroidRuntime? androidRuntime;
 
 		[UnmanagedCallersOnly]
 		static unsafe void RegisterJniNatives (IntPtr typeName_ptr, int typeName_len, IntPtr jniClass, IntPtr methods_ptr, int methods_len)

--- a/tests/Mono.Android-Tests/Java.Interop/JavaObjectExtensionsTests.cs
+++ b/tests/Mono.Android-Tests/Java.Interop/JavaObjectExtensionsTests.cs
@@ -56,6 +56,14 @@ namespace Java.InteropTests {
 			}
 		}
 
+		[Test]
+		public void JavaAs ()
+		{
+			using var v     = new Java.InteropTests.MyJavaInterfaceImpl ();
+			using var c     = v.JavaAs<Java.Lang.ICloneable>();
+			Assert.IsNotNull (c);
+		}
+
 		static Java.Lang.Object CreateObject ()
 		{
 			var ctor    = JNIEnv.GetMethodID (Java.Lang.Class.Object, "<init>", "()V");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9038

Changes: https://github.com/dotnet/java-interop/compare/ccafbe6a102a85efe84ceb210b3b8b93e49edbcb...7a058c0ee50d39dc5783d2b2770ea5e0f1001a56

  * dotnet/java-interop@7a058c0e: [Java.Interop] Add `IJavaPeerable.JavaAs()` extension method (dotnet/java-interop#1234)
  * dotnet/java-interop@6f9defa5: Bump to dotnet/android-tools/main@3debf8e0 (dotnet/java-interop#1236)
  * dotnet/java-interop@6923fb89: [ci] Add dependabot branches to build triggers (dotnet/java-interop#1233)
  * dotnet/java-interop@573028f3: [ci] Use macOS 13 Ventura build agents (dotnet/java-interop#1235)

dotnet/java-interop@7a058c0e adds a new `IJavaPeerable.JavaAs<T>()`
extension method, to perform type casts which return `null` when
the cast will not succeed instead of throwing an exception.

Update `AndroidValueManager.CreatePeer()` to check for Java-side
type compatibility (by way of `TypeManager.CreateInstance()`).
Previously, this would not throw:

	var instance        = …
	var r               = instance.PeerReference;
	var wrap_instance   = JniRuntime.CurrentRuntime.ValueManager.CreatePeer (
	        reference: ref r,
	        options: JniObjectReferenceOptions.Copy,
	        targetType: typeof (SomeInterfaceThatInstanceDoesNotImplement));
	// `wrap_instance` is not null, `.CreatePeer()` does not throw

	wrap_instance.SomeMethod();
	// will throw, due to a type mismatch.

`AndroidValueManager.CreatePeer()` will now return `null` if the
Java instance referenced by the `reference:` parameter is not
convertible to `targetType`, as per [`JNIEnv::IsAssignableFrom()`][0].

[0]: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#IsAssignableFrom