### PR TITLE
[XABT] Allow deployment artifacts to specify multiple JavaDependencyVerification JavaArtifact libraries.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1375,6 +1375,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Maven artifact specification &apos;{0}&apos; is invalid. The correct format is &apos;group_id:artifact_id:version&apos;..
+        /// </summary>
+        public static string XA4249 {
+            get {
+                return ResourceManager.GetString("XA4249", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Native library &apos;{0}&apos; will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as &apos;libs/armeabi-v7a/&apos;..
         /// </summary>
         public static string XA4300 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1067,4 +1067,9 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {2} - shared library file name
     </comment>
   </data>
+  <data name="XA4249" xml:space="preserve">
+    <value>Maven artifact specification '{0}' is invalid. The correct format is 'group_id:artifact_id:version'.</value>
+    <comment>The following are literal names and should not be translated: Maven, group_id, artifact_id
+{0} - A Maven artifact specification</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs
@@ -216,7 +216,7 @@ class DependencyResolver
 
 			if (MavenExtensions.TryParseArtifacts (id, log, out var parsed)) {
 				foreach (var art in parsed) {
-					log.LogMessage ("Ignoring Java dependency '{0}:{1}' version '{2}'", art.GroupId, art.Id, art.Version);
+					log.LogMessage ("Ignoring Java dependency '{0}'", art.VersionedArtifactString);
 					artifacts.Add (art.ArtifactString, art);
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
@@ -97,8 +97,7 @@ public class MavenDownload : AsyncTask
 
 		var result = new TaskItem (artifact_file);
 
-		result.SetMetadata ("JavaArtifact", $"{artifact.GroupId}:{artifact.Id}");
-		result.SetMetadata ("JavaVersion", artifact.Version);
+		result.SetMetadata ("JavaArtifact", artifact.VersionedArtifactString);
 
 		// Allow user to opt out of dependency verification
 		if (string.Compare (item.GetMetadataOrDefault ("VerifyDependencies", "true"), "false", true) == 0)
@@ -121,8 +120,7 @@ public class MavenDownload : AsyncTask
 				var pom_item = new TaskItem (kv.Value);
 				var pom_artifact = Artifact.Parse (kv.Key);
 
-				pom_item.SetMetadata ("JavaArtifact", $"{pom_artifact.GroupId}:{pom_artifact.Id}");
-				pom_item.SetMetadata ("JavaVersion", pom_artifact.Version);
+				pom_item.SetMetadata ("JavaArtifact", pom_artifact.VersionedArtifactString);
 
 				additionalPoms.Add (pom_item);
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -888,14 +888,9 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 			var collection = new XamarinAndroidBindingProject ();
 
 			// Dependencies ignored by <AndroidIgnoredJavaDependency>
-			var concurrent = new BuildItem ("AndroidIgnoredJavaDependency", "androidx.concurrent:concurrent-futures");
-			concurrent.Metadata.Add ("Version", "1.1.0");
-
-			var lifecycle = new BuildItem ("AndroidIgnoredJavaDependency", "androidx.lifecycle:lifecycle-runtime");
-			lifecycle.Metadata.Add ("Version", "2.6.2");
-
-			var parcelable = new BuildItem ("AndroidIgnoredJavaDependency", "androidx.versionedparcelable:versionedparcelable");
-			parcelable.Metadata.Add ("Version", "1.2.0");
+			var concurrent = new BuildItem ("AndroidIgnoredJavaDependency", "androidx.concurrent:concurrent-futures:1.1.0");
+			var lifecycle = new BuildItem ("AndroidIgnoredJavaDependency", "androidx.lifecycle:lifecycle-runtime:2.6.2");
+			var parcelable = new BuildItem ("AndroidIgnoredJavaDependency", "androidx.versionedparcelable:versionedparcelable:1.2.0");
 
 			var proj = new XamarinAndroidBindingProject {
 				Jars = { item, annotations_experimental_androidlib },
@@ -905,8 +900,7 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 
 			proj.AddReference (collection);
 			var collection_proj = proj.References.First ();
-			collection_proj.Metadata.Add ("JavaArtifact", "androidx.collection:collection");
-			collection_proj.Metadata.Add ("JavaVersion", "1.3.0");
+			collection_proj.Metadata.Add ("JavaArtifact", "androidx.collection:collection:1.3.0");
 
 			using var a = CreateDllBuilder ();
 			using var b = CreateDllBuilder ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/JavaDependencyVerificationTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/JavaDependencyVerificationTests.cs
@@ -161,7 +161,7 @@ public class JavaDependencyVerificationTests
 			BuildEngine = engine,
 			AndroidLibraries = [
 				CreateAndroidLibraryTaskItem ("com.google.android.material.jar", pom.FilePath),
-				CreateAndroidLibraryTaskItem ("com.google.android.material-core.jar", null, "com.google.android:material-core", "1.0"),
+				CreateAndroidLibraryTaskItem ("com.google.android.material-core.jar", null, "com.google.android:material-core:1.0"),
 			],
 			MicrosoftPackagesFile = package_finder.FilePath,
 		};
@@ -177,6 +177,7 @@ public class JavaDependencyVerificationTests
 	{
 		using var pom = new PomBuilder ("com.google.android", "material", "1.0")
 			.WithDependency ("com.google.android", "material-core", "1.0")
+			.WithDependency ("com.google.android", "material-foo", "1.0")
 			.BuildTemporary ();
 
 		var engine = new MockBuildEngine (TestContext.Out, []);
@@ -184,7 +185,8 @@ public class JavaDependencyVerificationTests
 			BuildEngine = engine,
 			AndroidLibraries = [
 				CreateAndroidLibraryTaskItem ("com.google.android.material.jar", pom.FilePath),
-				CreateAndroidLibraryTaskItem ("com.google.android.material-core.jar", null, "com.google.android:material-core", "1.0"),
+				CreateAndroidLibraryTaskItem ("com.google.android.material-core.jar", null, "com.google.android:material-core:1.0"),
+				CreateAndroidLibraryTaskItem ("com.google.android.material-foo.jar", null, "org.jetbrains.kotlin:kotlin-stdlib:2.0.0,com.google.android:material-foo:1.0"),
 			],
 		};
 
@@ -199,6 +201,7 @@ public class JavaDependencyVerificationTests
 	{
 		using var pom = new PomBuilder ("com.google.android", "material", "1.0")
 			.WithDependency ("com.google.android", "material-core", "1.0")
+			.WithDependency ("com.google.android", "material-foo", "1.0")
 			.BuildTemporary ();
 
 		var engine = new MockBuildEngine (TestContext.Out, []);
@@ -208,7 +211,8 @@ public class JavaDependencyVerificationTests
 				CreateAndroidLibraryTaskItem ("com.google.android.material.jar", pom.FilePath),
 			],
 			ProjectReferences = [
-				CreateAndroidLibraryTaskItem ("Google.Material.Core.csproj", null, "com.google.android:material-core", "1.0"),
+				CreateAndroidLibraryTaskItem ("Google.Material.Core.csproj", null, "com.google.android:material-core:1.0"),
+				CreateAndroidLibraryTaskItem ("Google.Material.Foo.csproj", null, "org.jetbrains.kotlin:kotlin-stdlib:2.0.0,com.google.android:material-foo:1.0"),
 			],
 		};
 
@@ -223,6 +227,7 @@ public class JavaDependencyVerificationTests
 	{
 		using var pom = new PomBuilder ("com.google.android", "material", "1.0")
 			.WithDependency ("com.google.android", "material-core", "1.0")
+			.WithDependency ("com.google.android", "material-foo", "1.0")
 			.BuildTemporary ();
 
 		var engine = new MockBuildEngine (TestContext.Out, []);
@@ -232,7 +237,8 @@ public class JavaDependencyVerificationTests
 				CreateAndroidLibraryTaskItem ("com.google.android.material.jar", pom.FilePath),
 			],
 			PackageReferences = [
-				CreateAndroidLibraryTaskItem ("Xamarin.Google.Material.Core", null, "com.google.android:material-core", "1.0"),
+				CreateAndroidLibraryTaskItem ("Xamarin.Google.Material.Core", null, "com.google.android:material-core:1.0"),
+				CreateAndroidLibraryTaskItem ("Xamarin.Google.Material.Foo", null, "org.jetbrains.kotlin:kotlin-stdlib:2.0.0,com.google.android:material-foo:1.0"),
 			],
 		};
 
@@ -247,6 +253,7 @@ public class JavaDependencyVerificationTests
 	{
 		using var pom = new PomBuilder ("com.google.android", "material", "1.0")
 			.WithDependency ("com.google.android", "material-core", "1.0")
+			.WithDependency ("com.google.android", "material-foo", "1.0")
 			.BuildTemporary ();
 
 		var engine = new MockBuildEngine (TestContext.Out, []);
@@ -256,7 +263,8 @@ public class JavaDependencyVerificationTests
 				CreateAndroidLibraryTaskItem ("com.google.android.material.jar", pom.FilePath),
 			],
 			IgnoredDependencies = [
-				CreateAndroidLibraryTaskItem ("com.google.android:material-core", rawVersion: "1.0"),
+				CreateAndroidLibraryTaskItem ("com.google.android:material-core:1.0"),
+				CreateAndroidLibraryTaskItem ("org.jetbrains.kotlin:kotlin-stdlib:2.0.0,com.google.android:material-foo:1.0"),
 			],
 		};
 
@@ -279,7 +287,7 @@ public class JavaDependencyVerificationTests
 			BuildEngine = engine,
 			AndroidLibraries = [
 				CreateAndroidLibraryTaskItem ("com.google.android.material.jar", pom.FilePath),
-				CreateAndroidLibraryTaskItem ("com.google.android.material-core.jar", null, "com.google.android:material-core", "1.0"),
+				CreateAndroidLibraryTaskItem ("com.google.android.material-core.jar", null, "com.google.android:material-core:1.0"),
 			],
 		};
 
@@ -312,7 +320,7 @@ public class JavaDependencyVerificationTests
 		Assert.AreEqual ("Java dependency 'com.google.android:material-core' is not satisfied.", engine.Errors [0].Message);
 	}
 
