### PR TITLE
[ci] Fix maestro publishing for stable packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,6 +38,7 @@
     <AndroidPackVersion>35.0.0</AndroidPackVersion>
     <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
     <IsStableBuild>false</IsStableBuild>
+    <IsStableBuild Condition=" '$(AndroidPackVersionSuffix)' == 'rtm' ">true</IsStableBuild>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
     -->
     <AndroidPackVersion>35.0.0</AndroidPackVersion>
     <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
-    <IsStableBuild>true</IsStableBuild>
+    <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,7 @@
     -->
     <AndroidPackVersion>35.0.0</AndroidPackVersion>
     <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
+    <IsStableBuild>true</IsStableBuild>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -462,75 +462,75 @@ extends:
 
     - stage: dotnet_prepare_release
       displayName: Prepare .NET Release
-      dependsOn: []
-      #- mac_build
-      #- linux_build
-      #condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
+      dependsOn:
+      - mac_build
+      - linux_build
+      condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
       jobs:
       # Check - "Xamarin.Android (Prepare .NET Release Sign Archives)"
-      #- template: sign-artifacts/jobs/v3.yml@yaml-templates
-      #  parameters:
-      #    name: sign_net_mac_win
-      #    poolName: $(VSEngMicroBuildPool)
-      #    artifactName: $(NuGetArtifactName)
-      #    signType: $(MicroBuildSignType)
-      #    signedArtifactName: nuget-signed
-      #    usePipelineArtifactTasks: true
-      #    use1ESTemplate: true
-      #    uploadPrefix: sign-mac-win
-      #    handleUnmappedFiles: fail
-      #    timeoutInMinutes: 240
+      - template: sign-artifacts/jobs/v3.yml@yaml-templates
+        parameters:
+          name: sign_net_mac_win
+          poolName: $(VSEngMicroBuildPool)
+          artifactName: $(NuGetArtifactName)
+          signType: $(MicroBuildSignType)
+          signedArtifactName: nuget-signed
+          usePipelineArtifactTasks: true
+          use1ESTemplate: true
+          uploadPrefix: sign-mac-win
+          handleUnmappedFiles: fail
+          timeoutInMinutes: 240
 
       # Check - "Xamarin.Android (Prepare .NET Release Sign Linux Archive)"
-      #- template: sign-artifacts/jobs/v3.yml@yaml-templates
-      #  parameters:
-      #    name: sign_net_linux
-      #    displayName: Sign Linux Archive
-      #    poolName: $(VSEngMicroBuildPool)
-      #    artifactName: $(LinuxNuGetArtifactName)
-      #    signType: $(MicroBuildSignType)
-      #    signedArtifactName: nuget-linux-signed
-      #    usePipelineArtifactTasks: true
-      #    use1ESTemplate: true
-      #    uploadPrefix: sign-linux
-      #    handleUnmappedFiles: fail
-      #    timeoutInMinutes: 120
+      - template: sign-artifacts/jobs/v3.yml@yaml-templates
+        parameters:
+          name: sign_net_linux
+          displayName: Sign Linux Archive
+          poolName: $(VSEngMicroBuildPool)
+          artifactName: $(LinuxNuGetArtifactName)
+          signType: $(MicroBuildSignType)
+          signedArtifactName: nuget-linux-signed
+          usePipelineArtifactTasks: true
+          use1ESTemplate: true
+          uploadPrefix: sign-linux
+          handleUnmappedFiles: fail
+          timeoutInMinutes: 120
 
       # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-      #- template: nuget-msi-convert/job/v3.yml@yaml-templates
