### PR TITLE
[ci] Simplify shipping drop metadata names

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -557,7 +557,7 @@ extends:
           - output: artifactsDrop
             dropServiceURI: https://devdiv.artifacts.visualstudio.com/DefaultCollection
             buildNumber: $(ReleaseDropPrefix)/symbols
-            dropMetadataContainerName: DropMetadata-$(Build.BuildId)-symbols-$(System.JobAttempt)
+            dropMetadataContainerName: DropMetadata-shipping-symbols
             sourcePath: $(Build.StagingDirectory)\symbols
             retentionDays: 120
             toLowerCase: false
@@ -574,7 +574,7 @@ extends:
 
         - task: DownloadPipelineArtifact@2
           inputs:
-            artifactName: DropMetadata-$(Build.BuildId)-nugets-$(System.JobAttempt)
+            artifactName: DropMetadata-shipping-nugets
             downloadPath: $(Build.StagingDirectory)\metadata
           displayName: Download nugets drop metadata
 


### PR DESCRIPTION
Using the $(System.JobAttempt) variable in the drop metadata artifact
name is problematic. In some cases the drop artifacts created by the
nuget-msi-convert job will be used by a different job, and the job
attempt number will not necessarily match if any jobs are re-ran.