### PR TITLE
[build] Fix the Legacy Xamarin.Android build

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -113,7 +113,7 @@
     <AndroidSupportedTargetJitAbis Condition=" '$(AndroidSupportedTargetJitAbis)' == '' ">armeabi-v7a:arm64-v8a:x86:x86_64</AndroidSupportedTargetJitAbis>
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
-    <MonoDarwinPackageUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2020-02/151/c633fe923832f0c3db3c4e6aa98e5592bf5a06e7/MonoFramework-MDK-6.12.0.145.macos10.xamarin.universal.pkg</MonoDarwinPackageUrl>
+    <MonoDarwinPackageUrl>https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-6.12.0.145.macos10.xamarin.universal.pkg</MonoDarwinPackageUrl>
     <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">6.12.0.145</MonoRequiredMinimumVersion>
     <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">$(MonoRequiredMinimumVersion)</MonoRequiredMaximumVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' And '$(RunningOnCI)' == 'true' ">False</IgnoreMaxMonoVersion>

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Android.Prepare
 
 			public static readonly Uri NugetUri = new Uri ("https://dist.nuget.org/win-x86-commandline/v6.0.0/nuget.exe");
 
-			public static Uri MonoArchive_BaseUri = new Uri ("https://xamjenkinsartifact.azureedge.net/mono-sdks/");
+			public static Uri MonoArchive_BaseUri = new Uri ("https://download.mono-project.com/mono-sdks/");
 
 			public static Uri BinutilsArchive = new Uri ($"https://github.com/xamarin/xamarin-android-binutils/releases/download/{BinutilsVersion}/xamarin-android-toolchain-{BinutilsVersion}.7z");
 		}
@@ -86,7 +86,7 @@ namespace Xamarin.Android.Prepare
 			public const bool UseEmoji                                     = true;
 			public const bool DullMode                                     = false;
 
-			public static string MonoSdksConfiguration                     => Context.Instance.Configuration.ToLowerInvariant ();
+			public static string MonoSdksConfiguration                     => "release";
 
 			public const string ZipCompressionFormatName = "zip";
 			public const string SevenZipCompressionFormatName = "7z";

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -246,8 +246,8 @@ namespace Xamarin.Android.NetTests {
 		[Test]
 		public void Redirect_Without_Protocol_Works()
 		{
-			var requestURI = new Uri ("https://httpbin.org/redirect-to?url=https://github.com/xamarin/xamarin-android");
-			var redirectedURI = new Uri ("https://github.com/xamarin/xamarin-android");
+			var requestURI = new Uri ("https://httpbin.org/redirect-to?url=https://github.com/dotnet/android");
+			var redirectedURI = new Uri ("https://github.com/dotnet/android");
 			using (var c = new HttpClient (CreateHandler ())) {
 				var tr = ConnectIgnoreFailure (() => c.GetAsync (requestURI), out bool connectionFailed);
 				if (connectionFailed)
@@ -265,8 +265,8 @@ namespace Xamarin.Android.NetTests {
 		[Test]
 		public void Redirect_POST_With_Content_Works ()
 		{
-			var requestURI = new Uri ("https://httpbin.org/redirect-to?url=https://github.com/xamarin/xamarin-android");
-			var redirectedURI = new Uri ("https://github.com/xamarin/xamarin-android");
+			var requestURI = new Uri ("https://httpbin.org/redirect-to?url=https://github.com/dotnet/android");
+			var redirectedURI = new Uri ("https://github.com/dotnet/android");
 			using (var c = new HttpClient (CreateHandler ())) {
 				var request = new HttpRequestMessage (HttpMethod.Post, requestURI);
 				request.Content = new StringContent("{}", Encoding.UTF8, "application/json");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9253
Fixes: https://github.com/dotnet/android/issues/9048

Multiple reports that `make prepare` now errors out:

	% make prepare
	…
	=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
	Downloading Mono archive
	=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

	Checking if all runtime files are present
	  • some files are missing, download and extraction required
	Downloading Mono archive from https://xamjenkinsartifact.azureedge.net/mono-sdks/android-debug-Darwin-d9a6e8710b37cd7f16cf52eff4f772556e57cc41.7z
	Failed to obtain Mono archive size. HTTP status code: BadRequest (400). Mono runtimes will be rebuilt
	Downloading Mono archive from https://xamjenkinsartifact.azureedge.net/mono-sdks/android-debug-Darwin-d9a6e8710b37cd7f16cf52eff4f772556e57cc41.7z
	Failed to obtain Mono archive size. HTTP status code: BadRequest (400). Mono runtimes will be rebuilt
	Downloading Mono archive from https://xamjenkinsartifact.azureedge.net/mono-sdks/android-debug-Darwin-d9a6e8710b37cd7f16cf52eff4f772556e57cc41.7z
	Failed to obtain Mono archive size. HTTP status code: BadRequest (400). Mono runtimes will be rebuilt
	Mono archive not present

	=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
	Installing Mono runtimes
	=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

	Step Xamarin.Android.Prepare.Step_InstallMonoRuntimes failed: Unable to build mono runtimes from sources.
	System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_InstallMonoRuntimes failed: Unable to build mono runtimes from sources.
	 ---> System.NotImplementedException: Unable to build mono runtimes from sources.
	   at Xamarin.Android.Prepare.Step_InstallMonoRuntimes.Execute(Context context) in /Users/wangyk/Projects/Practice/xamarin-android/build-tools/xaprepare/xaprepare/Steps/Step_InstallMonoRuntimes.cs:line 34
	   at Xamarin.Android.Prepare.Step.Run(Context context) in /Users/wangyk/Projects/Practice/xamarin-android/build-tools/xaprepare/xaprepare/Application/Step.cs:line 42
	   at Xamarin.Android.Prepare.Scenario.Run(Context context, Log log) in /Users/wangyk/Projects/Practice/xamarin-android/build-tools/xaprepare/xaprepare/Application/Scenario.cs:line 37
	   --- End of inner exception stack trace ---
	   at Xamarin.Android.Prepare.Scenario.Run(Context context, Log log) in /Users/wangyk/Projects/Practice/xamarin-android/build-tools/xaprepare/xaprepare/Application/Scenario.cs:line 48
	   at Xamarin.Android.Prepare.Context.Execute() in /Users/wangyk/Projects/Practice/xamarin-android/build-tools/xaprepare/xaprepare/Application/Context.cs:line 845
	   at Xamarin.Android.Prepare.App.Run(String[] args) in /Users/wangyk/Projects/Practice/xamarin-android/build-tools/xaprepare/xaprepare/Main.cs:line 174

This happens because the URL
<https://xamjenkinsartifact.azureedge.net/mono-sdks> no longer exists (for various sundry internal reasons), and was replaced by <https://download.mono-project.com/mono-sdks>.

Update `Configurables.Urls.MonoArchive_BaseUri` to use the new URL.

Additionally, the new URL only contains *release* artifacts.  Update `Configurables.Defaults.MonoSdksConfiguration` to always be `release` so that the appropriate archive and extracted directories are used.