-      #  parameters:
-      #    yamlResourceName: yaml-templates
-      #    dependsOn: sign_net_mac_win
-      #    artifactName: nuget-signed
-      #    artifactPatterns: |
-      #      !*Darwin*
-      #    propsArtifactName: $(NuGetArtifactName)
-      #    signType: $(MicroBuildSignType)
-      #    use1ESTemplate: true
-      #    postConvertSteps:
-      #    - task: DownloadPipelineArtifact@2
-      #      inputs:
-      #        artifactName: $(NuGetArtifactName)
-      #        downloadPath: $(Build.StagingDirectory)\sign-verify
-      #        patterns: |
-      #          **/SignVerifyIgnore.txt
+      - template: nuget-msi-convert/job/v3.yml@yaml-templates
+        parameters:
+          yamlResourceName: yaml-templates
+          dependsOn: sign_net_mac_win
+          artifactName: nuget-signed
+          artifactPatterns: |
+            !*Darwin*
+          propsArtifactName: $(NuGetArtifactName)
+          signType: $(MicroBuildSignType)
+          use1ESTemplate: true
+          postConvertSteps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: $(NuGetArtifactName)
+              downloadPath: $(Build.StagingDirectory)\sign-verify
+              patterns: |
+                **/SignVerifyIgnore.txt
 
-      #   - task: MicroBuildCodesignVerify@3
-      #      displayName: verify signed msi content
-      #      inputs:
-      #        TargetFolders: |
-      #          $(Build.ArtifactStagingDirectory)\bin\manifests
-      #          $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
-      #        ExcludeSNVerify: true
-      #        ApprovalListPathForCerts: $(Build.StagingDirectory)\sign-verify\SignVerifyIgnore.txt
+          - task: MicroBuildCodesignVerify@3
+            displayName: verify signed msi content
+            inputs:
+              TargetFolders: |
+                $(Build.ArtifactStagingDirectory)\bin\manifests
+                $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
+              ExcludeSNVerify: true
+              ApprovalListPathForCerts: $(Build.StagingDirectory)\sign-verify\SignVerifyIgnore.txt
 
       # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
       - job: push_signed_nugets
         displayName: Push Internal
-        dependsOn: []
-        #- nuget_convert
-        #- sign_net_linux
-        #condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(dependencies.sign_net_linux.result, 'Succeeded'))
+        dependsOn:
+        - nuget_convert
+        - sign_net_linux
+        condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(dependencies.sign_net_linux.result, 'Succeeded'))
         timeoutInMinutes: 60
         pool:
           name: AzurePipelines-EO
@@ -546,86 +546,62 @@ extends:
           clean: true
           submodules: recursive
 
-        #- task: DownloadPipelineArtifact@2
-        #  inputs:
-        #    artifactName: nuget-signed
-        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
-
-        #- task: DownloadPipelineArtifact@2
-        #  inputs:
-        #    artifactName: nuget-linux-signed
-        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
-
-        #- task: DownloadPipelineArtifact@2
-        #  inputs:
-        #    artifactName: vs-msi-nugets
-        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
-
-        #- task: DownloadPipelineArtifact@2
-        #  inputs:
-        #    artifactName: $(WindowsToolchainPdbArtifactName)
-        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
-
-        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-        #  parameters:
-        #    githubToken: $(GitHub.Token)
-        #    githubContext: $(NupkgCommitStatusName)
-        #    blobName: $(NupkgCommitStatusName)
-        #   packagePrefix: xamarin-android
-        #    artifactsPath: $(Build.StagingDirectory)\nuget-signed
-        #    yamlResourceName: yaml-templates
-
-        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-        #  parameters:
-        #    githubToken: $(GitHub.Token)
-        #    githubContext: $(VSDropCommitStatusName)
-        #    blobName: $(VSDropCommitStatusName)
-        #    packagePrefix: xamarin-android
-        #    artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
-        #    yamlResourceName: yaml-templates
-        #    downloadSteps:
-        #    - task: DownloadPipelineArtifact@2
-        #      inputs:
-        #        artifactName: vsdrop-signed
-        #        downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
-
-        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-        #  parameters:
-        #    githubToken: $(GitHub.Token)
-        #    githubContext: $(MultiTargetVSDropCommitStatusName)
-        #    blobName: $(MultiTargetVSDropCommitStatusName)
-        #    packagePrefix: xamarin-android
-        #    artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
-        #    yamlResourceName: yaml-templates
-        #    downloadSteps:
-        #    - task: DownloadPipelineArtifact@2
-        #      inputs:
-        #        artifactName: vsdrop-multitarget-signed
-        #        downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
-
         - task: DownloadPipelineArtifact@2
           inputs:
