### PR TITLE
Fixing adding pdb with one slash type and trying to remove another slash

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -597,7 +597,7 @@ namespace Xamarin.Android.Tasks
 
 		bool AddFileToArchiveIfNewer (ZipArchiveEx apk, string file, string inArchivePath, CompressionMethod compressionMethod = CompressionMethod.Default)
 		{
-			existingEntries.Remove (inArchivePath);
+			existingEntries.Remove (inArchivePath.Replace (Path.DirectorySeparatorChar, '/'));
 			if (apk.SkipExistingFile (file, inArchivePath, compressionMethod)) {
 				Log.LogDebugMessage ($"Skipping {file} as the archive file is up to date.");
 				return false;


### PR DESCRIPTION
When we build first to emulator and then change to device. Or we build to device and then change to emulator.
We were adding files in `existingEntries` with paths like this:
lib/armeabi-v7a/lib_Mono.Android.pdb.so
lib/arm64-v8a/lib_Mono.Android.pdb.so
lib/x86/lib_Mono.Android.pdb.so
lib/x86_64/lib_Mono.Android.pdb.so

And removing like this:
lib\armeabi-v7a/lib_Mono.Android.pdb.so
lib\arm64-v8a/lib_Mono.Android.pdb.so
lib\x86/lib_Mono.Android.pdb.so
lib\x86_64/lib_Mono.Android.pdb.so

Doing this all the pdb's were removed in the apk.

I saw this message when I build it locally:
`Removing lib/x86_64/lib_Mono.Android.pdb.so as it is not longer required.`

And then the runtime doesn't have the pdb information to load it and debug the app correctly.

In this PR I'm using the same workaround that you are using here:
https://github.com/dotnet/android/blob/175f3a0eded6a21ac06536168a3019ffcf4e80e0/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs#L228