### PR TITLE
[Xamarin.Android.Build.Tasks] Reduce BuildDependsOn duplication

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
@@ -34,7 +34,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <PropertyGroup>
   <BeforeBuildAndroidAssetPacks>
     UpdateAndroidAssets
-    ;_CalculateAssetsWithAssetPackMetaData
     ;_CalculateAssetPacks
     ;$(BeforeBuildAndroidAssetPacks)
     ;_CreateAssetPackManifests
@@ -75,7 +74,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   </ItemGroup>
 </Target>
 
-<Target Name="_CalculateAssetsWithAssetPackMetaData">
+<Target Name="_CalculateAssetPacks"
+    Condition=" '$(AndroidPackageFormat)' == 'aab' "
+  >
   <ItemGroup>
     <_AssetsWithAssetPackMetaData Include="@(AndroidAsset)" Condition=" '%(AndroidAsset.AssetPack)' != '' " />
   </ItemGroup>
@@ -84,12 +85,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       Code="XA0138"
       ResourceName="XA0138"
   />
-</Target>
-
-<Target Name="_CalculateAssetPacks"
-    DependsOnTargets="_CalculateAssetsWithAssetPackMetaData"
-    Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
-  >
   <!-- Enumerate the assetpacks directory and build a pack per top level directory -->
   <GetAssetPacks
       Assets="@(_AssetsWithAssetPackMetaData)"

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
@@ -34,6 +34,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <PropertyGroup>
   <BeforeBuildAndroidAssetPacks>
     UpdateAndroidAssets
+    ;_CalculateAssetsWithAssetPackMetaData
     ;_CalculateAssetPacks
     ;$(BeforeBuildAndroidAssetPacks)
     ;_CreateAssetPackManifests
@@ -74,9 +75,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   </ItemGroup>
 </Target>
 
-<Target Name="_CalculateAssetPacks"
-    Condition=" '$(AndroidPackageFormat)' == 'aab' "
-  >
+<Target Name="_CalculateAssetsWithAssetPackMetaData">
   <ItemGroup>
     <_AssetsWithAssetPackMetaData Include="@(AndroidAsset)" Condition=" '%(AndroidAsset.AssetPack)' != '' " />
   </ItemGroup>
@@ -85,6 +84,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       Code="XA0138"
       ResourceName="XA0138"
   />
+</Target>
+
+<Target Name="_CalculateAssetPacks"
+    DependsOnTargets="_CalculateAssetsWithAssetPackMetaData"
+    Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
+  >
   <!-- Enumerate the assetpacks directory and build a pack per top level directory -->
   <GetAssetPacks
       Assets="@(_AssetsWithAssetPackMetaData)"

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -31,19 +31,6 @@ It is shared between "legacy" binding projects and .NET 5 projects.
     <NoWarn Condition=" '$(DocumentationFile)' != '' ">$(NoWarn);CS1573;CS1591</NoWarn>
   </PropertyGroup>
 
-  <Target Name="_CheckNonIdealBindingConfigurations">
-    <AndroidWarning Code="XA1037"
-        ResourceName="XA1037"
-        FormatArguments="_AndroidUseJavaLegacyResolver;10"
-        Condition=" '$(_AndroidUseJavaLegacyResolver)' == 'true' "
-    />
-    <AndroidWarning Code="XA1037"
-        ResourceName="XA1037"
-        FormatArguments="_AndroidEmitLegacyInterfaceInvokers;10"
-        Condition=" '$(_AndroidEmitLegacyInterfaceInvokers)' == 'true' "
-    />
-  </Target>
-
   <Target Name="_CollectLibrariesToBind" DependsOnTargets="_CategorizeAndroidLibraries">
     <ItemGroup>
       <_LibrariesToBind  Include="@(EmbeddedJar)" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -33,7 +33,7 @@ _ResolveAssemblies MSBuild target.
       $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', ''))))
     </CoreBuildDependsOn>
     <CompileDependsOn>
-      _AddAndroidDefines;
+      AndroidPrepareForBuild;
       $(CompileDependsOn);
     </CompileDependsOn>
   </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -90,6 +90,7 @@ properties that determine build ordering.
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' ">
     <BuildDependsOn>
       $(AndroidBuildDependsOn);
+      _CalculateAssetsWithAssetPackMetaData;
       _CreateAar;
     </BuildDependsOn>
     <IncrementalCleanDependsOn>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -12,10 +12,10 @@ properties that determine build ordering.
 
   <PropertyGroup>
     <_AndroidBuildDependsOn>
-      AndroidPrepareForBuild;
       _CheckNonIdealConfigurations;
       _SetupMSBuildAllProjects;
       _SetupDesignTimeBuildForBuild;
+      AndroidPrepareForBuild;
       _CategorizeAndroidLibraries;
       _CreatePropertiesCache;
       _CleanIntermediateIfNeeded;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -11,8 +11,8 @@ properties that determine build ordering.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <AndroidBuildDependsOn>
