### PR TITLE
[tests] add fast deployment test for `.resx`

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@e68da1e817cb5ce1b31195c3745cc1fe5c12a53c
+xamarin/monodroid:main@d1d43ab161bfd493d982f40fd3e49ebfb274a110


### PR DESCRIPTION
Context: https://github.com/xamarin/monodroid/pull/1530

This is the missing test for monodroid#1530.

This would run `<FastDeploy/>` with inputs like:

    bin\Debug\de\Localization.resources.dll