### PR TITLE
[monodroid] treat `LocalRefsAreIndirect` as always true

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -39,7 +39,7 @@ namespace Android.Runtime {
 
 		internal static IntPtr IdentityHash (IntPtr v)
 		{
-			return JNIEnvInit.LocalRefsAreIndirect ? RuntimeNativeMethods._monodroid_get_identity_hash_code (Handle, v) : v;
+			return RuntimeNativeMethods._monodroid_get_identity_hash_code (Handle, v);
 		}
 
 		public static void CheckHandle (IntPtr jnienv)

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -23,7 +23,6 @@ namespace Android.Runtime
 			public uint            logCategories;
 			public int             version; // TODO: remove, not needed anymore
 			public int             androidSdkVersion;
-			public int             localRefsAreIndirect;
 			public int             grefGcThreshold;
 			public IntPtr          grefIGCUserPeer;
 			public int             isRunningOnDesktop;
@@ -40,7 +39,6 @@ namespace Android.Runtime
 		internal static bool AllocObjectSupported;
 		internal static bool IsRunningOnDesktop;
 		internal static bool jniRemappingInUse;
-		internal static bool LocalRefsAreIndirect;
 		internal static bool LogAssemblyCategory;
 		internal static bool MarshalMethodsEnabled;
 		internal static bool PropagateExceptions;
@@ -95,8 +93,6 @@ namespace Android.Runtime
 			java_class_loader = args->grefLoader;
 
 			mid_Class_forName = new JniMethodInfo (args->Class_forName, isStatic: true);
-
-			LocalRefsAreIndirect = args->localRefsAreIndirect == 1;
 
 			bool androidNewerThan10 = args->androidSdkVersion > 10;
 			BoundExceptionType = (BoundExceptionType)args->ioExceptionType;

--- a/src/native/monodroid/monodroid-glue-internal.hh
+++ b/src/native/monodroid/monodroid-glue-internal.hh
@@ -92,7 +92,6 @@ namespace xamarin::android::internal
 			unsigned int    logCategories;
 			int             version;
 			int             androidSdkVersion;
-			int             localRefsAreIndirect;
 			int             grefGcThreshold;
 			jobject         grefIGCUserPeer;
 			int             isRunningOnDesktop;
@@ -180,7 +179,6 @@ namespace xamarin::android::internal
 			fnptr = reinterpret_cast<TFunc*>(symptr);
 		}
 
-		int LocalRefsAreIndirect (JNIEnv *env, jclass runtimeClass, int version);
 		void create_xdg_directory (jstring_wrapper& home, size_t home_len, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept;
 		void create_xdg_directories_and_environment (jstring_wrapper &homeDir);
 		void lookup_bridge_info (MonoClass *klass, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info);

--- a/src/native/monodroid/monodroid-glue.cc
+++ b/src/native/monodroid/monodroid-glue.cc
@@ -772,21 +772,6 @@ MonodroidRuntime::create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks
 	return domain;
 }
 
-inline int
-MonodroidRuntime::LocalRefsAreIndirect (JNIEnv *env, jclass runtimeClass, int version)
-{
-	if (version < 14) {
-		java_System = nullptr;
-		java_System_identityHashCode = 0;
-		return 0;
-	}
-
-	java_System = RuntimeUtil::get_class_from_runtime_field (env, runtimeClass, "java_lang_System", true);
-	java_System_identityHashCode = env->GetStaticMethodID (java_System, "identityHashCode", "(Ljava/lang/Object;)I");
-
-	return 1;
-}
-
 force_inline void
 MonodroidRuntime::lookup_bridge_info (MonoClass *klass, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info)
 {
@@ -851,7 +836,6 @@ MonodroidRuntime::init_android_runtime (JNIEnv *env, jclass runtimeClass, jobjec
 	init.logCategories          = log_categories;
 	init.version                = env->GetVersion ();
 	init.androidSdkVersion      = android_api_level;
-	init.localRefsAreIndirect   = LocalRefsAreIndirect (env, runtimeClass, init.androidSdkVersion);
 	init.isRunningOnDesktop     = is_running_on_desktop ? 1 : 0;
 	init.brokenExceptionTransitions = application_config.broken_exception_transitions ? 1 : 0;
 	init.packageNamingPolicy    = static_cast<int>(application_config.package_naming_policy);
@@ -859,6 +843,9 @@ MonodroidRuntime::init_android_runtime (JNIEnv *env, jclass runtimeClass, jobjec
 	init.jniAddNativeMethodRegistrationAttributePresent = application_config.jni_add_native_method_registration_attribute_present ? 1 : 0;
 	init.jniRemappingInUse = application_config.jni_remapping_replacement_type_count > 0 || application_config.jni_remapping_replacement_method_index_entry_count > 0;
 	init.marshalMethodsEnabled  = application_config.marshal_methods_enabled;
+
+	java_System = RuntimeUtil::get_class_from_runtime_field (env, runtimeClass, "java_lang_System", true);
+	java_System_identityHashCode = env->GetStaticMethodID (java_System, "identityHashCode", "(Ljava/lang/Object;)I");
 
 	// GC threshold is 90% of the max GREF count
 	init.grefGcThreshold        = static_cast<int>(AndroidSystem::get_gref_gc_threshold ());


### PR DESCRIPTION
There is an API < 14 code path, that seems like we can just *remove* and tread all local refs as indirect.

This might speed up `JNIEnv.IdentityHash` a very small amount, as it no longer checks a `static bool` on each call.