### PR TITLE
[Build.Tasks] Bump to NuGet/Nuget.Client@324d7272

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" GeneratePathProperty="true" />
     <PackageReference Include="ILRepack" Version="2.0.28" />
     <PackageReference Include="Irony" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.9.1" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.CodeDom" />
     <PackageReference Include="System.IO.Hashing" Version="$(SystemIOHashingPackageVersion)" />


### PR DESCRIPTION
Bumps NuGet.ProjectModel and dependencies to v6.11.0.

Changes: https://github.com/NuGet/NuGet.Client/compare/623fde83a3cd73cb479ec7fa03866c6116894dbf...324d7272b8526a3826ef1f12fa6fc3a362b5bb79
AssemblyFileVersion:6.11.0.119
AssemblyInformationalVersion:6.11.0+324d7272b8526a3826ef1f12fa6fc3a362b5bb79.324d7272b8526a3826ef1f12fa6fc3a362b5bb79

Context: https://github.com/dotnet/android/pull/9098#issuecomment-2291293496
We believe this latest version contains published symbols that will
appease the VS symbol check.