### PR TITLE
[XABT] Replace SortedSet with HashSet.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/JCWGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JCWGenerator.cs
@@ -246,8 +246,8 @@ class JCWGenerator
 	{
 		logger.LogDebugMessage ($"Ensuring Java type collection in architecture '{state.TargetArch}' matches the one in architecture '{templateState.TargetArch}'");
 
-		var templateSet = new SortedSet<string> (templateState.AllJavaTypes.Select (t => t.FullName), StringComparer.Ordinal);
-		var typesSet = new SortedSet<string> (state.AllJavaTypes.Select (t => t.FullName), StringComparer.Ordinal);
+		var templateSet = new HashSet<string> (templateState.AllJavaTypes.Select (t => t.FullName), StringComparer.Ordinal);
+		var typesSet = new HashSet<string> (state.AllJavaTypes.Select (t => t.FullName), StringComparer.Ordinal);
 
 		if (typesSet.Count != templateSet.Count) {
 			throw new InvalidOperationException ($"Internal error: architecture '{state.TargetArch}' has a different number of types ({typesSet.Count}) than the template architecture '{templateState.TargetArch}' ({templateSet.Count})");


### PR DESCRIPTION
One question that came up with https://github.com/dotnet/android/pull/9208 was "why `SortedSet` instead of `HashSet`"?

Indeed a `HashSet` seems to be 10ms - 15ms faster to construct than the `SortedSet` while taking the same ~1ms to perform the `SetEquals` operation.