### PR TITLE
Missing androidx.window.[extensions|sidecar] warnings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
@@ -64,11 +64,15 @@ namespace Xamarin.Android.Tasks
 				foreach (var uses_library in app.Elements ("uses-library")) {
 					var attribute = uses_library.Attribute (androidNs + "name");
 					if (attribute != null && !string.IsNullOrEmpty (attribute.Value)) {
+						var required = uses_library.Attribute (androidNs + "required")?.Value;
 						var path = Path.Combine (AndroidSdkDirectory, "platforms", $"android-{AndroidApiLevel}", "optional", $"{attribute.Value}.jar");
 						if (File.Exists (path)) {
 							libraries.Add (new TaskItem (path));
 						} else {
-							Log.LogWarningForXmlNode ("XA4218", ManifestFile, attribute, Properties.Resources.XA4218, path);
+							if (!bool.TryParse (required, out bool isRequired))
+								isRequired = true;
+							if (isRequired)
+								Log.LogWarningForXmlNode ("XA4218", ManifestFile, attribute, Properties.Resources.XA4218, path);
 						}
 					}
 				}


### PR DESCRIPTION
Fixes #6809

We have an issues where if a library manifest contains the following element and the file dos NOT exist in `android-sdk\platforms\android-XX\optional` we get an XA4218 warning.

```xml
<uses-library
        android:name="androidx.window.sidecar"
        android:required="false" />
```

This is the warning.

```
Warning XA4218: Unable to find //manifest/application/uses-library at path: android-sdk\platforms\android-31\optional\androidx.window.sidecar.jar	obj\Release\120\android\AndroidManifest.xml
```

So the work around this issue if the `required` attribute is NOT `true` we should ignore the warning. If the library is `required` or the `required` attribute is NOT specified we should revert to to the current behavior.

This warnings can come up if people use vendor specific .aar files. The libraries they are referring too will never exist in the `sdk` `optional` folder.