-            buildType: specific
-            project: DevDiv
-            definition: 11410
-            buildVersionToDownload: specific
-            pipelineId: 9896489
-            allowPartiallySucceededBuilds: true
-            allowFailedBuilds: true
             artifactName: nuget-signed
             downloadPath: $(Build.StagingDirectory)\nuget-signed
+
         - task: DownloadPipelineArtifact@2
           inputs:
-            buildType: specific
-            project: DevDiv
-            definition: 11410
-            buildVersionToDownload: specific
-            pipelineId: 9896489
-            allowPartiallySucceededBuilds: true
-            allowFailedBuilds: true
             artifactName: nuget-linux-signed
             downloadPath: $(Build.StagingDirectory)\nuget-signed
 
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: vs-msi-nugets
+            downloadPath: $(Build.StagingDirectory)\nuget-signed
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: $(WindowsToolchainPdbArtifactName)
+            downloadPath: $(Build.StagingDirectory)\nuget-signed
+
+        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+          parameters:
+            githubToken: $(GitHub.Token)
+            githubContext: $(NupkgCommitStatusName)
+            blobName: $(NupkgCommitStatusName)
+            packagePrefix: xamarin-android
+            artifactsPath: $(Build.StagingDirectory)\nuget-signed
+            yamlResourceName: yaml-templates
+
+        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+          parameters:
+            githubToken: $(GitHub.Token)
+            githubContext: $(VSDropCommitStatusName)
+            blobName: $(VSDropCommitStatusName)
+            packagePrefix: xamarin-android
+            artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
+            yamlResourceName: yaml-templates
+            downloadSteps:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifactName: vsdrop-signed
+                downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
+
+        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+          parameters:
+            githubToken: $(GitHub.Token)
+            githubContext: $(MultiTargetVSDropCommitStatusName)
+            blobName: $(MultiTargetVSDropCommitStatusName)
+            packagePrefix: xamarin-android
+            artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+            yamlResourceName: yaml-templates
+            downloadSteps:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifactName: vsdrop-multitarget-signed
+                downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
         - task: DotNetCoreCLI@2
           displayName: build Xamarin.Android.Tools.BootstrapTasks.sln
@@ -645,20 +621,20 @@ extends:
               -c $(XA.Build.Configuration) -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
           condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
-        #- powershell: |
-        #    $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
-        #    $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
-        #    $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-        #    & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
-        #    & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
-        #  displayName: add build to default darc channel
-        #  condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
+        - powershell: |
+            $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
+            $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
+            $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+            & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
+            & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+          displayName: add build to default darc channel
+          condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
-        #- template: build-tools\automation\yaml-templates\upload-results.yaml@self
-        #  parameters:
-        #    xaSourcePath: $(System.DefaultWorkingDirectory)
-        #    artifactName: Prepare Release - Push Internal
-        #    includeBuildResults: true
+        - template: build-tools\automation\yaml-templates\upload-results.yaml@self
+          parameters:
+            xaSourcePath: $(System.DefaultWorkingDirectory)
+            artifactName: Prepare Release - Push Internal
+            includeBuildResults: true
 
     # Check - "Xamarin.Android (PoliCheck PoliCheck $(Language))"
     - template: security/policheck/v3.yml@yaml-templates

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -462,75 +462,75 @@ extends:
 
     - stage: dotnet_prepare_release
       displayName: Prepare .NET Release
-      dependsOn:
-      - mac_build
-      - linux_build
-      condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
+      dependsOn: []
+      #- mac_build
+      #- linux_build
+      #condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
       jobs:
       # Check - "Xamarin.Android (Prepare .NET Release Sign Archives)"
