### PR TITLE
[ci] Disable CodeQL on macOS and Linux build jobs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -73,8 +73,6 @@ extends:
         enableAllTools: false
       binskim:
         scanOutputDirectoryOnly: true
-      codeql:
-        runSourceLanguagesInSourceAnalysis: true
       policheck:
         enabled: false
         justification: Built in task does not support multi-language scanning

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -35,6 +35,11 @@ stages:
       CC: gcc-10
     ${{ if eq(parameters.use1ESTemplate, true) }}:
       templateContext:
+        sdl:
+          codeql:
+            compiled:
+              enabled: false
+              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build
         outputs:
         - output: pipelineArtifact
           displayName: upload linux sdk

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -43,6 +43,11 @@ stages:
       clean: all
     ${{ if eq(parameters.use1ESTemplate, true) }}:
       templateContext:
+        sdl:
+          codeql:
+            compiled:
+              enabled: false
+              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build
         outputParentDirectory: ${{ parameters.xaSourcePath }}/bin
         outputs:
         - output: pipelineArtifact


### PR DESCRIPTION
Attempt to save some build time on macOS and Linux by disabling CodeQL.
This step will still run during the Windows build job in CI, as well as
the macOS nightly build job.