### PR TITLE
[Mono.Android] Add properties for all documented AndroidManifest.xml attributes to `[Activity]`, `[Application]`, etc.

### DIFF
--- a/build-tools/manifest-attribute-codegen/metadata.xml
+++ b/build-tools/manifest-attribute-codegen/metadata.xml
@@ -73,16 +73,13 @@
   <type name="uses-split" ignore="true" />
   <type name="uses-static-library" ignore="true" />
 
-  <!-- <activity> -->
+  <!-- <activity> - https://developer.android.com/guide/topics/manifest/activity-element -->
   <element path="activity.allowEmbedded" type="bool" />
   <element path="activity.allowTaskReparenting" type="bool" />
-  <element path="activity.allowUntrustedActivityEmbedding" visible="false" />
-  <element path="activity.alwaysFocusable" visible="false" />
   <element path="activity.alwaysRetainTaskState" type="bool" />
-  <element path="activity.attributionTags" visible="false" />
   <element path="activity.autoRemoveFromRecents" type="bool" />
   <element path="activity.banner" visible="true" />
-  <element path="activity.canDisplayOnRemoteDevices" visible="false" />
+  <element path="activity.canDisplayOnRemoteDevices" type="bool" />
   <element path="activity.clearTaskOnLaunch" type="bool" />
   <element path="activity.colorMode" visible="true" />
   <element path="activity.configChanges" name="ConfigurationChanges" type="Android.Content.PM.ConfigChanges" />
@@ -90,52 +87,42 @@
   <element path="activity.directBootAware" type="bool" />
   <element path="activity.documentLaunchMode" type="Android.Content.PM.DocumentLaunchMode" />
   <element path="activity.enabled" type="bool" />
-  <element path="activity.enableOnBackInvokedCallback" visible="false" />
+  <element path="activity.enableOnBackInvokedCallback" type="bool" />
   <element path="activity.enableVrMode" visible="true" />
   <element path="activity.excludeFromRecents" type="bool" />
   <element path="activity.exported" type="bool" />
   <element path="activity.finishOnCloseSystemDialogs" type="bool" />
   <element path="activity.finishOnTaskLaunch" type="bool" />
-  <element path="activity.forceQueryable" visible="false" />
   <element path="activity.hardwareAccelerated" type="bool" />
   <element path="activity.icon" visible="true" />
   <element path="activity.immersive" type="bool" />
-  <element path="activity.inheritShowWhenLocked" visible="false" />
-  <element path="activity.knownActivityEmbeddingCerts" visible="false" />
   <element path="activity.label" visible="true" />
   <element path="activity.launchMode" type="Android.Content.PM.LaunchMode" />
   <element path="activity.lockTaskMode" visible="true" />
   <element path="activity.logo" visible="true" />
   <element path="activity.maxAspectRatio" type="float" />
   <element path="activity.maxRecents" type="int" />
-  <element path="activity.minAspectRatio" visible="false" />
   <element path="activity.multiprocess" name="MultiProcess" type="bool" />
   <element path="activity.name" visible="true" />
   <element path="activity.noHistory" type="bool" />
   <element path="activity.parentActivityName" name="ParentActivity" type="Type?" manualMap="true" />
   <element path="activity.permission" visible="true" />
   <element path="activity.persistableMode" type="Android.Content.PM.ActivityPersistableMode" />
-  <element path="activity.playHomeTransitionSound" visible="false" />
-  <element path="activity.preferMinimalPostProcessing" visible="false" />
-  <element path="activity.primaryUserOnly" visible="false" />
   <element path="activity.process" visible="true" />
-  <element path="activity.requiredDisplayCategory" visible="false" />
   <element path="activity.recreateOnConfigChanges" type="Android.Content.PM.ConfigChanges" />
   <element path="activity.relinquishTaskIdentity" type="bool" />
-  <element path="activity.requireContentUriPermissionFromCaller" visible="false" />
+  <element path="activity.requireContentUriPermissionFromCaller" type="Android.App.RequiredContentUriPermission" />
   <element path="activity.resizeableActivity" type="bool" />
   <element path="activity.resumeWhilePausing" type="bool" />
   <element path="activity.rotationAnimation" type="Android.Views.WindowRotationAnimation" />
   <element path="activity.roundIcon" visible="true" />
   <element path="activity.showForAllUsers" type="bool" />
   <element path="activity.showOnLockScreen" type="bool" obsolete="Please use ShowForAllUsers instead." />
-  <element path="activity.splitName" visible="false" />
   <element path="activity.supportsPictureInPicture" type="bool" />
   <element path="activity.screenOrientation" type="Android.Content.PM.ScreenOrientation" />
   <element path="activity.showWhenLocked" type="bool" />
   <element path="activity.singleUser" type="bool" />
   <element path="activity.stateNotNeeded" type="bool" />
-  <element path="activity.systemUserOnly" visible="false" />
   <element path="activity.taskAffinity" visible="true" />
   <element path="activity.theme" visible="true" />
   <element path="activity.turnScreenOn" type="bool" />
@@ -143,235 +130,274 @@
   <element path="activity.visibleToInstantApps" type="bool" />
   <element path="activity.windowSoftInputMode" type="Android.Views.SoftInput" />
 
-  <!-- <application> -->
-  <element path="application.allowAudioPlaybackCapture" visible="false" />
-  <element path="application.allowAutoRevokePermissionsExemption" visible="false" />
+  <!-- Undocumented attributes -->
+  <element path="activity.allowUntrustedActivityEmbedding" visible="false" />
+  <element path="activity.alwaysFocusable" visible="false" />
+  <element path="activity.attributionTags" visible="false" />
+  <element path="activity.forceQueryable" visible="false" />
+  <element path="activity.inheritShowWhenLocked" visible="false" />
+  <element path="activity.knownActivityEmbeddingCerts" visible="false" />
+  <element path="activity.minAspectRatio" visible="false" />
+  <element path="activity.playHomeTransitionSound" visible="false" />
+  <element path="activity.preferMinimalPostProcessing" visible="false" />
+  <element path="activity.primaryUserOnly" visible="false" />
+  <element path="activity.requiredDisplayCategory" visible="false" />
+  <element path="activity.splitName" visible="false" />
+  <element path="activity.systemUserOnly" visible="false" />
+
+  <!-- <application> - https://developer.android.com/guide/topics/manifest/application-element -->
   <element path="application.allowBackup" type="bool" />
   <element path="application.allowClearUserData" type="bool" />
