### PR TITLE
[ci] Disable CodeQL on CI/PR pipelines

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -73,11 +73,7 @@ extends:
         enableAllTools: false
       binskim:
         scanOutputDirectoryOnly: true
-      ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cql-disable-fix') }}:
-        codeql:
-          compiled:
-            enabled: false
-            justificationForDisabling: CodeQL disabled for non-main branch builds
+
       policheck:
         enabled: false
         justification: Built in task does not support multi-language scanning
@@ -101,10 +97,32 @@ extends:
       skipBuildTagsForGitHubPullRequests: true
     stages:
     - template: /build-tools/automation/yaml-templates/build-macos.yaml@self
+      parameters:
+        templateContext:
+          sdl:
+            codeql:
+              compiled:
+                enabled: false
+                justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
 
     - template: /build-tools/automation/yaml-templates/build-windows.yaml@self
+      parameters:
+        templateContext:
+          sdl:
+            ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cql-disable-fix') }}:
+              codeql:
+                compiled:
+                  enabled: false
+                  justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
 
     - template: /build-tools/automation/yaml-templates/build-linux.yaml@self
+      parameters:
+          templateContext:
+            sdl:
+              codeql:
+                compiled:
+                  enabled: false
+                  justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
 
     - stage: smoke_tests
       displayName: Package Tests

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -96,30 +96,10 @@ extends:
       skipBuildTagsForGitHubPullRequests: true
     stages:
     - template: /build-tools/automation/yaml-templates/build-macos.yaml@self
-      parameters:
-        templateContextSdl:
-          codeql:
-            compiled:
-              enabled: false
-              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
 
     - template: /build-tools/automation/yaml-templates/build-windows.yaml@self
-      parameters:
-        templateContext:
-          sdl:
-            ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cql-disable-fix') }}:
-              codeql:
-                compiled:
-                  enabled: false
-                  justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
 
     - template: /build-tools/automation/yaml-templates/build-linux.yaml@self
-      parameters:
-        templateContextSdl:
-          codeql:
-            compiled:
-              enabled: false
-              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
 
     - stage: smoke_tests
       displayName: Package Tests

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -73,6 +73,10 @@ extends:
         enableAllTools: false
       binskim:
         scanOutputDirectoryOnly: true
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: CodeQL runs against the nightly build
       policheck:
         enabled: false
         justification: Built in task does not support multi-language scanning

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -73,8 +73,8 @@ extends:
         enableAllTools: false
       binskim:
         scanOutputDirectoryOnly: true
-      codeql:
-        ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+      ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cql-disable-fix') }}:
+        codeql:
           compiled:
             enabled: false
             justificationForDisabling: CodeQL disabled for non-main branch builds

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -73,7 +73,6 @@ extends:
         enableAllTools: false
       binskim:
         scanOutputDirectoryOnly: true
-
       policheck:
         enabled: false
         justification: Built in task does not support multi-language scanning
@@ -117,12 +116,12 @@ extends:
 
     - template: /build-tools/automation/yaml-templates/build-linux.yaml@self
       parameters:
-          templateContext:
-            sdl:
-              codeql:
-                compiled:
-                  enabled: false
-                  justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
+        templateContext:
+          sdl:
+            codeql:
+              compiled:
+                enabled: false
+                justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
 
     - stage: smoke_tests
       displayName: Package Tests

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -97,12 +97,11 @@ extends:
     stages:
     - template: /build-tools/automation/yaml-templates/build-macos.yaml@self
       parameters:
-        templateContext:
-          sdl:
-            codeql:
-              compiled:
-                enabled: false
-                justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
+        templateContextSdl:
+          codeql:
+            compiled:
+              enabled: false
+              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
 
     - template: /build-tools/automation/yaml-templates/build-windows.yaml@self
       parameters:
@@ -116,12 +115,11 @@ extends:
 
     - template: /build-tools/automation/yaml-templates/build-linux.yaml@self
       parameters:
-        templateContext:
-          sdl:
-            codeql:
-              compiled:
-                enabled: false
-                justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
+        templateContextSdl:
+          codeql:
+            compiled:
+              enabled: false
+              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
 
     - stage: smoke_tests
       displayName: Package Tests

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -35,6 +35,7 @@ stages:
       CC: gcc-10
     ${{ if eq(parameters.use1ESTemplate, true) }}:
       templateContext:
+        sdl: ${{ parameters.stageName }}.templateContext.sdl
         outputs:
         - output: pipelineArtifact
           displayName: upload linux sdk

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -34,12 +34,6 @@ stages:
       CXX: g++-10
       CC: gcc-10
     ${{ if eq(parameters.use1ESTemplate, true) }}:
-      templateContext:
-        sdl:
-          codeql:
-            compiled:
-              enabled: false
-              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build
         outputs:
         - output: pipelineArtifact
           displayName: upload linux sdk

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -35,11 +35,6 @@ stages:
       CC: gcc-10
     ${{ if eq(parameters.use1ESTemplate, true) }}:
       templateContext:
-        sdl:
-          codeql:
-            compiled:
-              enabled: false
-              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build
         outputs:
         - output: pipelineArtifact
           displayName: upload linux sdk

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -12,6 +12,7 @@ parameters:
   stageName: linux_build
   stageDisplayName: Linux
   use1ESTemplate: true
+  templateContextSdl: []
 
 stages:
 - stage: ${{ parameters.stageName }}
@@ -35,7 +36,7 @@ stages:
       CC: gcc-10
     ${{ if eq(parameters.use1ESTemplate, true) }}:
       templateContext:
