### PR TITLE
Bump to xamarin/monodroid/main@12b1ae70

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@e68da1e817cb5ce1b31195c3745cc1fe5c12a53c
+xamarin/monodroid:main@12b1ae70cb082f467bc9a52c8c22e4492537e550


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/e68da1e8...12b1ae70

* Bump to dotnet/android/main@d01a564
* Bump to xamarin/androidtools/main@bea0d3e
* [tools/msbuild] make `_GetPrimaryCpuAbi` run again
* Bump to xamarin/android-sdk-installer/main@035c8a8
* Bump to dotnet/android/main@b69ad9e

I'm mainly doing this to test a build with the `_GetPrimaryCpuAbi` fix.