-  <element path="application.allowClearUserDataOnFailedRestore" visible="false" />
-  <element path="application.allowCrossUidActivitySwitchFromBelow" visible="false" />
-  <element path="application.allowNativeHeapPointerTagging" visible="false" />
+  <element path="application.allowCrossUidActivitySwitchFromBelow" type="bool" />
+  <element path="application.allowNativeHeapPointerTagging" type="bool" />
   <element path="application.allowTaskReparenting" type="bool" />
-  <element path="application.appCategory" visible="false" />
-  <element path="application.appComponentFactory" visible="false" />
-  <element path="application.attributionsAreUserVisible" visible="false" />
-  <element path="application.autoRevokePermissions" visible="false" />
   <element path="application.banner" visible="true" />
-  <element path="application.cantSaveState" visible="false" />
   <element path="application.backupAgent" type="Type?" manualMap="true" />
   <element path="application.backupInForeground" type="bool" />
-  <element path="application.classLoader" visible="false" />
-  <element path="application.crossProfile" visible="false" />
-  <element path="application.dataExtractionRules" visible="false" />
+  <element path="application.dataExtractionRules" visible="true" />
   <element path="application.debuggable" type="bool" />
-  <element path="application.defaultToDeviceProtectedStorage" visible="false" />
   <element path="application.description" visible="true" />
   <element path="application.directBootAware" type="bool" />
   <element path="application.enabled" type="bool" />
-  <element path="application.enableOnBackInvokedCallback" visible="false" />
   <element path="application.extractNativeLibs" type="bool" />
-  <element path="application.forceQueryable" visible="false" />
   <element path="application.fullBackupContent" type="bool" />
   <element path="application.fullBackupOnly" type="bool" />
-  <element path="application.gwpAsanMode" visible="false" />
+  <element path="application.gwpAsanMode" type="Android.Content.PM.GwpAsan" />
   <element path="application.hardwareAccelerated" type="bool" />
   <element path="application.hasCode" visible="true" />
-  <element path="application.hasFragileUserData" visible="false" />
+  <element path="application.hasFragileUserData" type="bool" />
   <element path="application.icon" visible="true" />
-  <element path="application.isGame" visible="false" />
   <element path="application.killAfterRestore" type="bool" />
-  <element path="application.knownActivityEmbeddingCerts" visible="false" />
   <element path="application.label" visible="true" />
   <element path="application.largeHeap" visible="true" />
-  <element path="application.localeConfig" visible="false" />
   <element path="application.logo" visible="true" />
   <element path="application.manageSpaceActivity" type="Type?" manualMap="true" />
+  <element path="application.name" manualMap="true" />
+  <element path="application.networkSecurityConfig" visible="true" />
+  <element path="application.permission" visible="true" />
+  <element path="application.persistent" type="bool" />
+  <element path="application.process" visible="true" />
+  <element path="application.requestLegacyExternalStorage" type="bool" />
+  <element path="application.requiredAccountType" visible="true" />
+  <element path="application.resizeableActivity" type="bool" />
+  <element path="application.restoreAnyVersion" type="bool" />
+  <element path="application.restrictedAccountType" visible="true" />
+  <element path="application.roundIcon" visible="true" />
+  <element path="application.supportsRtl" visible="true" />
+  <element path="application.taskAffinity" visible="true" />
+  <element path="application.testOnly" type="bool" />
+  <element path="application.theme" visible="true" />
+  <element path="application.uiOptions" type="Android.Content.PM.UiOptions" />
+  <element path="application.usesCleartextTraffic" type="bool" />
+  <element path="application.vmSafeMode" name="VMSafeMode" type="bool" />
+
+  <!-- Undocumented attributes -->
+  <element path="application.allowAudioPlaybackCapture" visible="false" />
+  <element path="application.allowAutoRevokePermissionsExemption" visible="false" />
+  <element path="application.allowClearUserDataOnFailedRestore" visible="false" />
+  <element path="application.appCategory" type="Android.Content.PM.ApplicationCategories" />
+  <element path="application.appComponentFactory" visible="false" />
+  <element path="application.attributionsAreUserVisible" visible="false" />
+  <element path="application.autoRevokePermissions" visible="false" />
+  <element path="application.cantSaveState" visible="false" />
+  <element path="application.classLoader" visible="false" />
+  <element path="application.crossProfile" visible="false" />
+  <element path="application.defaultToDeviceProtectedStorage" visible="false" />
+  <element path="application.enableOnBackInvokedCallback" visible="false" />
+  <element path="application.forceQueryable" visible="false" />
+  <element path="application.knownActivityEmbeddingCerts" visible="false" />
+  <element path="application.localeConfig" visible="false" />
   <element path="application.maxAspectRatio" visible="false" />
   <element path="application.memtagMode" visible="false" />
   <element path="application.minAspectRatio" visible="false" />
   <element path="application.multiArch" visible="false" />
-  <element path="application.name" manualMap="true" />
   <element path="application.nativeHeapZeroInitialized" visible="false" />
-  <element path="application.networkSecurityConfig" visible="true" />
   <element path="application.neverEncrypt" visible="false" />
-  <element path="application.permission" visible="true" />
-  <element path="application.persistent" type="bool" />
   <element path="application.persistentWhenFeatureAvailable" visible="false" />
   <element path="application.preserveLegacyExternalStorage" visible="false" />
-  <element path="application.process" visible="true" />
-  <element path="application.restoreAnyVersion" type="bool" />
   <element path="application.requestForegroundServiceExemption" visible="false" />
