### PR TITLE
Bump to 34.0.137 of the .NET 8 Android workload

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -43,8 +43,6 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNetPreviousVersion Condition=" '$(AndroidNetPreviousVersion)' == '' ">34.0.137</AndroidNetPreviousVersion>
-    <AndroidNetPreviousFeed Condition=" '$(AndroidNetPreviousFeed)' == '' ">https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-b0fd0113/nuget/v3/index.json</AndroidNetPreviousFeed>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/Configuration.props
+++ b/Configuration.props
@@ -44,6 +44,7 @@
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
     <AndroidNetPreviousVersion Condition=" '$(AndroidNetPreviousVersion)' == '' ">34.0.137</AndroidNetPreviousVersion>
+    <AndroidNetPreviousFeed Condition=" '$(AndroidNetPreviousFeed)' == '' ">https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-b0fd0113/nuget/v3/index.json</AndroidNetPreviousFeed>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/Configuration.props
+++ b/Configuration.props
@@ -43,7 +43,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNetPreviousVersion Condition=" '$(AndroidNetPreviousVersion)' == '' ">34.0.113</AndroidNetPreviousVersion>
+    <AndroidNetPreviousVersion Condition=" '$(AndroidNetPreviousVersion)' == '' ">34.0.137</AndroidNetPreviousVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,11 @@
 <configuration>
   <packageSources>
     <clear />
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-android -->
+    <add key="darc-pub-dotnet-android-b0fd011" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-b0fd0113/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-android -->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!-- ensure only the sources defined below are used -->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -120,9 +120,6 @@
     </PropertyGroup>
     <ItemGroup>
       <_NuGetSources Include="$(OutputPath.TrimEnd('\'))" />
-      <!-- This allows us to install our older Android .NET packs -->
-      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
-      <_NuGetSources Include="$(AndroidNetPreviousFeed)" />
       <_PreviewPacks Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' " Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.$(AndroidLatestUnstableApiLevel).*.nupkg" />
       <_InstallArguments Include="android" />
       <_InstallArguments Include="android-$(AndroidLatestUnstableApiLevel)" Condition=" '@(_PreviewPacks->Count())' != '0' " />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -122,6 +122,7 @@
       <_NuGetSources Include="$(OutputPath.TrimEnd('\'))" />
       <!-- This allows us to install our older Android .NET packs -->
       <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+      <_NuGetSources Include="$(AndroidNetPreviousFeed)" />
       <_PreviewPacks Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' " Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.$(AndroidLatestUnstableApiLevel).*.nupkg" />
       <_InstallArguments Include="android" />
       <_InstallArguments Include="android-$(AndroidLatestUnstableApiLevel)" Condition=" '@(_PreviewPacks->Count())' != '0' " />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -121,8 +121,7 @@
     <ItemGroup>
       <_NuGetSources Include="$(OutputPath.TrimEnd('\'))" />
       <!-- This allows us to install our older Android .NET packs -->
-      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
       <_PreviewPacks Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' " Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.$(AndroidLatestUnstableApiLevel).*.nupkg" />
       <_InstallArguments Include="android" />
       <_InstallArguments Include="android-$(AndroidLatestUnstableApiLevel)" Condition=" '@(_PreviewPacks->Count())' != '0' " />

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -106,8 +106,6 @@
     <!-- dotnet workload install maui-android -->
     <ItemGroup>
       <_NuGetSources Condition=" '$(MauiUseLocalPacks)' == 'true' " Include="$(MauiPackagePath.TrimEnd('\'))" />
