### PR TITLE
[build] fix `ConfigureLocalWorkload` target

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -265,11 +265,12 @@
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_PackProps, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
   </Target>
 
-  <Target Name="InstallManifestAndDependencies">
+  <Target Name="InstallManifestAndDependencies"
+      DependsOnTargets="DeleteExtractedWorkloadPacks;_GetDefaultPackageVersion">
     <PropertyGroup>
       <_LocalSdkManifestsFolder>$(BuildOutputDirectory)lib\sdk-manifests\$(DotNetSdkManifestsFolder)\</_LocalSdkManifestsFolder>
-      <_LocalAndroidManifestFolder>$(_LocalSdkManifestsFolder)microsoft.net.sdk.android\</_LocalAndroidManifestFolder>
-      <_EmptyWorkloadDir>$(_LocalSdkManifestsFolder)android.deps.workload\</_EmptyWorkloadDir>
+      <_LocalAndroidManifestFolder>$(_LocalSdkManifestsFolder)microsoft.net.sdk.android\$(AndroidPackVersionLong)\</_LocalAndroidManifestFolder>
+      <_EmptyWorkloadDir>$(_LocalSdkManifestsFolder)android.deps.workload\0.0.1\</_EmptyWorkloadDir>
       <_EmptyWorkloadJsonContent>
 <![CDATA[
 {"version": "0.0.1", "workloads": { "android-deps": { "extends" : [ "microsoft-net-runtime-android", "microsoft-net-runtime-android-aot" ] } } }


### PR DESCRIPTION
After 580166e6 was merged, the `ConfigureLocalWorkload` target was no longer working as some of the structure of the `sdk-manifests` folder has changed.

* We should run the `DeleteExtractedWorkloadPacks` target, as it will delete the `sdk-manifests/workloadset` folder.

Without doing this, the .NET SDK will *always* attempt to use the 34.99.0-preview.6.340 version in the "baseline" manifest.

* We also should put a versioned folder after each manifest directory.

So, for example:

    bin\Debug\lib\sdk-manifests\microsoft.net.sdk.android\ -> bin\Debug\lib\sdk-manifests\microsoft.net.sdk.android\35.0.0-preview.x.x\
    bin\Debug\lib\sdk-manifests\android.deps.workload\ -> bin\Debug\lib\sdk-manifests\android.deps.workload\0.0.1\

Now with a fresh checkout:

    dotnet msbuild -t:Prepare Xamarin.Android.sln
    .\dotnet-local.cmd build Xamarin.Android.sln
    .\dotnet-local.cmd build -t:ConfigureLocalWorkload build-tools\create-packs\Microsoft.Android.Sdk.proj

At this point, I can build app projects and the
`BuildBasicApplication` test passes locally.