-  <element path="application.requestLegacyExternalStorage" visible="false" />
   <element path="application.requestRawExternalStorageAccess" visible="false" />
-  <element path="application.requiredAccountType" visible="true" />
   <element path="application.requiredForAllUsers" visible="false" />
   <element path="application.resetEnabledSettingsOnAppDataCleared" visible="false" />
-  <element path="application.resizeableActivity" type="bool" />
   <element path="application.restoreNeedsApplication" visible="false" />
-  <element path="application.restrictedAccountType" visible="true" />
   <element path="application.rollbackDataPolicy" visible="false" />
-  <element path="application.roundIcon" visible="true" />
-  <element path="application.supportsRtl" visible="true" />
-  <element path="application.taskAffinity" visible="true" />
-  <element path="application.testOnly" visible="false" />
-  <element path="application.theme" visible="true" />
-  <element path="application.uiOptions" type="Android.Content.PM.UiOptions" />
   <element path="application.useEmbeddedDex" visible="false" />
-  <element path="application.usesCleartextTraffic" type="bool" />
   <element path="application.usesNonSdkApi" visible="false" />
-  <element path="application.vmSafeMode" name="VMSafeMode" type="bool" />
   <element path="application.zygotePreloadName" visible="false" />
+  
+  <!-- Documented as deprecated -->
+  <element path="application.isGame" visible="false" />
 
-  <!-- <grant-uri-permission> -->
+  <!-- <grant-uri-permission> - https://developer.android.com/guide/topics/manifest/grant-uri-permission-element -->
   <element path="grant-uri-permission.path" visible="true" />
-  <element path="grant-uri-permission.pathAdvancedPattern" visible="false" />
   <element path="grant-uri-permission.pathPattern" visible="true" />
   <element path="grant-uri-permission.pathPrefix" visible="true" />
+
+  <!-- Undocumented attributes -->
+  <element path="grant-uri-permission.pathAdvancedPattern" visible="false" />
   <element path="grant-uri-permission.pathSuffix" visible="false" />
 
-  <!-- <instrumentation> -->
-  <element path="instrumentation.banner" visible="false" />
+  <!-- <instrumentation> - https://developer.android.com/guide/topics/manifest/instrumentation-element -->
   <element path="instrumentation.functionalTest" type="bool" />
   <element path="instrumentation.handleProfiling" type="bool" />
   <element path="instrumentation.icon" visible="true" />
   <element path="instrumentation.label" visible="true" />
-  <element path="instrumentation.logo" visible="false" />
   <element path="instrumentation.name" visible="true" />
   <element path="instrumentation.roundIcon" visible="true" />
   <element path="instrumentation.targetPackage" visible="true" />
   <element path="instrumentation.targetProcesses" visible="true" />
 
-  <!-- <intent-filter> -->
+  <!-- Undocumented attributes -->
+  <element path="instrumentation.banner" visible="false" />
+  <element path="instrumentation.logo" visible="false" />
+
+  <!-- <intent-filter> - https://developer.android.com/guide/topics/manifest/intent-filter-element -->
   <!-- XABT uses a fully custom map for IntentFilterAttribute, you will need to add any new visible fields there yourself -->
-  <element path="intent-filter.banner" visible="false" />
   <element path="intent-filter.icon" visible="true" />
   <element path="intent-filter.label" visible="true" />
-  <element path="intent-filter.logo" visible="false" />
-  <element path="intent-filter.order" visible="false" />
   <element path="intent-filter.autoVerify" type="bool" />
   <element path="intent-filter.priority" type="int" />
   <element path="intent-filter.roundIcon" visible="true" />
 
-  <!-- <layout> -->
+  <!-- Undocumented attributes -->
+  <element path="intent-filter.banner" visible="false" />
+  <element path="intent-filter.logo" visible="false" />
+  <element path="intent-filter.order" visible="false" />
+
+  <!-- <layout> - https://developer.android.com/guide/topics/manifest/layout-element -->
   <element path="layout.defaultHeight" visible="true" />
   <element path="layout.defaultWidth" visible="true" />
   <element path="layout.gravity" visible="true" />
   <element path="layout.minHeight" visible="true" />
+  <element path="layout.minWidth" visible="true" />
+
+  <!-- Undocumented attributes -->
   <element path="layout.minimalHeight" visible="false" />
   <element path="layout.minimalWidth" visible="false" />
-  <element path="layout.minWidth" visible="true" />
   <element path="layout.windowLayoutAffinity" visible="false" />
 
-  <!-- <meta-data> -->
+  <!-- <meta-data> - https://developer.android.com/guide/topics/manifest/meta-data-element -->
   <element path="meta-data.name" type="string" readonly="true" />
   <element path="meta-data.resource" visible="true" />
   <element path="meta-data.value" visible="true" />
 
-  <!-- <permission> -->
-  <element path="permission.backgroundPermission" visible="false" />
-  <element path="permission.banner" visible="false" />
+  <!-- <permission> - https://developer.android.com/guide/topics/manifest/permission-element -->
   <element path="permission.description" visible="true" />
   <element path="permission.icon" visible="true" />
-  <element path="permission.knownCerts" visible="false" />
   <element path="permission.label" visible="true" />
-  <element path="permission.logo" visible="false" />
-  <element path="permission.maxSdkVersion" visible="false" />
   <element path="permission.name" visible="true" />
-  <element path="permission.permissionFlags" visible="false" />
   <element path="permission.permissionGroup" visible="true" />
   <element path="permission.protectionLevel" type="Android.Content.PM.Protection" />
   <element path="permission.roundIcon" visible="true" />
+
+  <!-- Undocumented attributes -->
+  <element path="permission.backgroundPermission" visible="false" />
+  <element path="permission.banner" visible="false" />
+  <element path="permission.knownCerts" visible="false" />
+  <element path="permission.logo" visible="false" />
+  <element path="permission.maxSdkVersion" visible="false" />
+  <element path="permission.permissionFlags" visible="false" />
   <element path="permission.request" visible="false" />
 
