### PR TITLE
[trimming] remove our usage of `[Preserve]`

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
@@ -40,6 +40,7 @@
 			<field name="handle_type" />
 			<field name="refs_added" />
 			<field name="weak_handle" />
+			<method name="SetHandleOnDeserialized" />
 		</type>
 		<type fullname="Java.Lang.Throwable">
 			<field name="handle" />

--- a/src/Mono.Android/Android.OS/AsyncTask.cs
+++ b/src/Mono.Android/Android.OS/AsyncTask.cs
@@ -64,7 +64,6 @@ namespace Android.OS {
 			JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor);
 		}
 
-		[Preserve (Conditional = true)]
 		protected override Java.Lang.Object? DoInBackground (params Java.Lang.Object[]? native_parms)
 		{
 			TParams[] parms = new TParams[native_parms?.Length ?? 0];

--- a/src/Mono.Android/Android.Runtime/XmlPullParserReader.cs
+++ b/src/Mono.Android/Android.Runtime/XmlPullParserReader.cs
@@ -25,7 +25,6 @@ namespace Android.Runtime
 			source.Close ();
 		}
 
-		[Preserve (Conditional=true)]
 		public static XmlResourceParserReader? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			return FromNative (handle, transfer);
@@ -387,7 +386,6 @@ namespace Android.Runtime
 			}
 		}
 
-		[Preserve (Conditional=true)]
 		public static XmlReader? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			return FromNative (handle, transfer);

--- a/src/Mono.Android/Android.Runtime/XmlReaderPullParser.cs
+++ b/src/Mono.Android/Android.Runtime/XmlReaderPullParser.cs
@@ -9,7 +9,6 @@ namespace Android.Runtime
 {
 	public class XmlReaderResourceParser : XmlReaderPullParser, IXmlResourceParser
 	{
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (XmlReader? value)
 		{
 			if (value == null)
@@ -127,7 +126,6 @@ namespace Android.Runtime
 
 	public class XmlReaderPullParser : Java.Lang.Object, IXmlPullParser
 	{
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (XmlReader? value)
 		{
 			if (value == null)

--- a/src/Mono.Android/Java.Lang/Object.cs
+++ b/src/Mono.Android/Java.Lang/Object.cs
@@ -82,7 +82,6 @@ namespace Java.Lang {
 
 		// Note: must be internal so that e.g. DataContractJsonSerializer will find it
 		[OnDeserialized]
-		[Preserve]
 		internal void SetHandleOnDeserialized (StreamingContext context)
 		{
 			if (Handle != IntPtr.Zero)

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -852,11 +852,6 @@
   <remove-node path="/api/package[@name='junit.framework']/class[@name='TestSuite']/method[parameter[@type='java.lang.Class']]" api-since="16" />
      -->
 
-  <!-- Preserve Mono.Android.App.IntentService::.ctor if the
-       type is used anywhere. -->
-
-  <attr path="/api/package[@name='mono.android.app']/class[@name='IntentService']/constructor[count(parameter) = 0]" name="customAttributes">[Preserve(Conditional = true)]</attr>
-
   <!--    Asyncification    -->
 
   <!-- Interfaces -->


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/5197

`[Preserve]` still works in some form, as the `ApplyPreserveAttribute` trimmer step will "mark" types it encounters. It unfortuantely, *does not* work if an assembly is deemed to be fully removed, as the `ApplyPreserveAttribute` will not be called for these types.

To better align with the future of .NET, we should remove *our* usage of `[Preserve]`. The only failing result is `Java.Lang.Object.SetHandleOnDeserialized` which can be preserved in `Mono.Android.xml` instead.

In a future PR, we can consider emitting warnings in customer code with `[Preserve]` usage.