### PR TITLE
Make sure debug and release builds of .a files are separate

### DIFF
--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -90,6 +90,12 @@ elseif(ENABLE_CLANG_UBSAN)
   set(STATIC_LIB_NAME_SUFFIX "-ubsan")
 endif()
 
+if(DEBUG_BUILD)
+  set(STATIC_LIB_NAME_SUFFIX "${STATIC_LIB_NAME_SUFFIX}-debug")
+else()
+  set(STATIC_LIB_NAME_SUFFIX "${STATIC_LIB_NAME_SUFFIX}-release")
+endif()
+
 if(USE_CCACHE)
   if(CMAKE_CXX_COMPILER MATCHES "/ccache/")
     message(STATUS "ccache: compiler already uses ccache")

--- a/src/native/tracing/CMakeLists.txt
+++ b/src/native/tracing/CMakeLists.txt
@@ -17,8 +17,6 @@ add_library(
 
 add_library(${LIB_ALIAS} ALIAS ${LIB_NAME})
 
-set_static_library_suffix(${LIB_NAME})
-
 target_include_directories(
   ${LIB_NAME}
   PUBLIC


### PR DESCRIPTION
Context: a7b576885624d09c4cc9d65412da2a7558fd3b36
Context: 2ec6f548de8e79c52ed2e61f7181cdf3d0324c20

a7b5768856, among other things, reorganized the way we build our native runtime.
One of the changes was subdivision of source code into separate subdirectories,
each of them a separate static library.  One of reasons behind it was preparation
for the future work where we will be linking the application native runtime dynamically
at application build time, mixing and matching various libraries as necessary.

For the last reason, some of the `.a` archives are output to the location where we store
files to be packaged and distributed to end users.  However, what a7b5768856 missed was
the fact that this mode operation causes later builds to overwrite the earlier ones, since
archive names are the same.  This can cause, for instance, the library debug build to be
silently replaced with the release one.  While this won't be a problem on CI (and thus in
our distribution packages), it may have weird effects on one's local workflow (e.g. parts
of the runtime may be built for release and parts for debug, depending on the build order).

2ec6f548de added a partial solution to this issue, but one that covered only the UBSAN and
ASAN scenarios and ignored the debug vs release ones.  This commit completes the fix by
making all output libraries use the `-debug` or `-release` prefix.

Also, libxamarin-native-tracing is not a static library, don't mistakenly treat it as one.