-      - template: sign-artifacts/jobs/v3.yml@yaml-templates
-        parameters:
-          name: sign_net_mac_win
-          poolName: $(VSEngMicroBuildPool)
-          artifactName: $(NuGetArtifactName)
-          signType: $(MicroBuildSignType)
-          signedArtifactName: nuget-signed
-          usePipelineArtifactTasks: true
-          use1ESTemplate: true
-          uploadPrefix: sign-mac-win
-          handleUnmappedFiles: fail
-          timeoutInMinutes: 240
+      #- template: sign-artifacts/jobs/v3.yml@yaml-templates
+      #  parameters:
+      #    name: sign_net_mac_win
+      #    poolName: $(VSEngMicroBuildPool)
+      #    artifactName: $(NuGetArtifactName)
+      #    signType: $(MicroBuildSignType)
+      #    signedArtifactName: nuget-signed
+      #    usePipelineArtifactTasks: true
+      #    use1ESTemplate: true
+      #    uploadPrefix: sign-mac-win
+      #    handleUnmappedFiles: fail
+      #    timeoutInMinutes: 240
 
       # Check - "Xamarin.Android (Prepare .NET Release Sign Linux Archive)"
-      - template: sign-artifacts/jobs/v3.yml@yaml-templates
-        parameters:
-          name: sign_net_linux
-          displayName: Sign Linux Archive
-          poolName: $(VSEngMicroBuildPool)
-          artifactName: $(LinuxNuGetArtifactName)
-          signType: $(MicroBuildSignType)
-          signedArtifactName: nuget-linux-signed
-          usePipelineArtifactTasks: true
-          use1ESTemplate: true
-          uploadPrefix: sign-linux
-          handleUnmappedFiles: fail
-          timeoutInMinutes: 120
+      #- template: sign-artifacts/jobs/v3.yml@yaml-templates
+      #  parameters:
+      #    name: sign_net_linux
+      #    displayName: Sign Linux Archive
+      #    poolName: $(VSEngMicroBuildPool)
+      #    artifactName: $(LinuxNuGetArtifactName)
+      #    signType: $(MicroBuildSignType)
+      #    signedArtifactName: nuget-linux-signed
+      #    usePipelineArtifactTasks: true
+      #    use1ESTemplate: true
+      #    uploadPrefix: sign-linux
+      #    handleUnmappedFiles: fail
+      #    timeoutInMinutes: 120
 
       # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-      - template: nuget-msi-convert/job/v3.yml@yaml-templates
-        parameters:
-          yamlResourceName: yaml-templates
-          dependsOn: sign_net_mac_win
-          artifactName: nuget-signed
-          artifactPatterns: |
-            !*Darwin*
-          propsArtifactName: $(NuGetArtifactName)
-          signType: $(MicroBuildSignType)
-          use1ESTemplate: true
-          postConvertSteps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              artifactName: $(NuGetArtifactName)
-              downloadPath: $(Build.StagingDirectory)\sign-verify
-              patterns: |
-                **/SignVerifyIgnore.txt
+      #- template: nuget-msi-convert/job/v3.yml@yaml-templates
+      #  parameters:
+      #    yamlResourceName: yaml-templates
+      #    dependsOn: sign_net_mac_win
+      #    artifactName: nuget-signed
+      #    artifactPatterns: |
+      #      !*Darwin*
+      #    propsArtifactName: $(NuGetArtifactName)
+      #    signType: $(MicroBuildSignType)
+      #    use1ESTemplate: true
+      #    postConvertSteps:
+      #    - task: DownloadPipelineArtifact@2
+      #      inputs:
+      #        artifactName: $(NuGetArtifactName)
+      #        downloadPath: $(Build.StagingDirectory)\sign-verify
+      #        patterns: |
+      #          **/SignVerifyIgnore.txt
 