-  <!-- <permission-group> -->
-  <element path="permission-group.backgroundRequest" visible="false" />
-  <element path="permission-group.backgroundRequestDetail" visible="false" />
-  <element path="permission-group.banner" visible="false" />
+  <!-- <permission-group> - https://developer.android.com/guide/topics/manifest/permission-group-element -->
   <element path="permission-group.description" visible="true" />
   <element path="permission-group.icon" visible="true" />
   <element path="permission-group.label" visible="true" />
-  <element path="permission-group.logo" visible="false" />
   <element path="permission-group.name" visible="true" />
+  <element path="permission-group.roundIcon" visible="true" />
+
+  <!-- Undocumented attributes -->
+  <element path="permission-group.backgroundRequest" visible="false" />
+  <element path="permission-group.backgroundRequestDetail" visible="false" />
+  <element path="permission-group.banner" visible="false" />
+  <element path="permission-group.logo" visible="false" />
   <element path="permission-group.permissionGroupFlags" visible="false" />
   <element path="permission-group.priority" visible="false" />
   <element path="permission-group.request" visible="false" />
   <element path="permission-group.requestDetail" visible="false" />
-  <element path="permission-group.roundIcon" visible="true" />
 
-  <!-- <permission-tree> -->
-  <element path="permission-tree.banner" visible="false" />
+  <!-- <permission-tree> - https://developer.android.com/guide/topics/manifest/permission-tree-element -->
   <element path="permission-tree.icon" visible="true" />
   <element path="permission-tree.label" visible="true" />
-  <element path="permission-tree.logo" visible="false" />
   <element path="permission-tree.name" visible="true" />
   <element path="permission-tree.roundIcon" visible="true" />
 
-  <!-- <property> -->
+  <!-- Undocumented attributes -->
+  <element path="permission-tree.banner" visible="false" />
+  <element path="permission-tree.logo" visible="false" />
+
+  <!-- <property> - https://developer.android.com/guide/topics/manifest/property-element -->
   <element path="property.name" type="string" readonly="true" />
   <element path="property.resource" visible="true" />
   <element path="property.value" visible="true" />
 
-  <!-- <provider> -->
-  <element path="provider.attributionTags" visible="false" />
+  <!-- <provider> - https://developer.android.com/guide/topics/manifest/provider-element -->
   <element path="provider.authorities" type="string[]" readonly="true" manualMap="true" />
-  <element path="provider.banner" visible="false" />
-  <element path="provider.description" visible="false" />
   <element path="provider.directBootAware" type="bool" />
   <element path="provider.enabled" type="bool" />
   <element path="provider.exported" type="bool" />
-  <element path="provider.forceUriPermissions" visible="false" />
   <element path="provider.grantUriPermissions" type="bool" />
   <element path="provider.icon" visible="true" />
   <element path="provider.initOrder" type="int" />
   <element path="provider.label" visible="true" />
-  <element path="provider.logo" visible="false" />
   <element path="provider.multiprocess" name="MultiProcess" type="bool" />
   <element path="provider.name" visible="true" />
   <element path="provider.permission" visible="true" />
   <element path="provider.process" visible="true" />
   <element path="provider.readPermission" visible="true" />
   <element path="provider.roundIcon" visible="true" />
-  <element path="provider.singleUser" visible="false" />
-  <element path="provider.splitName" visible="false" />
   <element path="provider.syncable" type="bool" />
-  <element path="provider.systemUserOnly" visible="false" />
-  <element path="provider.visibleToInstantApps" visible="false" />
   <element path="provider.writePermission" visible="true" />
 
-  <!-- <receiver> -->
-  <element path="receiver.attributionTags" visible="false" />
-  <element path="receiver.banner" visible="false" />
+  <!-- Undocumented attributes -->
+  <element path="provider.attributionTags" visible="false" />
+  <element path="provider.banner" visible="false" />
+  <element path="provider.description" visible="false" />
+  <element path="provider.forceUriPermissions" visible="false" />
+  <element path="provider.logo" visible="false" />
+  <element path="provider.singleUser" visible="false" />
+  <element path="provider.splitName" visible="false" />
+  <element path="provider.systemUserOnly" visible="false" />
+  <element path="provider.visibleToInstantApps" visible="false" />
+
+  <!-- <receiver> - https://developer.android.com/guide/topics/manifest/receiver-element -->
   <element path="receiver.description" visible="true" />
   <element path="receiver.directBootAware" type="bool" />
   <element path="receiver.enabled" type="bool" />
   <element path="receiver.exported" type="bool" />
   <element path="receiver.icon" visible="true" />
   <element path="receiver.label" visible="true" />
-  <element path="receiver.logo" visible="false" />
   <element path="receiver.name" visible="true" />
   <element path="receiver.permission" visible="true" />
   <element path="receiver.process" visible="true" />
   <element path="receiver.roundIcon" visible="true" />
+
+  <!-- Undocumented attributes -->
+  <element path="receiver.attributionTags" visible="false" />
+  <element path="receiver.banner" visible="false" />
+  <element path="receiver.logo" visible="false" />
   <element path="receiver.singleUser" visible="false" />
 
-  <!-- <service> -->
-  <element path="service.allowSharedIsolatedProcess" visible="false" />
-  <element path="service.attributionTags" visible="false" />
-  <element path="service.banner" visible="false" />
-  <element path="service.description" visible="false" />
+  <!-- <service> - https://developer.android.com/guide/topics/manifest/service-element -->
   <element path="service.directBootAware" type="bool" />
   <element path="service.enabled" type="bool" />
   <element path="service.exported" type="bool" />
-  <element path="service.externalService" visible="false" />
   <element path="service.foregroundServiceType" type="Android.Content.PM.ForegroundService" />
   <element path="service.icon" visible="true" />
   <element path="service.isolatedProcess" visible="true" />
   <element path="service.label" visible="true" />
-  <element path="service.logo" visible="false" />
   <element path="service.name" visible="true" />
   <element path="service.permission" visible="true" />
   <element path="service.process" visible="true" />
   <element path="service.roundIcon" visible="true" />
