### PR TITLE
[xaprepare] Always use release mono bundle

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Android.Prepare
 			public const bool UseEmoji                                     = true;
 			public const bool DullMode                                     = false;
 
-			public const string MonoSdksConfiguration                     => "release";
+			public const string MonoSdksConfiguration                      => "release";
 
 			public const string ZipCompressionFormatName = "zip";
 			public const string SevenZipCompressionFormatName = "7z";

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Android.Prepare
 			public const bool UseEmoji                                     = true;
 			public const bool DullMode                                     = false;
 
-			public static string MonoSdksConfiguration                     => Context.Instance.Configuration.ToLowerInvariant ();
+			public const string MonoSdksConfiguration                     => "release";
 
 			public const string ZipCompressionFormatName = "zip";
 			public const string SevenZipCompressionFormatName = "7z";

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Android.Prepare
 			public const bool UseEmoji                                     = true;
 			public const bool DullMode                                     = false;
 
-			public const string MonoSdksConfiguration                      => "release";
+			public const string MonoSdksConfiguration                      = "release";
 
 			public const string ZipCompressionFormatName = "zip";
 			public const string SevenZipCompressionFormatName = "7z";


### PR DESCRIPTION
The "debug" version of the mono archive appears to no longer exist due
to recent storage account changes.  The release bundles are still live,
so we should default to using those even for debug builds.