### PR TITLE
Remove native runtime support for instant run

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
@@ -44,7 +44,6 @@ namespace Xamarin.Android.Build.Tests
 			public bool   aot_lazy_load;
 			public bool   uses_assembly_preload;
 			public bool   broken_exception_transitions;
-			public bool   instant_run_enabled;
 			public bool   jni_add_native_method_registration_attribute_present;
 			public bool   have_runtime_config_blob;
 			public bool   have_assemblies_blob;
@@ -68,7 +67,7 @@ namespace Xamarin.Android.Build.Tests
 			public string android_package_name = String.Empty;
 		}
 
-		const uint ApplicationConfigFieldCount = 27;
+		const uint ApplicationConfigFieldCount = 26;
 
 		const string ApplicationConfigSymbolName = "application_config";
 		const string AppEnvironmentVariablesSymbolName = "app_environment_variables";
@@ -232,112 +231,107 @@ namespace Xamarin.Android.Build.Tests
 						ret.broken_exception_transitions = ConvertFieldToBool ("broken_exception_transitions", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 5: // instant_run_enabled: bool / .byte
-						AssertFieldType (envFile.Path, parser.SourceFilePath, ".byte", field [0], item.LineNumber);
-						ret.instant_run_enabled = ConvertFieldToBool ("instant_run_enabled", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
-						break;
-
-					case 6: // jni_add_native_method_registration_attribute_present: bool / .byte
+					case 5: // jni_add_native_method_registration_attribute_present: bool / .byte
 						AssertFieldType (envFile.Path, parser.SourceFilePath, ".byte", field [0], item.LineNumber);
 						ret.jni_add_native_method_registration_attribute_present = ConvertFieldToBool ("jni_add_native_method_registration_attribute_present", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 7: // have_runtime_config_blob: bool / .byte
+					case 6: // have_runtime_config_blob: bool / .byte
 						AssertFieldType (envFile.Path, parser.SourceFilePath, ".byte", field [0], item.LineNumber);
 						ret.have_runtime_config_blob = ConvertFieldToBool ("have_runtime_config_blob", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 8: // have_assemblies_blob: bool / .byte
+					case 7: // have_assemblies_blob: bool / .byte
 						AssertFieldType (envFile.Path, parser.SourceFilePath, ".byte", field [0], item.LineNumber);
 						ret.have_assemblies_blob = ConvertFieldToBool ("have_assemblies_blob", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 9: // marshal_methods_enabled: bool / .byte
+					case 8: // marshal_methods_enabled: bool / .byte
 						AssertFieldType (envFile.Path, parser.SourceFilePath, ".byte", field [0], item.LineNumber);
 						ret.marshal_methods_enabled = ConvertFieldToBool ("marshal_methods_enabled", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 10: // ignore_split_configs: bool / .byte
+					case 9: // ignore_split_configs: bool / .byte
 						AssertFieldType (envFile.Path, parser.SourceFilePath, ".byte", field [0], item.LineNumber);
 						ret.ignore_split_configs = ConvertFieldToBool ("ignore_split_configs", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 11: // bound_stream_io_exception_type: byte / .byte
+					case 10: // bound_stream_io_exception_type: byte / .byte
 						AssertFieldType (envFile.Path, parser.SourceFilePath, ".byte", field [0], item.LineNumber);
 						ret.bound_stream_io_exception_type = ConvertFieldToByte ("bound_stream_io_exception_type", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 12: // package_naming_policy: uint32_t / .word | .long
+					case 11: // package_naming_policy: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.package_naming_policy = ConvertFieldToUInt32 ("package_naming_policy", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 13: // environment_variable_count: uint32_t / .word | .long
+					case 12: // environment_variable_count: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.environment_variable_count = ConvertFieldToUInt32 ("environment_variable_count", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 14: // system_property_count: uint32_t / .word | .long
+					case 13: // system_property_count: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.system_property_count = ConvertFieldToUInt32 ("system_property_count", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 15: // number_of_assemblies_in_apk: uint32_t / .word | .long
+					case 14: // number_of_assemblies_in_apk: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.number_of_assemblies_in_apk = ConvertFieldToUInt32 ("number_of_assemblies_in_apk", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 16: // bundled_assembly_name_width: uint32_t / .word | .long
+					case 15: // bundled_assembly_name_width: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.bundled_assembly_name_width = ConvertFieldToUInt32 ("bundled_assembly_name_width", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 17: // number_of_assembly_store_files: uint32_t / .word | .long
+					case 16: // number_of_assembly_store_files: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.number_of_assembly_store_files = ConvertFieldToUInt32 ("number_of_assembly_store_files", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 18: // number_of_dso_cache_entries: uint32_t / .word | .long
+					case 17: // number_of_dso_cache_entries: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.number_of_dso_cache_entries = ConvertFieldToUInt32 ("number_of_dso_cache_entries", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 19: // number_of_aot_cache_entries: uint32_t / .word | .long
+					case 18: // number_of_aot_cache_entries: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.number_of_aot_cache_entries = ConvertFieldToUInt32 ("number_of_aot_cache_entries", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 20: // android_runtime_jnienv_class_token: uint32_t / .word | .long
+					case 19: // android_runtime_jnienv_class_token: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.android_runtime_jnienv_class_token = ConvertFieldToUInt32 ("android_runtime_jnienv_class_token", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 21: // jnienv_initialize_method_token: uint32_t / .word | .long
+					case 20: // jnienv_initialize_method_token: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.jnienv_initialize_method_token = ConvertFieldToUInt32 ("jnienv_initialize_method_token", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 22: // jnienv_registerjninatives_method_token: uint32_t / .word | .long
+					case 21: // jnienv_registerjninatives_method_token: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.jnienv_registerjninatives_method_token = ConvertFieldToUInt32 ("jnienv_registerjninatives_method_token", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 23: // jni_remapping_replacement_type_count: uint32_t / .word | .long
+					case 22: // jni_remapping_replacement_type_count: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.jni_remapping_replacement_type_count = ConvertFieldToUInt32 ("jni_remapping_replacement_type_count", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 24: // jni_remapping_replacement_method_index_entry_count: uint32_t / .word | .long
+					case 23: // jni_remapping_replacement_method_index_entry_count: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.jni_remapping_replacement_method_index_entry_count = ConvertFieldToUInt32 ("jni_remapping_replacement_method_index_entry_count", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 25: // mono_components_mask: uint32_t / .word | .long
+					case 24: // mono_components_mask: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.mono_components_mask = ConvertFieldToUInt32 ("mono_components_mask", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 26: // android_package_name: string / [pointer type]
+					case 25: // android_package_name: string / [pointer type]
 						Assert.IsTrue (expectedPointerTypes.Contains (field [0]), $"Unexpected pointer field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						pointers.Add (field [1].Trim ());
 						break;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfig.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfig.cs
@@ -29,7 +29,6 @@ namespace Xamarin.Android.Tasks
 		public bool   aot_lazy_load;
 		public bool   uses_assembly_preload;
 		public bool   broken_exception_transitions;
-		public bool   instant_run_enabled ;
 		public bool   jni_add_native_method_registration_attribute_present;
 		public bool   have_runtime_config_blob;
 		public bool   have_assemblies_blob;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
@@ -225,7 +225,6 @@ namespace Xamarin.Android.Tasks
 				aot_lazy_load = AotEnableLazyLoad,
 				uses_assembly_preload = UsesAssemblyPreload,
 				broken_exception_transitions = BrokenExceptionTransitions,
-				instant_run_enabled = false,
 				jni_add_native_method_registration_attribute_present = JniAddNativeMethodRegistrationAttributePresent,
 				have_runtime_config_blob = HaveRuntimeConfigBlob,
 				have_assemblies_blob = HaveAssemblyStore,

--- a/src/native/monodroid/embedded-assemblies.hh
+++ b/src/native/monodroid/embedded-assemblies.hh
@@ -112,9 +112,6 @@ namespace xamarin::android::internal {
 		{}
 #endif  // def RELEASE
 
-#if defined (DEBUG)
-		void try_load_typemaps_from_directory (const char *path);
-#endif
 		STATIC_IN_ANDROID_RELEASE const char* typemap_managed_to_java (MonoReflectionType *type, const uint8_t *mvid) noexcept;
 
 		void install_preload_hooks_for_appdomains ();

--- a/src/native/monodroid/monodroid-glue.cc
+++ b/src/native/monodroid/monodroid-glue.cc
@@ -228,22 +228,6 @@ MonodroidRuntime::should_register_file ([[maybe_unused]] const char *filename)
 inline void
 MonodroidRuntime::gather_bundled_assemblies (jstring_array_wrapper &runtimeApks, size_t *out_user_assemblies_count, bool have_split_apks)
 {
-#if defined(DEBUG)
-	if (application_config.instant_run_enabled) {
-		for (const char *od : AndroidSystem::override_dirs) {
-			if (od == nullptr || !Util::directory_exists (od)) {
-				continue;
-			}
-
-			// TODO: temporary hack for the location of typemaps, to be fixed
-			dynamic_local_string<SENSIBLE_PATH_MAX> above { od };
-			above.append ("/..");
-			log_debug (LOG_ASSEMBLY, "Loading TypeMaps from %s", above.get());
-			embeddedAssemblies.try_load_typemaps_from_directory (above.get());
-		}
-	}
-#endif
-
 	if (!AndroidSystem::is_embedded_dso_mode_enabled ()) {
 		*out_user_assemblies_count = embeddedAssemblies.register_from_filesystem<should_register_file> ();
 		return;

--- a/src/native/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/xamarin-app-stub/application_dso_stub.cc
@@ -47,7 +47,6 @@ const ApplicationConfig application_config = {
 	.aot_lazy_load = false,
 	.uses_assembly_preload = false,
 	.broken_exception_transitions = false,
-	.instant_run_enabled = false,
 	.jni_add_native_method_registration_attribute_present = false,
 	.have_runtime_config_blob = false,
 	.have_assembly_store = false,

--- a/src/native/xamarin-app-stub/xamarin-app.hh
+++ b/src/native/xamarin-app-stub/xamarin-app.hh
@@ -237,7 +237,6 @@ struct ApplicationConfig
 	bool aot_lazy_load;
 	bool uses_assembly_preload;
 	bool broken_exception_transitions;
-	bool instant_run_enabled;
 	bool jni_add_native_method_registration_attribute_present;
 	bool have_runtime_config_blob;
 	bool have_assembly_store;


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9292

With "Enhanced Fast Deployment" no longer part of .NET for Android, 
remove the native runtime side of its support.