### PR TITLE
[Xamarin.Android.Build.Tasks] remove `HasClassFiles` checks

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using System.Linq;
 using System.IO;
-using Xamarin.Android.Tools;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks
@@ -58,8 +57,6 @@ namespace Xamarin.Android.Tasks
 				referenceJavaLibraries.AddRange (ExternalJavaLibraries);
 
 			foreach (var item in distinct) {
-				if (!HasClassFiles (item.ItemSpec))
-					continue;
 				if (IsExcluded (item.ItemSpec)) {
 					referenceJavaLibraries.Add (item);
 				} else {
@@ -73,11 +70,6 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugTaskItems ("  ReferenceJavaLibraries:", ReferenceJavaLibraries);
 
 			return true;
-		}
-
-		bool HasClassFiles (string jar)
-		{
-			return Files.ZipAny (jar, entry => entry.FullName.EndsWith (".class", StringComparison.OrdinalIgnoreCase));
 		}
 
 		bool IsExcluded (string jar)


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/2882

During an incremental build + deploy of a `dotnet new maui` project, I noticed time spent in:

    62.52ms (1.8%) xamarin.android.build.tasks!Xamarin.Android.Tasks.DetermineJavaLibrariesToCompile.HasClassFiles(class System.String)

What's worse, is this happens once for build and again for deploy. Because there are 100+ `.jar` files, we are actively opening each one with libZipSharp to determine if there are any `.class` files.

In e6326dcb, we added the `HasClassFiles()` call to fix a problem with "Enhanced Fast Deployment". However, we have since completely removed this feature in:

* https://github.com/xamarin/monodroid/commit/93ab95e18077d56d9d55ce7b4069a534e2dea35e
* https://github.com/xamarin/monodroid/commit/2c64cd5f533616ff4751fb1df6bbfc7e170477ae

Removing the `HasClassFiles()` method completely, should improve the inner loop by around 120ms for `dotnet new maui` projects.