### PR TITLE
[release/8.0.2xx] [tests] fix `InvalidTargetPlatformVersion` for `net8.0`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -833,7 +833,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
-		public void InvalidTargetPlatformVersion ([Values ("android33", "android99.0")] string platformVersion)
+		public void InvalidTargetPlatformVersion ([Values ("android32", "android99.0")] string platformVersion)
 		{
 			const string targetFramework = "net8.0";
 			var project = new XamarinAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -833,7 +833,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
-		public void InvalidTargetPlatformVersion ([Values ("android32", "android99.0")] string platformVersion)
+		public void InvalidTargetPlatformVersion ([Values ("android99.0")] string platformVersion)
 		{
 			const string targetFramework = "net8.0";
 			var project = new XamarinAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -835,7 +835,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		[Test]
 		public void InvalidTargetPlatformVersion ([Values ("android33", "android99.0")] string platformVersion)
 		{
-			const string targetFramework = "net9.0";
+			const string targetFramework = "net8.0";
 			var project = new XamarinAndroidApplicationProject {
 				TargetFramework = $"{targetFramework}-{platformVersion}",
 			};


### PR DESCRIPTION
When 60dbcc9f was backported to .NET 8, the accompanying unit test was accidentally targeting .NET 9.