### PR TITLE
Bump recommended Android SDK versions for API 35

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:dev/pjc/sdkversprops@36d54b5fa0ee36c22f395d968af8ac328c7cc0a1
+xamarin/monodroid:main@8a0cbe1392bf88cb3f46710057e224e902b6bf55

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@ae47dedcdb9d7cd83c18630b3941ecb4b9441d7c
+xamarin/monodroid:dev/pjc/sdkversprops@e6e1a5b30053ee6d2617e2562c99151f32ef9fdd

--- a/Configuration.props
+++ b/Configuration.props
@@ -158,8 +158,8 @@
     <AvdManagerToolExe Condition=" '$(AvdManagerToolExe)' == '' and '$(HostOS)' == 'Windows' ">avdmanager.bat</AvdManagerToolExe>
     <AndroidToolPath Condition=" '$(AndroidToolPath)' == '' ">$(AndroidSdkFullPath)\tools</AndroidToolPath>
     <AndroidToolsBinPath Condition=" '$(AndroidToolsBinPath)' == '' ">$(AndroidToolPath)\bin</AndroidToolsBinPath>
-    <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">11.0</CommandLineToolsFolder>
-    <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">10406996_latest</CommandLineToolsVersion>
+    <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">12.0</CommandLineToolsFolder>
+    <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">11076708_latest</CommandLineToolsVersion>
     <CommandLineToolsBinPath Condition=" '$(CommandLineToolsBinPath)' == '' ">$(AndroidSdkFullPath)\cmdline-tools\$(CommandLineToolsFolder)\bin</CommandLineToolsBinPath>
     <!-- Version numbers and PkgVersion are found in https://dl-ssl.google.com/android/repository/repository2-3.xml -->
     <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">9364964</EmulatorVersion>

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -174,7 +174,6 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Tools.Aidl.pdb" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Tools.AndroidSdk.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Tools.AndroidSdk.pdb" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Tools.Versions.props" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)K4os.Compression.LZ4.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)ELFSharp.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)ManifestOverlays\Timing.xml" />

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Android.Prepare
 	{
 		const string BinutilsVersion                = "L_18.1.6-8.0.0";
 
-		const string MicrosoftOpenJDK17Version      = "17.0.12;
+		const string MicrosoftOpenJDK17Version      = "17.0.12";
 		const string MicrosoftOpenJDK17Release      = "17.0.12";
 		const string MicrosoftOpenJDK17RootDirName  = "jdk-17.0.12+7";
 

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -17,9 +17,9 @@ namespace Xamarin.Android.Prepare
 	{
 		const string BinutilsVersion                = "L_18.1.6-8.0.0";
 
-		const string MicrosoftOpenJDK17Version      = "17.0.8";
-		const string MicrosoftOpenJDK17Release      = "17.0.8.7";
-		const string MicrosoftOpenJDK17RootDirName  = "jdk-17.0.8+7";
+		const string MicrosoftOpenJDK17Version      = "17.0.12;
+		const string MicrosoftOpenJDK17Release      = "17.0.12";
+		const string MicrosoftOpenJDK17RootDirName  = "jdk-17.0.12+7";
 
 		static Context ctx => Context.Instance;
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Build.Tests
 					"AcceptAndroidSDKLicenses=true",
 					$"AndroidManifestType={manifestType}",
 				};
-				// When using the default Xamarin manifest, this test should fail if we can't install any of the defaults in Xamarin.Android.Tools.Versions.props
+				// When using the default Xamarin manifest, this test should fail if we can't install any of the defaults in Xamarin.Installer.Common.props
 				// When using the Google manifest, override the platform tools version to the one in their manifest as it only ever contains one version
 				if (manifestType == "GoogleV2") {
 					buildArgs.Add ($"AndroidSdkPlatformToolsVersion={GetCurrentPlatformToolsVersion ()}");


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/51151d727a0438dd049ad2678f9039d8f255d7b2

Introduces a Xamarin.Installer.Common.props file which replaces
Xamarin.Android.Tools.Versions.props, and includes the latest
set of recommended Android SDK components for API 35.