### PR TITLE
[installers] Ship `NuGet*` assemblies needed by `<AndroidMavenLibrary>`.

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -119,6 +119,15 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Mono.Options.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Mono.Options.pdb" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)MULTIDEX_JAR_LICENSE" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.Common.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.Configuration.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.DependencyResolver.Core.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.Frameworks.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.LibraryModel.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.Packaging.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.ProjectModel.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.Protocol.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.Versioning.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)startup.aotprofile" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)startup-xf.aotprofile" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)r8.jar" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9037

Attempting to use `<AndroidMavenLibrary>` in Visual Studio 17.11 P3, which ships .NET 9 P5, like this:

```xml
<ItemGroup>
  <AndroidMavenLibrary Include="com.squareup.okhttp3:okhttp" Version="4.9.3" />
</ItemGroup>
```

gives you the error:

```
1>C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.99.0-preview.5.308\tools\Xamarin.Android.Bindings.JavaDependencyVerification.targets(27,5): error XAJDV7028: System.IO.FileNotFoundException: Could not load file or assembly 'NuGet.ProjectModel, Version=6.9.1.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The specified file cannot be found.
1>C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.99.0-preview.5.308\tools\Xamarin.Android.Bindings.JavaDependencyVerification.targets(27,5): error XAJDV7028: File name: 'NuGet.ProjectModel, Version=6.9.1.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
1>C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.99.0-preview.5.308\tools\Xamarin.Android.Bindings.JavaDependencyVerification.targets(27,5): error XAJDV7028:    at Xamarin.Android.Tasks.NuGetPackageVersionFinder.Create(String filename, TaskLoggingHelper log)
1>C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.99.0-preview.5.308\tools\Xamarin.Android.Bindings.JavaDependencyVerification.targets(27,5): error XAJDV7028:    at Xamarin.Android.Tasks.DependencyResolver..ctor(String lockFile, TaskLoggingHelper log) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs:line 124
1>C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.99.0-preview.5.308\tools\Xamarin.Android.Bindings.JavaDependencyVerification.targets(27,5): error XAJDV7028:    at Xamarin.Android.Tasks.JavaDependencyVerification.RunTask() in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs:line 77
1>C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.99.0-preview.5.308\tools\Xamarin.Android.Bindings.JavaDependencyVerification.targets(27,5): error XAJDV7028:    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 25
```

We need to ship `NuGet.ProjectModel.dll` as well as its dependencies to ensure they are always available to our MSBuild tasks.

Note that NuGet does not ship `.pdb` files for these assemblies in their NuGet packages.  We will need to exclude these assemblies from `.pdb` checking.