### PR TITLE
[Xamarin.Android.Build.Tasks] remove `$XAMARIN_BUILD_ID`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -139,7 +139,6 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       AndroidPackageName="$(_AndroidPackage)"
       EnablePreloadAssembliesDefault="$(_AndroidEnablePreloadAssembliesDefault)"
       InstantRunEnabled="$(_InstantRunEnabled)">
-    <Output TaskParameter="BuildId" PropertyName="_XamarinBuildId" />
   </GeneratePackageManagerJava>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -22,8 +22,6 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "GPM";
 
-		Guid buildId = Guid.NewGuid ();
-
 		[Required]
 		public ITaskItem[] ResolvedAssemblies { get; set; }
 
@@ -81,9 +79,6 @@ namespace Xamarin.Android.Tasks
 		public bool EnableSGenConcurrent { get; set; }
 		public string? CustomBundleConfigFile { get; set; }
 
-		[Output]
-		public string BuildId { get; set; }
-
 		bool _Debug {
 			get {
 				return string.Equals (Debug, "true", StringComparison.OrdinalIgnoreCase);
@@ -92,9 +87,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			BuildId = buildId.ToString ();
-			Log.LogDebugMessage ("  [Output] BuildId: {0}", BuildId);
-
 			var doc = AndroidAppManifest.Load (Manifest, MonoAndroidHelper.SupportedVersions);
 			int minApiVersion = doc.MinSdkVersion == null ? 4 : (int) doc.MinSdkVersion;
 			// We need to include any special assemblies in the Assemblies list
@@ -190,9 +182,6 @@ namespace Xamarin.Android.Tasks
 			if (sequencePointsMode != SequencePointsMode.None && !environmentParser.HaveMonoDebug) {
 				AddEnvironmentVariable (defaultMonoDebug[0], defaultMonoDebug[1]);
 			}
-
-			if (!environmentParser.HavebuildId)
-				AddEnvironmentVariable ("XAMARIN_BUILD_ID", BuildId);
 
 			if (!environmentParser.HaveHttpMessageHandler) {
 				if (HttpClientHandlerType == null)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -942,7 +942,6 @@ namespace Lib2
 			var targets = new [] {
 				"_GenerateJavaStubs",
 				"_GeneratePackageManagerJava",
-				"_CompileNativeAssemblySources",
 				"_CreateApplicationSharedLibraries",
 			};
 			var proj = new XamarinAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -942,7 +942,6 @@ namespace Lib2
 			var targets = new [] {
 				"_GenerateJavaStubs",
 				"_GeneratePackageManagerJava",
-				"_CreateApplicationSharedLibraries",
 			};
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,

--- a/src/Xamarin.Android.Build.Tasks/Utilities/EnvironmentFilesParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/EnvironmentFilesParser.cs
@@ -11,7 +11,6 @@ namespace Xamarin.Android.Tasks
 	class EnvironmentFilesParser
 	{
 		public bool BrokenExceptionTransitions       { get; set; }
-		public bool HavebuildId                      { get; private set; }
 		public bool HaveHttpMessageHandler           { get; private set; }
 		public bool HaveLogLevel                     { get; private set; }
 		public bool HaveMonoDebug                    { get; private set; }
@@ -46,8 +45,6 @@ namespace Xamarin.Android.Tasks
 							log.LogCodedWarning ("XA2000", Properties.Resources.XA2000_gcParams_bridgeImpl);
 						}
 					}
-					if (lineToWrite.StartsWith ("XAMARIN_BUILD_ID=", StringComparison.Ordinal))
-						HavebuildId = true;
 					if (lineToWrite.StartsWith ("MONO_DEBUG=", StringComparison.Ordinal)) {
 						HaveMonoDebug = true;
 						if (sequencePointsMode != SequencePointsMode.None && !lineToWrite.Contains ("gen-compact-seq-points"))

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1728,17 +1728,9 @@ because xbuild doesn't support framework reference assemblies.
     EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
     CustomBundleConfigFile="$(AndroidBundleConfigurationFile)"
   >
-    <Output TaskParameter="BuildId" PropertyName="_XamarinBuildId" />
   </GeneratePackageManagerJava>
   <Touch Files="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp" AlwaysCreate="True" />
-  <WriteLinesToFile
-      File="$(_AndroidBuildIdFile)"
-      Lines="$(_XamarinBuildId)"
-      Overwrite="true"
-      WriteOnlyWhenDifferent="true"
-  />
   <ItemGroup>
-    <FileWrites Include="$(_AndroidBuildIdFile)" />
     <FileWrites Include="@(_EnvironmentAssemblySource)" />
   </ItemGroup>
 </Target>
@@ -2547,7 +2539,6 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(_AndroidAapt2VersionFile)" />
 	<Delete Files="$(IntermediateOutputPath)R.txt" />
 	<Delete Files="$(_AndroidMainDexListFile)" />
-	<Delete Files="$(_AndroidBuildIdFile)" />
 	<Delete Files="$(_ResolvedUserAssembliesHashFile)" />
 </Target>
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9212

`$XAMARIN_BUILD_ID` was a value that was only used by the `mono-symbolicate` feature from Xamarin. In .NET 6+, `mono-symbolicate` is not supported (and unfortunately, no replacement yet):

* https://github.com/dotnet/runtime/issues/106395

Likely, a new solution would use some new tool like `dotnet-symbol`, which is able to locate symbol information based on existing information inside managed `.dll`'s or even native libraries.

Remove `$XAMARIN_BUILD_ID`, in order to delete unused code, and improve incremental build times mentioned in #9212.