-	TaskItem CreateAndroidLibraryTaskItem (string name, string? manifest = null, string? javaArtifact = null, string? javaVersion = null, string? rawVersion = null)
+	TaskItem CreateAndroidLibraryTaskItem (string name, string? manifest = null, string? javaArtifact = null)
 	{
 		var item = new TaskItem (name);
 
@@ -320,10 +328,6 @@ public class JavaDependencyVerificationTests
 			item.SetMetadata ("Manifest", manifest);
 		if (javaArtifact is not null)
 			item.SetMetadata ("JavaArtifact", javaArtifact);
-		if (javaVersion is not null)
-			item.SetMetadata ("JavaVersion", javaVersion);
-		if (rawVersion is not null)
-			item.SetMetadata ("Version", rawVersion);
 
 		return item;
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MavenDownloadTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MavenDownloadTests.cs
@@ -136,8 +136,7 @@ public class MavenDownloadTests
 
 			var output_item = task.ResolvedAndroidMavenLibraries! [0];
 
-			Assert.AreEqual ("com.google.auto.value:auto-value-annotations", output_item.GetMetadata ("JavaArtifact"));
-			Assert.AreEqual ("1.10.4", output_item.GetMetadata ("JavaVersion"));
+			Assert.AreEqual ("com.google.auto.value:auto-value-annotations:1.10.4", output_item.GetMetadata ("JavaArtifact"));
 			Assert.AreEqual (Path.Combine (temp_cache_dir, "central", "com.google.auto.value", "auto-value-annotations", "1.10.4", "auto-value-annotations-1.10.4.pom"), output_item.GetMetadata ("Manifest"));
 		} finally {
 			DeleteTempDirectory (temp_cache_dir);
@@ -164,8 +163,7 @@ public class MavenDownloadTests
 
 			var output_item = task.ResolvedAndroidMavenLibraries! [0];
 
-			Assert.AreEqual ("androidx.core:core", output_item.GetMetadata ("JavaArtifact"));
-			Assert.AreEqual ("1.12.0", output_item.GetMetadata ("JavaVersion"));
+			Assert.AreEqual ("androidx.core:core:1.12.0", output_item.GetMetadata ("JavaArtifact"));
 			Assert.AreEqual (Path.Combine (temp_cache_dir, "google", "androidx.core", "core", "1.12.0", "core-1.12.0.pom"), output_item.GetMetadata ("Manifest"));
 		} finally {
 			DeleteTempDirectory (temp_cache_dir);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MavenExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MavenExtensions.cs
@@ -103,10 +103,6 @@ static class MavenExtensions
 		artifacts = new List<Artifact> ();
 		var item_name = task.ItemSpec;
 
-		// Convert "../../src/blah/Blah.csproj" to "Blah.csproj"
-		if (type == "ProjectReference")
-			item_name = Path.GetFileName (item_name);
-
 		var has_artifact = task.HasMetadata ("JavaArtifact");
 
 		// Lets callers know if user attempted to specify JavaArtifact, even if they did it incorrectly

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MavenExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MavenExtensions.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Tasks;
 static class MavenExtensions
 {
 	static readonly char [] separator = [':'];
-	static readonly char [] artifacts_separators = [';', ',', '\r', '\n'];
+	static readonly char [] artifacts_separators = [';', ',', '\r', '\n', '\t', ' '];
 
 	/// <summary>
 	/// Shortcut for !string.IsNullOrWhiteSpace (s)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9013

Today, our Java Dependency Verification feature is built around our recommended practice of 1 binding library per project.  This is reflected in the fact that `JavaArtifact` and `JavaVersion` only support a single library:

```xml
<PackageReference 
  Include="Xamarin.Kotlin.StdLib" 
  Version="1.7.10" 
  JavaArtifact="org.jetbrains.kotlin:kotlin-stdlib" 
  JavaVersion="1.7.10" />
```

However a user may choose to place multiple Java libraries in a single package (or project), and we have no way to express that.  Instead of using `JavaArtifact`/`JavaVersion` to specify a Java dependency, we will only use `JavaArtifact` and we will update the specification to include the artifact version: `org.jetbrains.kotlin:kotlin-stdlib:1.7.10`.  Additionally, this attribute now allows multiple Java artifacts to be specified by separating them with a comma, semicolon, or newline.

This change affects `@(PackageReference)`, `@(ProjectReference)`, `@(AndroidLibrary)`, and `@(AndroidIgnoredJavaDependency)`.

Examples:

```xml
<PackageReference 
  Include="Xamarin.Kotlin.StdLib" 
  Version="1.7.10" 
  JavaArtifact="org.jetbrains.kotlin:kotlin-stdlib:1.7.10" />

<ProjectReference 
  Include="..\My.Other.Binding\My.Other.Binding.csproj" 
  JavaArtifact="my.other.binding:mylib:1.0.0,my.other.binding:helperlib:1.0.0" />

<AndroidLibrary 
  Include="mydependency.jar" 
  JavaArtifact="my.library:dependency-library:1.0.0" />

<AndroidIgnoredJavaDependency 
  Include="com.google.errorprone:error_prone_annotations:2.15.0" />
```

Existing support for looking at NuGet package tags to automatically find Java libraries contained within has also been updated to support multiple `artifact` tags.  Note that separate tags are expected, not a single tag with multiple artifacts specified:

```xml
<!-- Correct -->
<PackageTags>
  artifact=my.other.binding:mylib:1.0.0
  artifact=my.other.binding:helperlib:1.0.0
</PackageTags>

<!-- Incorrect -->
<PackageTags>
  artifact=my.other.binding:mylib:1.0.0,my.other.binding:helperlib:1.0.0
</PackageTags>
```