### PR TITLE
[XABT] Scan for JCWs for each ABI in parallel.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -202,12 +202,14 @@ namespace Xamarin.Android.Tasks
 
 				(bool success, NativeCodeGenState? state) = GenerateJavaSourcesAndMaybeClassifyMarshalMethods (arch, archAssemblies, MaybeGetArchAssemblies (userAssembliesPerArch, arch), useMarshalMethods, generateJavaCode);
 
-				if (!success)
+				if (!success) {
 					generateSucceeded = false;
+				}
 
 				// If this is the first architecture, we need to store the state for later use
-				if (generateJavaCode)
+				if (generateJavaCode) {
 					templateCodeGenState = state;
+				}
 
 				nativeCodeGenStates.TryAdd (arch, state);
 			});

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -13,6 +13,7 @@ using Microsoft.Build.Utilities;
 using Java.Interop.Tools.TypeNameMappings;
 using Xamarin.Android.Tools;
 using Microsoft.Android.Build.Tasks;
+using System.Collections.Concurrent;
 
 namespace Xamarin.Android.Tasks
 {
@@ -324,9 +325,9 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			Dictionary<AndroidTargetArch, NativeCodeGenState>? nativeCodeGenStates = null;
+			ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>? nativeCodeGenStates = null;
 			if (enableMarshalMethods) {
-				nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<Dictionary<AndroidTargetArch, NativeCodeGenState>> (
+				nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>> (
 					ProjectSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateRegisterTaskKey),
 					RegisteredTaskObjectLifetime.Build
 				);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JCWGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JCWGenerator.cs
@@ -15,6 +15,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Mono.Cecil;
 using Xamarin.Android.Tools;
+using System.Collections.Concurrent;
 
 namespace Xamarin.Android.Tasks;
 
@@ -220,7 +221,7 @@ class JCWGenerator
 		return builder.ToString ();
 	}
 
-	public static void EnsureAllArchitecturesAreIdentical (TaskLoggingHelper logger, Dictionary<AndroidTargetArch, NativeCodeGenState> javaStubStates)
+	public static void EnsureAllArchitecturesAreIdentical (TaskLoggingHelper logger, ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState> javaStubStates)
 	{
 		if (javaStubStates.Count <= 1) {
 			return;


### PR DESCRIPTION
In order to ensure that all of our per-arch assemblies contain the same JCW types, we scan them all. We can parallelize this operation per-ABI to save time.  It is ok to parallelize Cecil here, as each "set" contains completely different assemblies coming from completely different assembly resolvers.

Fresh `dotnet build` of Android template (defaults to 4 architectures), total `GenerateJavaSourcesAndMaybeClassifyMarshalMethods` takes:

| | |
|-|-|
| `main` | 11835 ms |
| PR | 4548 ms |
