### PR TITLE
[Xamarin.Android.Build.Tasks] fix `<GenerateRtxt/>` during design-time builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateRtxt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateRtxt.cs
@@ -1,12 +1,7 @@
 // Copyright (C) 2022 Microsoft Ltd, Inc. All rights reserved.
 using System;
-using System.CodeDom;
-using System.CodeDom.Compiler;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks
@@ -22,7 +17,6 @@ namespace Xamarin.Android.Tasks
 		public string ResourceDirectory { get; set; }
 		public string[] AdditionalResourceDirectories { get; set; }
 
-		[Required]
 		public string JavaPlatformJarPath { get; set; }
 
 		public string ResourceFlagFile { get; set; }
@@ -35,7 +29,7 @@ namespace Xamarin.Android.Tasks
 
 			var resource_fixup = MonoAndroidHelper.LoadMapFile (BuildEngine4, Path.GetFullPath (CaseMapFile), StringComparer.OrdinalIgnoreCase);
 
-			var javaPlatformDirectory = Path.GetDirectoryName (JavaPlatformJarPath);
+			var javaPlatformDirectory = string.IsNullOrEmpty (JavaPlatformJarPath) ? "" : Path.GetDirectoryName (JavaPlatformJarPath);
 			var parser = new FileResourceParser () { Log = Log, JavaPlatformDirectory = javaPlatformDirectory, ResourceFlagFile = ResourceFlagFile};
 			var resources = parser.Parse (ResourceDirectory, AdditionalResourceDirectories, resource_fixup);
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -725,6 +725,21 @@ namespace UnamedProject
 		}
 
 		[Test]
+		public void DesignTimeBuildMissingAndroidPlatformJar ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), "35.0.0", []);
+			try {
+				var proj = new XamarinAndroidApplicationProject ();
+				using var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName));
+				Assert.IsTrue (builder.DesignTimeBuild (proj, parameters: [$"AndroidSdkDirectory={androidSdkPath}"]),
+					"design-time build should have succeeded.");
+			} finally {
+				Directory.Delete (androidSdkPath, recursive: true);
+			}
+		}
+
+		[Test]
 		public void AndroidResourceNotExist ()
 		{
 			var proj = new XamarinAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs
@@ -32,6 +32,8 @@ namespace Xamarin.Android.Tasks
 		};
 
 		protected XDocument LoadPublicXml () {
+			if (string.IsNullOrEmpty (JavaPlatformDirectory))
+				return null;
 			string publicXmlPath = Path.Combine (JavaPlatformDirectory, "data", "res", "values");
 			foreach (var file in publicXmlFiles) {
 				if (File.Exists (Path.Combine (publicXmlPath, file))) {
@@ -44,7 +46,6 @@ namespace Xamarin.Android.Tasks
 		public IList<R> Parse (string resourceDirectory, IEnumerable<string> additionalResourceDirectories, Dictionary<string, string> resourceMap)
 		{
 			Log.LogDebugMessage ($"Parsing Directory {resourceDirectory}");
-			string publicXmlPath = Path.Combine (JavaPlatformDirectory, "data", "res", "values");
 			publicXml = LoadPublicXml ();
 			var result = new List<R> ();
 			Dictionary<string, ICollection<R>> resources = new Dictionary<string, ICollection<R>> ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -452,10 +452,13 @@ namespace Xamarin.Android.Tasks
 		{
 			var platformPath = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (platform, MonoAndroidHelper.SupportedVersions);
 			if (platformPath == null) {
-				if (!designTimeBuild) {
-					var expectedPath = MonoAndroidHelper.AndroidSdk.GetPlatformDirectoryFromId (platform);
-					var sdkManagerMenuPath = buildingInsideVisualStudio ? Properties.Resources.XA5207_SDK_Manager_Windows : Properties.Resources.XA5207_SDK_Manager_CLI;
-					log.LogCodedError ("XA5207", Properties.Resources.XA5207, platform, Path.Combine (expectedPath, "android.jar"), string.Format (sdkManagerMenuPath, targetFramework, androidSdkDirectory));
+				var expectedPath = Path.Combine (AndroidSdk.GetPlatformDirectoryFromId (platform), "android.jar");
+				var sdkManagerMenuPath = buildingInsideVisualStudio ? Properties.Resources.XA5207_SDK_Manager_Windows : Properties.Resources.XA5207_SDK_Manager_CLI;
+				var details = string.Format (sdkManagerMenuPath, targetFramework, androidSdkDirectory);
+				if (designTimeBuild) {
+					log.LogDebugMessage (string.Format(Properties.Resources.XA5207, platform, expectedPath, details));
+				} else {
+					log.LogCodedError ("XA5207", Properties.Resources.XA5207, platform, expectedPath, details);
 				}
 				return null;
 			}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9285

Building a .NET 9 project without API 35 installed would fail with:

    MSB4044: The "GenerateRtxt" task was not given a value for the required parameter "JavaPlatformJarPath"

I was able to reproduce this in an MSBuild test that uses:

    var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), "35.0.0", []);

To fix this:

* Remove `[Required]` from the `JavaPlatformJarPath` property

* Add some extra checks if the value is `null` or empty

I also did some other cleanup:

* `MonoAndroidHelper` now logs during the `<GetJavaPlatformJar/>`
  task, even during a design-time build.

* Removed what looked like an unused, extra line in `FileResourceParser`:

    string publicXmlPath = Path.Combine (JavaPlatformDirectory, "data", "res", "values");