### PR TITLE
[Mono.Android] treat `AllocObjectSupported` as always true

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -22,13 +22,11 @@ namespace Android.Runtime {
 
 		internal AndroidRuntime (IntPtr jnienv,
 				IntPtr vm,
-				bool allocNewObjectSupported,
 				IntPtr classLoader,
 				IntPtr classLoader_loadClass,
 				bool jniAddNativeMethodRegistrationAttributePresent)
 			: base (new AndroidRuntimeOptions (jnienv,
 					vm,
-					allocNewObjectSupported,
 					classLoader,
 					classLoader_loadClass,
 					jniAddNativeMethodRegistrationAttributePresent))
@@ -87,7 +85,6 @@ namespace Android.Runtime {
 	class AndroidRuntimeOptions : JniRuntime.CreationOptions {
 		public AndroidRuntimeOptions (IntPtr jnienv,
 				IntPtr vm,
-				bool allocNewObjectSupported,
 				IntPtr classLoader,
 				IntPtr classLoader_loadClass,
 				bool jniAddNativeMethodRegistrationAttributePresent)
@@ -96,7 +93,6 @@ namespace Android.Runtime {
 			ClassLoader             = new JniObjectReference (classLoader, JniObjectReferenceType.Global);
 			ClassLoader_LoadClass_id= classLoader_loadClass;
 			InvocationPointer       = vm;
-			NewObjectRequired       = !allocNewObjectSupported;
 			ObjectReferenceManager  = new AndroidObjectReferenceManager ();
 			TypeManager             = new AndroidTypeManager (jniAddNativeMethodRegistrationAttributePresent);
 			ValueManager            = new AndroidValueManager ();

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -172,10 +172,7 @@ namespace Android.Runtime {
 
 		public static unsafe IntPtr StartCreateInstance (IntPtr jclass, IntPtr constructorId, JValue* constructorParameters)
 		{
-			if (JNIEnvInit.AllocObjectSupported) {
-				return AllocObject (jclass);
-			}
-			return NewObject (jclass, constructorId, constructorParameters);
+			return AllocObject (jclass);
 		}
 
 		public static unsafe IntPtr StartCreateInstance (IntPtr jclass, IntPtr constructorId, params JValue[] constructorParameters)
@@ -186,8 +183,6 @@ namespace Android.Runtime {
 
 		public static unsafe void FinishCreateInstance (IntPtr instance, IntPtr jclass, IntPtr constructorId, JValue* constructorParameters)
 		{
-			if (!JNIEnvInit.AllocObjectSupported)
-				return;
 			CallNonvirtualVoidMethod (instance, jclass, constructorId, constructorParameters);
 		}
 
@@ -199,10 +194,7 @@ namespace Android.Runtime {
 
 		public static unsafe IntPtr StartCreateInstance (Type type, string jniCtorSignature, JValue* constructorParameters)
 		{
-			if (JNIEnvInit.AllocObjectSupported) {
-				return AllocObject (type);
-			}
-			return CreateInstance (type, jniCtorSignature, constructorParameters);
+			return AllocObject (type);
 		}
 
 		public static unsafe IntPtr StartCreateInstance (Type type, string jniCtorSignature, params JValue[] constructorParameters)
@@ -213,9 +205,7 @@ namespace Android.Runtime {
 
 		public static unsafe IntPtr StartCreateInstance (string jniClassName, string jniCtorSignature, JValue* constructorParameters)
 		{
-			if (JNIEnvInit.AllocObjectSupported)
-				return AllocObject (jniClassName);
-			return CreateInstance (jniClassName, jniCtorSignature, constructorParameters);
+			return AllocObject (jniClassName);
 		}
 
 		public static unsafe IntPtr StartCreateInstance (string jniClassName, string jniCtorSignature, params JValue[] constructorParameters)
@@ -226,8 +216,6 @@ namespace Android.Runtime {
 
 		public static unsafe void FinishCreateInstance (IntPtr instance, string jniCtorSignature, JValue* constructorParameters)
 		{
-			if (!JNIEnvInit.AllocObjectSupported)
-				return;
 			InvokeConstructor (instance, jniCtorSignature, constructorParameters);
 		}
 

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -13,6 +13,7 @@ namespace Android.Runtime
 	static internal class JNIEnvInit
 	{
 #pragma warning disable 0649
+		// NOTE: Keep this in sync with the native side in src/native/monodroid/monodroid-glue-internal.hh
 		internal struct JnienvInitializeArgs {
 			public IntPtr          javaVm;
 			public IntPtr          env;

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -22,7 +22,6 @@ namespace Android.Runtime
 			public IntPtr          Class_forName;
 			public uint            logCategories;
 			public int             version; // TODO: remove, not needed anymore
-			public int             androidSdkVersion;
 			public int             grefGcThreshold;
 			public IntPtr          grefIGCUserPeer;
 			public int             isRunningOnDesktop;
@@ -36,7 +35,6 @@ namespace Android.Runtime
 #pragma warning restore 0649
 
 		internal static AndroidValueManager? AndroidValueManager;
-		internal static bool AllocObjectSupported;
 		internal static bool IsRunningOnDesktop;
 		internal static bool jniRemappingInUse;
 		internal static bool LogAssemblyCategory;
@@ -94,12 +92,10 @@ namespace Android.Runtime
 
 			mid_Class_forName = new JniMethodInfo (args->Class_forName, isStatic: true);
 
-			bool androidNewerThan10 = args->androidSdkVersion > 10;
 			BoundExceptionType = (BoundExceptionType)args->ioExceptionType;
-			androidRuntime = new AndroidRuntime (args->env, args->javaVm, androidNewerThan10, args->grefLoader, args->Loader_loadClass, args->jniAddNativeMethodRegistrationAttributePresent != 0);
+			androidRuntime = new AndroidRuntime (args->env, args->javaVm, args->grefLoader, args->Loader_loadClass, args->jniAddNativeMethodRegistrationAttributePresent != 0);
 			AndroidValueManager = (AndroidValueManager) androidRuntime.ValueManager;
 
-			AllocObjectSupported = androidNewerThan10;
 			IsRunningOnDesktop = args->isRunningOnDesktop == 1;
 
 			grefIGCUserPeer_class = args->grefIGCUserPeer;

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -120,7 +120,6 @@ public class MonoPackageManager {
 						localDateTimeOffset,
 						loader,
 						MonoPackageManager_Resources.Assemblies,
-						Build.VERSION.SDK_INT,
 						isEmulator (),
 						haveSplitApks
 					);

--- a/src/java-runtime/java/mono/android/Runtime.java
+++ b/src/java-runtime/java/mono/android/Runtime.java
@@ -23,7 +23,6 @@ public class Runtime {
 		int localDateTimeOffset,
 		ClassLoader loader,
 		String[] assemblies,
-		int apiLevel,
 		boolean isEmulator,
 		boolean haveSplitApks
 	);

--- a/src/native/monodroid/internal-pinvokes.cc
+++ b/src/native/monodroid/internal-pinvokes.cc
@@ -132,12 +132,6 @@ _monodroid_gc_wait_for_bridge_processing ()
     mono_gc_wait_for_bridge_processing ();
 }
 
-int
-_monodroid_get_android_api_level ()
-{
-    return monodroidRuntime.get_android_api_level ();
-}
-
 void
 monodroid_clear_gdb_wait ()
 {

--- a/src/native/monodroid/mono_android_Runtime.h
+++ b/src/native/monodroid/mono_android_Runtime.h
@@ -21,7 +21,7 @@ JNIEXPORT void JNICALL Java_mono_android_Runtime_init
  * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;ILjava/lang/ClassLoader;[Ljava/lang/String;IZZ)V
  */
 JNIEXPORT void JNICALL Java_mono_android_Runtime_initInternal
-  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jint, jobject, jobjectArray, jint, jboolean, jboolean);
+  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jint, jobject, jobjectArray, jboolean, jboolean);
 
 /*
  * Class:     mono_android_Runtime

--- a/src/native/monodroid/monodroid-glue-internal.hh
+++ b/src/native/monodroid/monodroid-glue-internal.hh
@@ -82,6 +82,7 @@ namespace xamarin::android::internal
 			Java   = 0x01,
 		};
 
+		// NOTE: Keep this in sync with managed side in src/Mono.Android/Android.Runtime/JNIEnvInit.cs
 		struct JnienvInitializeArgs {
 			JavaVM         *javaVm;
 			JNIEnv         *env;

--- a/src/native/monodroid/monodroid-glue-internal.hh
+++ b/src/native/monodroid/monodroid-glue-internal.hh
@@ -91,7 +91,6 @@ namespace xamarin::android::internal
 			jmethodID       Class_forName;
 			unsigned int    logCategories;
 			int             version;
-			int             androidSdkVersion;
 			int             grefGcThreshold;
 			jobject         grefIGCUserPeer;
 			int             isRunningOnDesktop;
@@ -118,15 +117,10 @@ namespace xamarin::android::internal
 		void Java_mono_android_Runtime_register (JNIEnv *env, jstring managedType, jclass nativeClass, jstring methods);
 		void Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
 		                                             jstring runtimeNativeLibDir, jobjectArray appDirs, jint localDateTimeOffset,
-		                                             jobject loader, jobjectArray assembliesJava, jint apiLevel, jboolean isEmulator,
+		                                             jobject loader, jobjectArray assembliesJava, jboolean isEmulator,
 		                                             jboolean haveSplitApks);
 
 		jint Java_JNI_OnLoad (JavaVM *vm, void *reserved);
-
-		int get_android_api_level () const
-		{
-			return android_api_level;
-		}
 
 		jclass get_java_class_System () const
 		{
@@ -252,7 +246,6 @@ namespace xamarin::android::internal
 #endif
 	private:
 		MonoMethod         *registerType          = nullptr;
-		int                 android_api_level     = 0;
 		volatile bool       monodroid_gdb_wait    = true;
 		jclass              java_System;
 		jmethodID           java_System_identityHashCode;

--- a/src/native/monodroid/monodroid-glue.cc
+++ b/src/native/monodroid/monodroid-glue.cc
@@ -819,7 +819,6 @@ MonodroidRuntime::init_android_runtime (JNIEnv *env, jclass runtimeClass, jobjec
 	init.env                    = env;
 	init.logCategories          = log_categories;
 	init.version                = env->GetVersion ();
-	init.androidSdkVersion      = android_api_level;
 	init.isRunningOnDesktop     = is_running_on_desktop ? 1 : 0;
 	init.brokenExceptionTransitions = application_config.broken_exception_transitions ? 1 : 0;
 	init.packageNamingPolicy    = static_cast<int>(application_config.package_naming_policy);
@@ -1353,7 +1352,7 @@ MonodroidRuntime::install_logging_handlers ()
 inline void
 MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
                                                           jstring runtimeNativeLibDir, jobjectArray appDirs, jint localDateTimeOffset,
-                                                          jobject loader, jobjectArray assembliesJava, jint apiLevel, jboolean isEmulator,
+                                                          jobject loader, jobjectArray assembliesJava, jboolean isEmulator,
                                                           jboolean haveSplitApks)
 {
 	char *mono_log_mask_raw = nullptr;
@@ -1394,7 +1393,6 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 		);
 	}
 
-	android_api_level = apiLevel;
 	AndroidSystem::detect_embedded_dso_mode (applicationDirs);
 	AndroidSystem::set_running_in_emulator (isEmulator);
 
@@ -1548,7 +1546,6 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 		0,
 		loader,
 		assembliesJava,
-		apiLevel,
 		/* isEmulator */ JNI_FALSE,
 		/* haveSplitApks */ JNI_FALSE
 	);
@@ -1557,7 +1554,7 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 JNIEXPORT void JNICALL
 Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
                                 jstring runtimeNativeLibDir, jobjectArray appDirs, jint localDateTimeOffset, jobject loader,
-                                jobjectArray assembliesJava, jint apiLevel, jboolean isEmulator,
+                                jobjectArray assembliesJava, jboolean isEmulator,
                                 jboolean haveSplitApks)
 {
 	monodroidRuntime.Java_mono_android_Runtime_initInternal (
@@ -1570,7 +1567,6 @@ Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang,
 		localDateTimeOffset,
 		loader,
 		assembliesJava,
-		apiLevel,
 		isEmulator,
 		application_config.ignore_split_configs ? false : haveSplitApks
 	);

--- a/src/native/pinvoke-override/generate-pinvoke-tables.cc
+++ b/src/native/pinvoke-override/generate-pinvoke-tables.cc
@@ -46,7 +46,6 @@ const std::vector<std::string> internal_pinvoke_names = {
 	"monodroid_free",
 	"_monodroid_freeifaddrs",
 	"_monodroid_gc_wait_for_bridge_processing",
-	"_monodroid_get_android_api_level",
 	"_monodroid_get_dns_servers",
 	"monodroid_get_dylib",
 	"_monodroid_get_identity_hash_code",

--- a/src/native/pinvoke-override/pinvoke-tables.include
+++ b/src/native/pinvoke-override/pinvoke-tables.include
@@ -11,7 +11,7 @@
 namespace {
 #if INTPTR_MAX == INT64_MAX
 	//64-bit internal p/invoke table
-	std::array<PinvokeEntry, 49> internal_pinvokes {{
+	std::array<PinvokeEntry, 48> internal_pinvokes {{
 		{0x452e23128e42f0a, "monodroid_get_log_categories", reinterpret_cast<void*>(&monodroid_get_log_categories)},
 		{0xa50ce5de13bf8b5, "_monodroid_timezone_get_default_id", reinterpret_cast<void*>(&_monodroid_timezone_get_default_id)},
 		{0x19055d65edfd668e, "_monodroid_get_network_interface_up_state", reinterpret_cast<void*>(&_monodroid_get_network_interface_up_state)},
@@ -43,7 +43,6 @@ namespace {
 		{0xc2a21d3f6c8ccc24, "_monodroid_lookup_replacement_method_info", reinterpret_cast<void*>(&_monodroid_lookup_replacement_method_info)},
 		{0xc5b4690e13898fa3, "monodroid_timing_start", reinterpret_cast<void*>(&monodroid_timing_start)},
 		{0xcc873ea8493d1dd5, "monodroid_embedded_assemblies_set_assemblies_prefix", reinterpret_cast<void*>(&monodroid_embedded_assemblies_set_assemblies_prefix)},
-		{0xce439cfbe29dec11, "_monodroid_get_android_api_level", reinterpret_cast<void*>(&_monodroid_get_android_api_level)},
 		{0xd1e121b94ea63f2e, "_monodroid_gref_get", reinterpret_cast<void*>(&_monodroid_gref_get)},
 		{0xd5151b00eb33d85e, "monodroid_TypeManager_get_java_class_name", reinterpret_cast<void*>(&monodroid_TypeManager_get_java_class_name)},
 		{0xda517ef392b6a888, "java_interop_free", reinterpret_cast<void*>(&java_interop_free)},
@@ -553,14 +552,13 @@ constexpr hash_t system_security_cryptography_native_android_library_hash = 0x18
 constexpr hash_t system_globalization_native_library_hash = 0x28b5c8fca080abd5;
 #else
 	//32-bit internal p/invoke table
-	std::array<PinvokeEntry, 49> internal_pinvokes {{
+	std::array<PinvokeEntry, 48> internal_pinvokes {{
 		{0xb7a486a, "monodroid_TypeManager_get_java_class_name", reinterpret_cast<void*>(&monodroid_TypeManager_get_java_class_name)},
 		{0xf562bd9, "monodroid_embedded_assemblies_set_assemblies_prefix", reinterpret_cast<void*>(&monodroid_embedded_assemblies_set_assemblies_prefix)},
 		{0x1a8eab17, "_monodroid_get_identity_hash_code", reinterpret_cast<void*>(&_monodroid_get_identity_hash_code)},
 		{0x227a2636, "monodroid_get_namespaced_system_property", reinterpret_cast<void*>(&monodroid_get_namespaced_system_property)},
 		{0x2a0e1744, "java_interop_strdup", reinterpret_cast<void*>(&java_interop_strdup)},
 		{0x2aea7c33, "_monodroid_max_gref_get", reinterpret_cast<void*>(&_monodroid_max_gref_get)},
-		{0x2f7d0f53, "_monodroid_get_android_api_level", reinterpret_cast<void*>(&_monodroid_get_android_api_level)},
 		{0x30b9487b, "_monodroid_get_dns_servers", reinterpret_cast<void*>(&_monodroid_get_dns_servers)},
 		{0x3227d81a, "monodroid_timing_start", reinterpret_cast<void*>(&monodroid_timing_start)},
 		{0x333d4835, "_monodroid_lookup_replacement_method_info", reinterpret_cast<void*>(&_monodroid_lookup_replacement_method_info)},
@@ -1095,6 +1093,6 @@ constexpr hash_t system_security_cryptography_native_android_library_hash = 0x93
 constexpr hash_t system_globalization_native_library_hash = 0xa66f1e5a;
 #endif
 
-constexpr size_t internal_pinvokes_count = 49;
+constexpr size_t internal_pinvokes_count = 48;
 constexpr size_t dotnet_pinvokes_count = 477;
 } // end of anonymous namespace

--- a/src/native/runtime-base/internal-pinvokes.hh
+++ b/src/native/runtime-base/internal-pinvokes.hh
@@ -35,7 +35,6 @@ void _monodroid_weak_gref_delete (jobject handle, char type, const char *threadN
 void _monodroid_lref_log_new (int lrefc, jobject handle, char type, const char *threadName, int threadId, const char  *from, int from_writable);
 void _monodroid_lref_log_delete (int lrefc, jobject handle, char type, const char *threadName, int threadId, const char  *from, int from_writable);
 void _monodroid_gc_wait_for_bridge_processing ();
-int _monodroid_get_android_api_level ();
 void monodroid_clear_gdb_wait ();
 void* _monodroid_get_identity_hash_code (JNIEnv *env, void *v);
 void* _monodroid_timezone_get_default_id ();


### PR DESCRIPTION
This removes an API < 10 code path, which should speed up all `JNIEnv.StartCreateInstance` / `FinishCreateInstance` calls by a very small amount. They no longer check a `AllocObjectSupported` field, which is now always `true`.

This also removes the need to pass in `androidSdkVersion` / `android_api_level` from the native side at startup.

We can also remove the `_monodroid_get_android_api_level()` p/invoke, which is unused.