-      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
-      <_NuGetSources Include="$(AndroidNetPreviousFeed)" />
       <_InstallArguments Include="--skip-manifest-update" />
       <_InstallArguments Include="--skip-sign-check" />
       <_InstallArguments Include="--verbosity diag" />

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -107,6 +107,7 @@
     <ItemGroup>
       <_NuGetSources Condition=" '$(MauiUseLocalPacks)' == 'true' " Include="$(MauiPackagePath.TrimEnd('\'))" />
       <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+      <_NuGetSources Include="$(AndroidNetPreviousFeed)" />
       <_InstallArguments Include="--skip-manifest-update" />
       <_InstallArguments Include="--skip-sign-check" />
       <_InstallArguments Include="--verbosity diag" />

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -106,8 +106,7 @@
     <!-- dotnet workload install maui-android -->
     <ItemGroup>
       <_NuGetSources Condition=" '$(MauiUseLocalPacks)' == 'true' " Include="$(MauiPackagePath.TrimEnd('\'))" />
-      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
       <_InstallArguments Include="--skip-manifest-update" />
       <_InstallArguments Include="--skip-sign-check" />
       <_InstallArguments Include="--verbosity diag" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -20,6 +20,11 @@
       <Uri>https://github.com/dotnet/cecil</Uri>
       <Sha>b9d928a9d65ed39b9257846e1b8e853cea609c00</Sha>
     </Dependency>
+    <!-- Previous .NET Android version -->
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="1">
+      <Uri>https://github.com/dotnet/android</Uri>
+      <Sha></Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22103.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,9 +21,9 @@
       <Sha>b9d928a9d65ed39b9257846e1b8e853cea609c00</Sha>
     </Dependency>
     <!-- Previous .NET Android version -->
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="1">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.137">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha></Sha>
+      <Sha>b0fd0113c829edd9bd1bc7d742255a237ff19f69</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,6 +12,9 @@
     <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.24379.1</MicrosoftDotNetCecilPackageVersion>
     <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
+    <!-- Previous .NET Android version -->
+    <MicrosoftAndroidSdkWindowsPackageVersion></MicrosoftAndroidSdkWindowsPackageVersion>
+    <AndroidNetPreviousVersion>$(MicrosoftAndroidSdkWindowsPackageVersion)</AndroidNetPreviousVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.24379.1</MicrosoftDotNetCecilPackageVersion>
     <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
     <!-- Previous .NET Android version -->
-    <MicrosoftAndroidSdkWindowsPackageVersion></MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.137</MicrosoftAndroidSdkWindowsPackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftAndroidSdkWindowsPackageVersion)</AndroidNetPreviousVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Changes: https://github.com/dotnet/android/compare/34.0.113...b0fd011

.NET 8 changelog:

* [Mono.Android] AndroidMessageHandler should follow HTTP-308 redirects
* [ci] Fix android source path for MAUI test job
* [ci] Update checkout path for nightly build
* [Mono.Android-Tests] Fix repo URL in redirect tests
* [Xamarin.Android.Build.Tasks] Support VS "Build Acceleration"
* [xaprepare] Always use release mono bundle
* [ci] Update sdk-insertions trigger to manual only
* Bump to dotnet/runtime/release/8.0@4a37e7305c 8.0.8
* Bump to dotnet/installer/release/8.0.2xx@b638a84fba 8.0.205-servicing.24212.27
* [ci] Disable CodeQL on macOS, Linux, non-main jobs
* [ci] Use DotNetCoreCLI to sign macOS files
* [tests] fix `InvalidTargetPlatformVersion` for `net8.0`
* [ci] Run "Push Internal" job on AzurePipelines-EO pool
* Bump to dotnet/runtime/release/8.0@2d5c0b720c 8.0.8
* [Mono.Android] Data sharing and Close() overrides
* [Xamarin.Android.Build.Tasks] fix `Inputs` for `_Generate*Java*` targets
* Bump to xamarin/monodroid@e6a7cf474a
* [release/8.0.4xx] Backport maestro and artifact drop infra improvements
* Bump to dotnet/runtime/release/8.0@62f69f1e86 8.0.9
* Bump to dotnet/runtime/release/8.0@ed13b35174 8.0.9
* [build] Update package metadata
* [Xamarin.Android.Build.Tasks] Rethink default property values
* [Xamarin.Android.Build.Tasks] Fix an issue with incremental builds
* [ci] Improve push_signed_nugets job condition