### PR TITLE
Bump to mono/debugger-libs/main@d5664344

### DIFF
--- a/external/debugger-libs.override.props
+++ b/external/debugger-libs.override.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- Disables the transitive restore of packages like Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Changes: https://github.com/mono/debugger-libs/compare/84c5c67f...d5664344
Context: https://github.com/dotnet/android/pull/9237

Updating this submodule in main, to align with changes on the `release/9.0.1xx-rc1` branch.

Notably, this sets `$(DisableTransitiveFrameworkReferenceDownloads)` for mono/debugger-libs to avoid restoring ASP.NET and Windows desktop packages for downlevel .NET versions.

Changes in mono/debugger-libs:

* Fix Policheck errors

* Adding AddExplicitInterfaceImplementation

* Fix add breakpoint and viewing locals from a pdb loaded on debugges

* Synchronize access to symbols dictionary

* [build] add extension point for consuming repositories