+
+  <!-- Undocumented attributes -->
+  <element path="service.allowSharedIsolatedProcess" visible="false" />
+  <element path="service.attributionTags" visible="false" />
+  <element path="service.banner" visible="false" />
+  <element path="service.description" visible="true" />
+  <element path="service.externalService" visible="false" />
+  <element path="service.logo" visible="false" />
   <element path="service.singleUser" visible="false" />
   <element path="service.splitName" visible="false" />
   <element path="service.stopWithTask" visible="false" />
@@ -379,28 +405,31 @@
   <element path="service.useAppZygote" visible="false" />
   <element path="service.visibleToInstantApps" visible="false" />
 
-  <!-- <uses-configuration> -->
+  <!-- <uses-configuration> - https://developer.android.com/guide/topics/manifest/uses-configuration-element -->
   <element path="uses-configuration.reqFiveWayNav" type="bool" />
   <element path="uses-configuration.reqHardKeyboard" type="bool" />
   <element path="uses-configuration.reqKeyboardType" visible="true" />
   <element path="uses-configuration.reqNavigation" visible="true" />
   <element path="uses-configuration.reqTouchScreen" visible="true" />
 
-  <!-- <uses-feature> -->
+  <!-- <uses-feature> https://developer.android.com/guide/topics/manifest/uses-feature-element -->
   <element path="uses-feature.glEsVersion" name="GLESVersion" manualMap="true" />
   <element path="uses-feature.name" readonly="true" />
   <element path="uses-feature.required" visible="true" />
   <element path="uses-feature.version" readonly="true" />
 
-  <!-- <uses-library> -->
+  <!-- <uses-library> - https://developer.android.com/guide/topics/manifest/uses-library-element -->
   <element path="uses-library.name" visible="true" />
   <element path="uses-library.required" type="bool" />
 
-  <!-- <uses-permission> -->
+  <!-- <uses-permission> - https://developer.android.com/guide/topics/manifest/uses-permission-element -->
   <element path="uses-permission.maxSdkVersion" visible="true" />
-  <element path="uses-permission.minSdkVersion" visible="false" />
   <element path="uses-permission.name" visible="true" />
+
+  <!-- Undocumented attributes -->
+  <element path="uses-permission.minSdkVersion" visible="false" />
   <element path="uses-permission.requiredFeature" visible="false" />
   <element path="uses-permission.requiredNotFeature" visible="false" />
   <element path="uses-permission.usesPermissionFlags" visible="false" />
+
 </metadata>

--- a/src/Mono.Android/Android.App/RequiredContentUriPermission.cs
+++ b/src/Mono.Android/Android.App/RequiredContentUriPermission.cs
@@ -1,0 +1,30 @@
+namespace Android.App;
+
+// Used by AndroidManifest.xml for the attribute 'activity.requireContentUriPermissionFromCaller'.
+public enum RequiredContentUriPermission
+{
+	/// <summary>
+	/// Default, no specific permissions are required.
+	/// </summary>
+	None = 0,
+
+	/// <summary>
+	/// Enforces the invoker to have read access to the passed content URIs.
+	/// </summary>
+	Read = 1,
+
+	/// <summary>
+	/// Enforces the invoker to have write access to the passed content URIs.
+	/// </summary>
+	Write = 2,
+
+	/// <summary>
+	/// Enforces the invoker to have either read or write access to the passed content URIs.
+	/// </summary>
+	ReadOrWrite = 3,
+
+	/// <summary>
+	/// Enforces the invoker to have write access to the passed content URIs.
+	/// </summary>
+	ReadAndWrite = 4,
+}

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Android.App\IntentFilterAttribute.Partial.cs" />
     <Compile Include="Android.App\MetaDataAttribute.Partial.cs" />
     <Compile Include="Android.App\PropertyAttribute.Partial.cs" />
+    <Compile Include="Android.App\RequiredContentUriPermission.cs" />
     <Compile Include="Android.App\UsesFeatureAttribute.Partial.cs" />
     <Compile Include="Android.App\UsesLibraryAttribute.Partial.cs" />
     <Compile Include="Android.App\UsesPermissionAttribute.Partial.cs" />

--- a/src/Mono.Android/PublicAPI/API-35/PublicAPI.Unshipped.txt
+++ b/src/Mono.Android/PublicAPI/API-35/PublicAPI.Unshipped.txt
@@ -502,12 +502,34 @@ Android.AdServices.Topics.EncryptedTopic.KeyIdentifier.get -> string!
 Android.AdServices.Topics.GetTopicsResponse.Builder.Builder(System.Collections.Generic.IList<Android.AdServices.Topics.Topic!>! topics, System.Collections.Generic.IList<Android.AdServices.Topics.EncryptedTopic!>! encryptedTopics) -> void
 Android.AdServices.Topics.GetTopicsResponse.EncryptedTopics.get -> System.Collections.Generic.IList<Android.AdServices.Topics.EncryptedTopic!>!
 Android.App.Activity.RequestPermissions(string![]! permissions, int requestCode, int deviceId) -> void
+Android.App.ActivityAttribute.CanDisplayOnRemoteDevices.get -> bool
+Android.App.ActivityAttribute.CanDisplayOnRemoteDevices.set -> void
+Android.App.ActivityAttribute.EnableOnBackInvokedCallback.get -> bool
+Android.App.ActivityAttribute.EnableOnBackInvokedCallback.set -> void
+Android.App.ActivityAttribute.RequireContentUriPermissionFromCaller.get -> Android.App.RequiredContentUriPermission
+Android.App.ActivityAttribute.RequireContentUriPermissionFromCaller.set -> void
 Android.App.Admin.ContentProtectionPolicy
 Android.App.Admin.ContentProtectionPolicy.Disabled = 1 -> Android.App.Admin.ContentProtectionPolicy
 Android.App.Admin.ContentProtectionPolicy.Enabled = 2 -> Android.App.Admin.ContentProtectionPolicy
 Android.App.Admin.ContentProtectionPolicy.NotControlledByPolicy = 0 -> Android.App.Admin.ContentProtectionPolicy
 Android.App.Admin.HeadlessDeviceOwnerMode.SingleUser = 2 -> Android.App.Admin.HeadlessDeviceOwnerMode
 Android.App.Admin.SecurityLogTags.BackupServiceToggled = 210044 -> Android.App.Admin.SecurityLogTags
