### PR TITLE
Refine 16k page alignment support

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -125,7 +125,7 @@
     <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">35.0.0</XABuildToolsFolder>
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' "></XAPlatformToolsPackagePrefix>
     <XAPlatformToolsVersion>34.0.5</XAPlatformToolsVersion>
-    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.15.1</XABundleToolVersion>
+    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.17.0</XABundleToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != ''">$(NUGET_PACKAGES)</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' != 'Windows'">$(HOME)/.nuget/packages</XAPackagesDir>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,7 +52,7 @@
     <MonoOptionsVersion>6.12.0.148</MonoOptionsVersion>
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
-    <ELFSharpVersion>2.13.1</ELFSharpVersion>
+    <ELFSharpVersion>2.17.3</ELFSharpVersion>
     <HumanizerVersion>2.14.1</HumanizerVersion>
     <MdocPackageVersion Condition=" '$(MdocPackageVersion)' == '' ">5.9.2.4</MdocPackageVersion>
   </PropertyGroup>

--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -102,7 +102,8 @@ Please file an issue with the exact error message using the 'Help->Send Feedback
 or 'Help->Report a Problem' in Visual Studio for Mac.
 + [XA0138](xa0138.md): %(AndroidAsset.AssetPack) and %(AndroidAsset.AssetPack) item metadata are only supported when `$(AndroidApplication)` is `true`.
 + [XA0139](xa0139.md): `@(AndroidAsset)` `{0}` has invalid `DeliveryType` metadata of `{1}`. Supported values are `installtime`, `ondemand` or `fastfollow`
-+ [XA0140](xa0140.md): 
++ [XA0140](xa0140.md):
++ [XA0141](xa0141.md): NuGet package '{0}' version '{1}' contains a shared library '{2}' which is not correctly aligned. See https://developer.android.com/guide/practices/page-sizes for more details
 
 ## XA1xxx: Project related
 

--- a/Documentation/docs-mobile/messages/xa0141.md
+++ b/Documentation/docs-mobile/messages/xa0141.md
@@ -1,0 +1,14 @@
+---
+title: .NET for Android warning XA0141
+description: XA0141 warning code
+ms.date: 22/07/2024
+---
+# .NET for Android warning XA0141
+
+## Issue
+
+NuGet package '{0}' version '{1}' contains a shared library '{2}' which is not correctly aligned. See https://developer.android.com/guide/practices/page-sizes for more details
+
+## Solution
+
+The indicated native shared library must be recompiled and relinked with the 16k alignment, as per URL indicated in the message.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -90,7 +90,8 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
         RuntimeIdentifier="$(RuntimeIdentifier)"
         EnableLLVM="$(EnableLLVM)"
         Profiles="@(AndroidAotProfile)"
-        StripLibraries="$(_AndroidAotStripLibraries)">
+        StripLibraries="$(_AndroidAotStripLibraries)"
+        ZipAlignmentPages="$(AndroidZipAlignment)">
       <Output PropertyName="_Triple"     TaskParameter="Triple" />
       <Output PropertyName="_ToolPrefix" TaskParameter="ToolPrefix" />
       <Output PropertyName="_MsymPath"   TaskParameter="MsymPath" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -48,12 +48,11 @@
 
     <!--
         Android package (apt/aab) alignment, expressed as the page size in kilobytes.  Two values are supported: 4 and 16.
-        Sometime next year the default value should be changed to 16 since it's going to be a Google Play store requirement for
-        application submissions.
+        Sometime next year 16 is going to be a Google Play store requirement for application submissions.
 
         When changing this default, change the value of `DefaultZipAlignment` in `src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs` as well
     -->
-    <_AndroidZipAlignment Condition=" '$(_AndroidZipAlignment)' == '' ">4</_AndroidZipAlignment>
+    <AndroidZipAlignment Condition=" '$(AndroidZipAlignment)' == '' ">16</AndroidZipAlignment>
   </PropertyGroup>
 
   <!--  User-facing configuration-specific defaults -->

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1059,4 +1059,12 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {0} - NuGet package id
 {1} - NuGet package version</comment>
   </data>