-      _ValidateLinkMode;
+    <_AndroidBuildDependsOn>
+      AndroidPrepareForBuild;
       _CheckNonIdealConfigurations;
       _SetupMSBuildAllProjects;
       _SetupDesignTimeBuildForBuild;
@@ -20,20 +20,19 @@ properties that determine build ordering.
       _CreatePropertiesCache;
       _CleanIntermediateIfNeeded;
       _CheckProjectItems;
-      AndroidPrepareForBuild;
       _CheckForContent;
       _CheckForObsoleteFrameworkAssemblies;
       _ValidateAndroidPackageProperties;
       AddLibraryJarsToBind;
       _CollectJavaSourceForBinding;
       _CompileBindingJava;
-      $(BuildDependsOn);
-    </AndroidBuildDependsOn>
+    </_AndroidBuildDependsOn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'True' ">
     <BuildDependsOn>
-      $(AndroidBuildDependsOn);
+      $(_AndroidBuildDependsOn);
+      $(BuildDependsOn);
       _CompileDex;
       $(_AfterCompileDex);
     </BuildDependsOn>
@@ -89,7 +88,8 @@ properties that determine build ordering.
 
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' ">
     <BuildDependsOn>
-      $(AndroidBuildDependsOn);
+      $(_AndroidBuildDependsOn);
+      $(BuildDependsOn);
       _CalculateAssetsWithAssetPackMetaData;
       _CreateAar;
     </BuildDependsOn>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -12,6 +12,7 @@ properties that determine build ordering.
 
   <PropertyGroup>
     <_AndroidBuildDependsOn>
+      _ValidateLinkMode
       _CheckNonIdealConfigurations;
       _SetupMSBuildAllProjects;
       _SetupDesignTimeBuildForBuild;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -10,8 +10,8 @@ properties that determine build ordering.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup Condition=" '$(AndroidApplication)' == 'True' ">
-    <BuildDependsOn>
+  <PropertyGroup>
+    <AndroidBuildDependsOn>
       _ValidateLinkMode;
       _CheckNonIdealConfigurations;
       _SetupMSBuildAllProjects;
@@ -20,6 +20,7 @@ properties that determine build ordering.
       _CreatePropertiesCache;
       _CleanIntermediateIfNeeded;
       _CheckProjectItems;
+      AndroidPrepareForBuild;
       _CheckForContent;
       _CheckForObsoleteFrameworkAssemblies;
       _ValidateAndroidPackageProperties;
@@ -27,6 +28,12 @@ properties that determine build ordering.
       _CollectJavaSourceForBinding;
       _CompileBindingJava;
       $(BuildDependsOn);
+    </AndroidBuildDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(AndroidApplication)' == 'True' ">
+    <BuildDependsOn>
+      $(AndroidBuildDependsOn);
       _CompileDex;
       $(_AfterCompileDex);
     </BuildDependsOn>
@@ -82,23 +89,7 @@ properties that determine build ordering.
 
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' ">
     <BuildDependsOn>
-      _ValidateLinkMode;
-      _CheckNonIdealBindingConfigurations;
-      _SetupMSBuildAllProjects;
-      _SetupDesignTimeBuildForBuild;
-      _CategorizeAndroidLibraries;
-      _CreatePropertiesCache;
-      _CleanIntermediateIfNeeded;
-      _AddAndroidDefines;
-      _CheckForContent;
-      _CheckForObsoleteFrameworkAssemblies;
-      _CalculateAssetsWithAssetPackMetaData;
-      _RemoveLegacyDesigner;
-      _ValidateAndroidPackageProperties;
-      AddLibraryJarsToBind;
-      _CollectJavaSourceForBinding;
-      _CompileBindingJava;
-      $(BuildDependsOn);
+      $(AndroidBuildDependsOn);
       _CreateAar;
     </BuildDependsOn>
     <IncrementalCleanDependsOn>
@@ -138,7 +129,7 @@ properties that determine build ordering.
     <CompileDependsOn>
       _SetupMSBuildAllProjects;
       _SetupDesignTimeBuildForCompile;
-      _AddAndroidDefines;
+      AndroidPrepareForBuild;
       _IncludeLayoutBindingSources;
       AddLibraryJarsToBind;
       _CollectLibrariesToBind;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -12,7 +12,7 @@ properties that determine build ordering.
 
   <PropertyGroup>
     <_AndroidBuildDependsOn>
-      _ValidateLinkMode
+      _ValidateLinkMode;
       _CheckNonIdealConfigurations;
       _SetupMSBuildAllProjects;
       _SetupDesignTimeBuildForBuild;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -567,9 +567,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 *******************************************
 -->
 
-<Target Name="_ValidateLinkMode">
-</Target>
-
 <Target Name="UpdateGeneratedFiles"
 		DependsOnTargets="ResolveAssemblyReferences;_RemoveLegacyDesigner;UpdateAndroidResources"
 	>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -486,7 +486,22 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   />
 </Target>
 
