### PR TITLE
[Xamarin.Android.Build.Tasks] Bump MinimumSupportedJavaVersion=17

### DIFF
--- a/build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in
+++ b/build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in
@@ -7,6 +7,7 @@
         <HostCpuCount Condition=" '$(HostCpuCount)' == '' ">@HOST_CPUS@</HostCpuCount>
         <HostBits Condition=" '$(HostBits)' == '' ">@ARCHITECTURE_BITS@</HostBits>
         <JavaSdkVersion>@JAVA_SDK_VERSION@</JavaSdkVersion>
+        <MinimumSupportedJavaSdkVersion>@MIN_SUPPORTED_JDK_VERSION@</MinimumSupportedJavaSdkVersion>
         <JavaSdkDirectory Condition=" '$(JavaSdkDirectory)' == '' ">@JavaSdkDirectory@</JavaSdkDirectory>
         <JavaCPath Condition=" '$(JavaCPath)' == '' ">@javac@</JavaCPath>
         <JarPath Condition=" '$(JarPath)' == '' ">@jar@</JarPath>

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -162,6 +162,7 @@ namespace Xamarin.Android.Prepare
 				{ "@java@",                 context.OS.JavaPath },
 				{ "@jar@",                  context.OS.JarPath },
 				{ "@NDK_LLVM_TAG@",         $"{context.OS.Type.ToLowerInvariant ()}-x86_64" },
+				{ "@MIN_SUPPORTED_JDK_VERSION@",    $"{Configurables.Defaults.MicrosoftOpenJDK17Version.Major}.0" },
 			};
 
 			return new GeneratedPlaceholdersFile (

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -2,7 +2,6 @@
 
   <!-- User-facing configuration-agnostic defaults -->
   <PropertyGroup>
-    <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">11.0</MinimumSupportedJavaVersion>
     <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
     <MonoAndroidResourcePrefix Condition=" '$(MonoAndroidResourcePrefix)' == '' ">Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix Condition=" '$(MonoAndroidAssetsPrefix)' == '' ">Assets</MonoAndroidAssetsPrefix>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -199,6 +199,7 @@
       <_XACommonPropsReplacement Include="@COMMAND_LINE_TOOLS_VERSION@=$(CommandLineToolsFolder)" />
       <_XACommonPropsReplacement Include="@BUNDLETOOL_VERSION@=$(XABundleToolVersion)" />
       <_XACommonPropsReplacement Include="@JAVA_SDK_VERSION@=$(JavaSdkVersion)" />
+      <_XACommonPropsReplacement Include="@MIN_SUPPORTED_JDK_VERSION@=$(MinimumSupportedJavaSdkVersion)" />
       <!-- <_XACommonPropsReplacement Include="@NDK_PKG_REVISION@=$(AndroidNdkPkgRevision)" /> -->
       <_XACommonPropsReplacement Include="@NDK_PKG_REVISION@=26.3.11579264" />
       <_XACommonPropsReplacement Include="@NDK_ARM64_V8A_API@=$(AndroidNdkApiLevel_ArmV8a)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -8,6 +8,7 @@
 		<AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
 		<AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">@NDK_PKG_REVISION@</AndroidNdkVersion>
 		<JavaSdkVersion Condition="'$(JavaSdkVersion)' == ''">@JAVA_SDK_VERSION@</JavaSdkVersion>
+		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">@MIN_SUPPORTED_JDK_VERSION@</MinimumSupportedJavaVersion>
 	</PropertyGroup>
 	<PropertyGroup>
 		<_JavaInteropReferences>Java.Interop;System.Runtime</_JavaInteropReferences>
@@ -17,7 +18,6 @@
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
 		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">17.0.99</LatestSupportedJavaVersion>
-		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>
 		<AndroidUseApkSigner Condition=" '$(AndroidUseApkSigner)' == '' ">True</AndroidUseApkSigner>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/9159#issuecomment-2317390991

Bump `$(MinimumSupportedJavaVersion)` to 17.0, and base this value on the `Configurables.Defaults.MicrosoftOpenJDK17Version` value so that if (when) we bump the JDK we build against, the major version value of `$(MinimumSupportedJavaVersion)` follows suit.

Additionally, remove the `$(MinimumSupportedJavaVersion)` definition in `Microsoft.Android.Sdk.DefaultProperties.targets` so that it's only defined in one location.