### PR TITLE
Fix an off-by-one error demangling satellite assembly names

### DIFF
--- a/src/native/monodroid/embedded-assemblies.hh
+++ b/src/native/monodroid/embedded-assemblies.hh
@@ -324,8 +324,7 @@ namespace xamarin::android::internal {
 		static constexpr size_t get_mangled_prefix_length ()
 		{
 			if constexpr (IsSatelliteAssembly) {
-				// +1 for the extra `-` char in the culture portion of satellite assembly's name;
-				return SharedConstants::MANGLED_ASSEMBLY_SATELLITE_ASSEMBLY_MARKER.length () + 1;
+				return SharedConstants::MANGLED_ASSEMBLY_SATELLITE_ASSEMBLY_MARKER.length ();
 			} else {
 				return SharedConstants::MANGLED_ASSEMBLY_REGULAR_ASSEMBLY_MARKER.length ();
 			}


### PR DESCRIPTION
When assemblies are packaged in the APK archive, their names are
"mangled" so that we don't create clashes with "real" shared libraries,
which are placed in the same directory.  Additionally, since the `lib/`
directory in the APK archive supports only single level of directories,
we must encode satellite assembly culture in the file name, instead of
putting it in a subdirectory.

Unfortunately, when the code was committed, an off-by-one error crept
in, when converting satellite assembly names to their `culture/name`
for.  As the result, the first character of the culture was omitted
which would cause the satellite assemblies not to be loaded properly.

Fix the issue by using the correct mangled name prefix length.