### PR TITLE
Bump to xamarin/monodroid/main@e68da1e8

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@d1d43ab161bfd493d982f40fd3e49ebfb274a110
+xamarin/monodroid:main@e68da1e817cb5ce1b31195c3745cc1fe5c12a53c


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/d1d43ab1...e68da1e8

* Bump external/xamarin-android from 35f41dc to cb23f7e
* [s360] Ignore irrelevant lz4 warnings
* Bump to dotnet/android@c157aed
* Bump to xamarin/android-sdk-installer@05e4d62
* [tools/msbuild] fix <FastDeploy/> creation of subdirectories