-          - task: MicroBuildCodesignVerify@3
-            displayName: verify signed msi content
-            inputs:
-              TargetFolders: |
-                $(Build.ArtifactStagingDirectory)\bin\manifests
-                $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
-              ExcludeSNVerify: true
-              ApprovalListPathForCerts: $(Build.StagingDirectory)\sign-verify\SignVerifyIgnore.txt
+      #   - task: MicroBuildCodesignVerify@3
+      #      displayName: verify signed msi content
+      #      inputs:
+      #        TargetFolders: |
+      #          $(Build.ArtifactStagingDirectory)\bin\manifests
+      #          $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
+      #        ExcludeSNVerify: true
+      #        ApprovalListPathForCerts: $(Build.StagingDirectory)\sign-verify\SignVerifyIgnore.txt
 
       # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
       - job: push_signed_nugets
         displayName: Push Internal
-        dependsOn:
-        - nuget_convert
-        - sign_net_linux
-        condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(dependencies.sign_net_linux.result, 'Succeeded'))
+        dependsOn: []
+        #- nuget_convert
+        #- sign_net_linux
+        #condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(dependencies.sign_net_linux.result, 'Succeeded'))
         timeoutInMinutes: 60
         pool:
           name: AzurePipelines-EO
@@ -546,62 +546,86 @@ extends:
           clean: true
           submodules: recursive
 
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            artifactName: nuget-signed
-            downloadPath: $(Build.StagingDirectory)\nuget-signed
+        #- task: DownloadPipelineArtifact@2
+        #  inputs:
+        #    artifactName: nuget-signed
+        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
+
+        #- task: DownloadPipelineArtifact@2
+        #  inputs:
+        #    artifactName: nuget-linux-signed
+        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
+
+        #- task: DownloadPipelineArtifact@2
+        #  inputs:
+        #    artifactName: vs-msi-nugets
+        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
+
+        #- task: DownloadPipelineArtifact@2
+        #  inputs:
+        #    artifactName: $(WindowsToolchainPdbArtifactName)
+        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
+
+        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+        #  parameters:
+        #    githubToken: $(GitHub.Token)
+        #    githubContext: $(NupkgCommitStatusName)
+        #    blobName: $(NupkgCommitStatusName)
+        #   packagePrefix: xamarin-android
+        #    artifactsPath: $(Build.StagingDirectory)\nuget-signed
+        #    yamlResourceName: yaml-templates
+
+        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+        #  parameters:
+        #    githubToken: $(GitHub.Token)
+        #    githubContext: $(VSDropCommitStatusName)
+        #    blobName: $(VSDropCommitStatusName)
+        #    packagePrefix: xamarin-android
+        #    artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
+        #    yamlResourceName: yaml-templates
+        #    downloadSteps:
+        #    - task: DownloadPipelineArtifact@2
+        #      inputs:
+        #        artifactName: vsdrop-signed
+        #        downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
+
+        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+        #  parameters:
+        #    githubToken: $(GitHub.Token)
+        #    githubContext: $(MultiTargetVSDropCommitStatusName)
+        #    blobName: $(MultiTargetVSDropCommitStatusName)
+        #    packagePrefix: xamarin-android
+        #    artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+        #    yamlResourceName: yaml-templates
+        #    downloadSteps:
+        #    - task: DownloadPipelineArtifact@2
+        #      inputs:
+        #        artifactName: vsdrop-multitarget-signed
+        #        downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
         - task: DownloadPipelineArtifact@2
           inputs:
+            buildType: specific
+            project: DevDiv
+            definition: 11410
+            buildVersionToDownload: specific
+            pipelineId: 9896489
+            allowPartiallySucceededBuilds: true
+            allowFailedBuilds: true
+            artifactName: nuget-signed
+            downloadPath: $(Build.StagingDirectory)\nuget-signed
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            buildType: specific
+            project: DevDiv
+            definition: 11410
+            buildVersionToDownload: specific
+            pipelineId: 9896489
+            allowPartiallySucceededBuilds: true
+            allowFailedBuilds: true
             artifactName: nuget-linux-signed
             downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            artifactName: vs-msi-nugets