+  <data name="XA0141" xml:space="preserve">
+    <value>NuGet package '{0}' version '{1}' contains a shared library '{2}' which is not correctly aligned. See https://developer.android.com/guide/practices/page-sizes for more details</value>
+    <comment>The following is a literal name and should not be translated: NuGet
+{0} - NuGet package id
+{1} - NuGet package version
+{2} - shared library file name
+    </comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs
@@ -7,9 +7,9 @@ namespace Xamarin.Android.Tasks
 {
 	public class AndroidZipAlign : AndroidRunToolTask
 	{
-		// Sometime next year the default value should be changed to 16 since it's going to be a Google Play store requirement for
-		// application submissions
-		internal const int DefaultZipAlignment = 4;
+		// Default to 16 since it's going to be a Google Play store requirement for application submissions sometime next year
+		internal const int DefaultZipAlignment64Bit = 16;
+		internal const int ZipAlignment32Bit = 4; // This must never change
 
 		public override string TaskPrefix => "AZA";
 
@@ -19,7 +19,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem DestinationDirectory { get; set; }
 
-		int alignment = DefaultZipAlignment;
+		int alignment = DefaultZipAlignment64Bit;
 		public int Alignment {
 			get {return alignment;}
 			set {alignment = value;}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -80,7 +80,6 @@ namespace Xamarin.Android.Tasks
 		public string AndroidSequencePointsMode { get; set; }
 		public bool EnableSGenConcurrent { get; set; }
 		public string? CustomBundleConfigFile { get; set; }
-		public int ZipAlignmentPages { get; set; } = AndroidZipAlign.DefaultZipAlignment;
 
 		[Output]
 		public string BuildId { get; set; }
@@ -335,7 +334,6 @@ namespace Xamarin.Android.Tasks
 
 			bool haveRuntimeConfigBlob = !String.IsNullOrEmpty (RuntimeConfigBinFilePath) && File.Exists (RuntimeConfigBinFilePath);
 			var jniRemappingNativeCodeInfo = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<GenerateJniRemappingNativeCode.JniRemappingNativeCodeInfo> (ProjectSpecificTaskObjectKey (GenerateJniRemappingNativeCode.JniRemappingNativeCodeInfoKey), RegisteredTaskObjectLifetime.Build);
-			uint zipAlignmentMask = MonoAndroidHelper.ZipAlignmentToMask (ZipAlignmentPages);
 			var appConfigAsmGen = new ApplicationConfigNativeAssemblyGenerator (environmentVariables, systemProperties, Log) {
 				UsesMonoAOT = usesMonoAOT,
 				UsesMonoLLVM = EnableLLVM,
@@ -359,7 +357,6 @@ namespace Xamarin.Android.Tasks
 				JNIEnvRegisterJniNativesToken = jnienv_registerjninatives_method_token,
 				JniRemappingReplacementTypeCount = jniRemappingNativeCodeInfo == null ? 0 : jniRemappingNativeCodeInfo.ReplacementTypeCount,
 				JniRemappingReplacementMethodIndexEntryCount = jniRemappingNativeCodeInfo == null ? 0 : jniRemappingNativeCodeInfo.ReplacementMethodIndexEntryCount,
-				ZipAlignmentMask = zipAlignmentMask,
 				MarshalMethodsEnabled = EnableMarshalMethods,
 				IgnoreSplitConfigs = ShouldIgnoreSplitConfigs (),
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -54,6 +54,8 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem [] Profiles { get; set; } = Array.Empty<ITaskItem> ();
 
+		public int ZipAlignmentPages { get; set; } = AndroidZipAlign.DefaultZipAlignment64Bit;
+
 		[Required, Output]
 		public ITaskItem [] ResolvedAssemblies { get; set; } = Array.Empty<ITaskItem> ();
 
@@ -324,6 +326,29 @@ namespace Xamarin.Android.Tasks
 				}
 				ldFlags.Append ("-s");
 			}
+
+			uint maxPageSize;
+			switch (arch) {
+				case AndroidTargetArch.Arm64:
+				case AndroidTargetArch.X86_64:
+					maxPageSize = MonoAndroidHelper.ZipAlignmentToPageSize (ZipAlignmentPages);
+					break;
+
+				case AndroidTargetArch.Arm:
+				case AndroidTargetArch.X86:
+					maxPageSize = MonoAndroidHelper.ZipAlignmentToPageSize (AndroidZipAlign.ZipAlignment32Bit);
+					break;
+
+				default:
+					throw new InvalidOperationException ($"Internal error: unsupported target architecture {arch}");
+			}
+
+			if (ldFlags.Length > 0) {
+				ldFlags.Append (' ');
+			}
+
+			ldFlags.Append ("-z ");
+			ldFlags.Append ($"max-page-size={maxPageSize}");
 
 			return ldFlags.ToString ();
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AndroidBinUtilsDirectory { get; set; }
 
-		public int ZipAlignmentPages { get; set; } = AndroidZipAlign.DefaultZipAlignment;
+		public int ZipAlignmentPages { get; set; } = AndroidZipAlign.DefaultZipAlignment64Bit;
 
 		public override System.Threading.Tasks.Task RunTaskAsync ()
 		{
@@ -145,10 +145,12 @@ namespace Xamarin.Android.Tasks
 
 				targetLinkerArgs.Clear ();
 				string elf_arch;
+				uint maxPageSize;
 				switch (abi) {
 					case "armeabi-v7a":
 						targetLinkerArgs.Add ("-X");
 						elf_arch = "armelf_linux_eabi";
+						maxPageSize = MonoAndroidHelper.ZipAlignmentToPageSize (AndroidZipAlign.ZipAlignment32Bit);
 						break;
 
 					case "arm64":
@@ -156,14 +158,17 @@ namespace Xamarin.Android.Tasks
 					case "aarch64":
 						targetLinkerArgs.Add ("--fix-cortex-a53-843419");
 						elf_arch = "aarch64linux";
+						maxPageSize = MonoAndroidHelper.ZipAlignmentToPageSize (ZipAlignmentPages);
 						break;
 
 					case "x86":
 						elf_arch = "elf_i386";
+						maxPageSize = MonoAndroidHelper.ZipAlignmentToPageSize (AndroidZipAlign.ZipAlignment32Bit);
 						break;
 
 					case "x86_64":
 						elf_arch = "elf_x86_64";
+						maxPageSize = MonoAndroidHelper.ZipAlignmentToPageSize (ZipAlignmentPages);
 						break;
 
 					default:
@@ -186,7 +191,6 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-				uint maxPageSize = MonoAndroidHelper.ZipAlignmentToPageSize (ZipAlignmentPages);
 				targetLinkerArgs.Add ("-z");
 				targetLinkerArgs.Add ($"max-page-size={maxPageSize}");
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
@@ -63,12 +63,11 @@ namespace Xamarin.Android.Build.Tests
 			public uint   jnienv_registerjninatives_method_token;
 			public uint   jni_remapping_replacement_type_count;
 			public uint   jni_remapping_replacement_method_index_entry_count;
-			public uint   zip_alignment_mask;
 			public uint   mono_components_mask;
 			public string android_package_name = String.Empty;
 		}
 
-		const uint ApplicationConfigFieldCount = 27;
+		const uint ApplicationConfigFieldCount = 26;
 
 		const string ApplicationConfigSymbolName = "application_config";
 		const string AppEnvironmentVariablesSymbolName = "app_environment_variables";
@@ -327,17 +326,12 @@ namespace Xamarin.Android.Build.Tests
 						ret.jni_remapping_replacement_method_index_entry_count = ConvertFieldToUInt32 ("jni_remapping_replacement_method_index_entry_count", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 24: // zip_alignment_mask: uint32_t / .word | .long
-						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
-						ret.zip_alignment_mask = ConvertFieldToUInt32 ("zip_alignment_mask", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
-						break;
-
-					case 25: // mono_components_mask: uint32_t / .word | .long
+					case 24: // mono_components_mask: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.mono_components_mask = ConvertFieldToUInt32 ("mono_components_mask", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 26: // android_package_name: string / [pointer type]
+					case 25: // android_package_name: string / [pointer type]
 						Assert.IsTrue (expectedPointerTypes.Contains (field [0]), $"Unexpected pointer field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						pointers.Add (field [1].Trim ());
 						break;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfig.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfig.cs
@@ -55,9 +55,6 @@ namespace Xamarin.Android.Tasks
 		public uint   jni_remapping_replacement_type_count;
 		public uint   jni_remapping_replacement_method_index_entry_count;
 
-		// 3, for 4-byte alignment (4k memory pages); 15, for 16-byte alignment (16k memory pages)
-		public uint   zip_alignment_mask;
-
 		[NativeAssembler (NumberFormat = LLVMIR.LlvmIrVariableNumberFormat.Hexadecimal)]
 		public uint   mono_components_mask;
 		public string android_package_name = String.Empty;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
@@ -183,7 +183,6 @@ namespace Xamarin.Android.Tasks
 		public int JNIEnvRegisterJniNativesToken { get; set; }
 		public int JniRemappingReplacementTypeCount { get; set; }
 		public int JniRemappingReplacementMethodIndexEntryCount { get; set; }
-		public uint ZipAlignmentMask { get; set; }
 		public MonoComponent MonoComponents { get; set; }
 		public PackageNamingPolicy PackageNamingPolicy { get; set; }
 		public List<ITaskItem> NativeLibraries { get; set; }
@@ -245,7 +244,6 @@ namespace Xamarin.Android.Tasks
 				jnienv_registerjninatives_method_token = (uint)JNIEnvRegisterJniNativesToken,
 				jni_remapping_replacement_type_count = (uint)JniRemappingReplacementTypeCount,
 				jni_remapping_replacement_method_index_entry_count = (uint)JniRemappingReplacementMethodIndexEntryCount,
-				zip_alignment_mask = ZipAlignmentMask,
 				mono_components_mask = (uint)MonoComponents,
 				android_package_name = AndroidPackageName,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ELFHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ELFHelper.cs
@@ -65,35 +65,34 @@ namespace Xamarin.Android.Tasks
 				}
 				log.LogDebugMessage ($"    expected segment alignment of 0x{pageSize:x}, found 0x{segment64.Alignment:x}");
 
-				// TODO: turn into a coded warning and, eventually, error. Need better wording.
-				//       Until dotnet runtime produces properly aligned libraries, this should be a plain message as a warning
-				//       would break all the tests that require no warnings to be produced during build.
-				log.LogMessage ($"Native {elf64.Machine} shared library '{Path.GetFileName (path)}', from NuGet package {GetNugetPackageInfo ()} isn't properly aligned.");
+				(string packageId, string packageVersion) = GetNugetPackageInfo ();
+				log.LogCodedWarning ("XA0141", packageId, packageVersion, Path.GetFileName (path));
 				break;
 			}
 
-			string GetNugetPackageInfo ()
+			(string packageId, string packageVersion) GetNugetPackageInfo ()
 			{
 				const string Unknown = "<unknown>";
 
 				if (item == null) {
-					return Unknown;
+					return (Unknown, Unknown);
 				}
 
-				var sb = new StringBuilder ();
 				string? metaValue = item.GetMetadata ("NuGetPackageId");
 				if (String.IsNullOrEmpty (metaValue)) {
-					return Unknown;
+					return (Unknown, Unknown);
 				}
 
-				sb.Append (metaValue);
+				string id = metaValue;
+				string version;
 				metaValue = item.GetMetadata ("NuGetPackageVersion");
 				if (!String.IsNullOrEmpty (metaValue)) {
-					sb.Append (" version ");
-					sb.Append (metaValue);
+					version = metaValue;
+				} else {
+					version = Unknown;
 				}
 
-				return sb.ToString ();
+				return (id, version);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -713,7 +713,6 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		public static uint ZipAlignmentToMask (int alignment) => ZipAlignmentToMaskOrPageSize (alignment, needMask: true);
 		public static uint ZipAlignmentToPageSize (int alignment) => ZipAlignmentToMaskOrPageSize (alignment, needMask: false);
 
 		static uint ZipAlignmentToMaskOrPageSize (int alignment, bool needMask)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2092,6 +2092,7 @@ because xbuild doesn't support framework reference assemblies.
     IncludeFiles="@(AndroidPackagingOptionsInclude)"
     ZipFlushFilesLimit="$(_ZipFlushFilesLimit)"
     ZipFlushSizeLimit="$(_ZipFlushSizeLimit)"
+    ZipAlignmentPages="$(AndroidZipAlignment)"
     UseAssemblyStore="$(AndroidUseAssemblyStore)">
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
@@ -2129,6 +2130,7 @@ because xbuild doesn't support framework reference assemblies.
       IncludeFiles="@(AndroidPackagingOptionsInclude)"
       ZipFlushFilesLimit="$(_ZipFlushFilesLimit)"
       ZipFlushSizeLimit="$(_ZipFlushSizeLimit)"
+      ZipAlignmentPages="$(AndroidZipAlignment)"
       UseAssemblyStore="$(AndroidUseAssemblyStore)">
     <Output TaskParameter="OutputFiles" ItemName="BaseZipFile" />
   </BuildBaseAppBundle>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1724,7 +1724,6 @@ because xbuild doesn't support framework reference assemblies.
     UseAssemblyStore="$(AndroidUseAssemblyStore)"
     EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
     CustomBundleConfigFile="$(AndroidBundleConfigurationFile)"
-    ZipAlignmentPages="$(_AndroidZipAlignment)"
   >
     <Output TaskParameter="BuildId" PropertyName="_XamarinBuildId" />
   </GeneratePackageManagerJava>
@@ -2011,7 +2010,7 @@ because xbuild doesn't support framework reference assemblies.
       ApplicationSharedLibraries="@(_ApplicationSharedLibrary)"
       DebugBuild="$(AndroidIncludeDebugSymbols)"
       AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
-      ZipAlignmentPages="$(_AndroidZipAlignment)"
+      ZipAlignmentPages="$(AndroidZipAlignment)"
   />
   <ItemGroup>
     <FileWrites Include="@(_ApplicationSharedLibrary)" />
@@ -2356,7 +2355,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="%(ApkAbiFilesSigned.FullPath)" Condition=" '$(AndroidUseApkSigner)' == 'true' "/>
 	<AndroidZipAlign Condition=" '$(AndroidUseApkSigner)' == 'true' "
 		Source="%(ApkAbiFilesIntermediate.Identity)"
-		Alignment="$(_AndroidZipAlignment)"
+		Alignment="$(AndroidZipAlignment)"
 		DestinationDirectory="$(OutDir)"
 		ToolPath="$(ZipAlignToolPath)"
 		ToolExe="$(ZipalignToolExe)"
@@ -2392,7 +2391,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Message Text="Unaligned android package '%(ApkAbiFilesUnaligned.FullPath)'"  Condition=" '$(AndroidUseApkSigner)' != 'True' And '$(AndroidPackageFormat)' != 'aab' "/>
 	<AndroidZipAlign Condition=" '$(AndroidUseApkSigner)' != 'True' And '$(AndroidPackageFormat)' != 'aab' "
 		Source="%(ApkAbiFilesUnaligned.Identity)"
-		Alignment="$(_AndroidZipAlignment)"
+		Alignment="$(AndroidZipAlignment)"
 		DestinationDirectory="$(OutDir)"
 		ToolPath="$(ZipAlignToolPath)"
 		ToolExe="$(ZipalignToolExe)"

--- a/src/native/monodroid/embedded-assemblies-zip.cc
+++ b/src/native/monodroid/embedded-assemblies-zip.cc
@@ -59,10 +59,10 @@ EmbeddedAssemblies::zip_load_entry_common (size_t entry_index, std::vector<uint8
 		}
 	}
 
-	// assemblies must be 4-byte aligned, or Bad Things happen
-	if ((state.data_offset & application_config.zip_alignment_mask) != 0) {
+	// assemblies must be 16-byte or 4-byte aligned, or Bad Things happen
+	if (((state.data_offset & 0xf) != 0) || ((state.data_offset & 0x3) != 0)) {
 		log_fatal (LOG_ASSEMBLY, "Assembly '%s' is located at bad offset %lu within the .apk", entry_name.get (), state.data_offset);
-		log_fatal (LOG_ASSEMBLY, "You MUST run `zipalign` on %s to align it on %u bytes ", strrchr (state.file_name, '/') + 1, application_config.zip_alignment_mask + 1);
+		log_fatal (LOG_ASSEMBLY, "You MUST run `zipalign` on %s to align it on 4 or 16 bytes ", strrchr (state.file_name, '/') + 1);
 		Helpers::abort_application ();
 	}
 

--- a/src/native/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/xamarin-app-stub/application_dso_stub.cc
@@ -66,7 +66,6 @@ const ApplicationConfig application_config = {
 	.jnienv_registerjninatives_method_token = 3,
 	.jni_remapping_replacement_type_count = 2,
 	.jni_remapping_replacement_method_index_entry_count = 2,
-	.zip_alignment_mask = 3,
 	.mono_components_mask = MonoComponent::None,
 	.android_package_name = android_package_name,
 };

--- a/src/native/xamarin-app-stub/xamarin-app.hh
+++ b/src/native/xamarin-app-stub/xamarin-app.hh
@@ -253,7 +253,6 @@ struct ApplicationConfig
 	uint32_t jnienv_registerjninatives_method_token;
 	uint32_t jni_remapping_replacement_type_count;
 	uint32_t jni_remapping_replacement_method_index_entry_count;
-	uint32_t zip_alignment_mask; // 3, for 4-byte alignment (4k memory pages); 15, for 16-byte alignment (16k memory pages)
 	MonoComponent mono_components_mask;
 	const char *android_package_name;
 };


### PR DESCRIPTION
Context: ddb215b762d94801b61b72acc879b2eefe3e9e46
Context: https://github.com/google/bundletool/releases/tag/1.17.0

  * ddb215b7 added an field to the `application_config` structure which
    specified the mask required to check whether entries in the APK that
    we read at run time are properly alignment at the 4k or 16k page
    boundary.  This PR removes that code because it's possible that
    `bundletool` will change the package alignment **after** our code is
    already built.  This would cause a false negative and an abort during
    application execution.
    Instead, we simply check whether the entry is 4k **or** 16k aligned.

  * Bump `bundletool` to 1.17.0, which now defaults to producing
    16k-aligned archives.

  * Pass required alignment flags to Mono AOT compiler to produce
    properly aligned shared libraries.

  * Don't align 32-bit shared libraries to 16k, always use 4k alignment.
    This is in line with what NDK r27 does.