### PR TITLE
[build] Bump `$(XABuildToolsVersion)`=35

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -121,8 +121,8 @@
     <XABuildToolsPackagePrefixLinux></XABuildToolsPackagePrefixLinux>
     <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">$(XABuildToolsPackagePrefixMacOS)</XABuildToolsPackagePrefix>
     <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Windows' ">$(XABuildToolsPackagePrefixWindows)</XABuildToolsPackagePrefix>
-    <XABuildToolsVersion>34</XABuildToolsVersion>
-    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">34.0.0</XABuildToolsFolder>
+    <XABuildToolsVersion>35</XABuildToolsVersion>
+    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">35.0.0</XABuildToolsFolder>
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' "></XAPlatformToolsPackagePrefix>
     <XAPlatformToolsVersion>34.0.5</XAPlatformToolsVersion>
     <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.15.1</XABundleToolVersion>

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Android.Prepare
 					buildToolName: $"android-ndk-r{AndroidNdkVersion}",
 					buildToolVersion: AndroidPkgRevision
 				),
-				new AndroidToolchainComponent ($"{XABuildToolsPackagePrefix}build-tools_r{XABuildToolsVersion}-{altOsTag}",
+				new AndroidToolchainComponent ($"{XABuildToolsPackagePrefix}build-tools_r{XABuildToolsVersion}_{altOsTag}",
 					destDir: Path.Combine ("build-tools", XABuildToolsFolder),
 					isMultiVersion: true,
 					buildToolName: "android-sdk-build-tools",

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Get_Android_BuildTools.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Get_Android_BuildTools.cs
@@ -18,9 +18,9 @@ namespace Xamarin.Android.Prepare
 			string XABuildToolsPackagePrefixWindows = Context.Instance.Properties [KnownProperties.XABuildToolsPackagePrefixWindows] ?? string.Empty;
 			string XABuildToolsPackagePrefixLinux = Context.Instance.Properties [KnownProperties.XABuildToolsPackagePrefixLinux] ?? string.Empty;
 
-			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}-macosx.zip", prefix: XABuildToolsPackagePrefixMacOS));
-			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}-windows.zip", prefix: XABuildToolsPackagePrefixWindows));
-			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}-linux.zip", prefix: XABuildToolsPackagePrefixLinux));
+			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}_macosx.zip", prefix: XABuildToolsPackagePrefixMacOS));
+			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}_windows.zip", prefix: XABuildToolsPackagePrefixWindows));
+			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}_linux.zip", prefix: XABuildToolsPackagePrefixLinux));
 		}
 
 		protected override async Task<bool> Execute (Context context)

--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <_BuildTools Include="build-tools_r$(XABuildToolsVersion)-macosx.zip">
+    <_BuildTools Include="build-tools_r$(XABuildToolsVersion)_macosx.zip">
       <Platform>osx</Platform>
       <HostOS>Darwin</HostOS>
       <FilesToExtract>aapt2</FilesToExtract>
     </_BuildTools>
-    <_BuildTools Include="build-tools_r$(XABuildToolsVersion)-linux.zip">
+    <_BuildTools Include="build-tools_r$(XABuildToolsVersion)_linux.zip">
       <Platform>linux</Platform>
       <HostOS>Linux</HostOS>
       <FilesToExtract>aapt2</FilesToExtract>
     </_BuildTools>
-    <_BuildTools Include="build-tools_r$(XABuildToolsVersion)-windows.zip">
+    <_BuildTools Include="build-tools_r$(XABuildToolsVersion)_windows.zip">
       <Platform>windows</Platform>
       <HostOS></HostOS>
       <FilesToExtract>aapt2.exe</FilesToExtract>


### PR DESCRIPTION
Context: https://developer.android.com/tools/releases/build-tools

Update `$(XABuildToolsVersion)` to 35, which is the latest version of the Android SDK Build Tools.

Does it build™?