+Android.App.ApplicationAttribute.AllowCrossUidActivitySwitchFromBelow.get -> bool
+Android.App.ApplicationAttribute.AllowCrossUidActivitySwitchFromBelow.set -> void
+Android.App.ApplicationAttribute.AllowNativeHeapPointerTagging.get -> bool
+Android.App.ApplicationAttribute.AllowNativeHeapPointerTagging.set -> void
+Android.App.ApplicationAttribute.AppCategory.get -> Android.Content.PM.ApplicationCategories
+Android.App.ApplicationAttribute.AppCategory.set -> void
+Android.App.ApplicationAttribute.DataExtractionRules.get -> string?
+Android.App.ApplicationAttribute.DataExtractionRules.set -> void
+Android.App.ApplicationAttribute.GwpAsanMode.get -> Android.Content.PM.GwpAsan
+Android.App.ApplicationAttribute.GwpAsanMode.set -> void
+Android.App.ApplicationAttribute.HasFragileUserData.get -> bool
+Android.App.ApplicationAttribute.HasFragileUserData.set -> void
+Android.App.ApplicationAttribute.RequestLegacyExternalStorage.get -> bool
+Android.App.ApplicationAttribute.RequestLegacyExternalStorage.set -> void
+Android.App.ApplicationAttribute.TestOnly.get -> bool
+Android.App.ApplicationAttribute.TestOnly.set -> void
 Android.App.ApplicationStartInfo
 Android.App.ApplicationStartInfo.DefiningUid.get -> int
 Android.App.ApplicationStartInfo.DescribeContents() -> int
@@ -735,6 +757,12 @@ Android.App.PropertyAttribute.Resource.get -> string?
 Android.App.PropertyAttribute.Resource.set -> void
 Android.App.PropertyAttribute.Value.get -> string?
 Android.App.PropertyAttribute.Value.set -> void
+Android.App.RequiredContentUriPermission
+Android.App.RequiredContentUriPermission.None = 0 -> Android.App.RequiredContentUriPermission
+Android.App.RequiredContentUriPermission.Read = 1 -> Android.App.RequiredContentUriPermission
+Android.App.RequiredContentUriPermission.ReadAndWrite = 4 -> Android.App.RequiredContentUriPermission
+Android.App.RequiredContentUriPermission.ReadOrWrite = 3 -> Android.App.RequiredContentUriPermission
+Android.App.RequiredContentUriPermission.Write = 2 -> Android.App.RequiredContentUriPermission
 Android.App.SdkSandbox.AppOwnedSdkSandboxInterface
 Android.App.SdkSandbox.AppOwnedSdkSandboxInterface.AppOwnedSdkSandboxInterface(string! name, long version, Android.OS.IBinder! binder) -> void
 Android.App.SdkSandbox.AppOwnedSdkSandboxInterface.DescribeContents() -> int
