### PR TITLE
[bundletool] Remove com/sun/jna content

### DIFF
--- a/build-tools/create-packs/SignVerifyIgnore.txt
+++ b/build-tools/create-packs/SignVerifyIgnore.txt
@@ -1,3 +1,2 @@
 **\*.xml,ignore unsigned xml
 **\cab*.cab.cab,ignore unsigned .cab
-**\com\sun\jna\win32-*\jnidispatch.dll, ignore external bundletool.jar content

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -21,12 +21,14 @@
       DependsOnTargets="_DownloadBundleTool"
       Inputs="$(_BundleToolDownloadLocation)"
       Outputs="$(_Destination)bundletool.jar" >
-    <!-- Strip aapt2 from bundletool.jar, as we pass it our own path to aapt2.
-      This simplifies macOS signing/hardening and reduces our installation footprint slightly. -->
+    <!-- Strip jna content from bundletool.jar.
+      This simplifies signing/hardening and reduces our installation footprint slightly. -->
     <RemoveDir Directories="$(_BundleToolExtractLocation)" />
     <MakeDir Directories="$(_BundleToolExtractLocation)" />
     <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="$(_JarPath) -xf &quot;$(_BundleToolDownloadLocation)&quot;" />
-    <Delete Files="$(_BundleToolDownloadLocation);$(_BundleToolExtractLocation)\linux\aapt2;$(_BundleToolExtractLocation)\macos\aapt2;$(_BundleToolExtractLocation)\windows\aapt2.exe" />
+    <Delete Files="$(_BundleToolDownloadLocation)" />
+    <Delete Files="$(_BundleToolExtractLocation)\linux\aapt2;$(_BundleToolExtractLocation)\macos\aapt2;$(_BundleToolExtractLocation)\windows\aapt2.exe" />
+    <RemoveDir Directories="$(_BundleToolExtractLocation)\com\sun\jna" />
     <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="$(_JarPath) -cmf META-INF/MANIFEST.MF &quot;$(_BundleToolDownloadLocation)&quot; ." />
     <RemoveDir Directories="$(_BundleToolExtractLocation)" />
     <Copy

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -14,7 +14,6 @@
     <DownloadUri
         SourceUris="https://github.com/google/bundletool/releases/download/$(XABundleToolVersion)/bundletool-all-$(XABundleToolVersion).jar"
         DestinationFiles="$(_BundleToolDownloadLocation)"
-        HashHeader="TESTARA"
     />
   </Target>
 

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -4,7 +4,8 @@
     <_Destination>$(MicrosoftAndroidSdkOutDir)</_Destination>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <_BundleToolDownloadLocation>$(AndroidToolchainCacheDirectory)\bundletool-all-$(XABundleToolVersion).jar</_BundleToolDownloadLocation>
-    <_BundleToolExtractLocation>$(AndroidToolchainCacheDirectory)\bundletool-unzip</_BundleToolExtractLocation>
+    <_BundleToolCopyLocation>$(AndroidToolchainCacheDirectory)\bundletool-all-$(XABundleToolVersion)-copy.jar</_BundleToolCopyLocation>
+    <_BundleToolExtractLocation>$(AndroidToolchainCacheDirectory)\bundletool-unzip-$(XABundleToolVersion)</_BundleToolExtractLocation>
     <_JarPath Condition=" '$(JavaSdkDirectory)' != '' ">$(JavaSdkDirectory)/bin/jar</_JarPath>
     <_JarPath Condition=" '$(_JarPath)' == '' ">jar</_JarPath>
   </PropertyGroup>
@@ -13,6 +14,7 @@
     <DownloadUri
         SourceUris="https://github.com/google/bundletool/releases/download/$(XABundleToolVersion)/bundletool-all-$(XABundleToolVersion).jar"
         DestinationFiles="$(_BundleToolDownloadLocation)"
+        HashHeader="TESTARA"
     />
   </Target>
 
@@ -25,14 +27,19 @@
           This simplifies signing/hardening and reduces our installation footprint slightly. -->
     <RemoveDir Directories="$(_BundleToolExtractLocation)" />
     <MakeDir Directories="$(_BundleToolExtractLocation)" />
-    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="$(_JarPath) -xf &quot;$(_BundleToolDownloadLocation)&quot;" />
-    <Delete Files="$(_BundleToolDownloadLocation)" />
-    <Delete Files="$(_BundleToolExtractLocation)\linux\aapt2;$(_BundleToolExtractLocation)\macos\aapt2;$(_BundleToolExtractLocation)\windows\aapt2.exe" />
-    <RemoveDir Directories="$(_BundleToolExtractLocation)\com\sun\jna" />
-    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="$(_JarPath) -cmf META-INF/MANIFEST.MF &quot;$(_BundleToolDownloadLocation)&quot; ." />
-    <RemoveDir Directories="$(_BundleToolExtractLocation)" />
     <Copy
         SourceFiles="$(_BundleToolDownloadLocation)"
+        DestinationFiles="$(_BundleToolCopyLocation)"
+        SkipUnchangedFiles="True"
+    />
+    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="$(_JarPath) -xf &quot;$(_BundleToolCopyLocation)&quot;" />
+    <Delete Files="$(_BundleToolCopyLocation)" />
+    <Delete Files="$(_BundleToolExtractLocation)\linux\aapt2;$(_BundleToolExtractLocation)\macos\aapt2;$(_BundleToolExtractLocation)\windows\aapt2.exe" />
+    <RemoveDir Directories="$(_BundleToolExtractLocation)\com\sun\jna" />
+    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="$(_JarPath) -cmf META-INF/MANIFEST.MF &quot;$(_BundleToolCopyLocation)&quot; ." />
+    <RemoveDir Directories="$(_BundleToolExtractLocation)" />
+    <Copy
+        SourceFiles="$(_BundleToolCopyLocation)"
         DestinationFiles="$(_Destination)bundletool.jar"
         SkipUnchangedFiles="True"
     />

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -21,8 +21,8 @@
       DependsOnTargets="_DownloadBundleTool"
       Inputs="$(_BundleToolDownloadLocation)"
       Outputs="$(_Destination)bundletool.jar" >
-    <!-- Strip jna content from bundletool.jar.
-      This simplifies signing/hardening and reduces our installation footprint slightly. -->
+    <!-- Strip unused jna content and aapt2 from bundletool.jar, as we pass it our own path to aapt2.
+          This simplifies signing/hardening and reduces our installation footprint slightly. -->
     <RemoveDir Directories="$(_BundleToolExtractLocation)" />
     <MakeDir Directories="$(_BundleToolExtractLocation)" />
     <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="$(_JarPath) -xf &quot;$(_BundleToolDownloadLocation)&quot;" />


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/c89de29a69eaa913255a6971d5305529bc085ebe

Various symbol and signing checks have been failing after bumping
bundletool.jar to version 1.17.0. We can fix these by stripping out the
offending content from bundletool.jar.