### PR TITLE
[Xamarin.Android.Build.Tasks] introduce `LlvmIrTypeCache`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 	abstract class LlvmIrComposer
 	{
 		bool constructed;
+		readonly LlvmIrTypeCache cache = new();
 
 		protected readonly TaskLoggingHelper Log;
 
@@ -22,7 +23,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		public LlvmIrModule Construct ()
 		{
-			var module = new LlvmIrModule ();
+			var module = new LlvmIrModule (cache);
 			Construct (module);
 			module.AfterConstruction ();
 			constructed = true;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
@@ -43,9 +43,12 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		LlvmIrFunction? puts;
 		LlvmIrFunction? abort;
 
-		public LlvmIrModule ()
+		public readonly LlvmIrTypeCache TypeCache;
+
+		public LlvmIrModule (LlvmIrTypeCache cache)
 		{
-			metadataManager = new LlvmIrMetadataManager ();
+			TypeCache = cache;
+			metadataManager = new LlvmIrMetadataManager (cache);
 
 			// Only model agnostic items can be added here
 			LlvmIrMetadataItem flags = metadataManager.Add (LlvmIrKnownMetadata.LlvmModuleFlags);
@@ -330,7 +333,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		void PrepareStructure (StructureInstance structure)
 		{
 			foreach (StructureMemberInfo smi in structure.Info.Members) {
-				if (smi.IsIRStruct ()) {
+				if (smi.IsIRStruct (TypeCache)) {
 					object? instance = structure.Obj == null ? null : smi.GetValue (structure.Obj);
 					if (instance == null) {
 						continue;
@@ -341,7 +344,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					continue;
 				}
 
-				if (smi.Info.IsNativePointerToPreallocatedBuffer (out ulong bufferSize)) {
+				if (smi.Info.IsNativePointerToPreallocatedBuffer (TypeCache, out ulong bufferSize)) {
 					if (bufferSize == 0) {
 						bufferSize = structure.Info.GetBufferSizeFromProvider (smi, structure);
 					}
@@ -658,7 +661,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				return (StructureInfo)sinfo;
 			}
 
-			var ret = new StructureInfo (this, t);
+			var ret = new StructureInfo (this, t, TypeCache);
 			structures.Add (t, ret);
 
 			return ret;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrTypeCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrTypeCache.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Xamarin.Android.Tasks.LLVMIR;
+
+class LlvmIrTypeCache
+{
+    readonly Dictionary<MemberInfo, NativePointerAttribute?> pointerAttributes = [];
+    readonly Dictionary<MemberInfo, NativeAssemblerAttribute?> assemblerAttributes = [];
+
+    public NativePointerAttribute? GetNativePointerAttribute (MemberInfo mi)
+    {
+        if (!pointerAttributes.TryGetValue (mi, out var attr)) {
+            pointerAttributes[mi] = attr = mi.GetCustomAttribute<NativePointerAttribute> ();
+        }
+        return attr;
+    }
+
+    public NativeAssemblerAttribute? GetNativeAssemblerAttribute (MemberInfo mi)
+    {
+        if (!assemblerAttributes.TryGetValue (mi, out var attr)) {
+            assemblerAttributes[mi] = attr = mi.GetCustomAttribute<NativeAssemblerAttribute> ();
+        }
+        return attr;
+    }
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/MemberInfoUtilities.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/MemberInfoUtilities.cs
@@ -5,14 +5,14 @@ namespace Xamarin.Android.Tasks.LLVMIR
 {
 	static class MemberInfoUtilities
 	{
-		public static bool IsNativePointer (this MemberInfo mi)
+		public static bool IsNativePointer (this MemberInfo mi, LlvmIrTypeCache cache)
 		{
-			return mi.GetCustomAttribute <NativePointerAttribute> () != null;
+			return cache.GetNativePointerAttribute (mi) != null;
 		}
 
-		public static bool IsNativePointerToPreallocatedBuffer (this MemberInfo mi, out ulong requiredBufferSize)
+		public static bool IsNativePointerToPreallocatedBuffer (this MemberInfo mi, LlvmIrTypeCache cache, out ulong requiredBufferSize)
 		{
-			var attr = mi.GetCustomAttribute <NativePointerAttribute> ();
+			var attr = cache.GetNativePointerAttribute (mi);
 			if (attr == null) {
 				requiredBufferSize = 0;
 				return false;
@@ -22,9 +22,9 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			return attr.PointsToPreAllocatedBuffer;
 		}
 
-		public static bool PointsToSymbol (this MemberInfo mi, out string? symbolName)
+		public static bool PointsToSymbol (this MemberInfo mi, LlvmIrTypeCache cache, out string? symbolName)
 		{
-			var attr = mi.GetCustomAttribute <NativePointerAttribute> ();
+			var attr = cache.GetNativePointerAttribute (mi);
 			if (attr == null || attr.PointsToSymbol == null) {
 				symbolName = null;
 				return false;
@@ -34,27 +34,27 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			return true;
 		}
 
-		public static bool ShouldBeIgnored (this MemberInfo mi)
+		public static bool ShouldBeIgnored (this MemberInfo mi, LlvmIrTypeCache cache)
 		{
-			var attr = mi.GetCustomAttribute<NativeAssemblerAttribute> ();
+			var attr = cache.GetNativeAssemblerAttribute (mi);
 			return attr != null && attr.Ignore;
 		}
 
-		public static bool UsesDataProvider (this MemberInfo mi)
+		public static bool UsesDataProvider (this MemberInfo mi, LlvmIrTypeCache cache)
 		{
-			var attr = mi.GetCustomAttribute<NativeAssemblerAttribute> ();
+			var attr = cache.GetNativeAssemblerAttribute (mi);
 			return attr != null && attr.UsesDataProvider;
 		}
 
-		public static bool IsInlineArray (this MemberInfo mi)
+		public static bool IsInlineArray (this MemberInfo mi, LlvmIrTypeCache cache)
 		{
-			var attr = mi.GetCustomAttribute<NativeAssemblerAttribute> ();
+			var attr = cache.GetNativeAssemblerAttribute (mi);
 			return attr != null && attr.InlineArray;
 		}
 
-		public static int GetInlineArraySize (this MemberInfo mi)
+		public static int GetInlineArraySize (this MemberInfo mi, LlvmIrTypeCache cache)
 		{
-			var attr = mi.GetCustomAttribute<NativeAssemblerAttribute> ();
+			var attr = cache.GetNativeAssemblerAttribute (mi);
 			if (attr == null || !attr.InlineArray) {
 				return -1;
 			}
@@ -62,9 +62,9 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			return attr.InlineArraySize;
 		}
 
-		public static bool InlineArrayNeedsPadding (this MemberInfo mi)
+		public static bool InlineArrayNeedsPadding (this MemberInfo mi, LlvmIrTypeCache cache)
 		{
-			var attr = mi.GetCustomAttribute<NativeAssemblerAttribute> ();
+			var attr = cache.GetNativeAssemblerAttribute (mi);
 			if (attr == null || !attr.InlineArray) {
 				return false;
 			}
@@ -72,9 +72,9 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			return attr.NeedsPadding;
 		}
 
-		public static LlvmIrVariableNumberFormat GetNumberFormat (this MemberInfo mi)
+		public static LlvmIrVariableNumberFormat GetNumberFormat (this MemberInfo mi, LlvmIrTypeCache cache)
 		{
-			var attr = mi.GetCustomAttribute<NativeAssemblerAttribute> ();
+			var attr = cache.GetNativeAssemblerAttribute (mi);
 			if (attr == null) {
 				return LlvmIrVariableNumberFormat.Default;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/TypeUtilities.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/TypeUtilities.cs
@@ -46,15 +46,15 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				type != typeof (object);
 		}
 
-		public static bool IsIRStruct (this StructureMemberInfo smi)
+		public static bool IsIRStruct (this StructureMemberInfo smi, LlvmIrTypeCache cache)
 		{
 			Type type = smi.MemberType;
 
 			// type.IsStructure() handles checks for primitive types, enums etc
 			return
 				type != typeof(string) &&
-				!smi.Info.IsInlineArray () &&
-				!smi.Info.IsNativePointer () &&
+				!smi.Info.IsInlineArray (cache) &&
+				!smi.Info.IsNativePointer (cache) &&
 				(type.IsStructure () || type.IsClass);
 		}
 


### PR DESCRIPTION
Context: https://github.com/dotnet/android/blob/main/Documentation/guides/tracing.md#how-to-dotnet-trace-a-build

Making a XAML or small C# change in a .NET MAUI project and running an incremental build, shows a reasonable amount of time spent in `<GenerateJavaStubs />` -- even with a device attached.

If I attach `dotnet trace` to `dotnet build`, I can see time spent in:

    117.08ms (2.20%) xamarin.android.build.tasks!Xamarin.Android.Tasks.LLVMIR.MemberInfoUtilities.GetNumberFormat(class System.Reflection.MemberInfo)
     82.33ms (1.60%) xamarin.android.build.tasks!Xamarin.Android.Tasks.LLVMIR.MemberInfoUtilities.IsNativePointerToPreallocatedBuffer(class System.Reflection.MemberInfo,unsigned int64&)
     29.30ms (0.56%) xamarin.android.build.tasks!Xamarin.Android.Tasks.LLVMIR.MemberInfoUtilities.UsesDataProvider(class System.Reflection.MemberInfo)
     17.49ms (0.33%) xamarin.android.build.tasks!Xamarin.Android.Tasks.LLVMIR.MemberInfoUtilities.PointsToSymbol(class System.Reflection.MemberInfo,class System.String&)
     15.03ms (0.29%) xamarin.android.build.tasks!Xamarin.Android.Tasks.LLVMIR.MemberInfoUtilities.IsNativePointer(class System.Reflection.MemberInfo)
      3.59ms (0.07%) xamarin.android.build.tasks!Xamarin.Android.Tasks.LLVMIR.MemberInfoUtilities.IsInlineArray(class System.Reflection.Membe

Where all of this time is spent in `MemberInfoUtilities` doing System.Reflection to lookup members such as:

    [NativeAssembler (NumberFormat = LLVMIR.LlvmIrVariableNumberFormat.Hexadecimal)]
    public uint   mono_components_mask;

Introduce `LlvmIrTypeCache` to cache `NativePointerAttribute` or `NativeAssemblerAttribute` values based on `MemberInfo`. This cache will live the lifetime of a `LlvmIrComposer` instance, so future builds will not persist the cache.

With these changes in place, I see a modest improvement in an incremental build with a XAML change with an attached device (1 RID):

    Before:
    Task GenerateJavaStubs 1008ms
    After:
    Task GenerateJavaStubs 872ms

So, this probably improves things by about 100ms or so.