### PR TITLE
[Xamarin.Android.Build.Tasks] default wildcard for `proguard-rules.pro`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -59,6 +59,7 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
     <AndroidJavaSource    Include="**\*.java" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <ProguardConfiguration Include="**\proguard.cfg" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <ProguardConfiguration Include="**\proguard.txt" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <ProguardConfiguration Include="**\proguard-rules.pro" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In an email thread, a customer was having trouble using a proguard rule file named `proguard-rules.pro`.

This seems to be a common name for the file, with ~96k results on GitHub:

* https://github.com/search?q=path%3A*proguard-rules.pro&type=Code