### PR TITLE
[ci] Use DotNetCoreCLI to sign macOS files

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -74,7 +74,9 @@ extends:
       binskim:
         scanOutputDirectoryOnly: true
       codeql:
-        runSourceLanguagesInSourceAnalysis: true
+        compiled:
+          enabled: false
+          justificationForDisabling: CodeQL tasks run during the nightly build pipeline
       policheck:
         enabled: false
         justification: Built in task does not support multi-language scanning

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -74,9 +74,7 @@ extends:
       binskim:
         scanOutputDirectoryOnly: true
       codeql:
-        compiled:
-          enabled: false
-          justificationForDisabling: CodeQL tasks run during the nightly build pipeline
+        runSourceLanguagesInSourceAnalysis: true
       policheck:
         enabled: false
         justification: Built in task does not support multi-language scanning

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -71,46 +71,45 @@ steps:
     condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
 
 # Restore needs to be executed first or MicroBuild targets won't be imported in time
-- task: MSBuild@1
+- task: DotNetCoreCLI@2
   displayName: msbuild /t:Restore sign-content.proj
   condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
-    solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
-    configuration: $(XA.Build.Configuration)
-    msbuildArguments: /t:Restore /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/restore-sign-content.binlog
+    projects: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
+    arguments: /t:Restore /p:Configuration=$(XA.Build.Configuration) /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/restore-sign-content.binlog
 
-- task: MSBuild@1
+- task: DotNetCoreCLI@2
   displayName: PKG signing - add entitlements and sign
   condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
-    solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
-    configuration: $(XA.Build.Configuration)
-    msbuildArguments: >-
+    projects: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
+    arguments: >-
       /t:AddMachOEntitlements;AddMSBuildFilesUnixSign;AddMSBuildFilesUnixSignAndHarden;Build
+      /p:Configuration=$(XA.Build.Configuration)
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-content.binlog
 
-- task: MSBuild@1
+- task: DotNetCoreCLI@2
   displayName: PKG signing - sign binutils libraries
   condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
-    solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
-    configuration: $(XA.Build.Configuration)
-    msbuildArguments: >-
+    projects: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
+    arguments: >-
       /t:AddBinUtilsFilesUnixSign;Build
+      /p:Configuration=$(XA.Build.Configuration)
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-bu-lib.binlog
 
-- task: MSBuild@1
+- task: DotNetCoreCLI@2
   displayName: PKG signing - sign binutils executables
   condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
-    solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
-    configuration: $(XA.Build.Configuration)
-    msbuildArguments: >-
+    projects: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
+    arguments: >-
       /t:AddBinUtilsFilesUnixSignAndHarden;Build
+      /p:Configuration=$(XA.Build.Configuration)
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-bu-ex.binlog

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -76,7 +76,7 @@ steps:
   condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
     projects: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
-    arguments: /t:Restore /p:Configuration=$(XA.Build.Configuration) /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/restore-sign-content.binlog
+    arguments: /t:Restore /p:Configuration=$(XA.Build.Configuration) -v:n /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/restore-sign-content.binlog
 
 - task: DotNetCoreCLI@2
   displayName: PKG signing - add entitlements and sign
@@ -85,7 +85,7 @@ steps:
     projects: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     arguments: >-
       /t:AddMachOEntitlements;AddMSBuildFilesUnixSign;AddMSBuildFilesUnixSignAndHarden;Build
-      /p:Configuration=$(XA.Build.Configuration)
+      /p:Configuration=$(XA.Build.Configuration) -v:n
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-content.binlog
@@ -97,7 +97,7 @@ steps:
     projects: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     arguments: >-
       /t:AddBinUtilsFilesUnixSign;Build
-      /p:Configuration=$(XA.Build.Configuration)
+      /p:Configuration=$(XA.Build.Configuration) -v:n
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-bu-lib.binlog
@@ -109,7 +109,7 @@ steps:
     projects: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     arguments: >-
       /t:AddBinUtilsFilesUnixSignAndHarden;Build
-      /p:Configuration=$(XA.Build.Configuration)
+      /p:Configuration=$(XA.Build.Configuration) -v:n
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-bu-ex.binlog


### PR DESCRIPTION
We've been having issues with the signing steps that run doing the macOS
build.  Migration to a new post-build workflow is in progress, however
this will hopefully fix things more quickly and be safer to backport.