### PR TITLE
Expand Java directory mapping message to support multiple directories

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
@@ -142,8 +142,7 @@ namespace Xamarin.Android.Tasks
 		{
 			var match = CodeErrorRegEx.Match (singleLine);
 			var exceptionMatch = ExceptionRegEx.Match (singleLine);
-			var lp = lpRegex.Match (singleLine);
-			if (lp.Success) {
+			foreach (Match lp in lpRegex.Matches (singleLine)) {
 				var id = lp.Groups["identifier"].Value;
 				var asmName = assemblyMap.GetAssemblyNameForImportDirectory (id);
 				if (!string.IsNullOrEmpty (asmName)) {


### PR DESCRIPTION
Fixes #9089

Improve the error reporting so we emit mapping information for all the `lp` directories in an error message. 
The previous code only handled the first one, so lets get all of them.

So we go from 

```
Directory 'obj/Debug/net8.0-android/lp/548' is from 'protolitewellknowntypes-18.0.0.aar'.`
```

to 

```
Directory 'obj/Debug/net8.0-android/lp/548' is from 'foo1-18.0.0.aar'.
Directory 'obj/Debug/net8.0-android/lp/59' is from 'foo2-18.0.0.aar'.
```