### PR TITLE
[trimming] use public `$(MetricsSupport)` property

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -119,7 +119,7 @@
     <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
     <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
     <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == '' and '$(TrimMode)' == 'partial'">true</JsonSerializerIsReflectionEnabledByDefault>
-    <_SystemDiagnosticsMetricsMeterIsSupported Condition="'$(_SystemDiagnosticsMetricsMeterIsSupported)' == ''">false</_SystemDiagnosticsMetricsMeterIsSupported>
+    <MetricsSupport Condition="'$(MetricsSupport)' == ''">false</MetricsSupport>
     <AndroidAvoidEmitForPerformance Condition="'$(AndroidAvoidEmitForPerformance)' == ''">$(AvoidEmitForPerformance)</AndroidAvoidEmitForPerformance>
     <AndroidAvoidEmitForPerformance Condition="'$(AndroidAvoidEmitForPerformance)' == ''">true</AndroidAvoidEmitForPerformance>
     <!-- Verify DI trimmability at development-time, but turn the validation off for production/trimmed builds. -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
@@ -46,11 +46,6 @@ See: https://github.com/dotnet/runtime/blob/b13715b6984889a709ba29ea8a1961db469f
         Value="$(AndroidAvoidEmitForPerformance)"
         Trim="true"
     />
-    <!-- https://github.com/dotnet/runtime/commit/3aeefbdd5e975e287effaa8670422837dc661d68 -->
-    <RuntimeHostConfigurationOption Include="System.Diagnostics.Metrics.Meter.IsSupported"
-        Value="$(_SystemDiagnosticsMetricsMeterIsSupported)"
-        Trim="true"
-    />
   </ItemGroup>
 
   <Target Name="_ParseRuntimeConfigFiles"


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/9060#issuecomment-2199309388
Context: https://github.com/dotnet/sdk/blob/e18cfb7a09d74952d5e9c2448d31dee313e059bb/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L522-L525

In eb6397d4, we introduced `$(_SystemDiagnosticsMetricsMeterIsSupported)` to avoid a startup time regression with `HttpClient`-related code. At the time, the public property `$(MetricsSupport)` had not been introduced yet in the .NET SDK.

Let's use `$(MetricsSupport)` instead of the private `$(_SystemDiagnosticsMetricsMeterIsSupported)` property.