### PR TITLE
[Xamarin.Android.Build.Tasks] fix `$(DestinationSubDirectory)` double slash

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -186,8 +186,9 @@ namespace Xamarin.Android.Tasks
 				}
 
 				string destination = Path.Combine (abi, item.GetMetadata ("DestinationSubDirectory"));
-				//Log.LogDebugMessage ($"DEBUG!!!'{item.ItemSpec}' '{rid}' = '{abi}'. DestinationSubDirectory='{destination}'");
-				item.SetMetadata ("DestinationSubDirectory", destination + Path.DirectorySeparatorChar);
+				if (!destination.EndsWith (Path.DirectorySeparatorChar.ToString ())) {
+					item.SetMetadata ("DestinationSubDirectory", destination + Path.DirectorySeparatorChar);
+				}
 				item.SetMetadata ("DestinationSubPath", Path.Combine (destination, Path.GetFileName (item.ItemSpec)));
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -186,9 +186,10 @@ namespace Xamarin.Android.Tasks
 				}
 
 				string destination = Path.Combine (abi, item.GetMetadata ("DestinationSubDirectory"));
-				if (!destination.EndsWith (Path.DirectorySeparatorChar.ToString ())) {
-					item.SetMetadata ("DestinationSubDirectory", destination + Path.DirectorySeparatorChar);
+				if (destination.Length > 0 && destination [destination.Length - 1] != Path.DirectorySeparatorChar) {
+					destination += Path.DirectorySeparatorChar;
 				}
+				item.SetMetadata ("DestinationSubDirectory", destination);
 				item.SetMetadata ("DestinationSubPath", Path.Combine (destination, Path.GetFileName (item.ItemSpec)));
 			}
 		}

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -583,6 +583,7 @@ namespace Xamarin.Android.Build.Tests
 				builder.BuildLogFile = "install3.log";
 				Assert.IsTrue (builder.Install (app, doNotCleanupOnUpdate: true, saveProject: false), "Third install should have succeeded.");
 				logLines = builder.LastBuildOutput;
+				Assert.IsFalse (logLines.Any (l => l.Contains ("Remove redundant file")), "No redundant files should be deleted");
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("UnnamedProject.dll")), "UnnamedProject.dll should have been uploaded");
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("Library1.dll")), "Library1.dll should have been uploaded");
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync SkipCopyFile") && l.Contains ("Library2.dll")), "Library2.dll should not have been uploaded");

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -155,8 +155,10 @@ namespace Xamarin.Android.Build.Tests
 				"Xamarin.AndroidX.AppCompat.dll",
 				"Xamarin.AndroidX.Core.dll",
 			};
+			var logLines = b.LastBuildOutput;
+			Assert.IsFalse (logLines.Any (l => l.Contains ("Remove redundant file")), "No redundant files should be deleted");
 			foreach (var assembly in assemblies) {
-				Assert.IsTrue (b.LastBuildOutput.Any (l => l.Contains (assembly) && l.Contains ("NotifySync SkipCopyFile")), $"{assembly} should be skipped, but no relevant log line");
+				Assert.IsTrue (logLines.Any (l => l.Contains (assembly) && l.Contains ("NotifySync SkipCopyFile")), $"{assembly} should be skipped, but no relevant log line");
 			}
 
 			Assert.IsTrue (b.Uninstall (proj), "uninstall should have succeeded.");


### PR DESCRIPTION
I noticed in a `.binlog` in .NET 9:

    ProcessAssemblies
        ...
        OutputItems
            ...
            D:\.nuget\packages\microsoft.maui.controls.core\9.0.0-preview.7.24407.4\lib\net9.0-android35.0\ar\Microsoft.Maui.Controls.resources.dll
                DestinationSubDirectory = arm64-v8a\ar\\

I believe this causes an issue, later down the line:

    FastDeploy
    ...
    Remove redundant file files/.__override__/arm64-v8a/ar/Microsoft.Maui.Controls.resources.dll

So, `<FastDeploy/>` seems to delete every `Microsoft.Maui.Controls.resources.dll` file, because it is passed in:

    obj\Debug\net9.0-android\android\assets\arm64-v8a\ar\Microsoft.Maui.Controls.resources.dll
    TargetPath = arm64-v8a\ar\\Microsoft.Maui.Controls.resources.dll

I think this was introduced in 86260ed3, we can fix it by only appending to `%(DestinationSubDirectory)` if it *doesn't* end with a `DirectorySeparatorChar`.

There may be additional safety we could add to the `<FastDeploy/>` task, in a separate PR.

To test this going forward, I'm going to review our MSBuild performance tests, and see if we can adjust the timings there.