### PR TITLE
[tests] re-enable `JavaAbstractMethodTest`

### DIFF
--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
@@ -181,7 +181,6 @@ namespace Xamarin.Android.JcwGenTests {
 		}
 
 		[Test]
-		[Ignore("https://github.com/dotnet/runtime/issues/103987")]
 		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void JavaAbstractMethodTest ()
 		{


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/103987

dotnet/runtime#103987 was fixed, and we should have the changes in 094bf612.

Let's enable the test again.