### PR TITLE
[Xamarin.Android.Build.Tasks] fix `Inputs` for `_Generate*Java*` targets

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1444,7 +1444,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GenerateJavaStubs"
     DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest)"
-    Inputs="@(_AndroidMSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
+    Inputs="@(_AndroidMSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
     Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
 
   <PropertyGroup>
@@ -1691,7 +1691,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GeneratePackageManagerJava"
   DependsOnTargets="$(_GeneratePackageManagerJavaDependsOn)"
-  Inputs="@(_AndroidMSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
+  Inputs="@(_AndroidMSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
   Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp">
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/8967
Context: https://github.com/dotnet/android/pull/9001

You can cause a build error in .NET 8 by doing:

* Start an x86 or x86_64 emulator
* `dotnet build -t:Run`
* Close the emulator, attach an arm or arm64 device
* `dotnet build -t:Run`

Emits the error:

    C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.0.113\tools\Xamarin.Android.Common.targets(2063,3): error XA3006: Could not compile native assembly file: typemaps.x86_64.ll
    stderr | C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.0.113\tools\binutils\bin\llc.exe: error: C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.0.113\tools\binutils\bin\llc.exe: typemaps.x86_64.ll: error: Could not open input file: no such file or directory

This works fine in Visual Studio, but not at the command-line.

The underlying problem is due to `_GeneratePackageManagerJava` target running, while the `_GenerateJavaStubs` target *did not*:

    Skipping target "_GenerateJavaStubs" because all output files are up-to-date with respect to the input files.
    ...
    Input file "obj\Debug\net8.0-android\resolvedassemblies.hash" is newer than output file "obj\Debug\net8.0-android\stamp\_GeneratePackageManagerJava.stamp".

These two targets should almost always run together, so we should ensure that they do.

This problem also doesn't happen .NET 9, as both targets are invalidated for a different reason:

    Target Name=_LinkAssembliesNoShrink Project=UnnamedProject.csproj
    Building target "_LinkAssembliesNoShrink" completely.
    Output file "obj\Debug\android\assets\x86_64\UnnamedProject.dll" does not exist.

Since, we build per-RID in .NET 9, `obj\Debug\android\assets\x86_64\UnnamedProject.dll` has an `x86_64` in the path, which is not present in the .NET 8 build.

Reviewing the two sets of `Inputs`:

    <Target Name="_GenerateJavaStubs"
        ...
        Inputs="@(_AndroidMSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
    ...
    <Target Name="_GeneratePackageManagerJava"
        ...
        Inputs="@(_AndroidMSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"

Let's align them more closely by:

* Track assembly changes in the exact same way:

```
$(_ResolvedUserAssembliesHashFile);@(_ResolvedUserMonoAndroidAssemblies);
```

This way if an assembly is added, removed, or timestamp changed: both targets are in sync.

* Don't track `$(MSBuildProjectFile)`, this should already be in `@(_AndroidMSBuildAllProjects)`.

With this change in place manually, I'm not able to reproduce the problem any longer.

PR #9001 may also have fixed this issue, but it could cause targets to run on every incremental build -- a performance issue.