### PR TITLE
[Xamarin.Android.Build.Tasks] Remove ILRepack

### DIFF
--- a/Documentation/guides/MSBuildBestPractices.md
+++ b/Documentation/guides/MSBuildBestPractices.md
@@ -19,22 +19,7 @@ Waiting for debugger to attach (dotnet PID 13001).  Press enter to continue...
 
 You can then use VS or VSCode to attach to this process and debug you tasks.
 
-In the case of .NET for Android we need to do a couple of thing first though. Firstly
-we need to disable the use of `ILRepacker` on the `Xamarin.Android.Build.Tasks`
-assembly. This is because `ILRepacker` does NOT handle debug symbols very well.
-Assemblies it generates seem to be JIT optimized so the debugger will not load
-the symbols. A new MSBuild property has been introduced to disable this feature
-while debugging. `_ILRepackEnabled` can be set as an environment variable which
-MSBuild will pickup. You will also need to build the `Debug` Configuration.
-
-```dotnetcli
-export CONFIGURATION=Debug
-make prepare && _ILRepackEnabled=false make jenkins
-```
-
-This will disable the `ILRepacker` for the build.
-
-You can then start your test app with the `dotnet-local` script (so it uses your build)
+You can start your test app with the `dotnet-local` script (so it uses your build).
 
 ### [MacOS](#tab/macos)
 

--- a/build-tools/create-packs/SignList.xml
+++ b/build-tools/create-packs/SignList.xml
@@ -2,6 +2,7 @@
   <ItemGroup>
     <!-- Do not sign files that already have a signature -->
     <Skip Include="libZipSharp*" />
+    <Skip Include="NuGet*" />
   </ItemGroup>
 
   <ItemGroup>
@@ -10,6 +11,7 @@
     <ThirdParty Include="Irony.dll" />
     <ThirdParty Include="K4os.Compression.LZ4.dll" />
     <ThirdParty Include="ELFSharp.dll" />
+    <ThirdParty Include="Newtonsoft.Json.dll" />
     <ThirdParty Include="protobuf-net.dll" />
     <ThirdParty Include="SgmlReaderDll.dll" />
     <ThirdParty Include="aapt2.exe" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -119,6 +119,7 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Mono.Options.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Mono.Options.pdb" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)MULTIDEX_JAR_LICENSE" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Newtonsoft.Json.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.Common.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.Configuration.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.DependencyResolver.Core.dll" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -143,6 +143,7 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)System.Collections.Immutable.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)System.Buffers.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)System.IO.Hashing.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)System.Reflection.Metadata.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Aapt2.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Analysis.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Application.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -26,7 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="ILRepack" Version="2.0.28" />
     <PackageReference Include="Irony" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -28,7 +28,6 @@
     <_MultiDexAarInAndroidSdk>extras\android\m2repository\com\android\support\multidex\1.0.1\multidex-1.0.1.aar</_MultiDexAarInAndroidSdk>
     <_SupportLicense Condition="Exists('$(_AndroidSdkLocation)\extras\android\m2repository\NOTICE.txt')">$(_AndroidSdkLocation)\extras\android\m2repository\NOTICE.txt</_SupportLicense>
     <_SupportLicense Condition="Exists('$(_AndroidSdkLocation)\extras\android\m2repository\m2repository\NOTICE.txt')">$(_AndroidSdkLocation)\extras\android\m2repository\m2repository\NOTICE.txt</_SupportLicense>
-    <_ILRepackEnabled Condition=" '$(_ILRepackEnabled)' == '' ">true</_ILRepackEnabled>
   </PropertyGroup>
   <ItemGroup>
     <None
@@ -288,42 +287,6 @@
         DestinationFiles="@(_MonoScriptDestination)"
     />
     <Exec Command="chmod +x @(_MonoScriptDestination->'%(Identity)', ' ')" />
-  </Target>
-
-  <ItemGroup>
-    <InputAssemblies Include="$(OutputPath)Newtonsoft.Json.dll" />
-    <InputAssemblies Include="$(OutputPath)System.Collections.Immutable.dll" />
-    <InputAssemblies Include="$(OutputPath)System.Reflection.Metadata.dll" />
-  </ItemGroup>
-
-  <Target Name="ILRepacker"
-      Condition=" '$(_ILRepackEnabled)' == 'true' "
-      BeforeTargets="CopyFilesToOutputDirectory"
-      Inputs="$(MSBuildAllProjects);@(IntermediateAssembly);@(InputAssemblies)"
-      Outputs="$(IntermediateOutputPath)ILRepacker.stamp" >
-    <ItemGroup>
-      <_InputAssembliesThatExist Include="@(InputAssemblies)" Condition="Exists('%(Identity)')" />
-      <_NetstandardPath Include="@(ReferencePath->'%(RootDir)%(Directory)')" Condition="'%(FileName)%(Extension)' == 'netstandard.dll'" />
-    </ItemGroup>
-    <PropertyGroup>
-      <_NetstandardDir>@(_NetstandardPath)</_NetstandardDir>
-      <_ILRepackArgs>/out:&quot;$(MSBuildThisFileDirectory)$(IntermediateOutputPath)$(AssemblyName).dll&quot; /internalize</_ILRepackArgs>
-      <_ILRepackArgs>$(_ILRepackArgs) /keyfile:&quot;$(XamarinAndroidSourcePath)product.snk&quot;</_ILRepackArgs>
-      <_ILRepackArgs>$(_ILRepackArgs) &quot;$(MSBuildThisFileDirectory)$(IntermediateOutputPath)$(AssemblyName).dll&quot;</_ILRepackArgs>
-      <_ILRepackArgs>$(_ILRepackArgs) @(_InputAssembliesThatExist->'&quot;%(Identity)&quot;', ' ')</_ILRepackArgs>
-      <_ILRepackArgs>$(_ILRepackArgs) /lib:&quot;$(_NetstandardDir.TrimEnd('\'))&quot;</_ILRepackArgs> <!-- Path to netstandard.dll -->
-    </PropertyGroup>
-    <Exec
-      Command="$(ManagedRuntime) $(ManagedRuntimeArgs) &quot;$(ILRepack)&quot; $(_ILRepackArgs)"
-      WorkingDirectory="$(OutputPath)"
-    />
-    <Touch
-      Files="$(IntermediateOutputPath)ILRepacker.stamp"
-      AlwaysCreate="True"
-    />
-    <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)ILRepacker.stamp" />
-    </ItemGroup>
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
The historical reasons for needing to ILRepack assemblies should no
longer be a concern in a .NET world without VS for Mac.

The ILRepacker target has been removed, and the remaining assemblies
that were being repacked have been added to the workload SDK packs.