### PR TITLE
[Xamarin.Android.Build.Tasks] fix NRE in XAJavaTypeScanner

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/XAJavaTypeScanner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XAJavaTypeScanner.cs
@@ -50,8 +50,10 @@ class XAJavaTypeScanner
 			}
 
 			AssemblyDefinition? asmdef = resolver.Load (asmItem.ItemSpec);
-			if (asmdef == null)
+			if (asmdef == null) {
+				log.LogDebugMessage ($"[{targetArch}] Unable to load assembly '{asmItem.ItemSpec}'");
 				continue;
+			}
 
 			foreach (ModuleDefinition md in asmdef.Modules) {
 				foreach (TypeDefinition td in md.Types) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/XAJavaTypeScanner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XAJavaTypeScanner.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -48,7 +49,9 @@ class XAJavaTypeScanner
 				throw new InvalidOperationException ($"Internal error: assembly '{asmItem.ItemSpec}' should be in the '{targetArch}' architecture, but is in '{arch}' instead.");
 			}
 
-			AssemblyDefinition asmdef = resolver.Load (asmItem.ItemSpec);
+			AssemblyDefinition? asmdef = resolver.Load (asmItem.ItemSpec);
+			if (asmdef == null)
+				continue;
 
 			foreach (ModuleDefinition md in asmdef.Modules) {
 				foreach (TypeDefinition td in md.Types) {


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9842772&view=logs&j=9a1c0345-5071-55ee-c0f3-a2911782c698&t=1e33272b-48f7-5132-3788-3179300312b4

We saw an NRE in `XAJavaTypeScanner` in the build linked above:

    Microsoft.Android.Sdk.Darwin/34.0.95/tools/Xamarin.Android.Common.targets(1536,3): error XAGJS7001: System.NullReferenceException: Object reference not set to an instance of an object.
    Microsoft.Android.Sdk.Darwin/34.0.95/tools/Xamarin.Android.Common.targets(1536,3): error XAGJS7001:    at Xamarin.Android.Tasks.XAJavaTypeScanner.GetJavaTypes(ICollection`1 inputAssemblies, XAAssemblyResolver resolver)
    Microsoft.Android.Sdk.Darwin/34.0.95/tools/Xamarin.Android.Common.targets(1536,3): error XAGJS7001:    at Xamarin.Android.Tasks.GenerateJavaStubs.Run(XAAssemblyResolver res, Boolean useMarshalMethods)
    Microsoft.Android.Sdk.Darwin/34.0.95/tools/Xamarin.Android.Common.targets(1536,3): error XAGJS7001:    at Xamarin.Android.Tasks.GenerateJavaStubs.RunTask()
    Microsoft.Android.Sdk.Darwin/34.0.95/tools/Xamarin.Android.Common.targets(1536,3): error XAGJS7001:    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 25

I set `#nullable enable` in this file, and fixed the one warning that exists.