### PR TITLE
[ci] Update nuget-msi-convert dependencies

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -501,7 +501,7 @@ extends:
       - template: nuget-msi-convert/job/v4.yml@yaml-templates
         parameters:
           yamlResourceName: yaml-templates
-          dependsOn: sign_net_mac_win
+          dependsOn: [ sign_net_mac_win, sign_net_linux ]
           artifactName: nuget-signed
           artifactPatterns: |
             !*Darwin*


### PR DESCRIPTION
This job depends on the outputs of both the sign_net_mac_win and
sign_net_linux jobs.