-<Target Name="_CheckNonIdealConfigurations">
+<Target Name="_CheckNonIdealLibraryConfigurations"
+    Condition=" '$(AndroidApplication)' != 'true' ">
+  <AndroidWarning Code="XA1037"
+      ResourceName="XA1037"
+      FormatArguments="_AndroidUseJavaLegacyResolver;10"
+      Condition=" '$(_AndroidUseJavaLegacyResolver)' == 'true' "
+  />
+  <AndroidWarning Code="XA1037"
+      ResourceName="XA1037"
+      FormatArguments="_AndroidEmitLegacyInterfaceInvokers;10"
+      Condition=" '$(_AndroidEmitLegacyInterfaceInvokers)' == 'true' "
+  />
+</Target>
+
+<Target Name="_CheckNonIdealAppConfigurations"
+    Condition=" '$(AndroidApplication)' == 'true' ">
   <AndroidWarning Code="XA0119"
       ResourceName="XA0119_AOT"
       Condition=" '$(EmbedAssembliesIntoApk)' != 'True' And '$(AotAssemblies)' == 'True' "
@@ -540,16 +555,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       FormatArguments="AndroidFastDeploymentType;9"
       Condition=" '$(AndroidFastDeploymentType)' != '' "
   />
-  <AndroidWarning Code="XA1037"
-      ResourceName="XA1037"
-      FormatArguments="_AndroidUseJavaLegacyResolver;10"
-      Condition=" '$(_AndroidUseJavaLegacyResolver)' == 'true' and '$(AndroidApplication)' != 'true' "
-  />
-  <AndroidWarning Code="XA1037"
-      ResourceName="XA1037"
-      FormatArguments="_AndroidEmitLegacyInterfaceInvokers;10"
-      Condition=" '$(_AndroidEmitLegacyInterfaceInvokers)' == 'true' and '$(AndroidApplication)' != 'true' "
-  />
+</Target>
+
+<Target Name="_CheckNonIdealConfigurations"
+    DependsOnTargets="_CheckNonIdealLibraryConfigurations;_CheckNonIdealAppConfigurations">
 </Target>
 
 <!--

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -567,6 +567,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 *******************************************
 -->
 
+<!-- Used by Xamarin.AndroidX.Migration.targets -->
+<Target Name="_ValidateLinkMode">
+</Target>
+
 <Target Name="UpdateGeneratedFiles"
 		DependsOnTargets="ResolveAssemblyReferences;_RemoveLegacyDesigner;UpdateAndroidResources"
 	>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -540,6 +540,16 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       FormatArguments="AndroidFastDeploymentType;9"
       Condition=" '$(AndroidFastDeploymentType)' != '' "
   />
+  <AndroidWarning Code="XA1037"
+      ResourceName="XA1037"
+      FormatArguments="_AndroidUseJavaLegacyResolver;10"
+      Condition=" '$(_AndroidUseJavaLegacyResolver)' == 'true' and '$(AndroidApplication)' != 'true' "
+  />
+  <AndroidWarning Code="XA1037"
+      ResourceName="XA1037"
+      FormatArguments="_AndroidEmitLegacyInterfaceInvokers;10"
+      Condition=" '$(_AndroidEmitLegacyInterfaceInvokers)' == 'true' and '$(AndroidApplication)' != 'true' "
+  />
 </Target>
 
 <!--
@@ -616,10 +626,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <CallTarget Targets="_CleanMonoAndroidIntermediateDir" Condition=" '$(_AndroidBuildPropertiesCacheExists)' == 'True' " />
   <MakeDir Directories="$(_AndroidStampDirectory)" Condition=" !Exists('$(_AndroidStampDirectory)') " />
   <Touch Files="$(_AndroidStampDirectory)_CleanIntermediateIfNeeded.stamp" AlwaysCreate="true" />
-</Target>
-
-<Target Name="_AddAndroidDefines"
-		DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
 </Target>
 
 <PropertyGroup>


### PR DESCRIPTION
I was looking to extend the `BuildDependsOn` target ordering used to
structure application and library builds and noticed a fair amount of
target duplication that may benefit from some consolidation.

A new `_AndroidBuildDependsOn` property has been added to include the
core targets that builds of both project types depend on.

The  `_CheckNonIdealBindingConfigurations` target has been merged with
`_CheckNonIdealConfigurations`.

The `_CheckProjectItems` target will now run for both app and library
projects, as the corresponding `CheckProjectItems` task is already
conditional based on the value of `$(AndroidApplication)`.

The `_AddAndroidDefines` target has been removed in favor of the more
widely used `AndroidPrepareForBuild` target, both of which are empty
targets that depend on `$(_OnResolveMonoAndroidSdks)`.

The `_RemoveLegacyDesigner` target has been removed from the library
specific target list, it should already run for each project type as part
of the `UpdateGeneratedFiles` target.