### PR TITLE
[tests] fix 1,170 build warnings

### DIFF
--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.NET.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.NET.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DotNetAndroidTargetFramework)</TargetFramework>
+    <SupportedOSPlatformVersion>$(AndroidMinimumDotNetApiLevel)</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.NUnitLite</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.NET.csproj
+++ b/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.NET.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DotNetAndroidTargetFramework)</TargetFramework>
+    <SupportedOSPlatformVersion>$(AndroidMinimumDotNetApiLevel)</SupportedOSPlatformVersion>
     <RootNamespace>Java.Interop_Tests</RootNamespace>
     <AssemblyName>Java.Interop-Tests</AssemblyName>
     <OutputType>Library</OutputType>

--- a/tests/Mono.Android-Tests/Mono.Android-Test.Library/Mono.Android-Test.Library.NET.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Test.Library/Mono.Android-Test.Library.NET.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DotNetAndroidTargetFramework)</TargetFramework>
+    <SupportedOSPlatformVersion>$(AndroidMinimumDotNetApiLevel)</SupportedOSPlatformVersion>
     <RootNamespace>Xamarin.Android.RuntimeTests</RootNamespace>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DotNetAndroidTargetFramework)</TargetFramework>
-    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(AndroidMinimumDotNetApiLevel)</SupportedOSPlatformVersion>
     <RootNamespace>Xamarin.Android.RuntimeTests</RootNamespace>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>

--- a/tests/TestRunner.Core/TestRunner.Core.NET.csproj
+++ b/tests/TestRunner.Core/TestRunner.Core.NET.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DotNetAndroidTargetFramework)</TargetFramework>
+    <SupportedOSPlatformVersion>$(AndroidMinimumDotNetApiLevel)</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.UnitTests</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tests/TestRunner.NUnit/TestRunner.NUnit.NET.csproj
+++ b/tests/TestRunner.NUnit/TestRunner.NUnit.NET.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DotNetAndroidTargetFramework)</TargetFramework>
+    <SupportedOSPlatformVersion>$(AndroidMinimumDotNetApiLevel)</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.UnitTests.NUnit</RootNamespace>
     <AssemblyName>TestRunner.NUnit.NET</AssemblyName>


### PR DESCRIPTION
There are lots of warnings like:

    .\dotnet-local.cmd build .\tests\Mono.Android-Tests\Runtime-Microsoft.Android.Sdk\Mono.Android.NET-Tests.csproj
    ...
    .\tests\Mono.Android-Tests\Java.Interop\JavaConvertTest.cs(134,20):
    warning CA1416: This call site is reachable on all platforms. 'Object' is only supported on: 'Android' 21.0 and later.
    (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
    ...
    Build succeeded with 1192 warning(s) in 44.4s

Several APK test projects need to set:

    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>

In order to keep the .NET analyzer happy.

After these changes:

    Build succeeded with 22 warning(s) in 38.4s