-            downloadPath: $(Build.StagingDirectory)\nuget-signed
-
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            artifactName: $(WindowsToolchainPdbArtifactName)
-            downloadPath: $(Build.StagingDirectory)\nuget-signed
-
-        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-          parameters:
-            githubToken: $(GitHub.Token)
-            githubContext: $(NupkgCommitStatusName)
-            blobName: $(NupkgCommitStatusName)
-            packagePrefix: xamarin-android
-            artifactsPath: $(Build.StagingDirectory)\nuget-signed
-            yamlResourceName: yaml-templates
-
-        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-          parameters:
-            githubToken: $(GitHub.Token)
-            githubContext: $(VSDropCommitStatusName)
-            blobName: $(VSDropCommitStatusName)
-            packagePrefix: xamarin-android
-            artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
-            yamlResourceName: yaml-templates
-            downloadSteps:
-            - task: DownloadPipelineArtifact@2
-              inputs:
-                artifactName: vsdrop-signed
-                downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
-
-        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-          parameters:
-            githubToken: $(GitHub.Token)
-            githubContext: $(MultiTargetVSDropCommitStatusName)
-            blobName: $(MultiTargetVSDropCommitStatusName)
-            packagePrefix: xamarin-android
-            artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
-            yamlResourceName: yaml-templates
-            downloadSteps:
-            - task: DownloadPipelineArtifact@2
-              inputs:
-                artifactName: vsdrop-multitarget-signed
-                downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
         - task: DotNetCoreCLI@2
           displayName: build Xamarin.Android.Tools.BootstrapTasks.sln
@@ -621,20 +645,20 @@ extends:
               -c $(XA.Build.Configuration) -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
           condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
-        - powershell: |
-            $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
-            $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
-            $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-            & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
-            & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
-          displayName: add build to default darc channel
-          condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
+        #- powershell: |
+        #    $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
+        #    $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
+        #    $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+        #    & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
+        #    & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+        #  displayName: add build to default darc channel
+        #  condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
-        - template: build-tools\automation\yaml-templates\upload-results.yaml@self
-          parameters:
-            xaSourcePath: $(System.DefaultWorkingDirectory)
-            artifactName: Prepare Release - Push Internal
-            includeBuildResults: true
+        #- template: build-tools\automation\yaml-templates\upload-results.yaml@self
+        #  parameters:
+        #    xaSourcePath: $(System.DefaultWorkingDirectory)
+        #    artifactName: Prepare Release - Push Internal
+        #    includeBuildResults: true
 
     # Check - "Xamarin.Android (PoliCheck PoliCheck $(Language))"
     - template: security/policheck/v3.yml@yaml-templates

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -194,6 +194,7 @@
 
     <PushToAzureDevOpsArtifacts
         ItemsToPush="@(ItemsToPush)"
+        IsStableBuild="$(IsStableBuild)"
         ManifestBuildData="@(ManifestBuildData)"
         ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"
         ManifestBranch="$(BUILD_SOURCEBRANCH)"


### PR DESCRIPTION
We've seen the build promotion pipeline fail when trying to publish
stable package versions:

    error : Package 'Microsoft.iOS.Ref.net8.0_17.5' has stable version '17.5.8001' but is targeted at a non-isolated feed 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json'

This is because we were not declaring these packages as stable when
building the build asset registry manifest.

Fix this by passing the `$(IsStableBuild)` property to the build asset
manifest creation task. This property needs to be updated manually when
switching to stable package versioning (see commit 4ea5dbb921).

When `$(IsStableBuild)` is set to true, packages will be pushed to an
isolated feed during publishing, such as:

      Package Microsoft.Android.Ref.34@34.0.125 (Shipping) should go to https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-b8317b6f/nuget/v3/index.json (Isolated, Public)
