### PR TITLE
$(AndroidPackVersionSuffix)=rc.1; net9 is 35.0.0-rc.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>35.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
     <IsStableBuild>false</IsStableBuild>
     <IsStableBuild Condition=" '$(AndroidPackVersionSuffix)' == 'rtm' ">true</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
We branched for .NET 9 Preview 7 from ab412a56 into release/9.0.1xx-preview7; the main branch is now .NET 9 RC 1.

Update dotnet/android/main's version number to 35.0.0-rc.1.