-        sdl: ${{ parameters.stageName }}.templateContext.sdl
+        sdl: ${{ parameters.templateContextSdl }}
         outputs:
         - output: pipelineArtifact
           displayName: upload linux sdk

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -34,6 +34,7 @@ stages:
       CXX: g++-10
       CC: gcc-10
     ${{ if eq(parameters.use1ESTemplate, true) }}:
+      templateContext:
         outputs:
         - output: pipelineArtifact
           displayName: upload linux sdk

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -12,7 +12,6 @@ parameters:
   stageName: linux_build
   stageDisplayName: Linux
   use1ESTemplate: true
-  templateContextSdl: []
 
 stages:
 - stage: ${{ parameters.stageName }}
@@ -36,7 +35,11 @@ stages:
       CC: gcc-10
     ${{ if eq(parameters.use1ESTemplate, true) }}:
       templateContext:
-        sdl: ${{ parameters.templateContextSdl }}
+        sdl:
+          codeql:
+            compiled:
+              enabled: false
+              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build
         outputs:
         - output: pipelineArtifact
           displayName: upload linux sdk

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -16,6 +16,7 @@ parameters:
   testAssembliesArtifactName: $(TestAssembliesArtifactName)
   windowsToolchainPdbArtifactName: $(WindowsToolchainPdbArtifactName)
   use1ESTemplate: true
+  templateContextSdl: []
 
 stages:
 - stage: ${{ parameters.stageName }}
@@ -43,7 +44,7 @@ stages:
       clean: all
     ${{ if eq(parameters.use1ESTemplate, true) }}:
       templateContext:
-        sdl: ${{ parameters.stageName }}.templateContext.sdl
+        sdl: ${{ parameters.templateContextSdl }}
         outputParentDirectory: ${{ parameters.xaSourcePath }}/bin
         outputs:
         - output: pipelineArtifact

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -43,11 +43,6 @@ stages:
       clean: all
     ${{ if eq(parameters.use1ESTemplate, true) }}:
       templateContext:
-        sdl:
-          codeql:
-            compiled:
-              enabled: false
-              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build
         outputParentDirectory: ${{ parameters.xaSourcePath }}/bin
         outputs:
         - output: pipelineArtifact

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -16,7 +16,6 @@ parameters:
   testAssembliesArtifactName: $(TestAssembliesArtifactName)
   windowsToolchainPdbArtifactName: $(WindowsToolchainPdbArtifactName)
   use1ESTemplate: true
-  templateContextSdl: []
 
 stages:
 - stage: ${{ parameters.stageName }}
@@ -44,7 +43,11 @@ stages:
       clean: all
     ${{ if eq(parameters.use1ESTemplate, true) }}:
       templateContext:
-        sdl: ${{ parameters.templateContextSdl }}
+        sdl:
+          codeql:
+            compiled:
+              enabled: false
+              justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build
         outputParentDirectory: ${{ parameters.xaSourcePath }}/bin
         outputs:
         - output: pipelineArtifact

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -43,6 +43,7 @@ stages:
       clean: all
     ${{ if eq(parameters.use1ESTemplate, true) }}:
       templateContext:
+        sdl: ${{ parameters.stageName }}.templateContext.sdl
         outputParentDirectory: ${{ parameters.xaSourcePath }}/bin
         outputs:
         - output: pipelineArtifact

--- a/build-tools/automation/yaml-templates/build-windows.yaml
+++ b/build-tools/automation/yaml-templates/build-windows.yaml
@@ -10,7 +10,6 @@ parameters:
   repositoryAlias: self
   stageName: win_build_test
   stageDisplayName: Windows
-  use1ESTemplate: true
 
 # This stage ensures Windows specific build steps continue to work, and runs unit tests.
 stages:
@@ -28,14 +27,6 @@ stages:
       image: $(WindowsPoolImage1ESPT)
       os: windows
     timeoutInMinutes: 240
-    ${{ if eq(parameters.use1ESTemplate, true) }}:
-      templateContext:
-        sdl:
-          ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cql-disable-fix') }}:
-            codeql:
-              compiled:
-                enabled: false
-                justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
     steps:
     - template: sdk-unified/steps/checkout/v1.yml@yaml-templates
       parameters:

--- a/build-tools/automation/yaml-templates/build-windows.yaml
+++ b/build-tools/automation/yaml-templates/build-windows.yaml
@@ -10,6 +10,7 @@ parameters:
   repositoryAlias: self
   stageName: win_build_test
   stageDisplayName: Windows
+  use1ESTemplate: true
 
 # This stage ensures Windows specific build steps continue to work, and runs unit tests.
 stages:
@@ -27,6 +28,14 @@ stages:
       image: $(WindowsPoolImage1ESPT)
       os: windows
     timeoutInMinutes: 240
+    ${{ if eq(parameters.use1ESTemplate, true) }}:
+      templateContext:
+        sdl:
+          ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/cql-disable-fix') }}:
+            codeql:
+              compiled:
+                enabled: false
+                justificationForDisabling: CodeQL runs against the Windows build and nightly macOS build on main
     steps:
     - template: sdk-unified/steps/checkout/v1.yml@yaml-templates
       parameters:


### PR DESCRIPTION
The conditions to disable CodeQL across different jobs and branches do
not appear be working as expected. The 'make prepare-update-mono' step
has been hanging intermittently on macOS, which appears to be due to
CodeQL.

Fix this by disabling CodeQL on this pipeline and only running it against
the nightly build.