### PR TITLE
[native] Change name of static libraries in some cases

### DIFF
--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -64,6 +64,10 @@ endif()
 option(ENABLE_CLANG_ASAN "Enable the clang AddressSanitizer support" OFF)
 option(ENABLE_CLANG_UBSAN "Enable the clang UndefinedBehaviorSanitizer support" OFF)
 
+if(ENABLE_CLANG_ASAN AND ENABLE_CLANG_UBSAN)
+  message(FATAL_ERROR "Both ASAN and UBSAN builds cannot be enabled at the same time")
+endif()
+
 if(ENABLE_CLANG_ASAN OR ENABLE_CLANG_UBSAN)
   set(STRIP_DEBUG_DEFAULT OFF)
   set(ANALYZERS_ENABLED ON)
@@ -79,6 +83,12 @@ option(STRIP_DEBUG "Strip debugging information when linking" ${STRIP_DEBUG_DEFA
 option(DISABLE_DEBUG "Disable the built-in debugging code" OFF)
 option(USE_CCACHE "Use ccache, if found, to speed up recompilation" ON)
 option(DONT_INLINE "Do not inline any functions which are usually inlined, to get better stack traces" ${DONT_INLINE_DEFAULT})
+
+if(ENABLE_CLANG_ASAN)
+  set(STATIC_LIB_NAME_SUFFIX "-asan")
+elseif(ENABLE_CLANG_UBSAN)
+  set(STATIC_LIB_NAME_SUFFIX "-ubsan")
+endif()
 
 if(USE_CCACHE)
   if(CMAKE_CXX_COMPILER MATCHES "/ccache/")
@@ -440,6 +450,19 @@ add_compile_options("$<$<COMPILE_LANGUAGE:C>:${COMMON_C_ARGS}>")
 
 add_link_options("$<$<COMPILE_LANGUAGE:CXX>:${COMMON_CXX_LINKER_ARGS}>")
 add_link_options("$<$<COMPILE_LANGUAGE:C>:${COMMON_C_LINKER_ARGS}>")
+
+#
+# Helper macros
+#
+macro(set_static_library_suffix TARGET_NAME)
+  if(STATIC_LIB_NAME_SUFFIX)
+    set_target_properties(
+      ${TARGET_NAME}
+      PROPERTIES
+      SUFFIX "${STATIC_LIB_NAME_SUFFIX}.a"
+    )
+  endif()
+endmacro()
 
 add_subdirectory(libunwind)
 add_subdirectory(lz4)

--- a/src/native/java-interop/CMakeLists.txt
+++ b/src/native/java-interop/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(
 
 add_library(${LIB_ALIAS} ALIAS ${LIB_NAME})
 
+set_static_library_suffix(${LIB_NAME})
+
 target_include_directories(
   ${LIB_NAME}
   PUBLIC

--- a/src/native/monodroid/CMakeLists.txt
+++ b/src/native/monodroid/CMakeLists.txt
@@ -18,7 +18,7 @@ if(DEBUG_BUILD)
   set(CMAKE_C_FLAGS_DEBUG ${XA_COMPILER_FLAGS_DEBUG})
   set(CMAKE_CXX_FLAGS_DEBUG ${XA_COMPILER_FLAGS_DEBUG})
 elseif(NOT ANALYZERS_ENABLED)
-  set(BUILD_STATIC_LIBRARY ON)
+  set(BUILD_STATIC_LIBRARY OFF) # Turn off for now, until we implement dynamic runtime linking at app build time
 endif()
 
 # Library directories
@@ -101,6 +101,7 @@ if(BUILD_STATIC_LIBRARY)
     STATIC
     ${XAMARIN_MONODROID_SOURCES}
   )
+  set_static_library_suffix(${XAMARIN_MONO_ANDROID_STATIC_LIB})
 endif()
 
 macro(lib_target_options TARGET_NAME)

--- a/src/native/pinvoke-override/CMakeLists.txt
+++ b/src/native/pinvoke-override/CMakeLists.txt
@@ -35,6 +35,8 @@ macro(create_library _libname _alias _sources)
 
   add_library(${_alias} ALIAS ${_libname})
 
+  set_static_library_suffix(${_libname})
+
   target_compile_definitions(
     ${_libname}
     PRIVATE

--- a/src/native/runtime-base/CMakeLists.txt
+++ b/src/native/runtime-base/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(
 
 add_library(${LIB_ALIAS} ALIAS ${LIB_NAME})
 
+set_static_library_suffix(${LIB_NAME})
+
 target_compile_options(
   ${LIB_NAME}
   PRIVATE

--- a/src/native/shared/CMakeLists.txt
+++ b/src/native/shared/CMakeLists.txt
@@ -28,12 +28,16 @@ add_library(
 )
 add_library(${LIB_ALIAS} ALIAS ${LIB_NAME})
 
+set_static_library_suffix(${LIB_NAME})
+
 add_library(
   ${LIB_NAME_NO_ABI}
   STATIC
   ${XA_SHARED_SOURCES}
 )
 add_library(${LIB_ALIAS_NO_ABI} ALIAS ${LIB_NAME_NO_ABI})
+
+set_static_library_suffix(${LIB_NAME_NO_ABI})
 
 macro(lib_target_options TARGET_NAME)
   target_include_directories(

--- a/src/native/tracing/CMakeLists.txt
+++ b/src/native/tracing/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(
 
 add_library(${LIB_ALIAS} ALIAS ${LIB_NAME})
 
+set_static_library_suffix(${LIB_NAME})
+
 target_include_directories(
   ${LIB_NAME}
   PUBLIC


### PR DESCRIPTION
The native runtime is subdivided into a collection of static libraries,
linked into the target shared library based on a set of conditions.

Some static libraries are "private" and aren't copied to packages, but
some are "public" in that they can be shipped in our nugets (when
dynamic runtime linking at app build time is implemented).  At the same
time, we have several build configurations which differ in their build
and link configurations, and especially in whether or not they link
against the shared C++ standard library or not.  In particular, the ASAN
and UBSAN builds require enabling of exceptions, RTTI and linking
against the shared C++ library.

Static component libraries will be built with the same set of
compilation and linking flags, and without modifying their output names
in some way, they may result in linking errors similar to:

```
native failed with 25 error(s) (0.6s) → 
    ld.lld : error : undefined symbol: std::logic_error::logic_error(char const*)
    clang++ : error : linker command failed with exit code 1 (use -v to see invocation)
    ld.lld : error : undefined symbol: __gxx_personality_v0
    ld.lld : error : undefined symbol: __cxa_begin_catch
    ld.lld : error : undefined symbol: std::__ndk1::mutex::lock()
    ld.lld : error : undefined symbol: std::__ndk1::mutex::unlock()
    ld.lld : error : undefined symbol: __cxa_end_cleanup
```

This kind of errors may not show during the very first build of the
repository, but it will show on any subsequent build since the static
component library name used by **all** the configurations is the same,
but the compilation and linking flags are different.  If, e.g., UBSAN
build follows the standard build, it will replace the previously built
library with its own version but different linking requirements.
Subsequent build of non-UBSAN version of library will try to use the
static component library built with UBSAN flags, resulting in the
linking error above.

In order to avoid this kind of confusion but also minimize the number of
branches in CMake script files, this commit simply makes sure that all
the relevant static component libraries use an optional suffix when
generating their output.  By default the suffix is empty, resulting in
e.g. `libruntime-base.a`, but with UBSAN enabled, it will produce
`libruntime-base-ubsan.a` thus making sure the builds don't step on each
other's toes.