@@ -746,6 +774,8 @@ Android.App.SdkSandbox.AppOwnedSdkSandboxInterface.WriteToParcel(Android.OS.Parc
 Android.App.SdkSandbox.SdkSandboxManager.AppOwnedSdkSandboxInterfaces.get -> System.Collections.Generic.IList<Android.App.SdkSandbox.AppOwnedSdkSandboxInterface!>!
 Android.App.SdkSandbox.SdkSandboxManager.RegisterAppOwnedSdkSandboxInterface(Android.App.SdkSandbox.AppOwnedSdkSandboxInterface! appOwnedSdkSandboxInterface) -> void
 Android.App.SdkSandbox.SdkSandboxManager.UnregisterAppOwnedSdkSandboxInterface(string! name) -> void
+Android.App.ServiceAttribute.Description.get -> string?
+Android.App.ServiceAttribute.Description.set -> void
 Android.App.Usage.StorageStats.GetAppBytesByDataType(Android.App.Usage.StorageStatsAppDataType dataType) -> long
 Android.App.Usage.StorageStatsAppDataType
 Android.App.Usage.StorageStatsAppDataType.FileTypeApk = 3 -> Android.App.Usage.StorageStatsAppDataType

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -184,11 +184,14 @@ namespace Xamarin.Android.Manifest {
 			{ typeof (float),               (value, p, r, v, c) => value.ToString () },
 			{ typeof (string),              (value, p, r, v, c) => value.ToString () },
 			{ typeof (ActivityPersistableMode),     (value, p, r, v, c) => ToString ((ActivityPersistableMode) value) },
+			{ typeof (ApplicationCategories),     (value, p, r, v, c) => ToString ((ApplicationCategories) value) },
 			{ typeof (ConfigChanges),       (value, p, r, v, c) => ToString ((ConfigChanges) value) },
 			{ typeof (DocumentLaunchMode),  (value, p, r, v, c) => ToString ((DocumentLaunchMode) value) },
 			{ typeof (ForegroundService),   (value, p, r, v, c) => ToString ((ForegroundService) value) },
+			{ typeof (GwpAsan),   (value, p, r, v, c) => ToString ((GwpAsan) value) },
 			{ typeof (LaunchMode),          (value, p, r, v, c) => ToString ((LaunchMode) value) },
 			{ typeof (Protection),          (value, p, r, v, c) => ToString ((Protection) value) },
+			{ typeof (RequiredContentUriPermission),        (value, p, r, v, c) => ToString ((RequiredContentUriPermission) value) },
 			{ typeof (ScreenOrientation),   (value, p, r, v, c) => ToString ((ScreenOrientation) value, v) },
 			{ typeof (SoftInput),           (value, p, r, v, c) => ToString ((SoftInput) value) },
 			{ typeof (UiOptions),           (value, p, r, v, c) => ToString ((UiOptions) value) },
@@ -406,6 +409,44 @@ namespace Xamarin.Android.Manifest {
 			//	values.Add ("newValue");
 
 			return string.Join ("|", values.ToArray ());
+		}
+
+		static string ToString (ApplicationCategories value)
+		{
+			return value switch {
+				ApplicationCategories.Accessibility => "accessibility",
+				ApplicationCategories.Audio => "audio",
+				ApplicationCategories.Game => "game",
+				ApplicationCategories.Image => "image",
+				ApplicationCategories.Maps => "maps",
+				ApplicationCategories.News => "news",
+				ApplicationCategories.Productivity => "productivity",
+				ApplicationCategories.Social => "social",
+				ApplicationCategories.Video => "video",
+				_ => throw new ArgumentException ($"Unsupported ApplicationCategories value '{value}'."),
+			};
+		}
+
+		static string ToString (RequiredContentUriPermission value)
+		{
+			return value switch {
+				RequiredContentUriPermission.None => "none",
+				RequiredContentUriPermission.Read => "read",
+				RequiredContentUriPermission.Write => "write",
+				RequiredContentUriPermission.ReadOrWrite => "readOrWrite",
+				RequiredContentUriPermission.ReadAndWrite => "readAndWrite",
+				_ => throw new ArgumentException ($"Unsupported RequiredContentUriPermission value '{value}'."),
+			};
+		}
+
+		static string ToString (GwpAsan value)
+		{
+			return value switch {
+				GwpAsan.Always => "always",
+				GwpAsan.Default => "never",
+				GwpAsan.Never => "never",
+				_ => throw new ArgumentException ($"Unsupported GwpAsan value '{value}'."),
+			};
 		}
 
 		IEnumerator<string> IEnumerable<string>.GetEnumerator ()

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -161,6 +161,8 @@
     <Compile Include="..\..\build-tools\xa-prep-tasks\Xamarin.Android.BuildTools.PrepTasks\Sleep.cs">
       <Link>Xamarin.Android.BuildTools.PrepTasks\Sleep.cs</Link>
     </Compile>
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ApplicationCategories.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.GwpAsan.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.LaunchMode.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ScreenOrientation.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ConfigChanges.cs" />
@@ -172,6 +174,7 @@
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ActivityPersistableMode.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.DocumentLaunchMode.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.WindowRotationAnimation.cs" />
+    <_MonoAndroidEnum Include="..\Mono.Android\Android.App\RequiredContentUriPermission.cs" />
     <Compile Include="@(_MonoAndroidEnum)">
       <Link>Mono.Android\%(Filename)%(Extension)</Link>
     </Compile>

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -30,6 +30,8 @@ public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniName
 
 	public string? Banner { get; set; }
 
+	public bool CanDisplayOnRemoteDevices { get; set; }
+
 	public bool ClearTaskOnLaunch { get; set; }
 
 	public string? ColorMode { get; set; }
@@ -43,6 +45,8 @@ public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniName
 	public Android.Content.PM.DocumentLaunchMode DocumentLaunchMode { get; set; }
 
 	public bool Enabled { get; set; }
+
+	public bool EnableOnBackInvokedCallback { get; set; }
 
 	public string? EnableVrMode { get; set; }
 
@@ -89,6 +93,8 @@ public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniName
 	public Android.Content.PM.ConfigChanges RecreateOnConfigChanges { get; set; }
 
 	public bool RelinquishTaskIdentity { get; set; }
+
+	public Android.App.RequiredContentUriPermission RequireContentUriPermissionFromCaller { get; set; }
 
 	public bool ResizeableActivity { get; set; }
 
@@ -161,6 +167,12 @@ public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniName
 			setter: (self, value) => self.Banner = (string?) value
 		);
 		mapping.Add (
+			member: "CanDisplayOnRemoteDevices",
+			attributeName: "canDisplayOnRemoteDevices",
+			getter: self => self.CanDisplayOnRemoteDevices,
+			setter: (self, value) => self.CanDisplayOnRemoteDevices = (bool) value
+		);
+		mapping.Add (
 			member: "ClearTaskOnLaunch",
 			attributeName: "clearTaskOnLaunch",
 			getter: self => self.ClearTaskOnLaunch,
@@ -201,6 +213,12 @@ public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniName
 			attributeName: "enabled",
 			getter: self => self.Enabled,
 			setter: (self, value) => self.Enabled = (bool) value
+		);
+		mapping.Add (
+			member: "EnableOnBackInvokedCallback",
+			attributeName: "enableOnBackInvokedCallback",
+			getter: self => self.EnableOnBackInvokedCallback,
+			setter: (self, value) => self.EnableOnBackInvokedCallback = (bool) value
 		);
 		mapping.Add (
 			member: "EnableVrMode",
@@ -333,6 +351,12 @@ public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniName
 			attributeName: "relinquishTaskIdentity",
 			getter: self => self.RelinquishTaskIdentity,
 			setter: (self, value) => self.RelinquishTaskIdentity = (bool) value
+		);
+		mapping.Add (
+			member: "RequireContentUriPermissionFromCaller",
+			attributeName: "requireContentUriPermissionFromCaller",
+			getter: self => self.RequireContentUriPermissionFromCaller,
+			setter: (self, value) => self.RequireContentUriPermissionFromCaller = (Android.App.RequiredContentUriPermission) value
 		);
 		mapping.Add (
 			member: "ResizeableActivity",

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
@@ -24,13 +24,21 @@ public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniN
 
 	public bool AllowClearUserData { get; set; }
 
+	public bool AllowCrossUidActivitySwitchFromBelow { get; set; }
+
+	public bool AllowNativeHeapPointerTagging { get; set; }
+
 	public bool AllowTaskReparenting { get; set; }
+
+	public Android.Content.PM.ApplicationCategories AppCategory { get; set; }
 
 	public Type? BackupAgent { get; set; }
 
 	public bool BackupInForeground { get; set; }
 
 	public string? Banner { get; set; }
+
+	public string? DataExtractionRules { get; set; }
 
 	public bool Debuggable { get; set; }
 
@@ -46,9 +54,13 @@ public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniN
 
 	public bool FullBackupOnly { get; set; }
 
+	public Android.Content.PM.GwpAsan GwpAsanMode { get; set; }
+
 	public bool HardwareAccelerated { get; set; }
 
 	public bool HasCode { get; set; }
+
+	public bool HasFragileUserData { get; set; }
 
 	public string? Icon { get; set; }
 
@@ -72,6 +84,8 @@ public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniN
 
 	public string? Process { get; set; }
 
+	public bool RequestLegacyExternalStorage { get; set; }
+
 	public string? RequiredAccountType { get; set; }
 
 	public bool ResizeableActivity { get; set; }
@@ -85,6 +99,8 @@ public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniN
 	public bool SupportsRtl { get; set; }
 
 	public string? TaskAffinity { get; set; }
+
+	public bool TestOnly { get; set; }
 
 	public string? Theme { get; set; }
 
@@ -112,10 +128,28 @@ public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniN
 			setter: (self, value) => self.AllowClearUserData = (bool) value
 		);
 		mapping.Add (
+			member: "AllowCrossUidActivitySwitchFromBelow",
+			attributeName: "allowCrossUidActivitySwitchFromBelow",
+			getter: self => self.AllowCrossUidActivitySwitchFromBelow,
+			setter: (self, value) => self.AllowCrossUidActivitySwitchFromBelow = (bool) value
+		);
+		mapping.Add (
+			member: "AllowNativeHeapPointerTagging",
+			attributeName: "allowNativeHeapPointerTagging",
+			getter: self => self.AllowNativeHeapPointerTagging,
+			setter: (self, value) => self.AllowNativeHeapPointerTagging = (bool) value
+		);
+		mapping.Add (
 			member: "AllowTaskReparenting",
 			attributeName: "allowTaskReparenting",
 			getter: self => self.AllowTaskReparenting,
 			setter: (self, value) => self.AllowTaskReparenting = (bool) value
+		);
+		mapping.Add (
+			member: "AppCategory",
+			attributeName: "appCategory",
+			getter: self => self.AppCategory,
+			setter: (self, value) => self.AppCategory = (Android.Content.PM.ApplicationCategories) value
 		);
 		mapping.Add (
 			member: "BackupInForeground",
@@ -128,6 +162,12 @@ public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniN
 			attributeName: "banner",
 			getter: self => self.Banner,
 			setter: (self, value) => self.Banner = (string?) value
+		);
+		mapping.Add (
+			member: "DataExtractionRules",
+			attributeName: "dataExtractionRules",
+			getter: self => self.DataExtractionRules,
+			setter: (self, value) => self.DataExtractionRules = (string?) value
 		);
 		mapping.Add (
 			member: "Debuggable",
@@ -172,6 +212,12 @@ public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniN
 			setter: (self, value) => self.FullBackupOnly = (bool) value
 		);
 		mapping.Add (
+			member: "GwpAsanMode",
+			attributeName: "gwpAsanMode",
+			getter: self => self.GwpAsanMode,
+			setter: (self, value) => self.GwpAsanMode = (Android.Content.PM.GwpAsan) value
+		);
+		mapping.Add (
 			member: "HardwareAccelerated",
 			attributeName: "hardwareAccelerated",
 			getter: self => self.HardwareAccelerated,
@@ -182,6 +228,12 @@ public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniN
 			attributeName: "hasCode",
 			getter: self => self.HasCode,
 			setter: (self, value) => self.HasCode = (bool) value
+		);
+		mapping.Add (
+			member: "HasFragileUserData",
+			attributeName: "hasFragileUserData",
+			getter: self => self.HasFragileUserData,
+			setter: (self, value) => self.HasFragileUserData = (bool) value
 		);
 		mapping.Add (
 			member: "Icon",
@@ -238,6 +290,12 @@ public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniN
 			setter: (self, value) => self.Process = (string?) value
 		);
 		mapping.Add (
+			member: "RequestLegacyExternalStorage",
+			attributeName: "requestLegacyExternalStorage",
+			getter: self => self.RequestLegacyExternalStorage,
+			setter: (self, value) => self.RequestLegacyExternalStorage = (bool) value
+		);
+		mapping.Add (
 			member: "RequiredAccountType",
 			attributeName: "requiredAccountType",
 			getter: self => self.RequiredAccountType,
@@ -278,6 +336,12 @@ public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniN
 			attributeName: "taskAffinity",
 			getter: self => self.TaskAffinity,
 			setter: (self, value) => self.TaskAffinity = (string?) value
+		);
+		mapping.Add (
+			member: "TestOnly",
+			attributeName: "testOnly",
+			getter: self => self.TestOnly,
+			setter: (self, value) => self.TestOnly = (bool) value
 		);
 		mapping.Add (
 			member: "Theme",

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
@@ -20,6 +20,8 @@ public sealed partial class ServiceAttribute : Attribute, Java.Interop.IJniNameP
 	{
 	}
 
+	public string? Description { get; set; }
+
 	public bool DirectBootAware { get; set; }
 
 	public bool Enabled { get; set; }
@@ -47,6 +49,12 @@ public sealed partial class ServiceAttribute : Attribute, Java.Interop.IJniNameP
 
 	static ServiceAttribute ()
 	{
+		mapping.Add (
+			member: "Description",
+			attributeName: "description",
+			getter: self => self.Description,
+			setter: (self, value) => self.Description = (string?) value
+		);
 		mapping.Add (
 			member: "DirectBootAware",
 			attributeName: "directBootAware",


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9092

[Previously](https://github.com/dotnet/android/issues/8272), we created a process for automatically determining the possible attributes for elements in `AndroidManifest.xml` and generating the `Mono.Android` `[Application]`, `[Activity]`, etc. attributes for users to consume.  At the time, we merely created the process, but did not use it to expose any new attributes that have been added in previous Android API levels that we never exposed.

This commit exposes all Google-documented manifest attributes for the elements we support.  The undocumented manifest attributes were moved around in the file to a section denoted as "undocumented".