### PR TITLE
Fix R8 Message processing to remove false positives.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
@@ -125,6 +125,8 @@ namespace Xamarin.Android.Tasks
 			return cmd;
 		}
 
+		// Note: We do not want to call the base.LogEventsFromTextOutput as it will incorrectly identify
+		// Warnings and Info messages as errors.
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
 			CheckForError (singleLine);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
@@ -42,6 +42,11 @@ namespace Xamarin.Android.Tasks
 
 		public string ExtraArguments { get; set; }
 
+		public D8 ()
+		{
+			CallBaseLogEventsFromTextOutput = false;
+		}
+
 		protected override string GenerateCommandLineCommands ()
 		{
 			return GetCommandLineBuilder ().ToString ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
@@ -42,11 +42,6 @@ namespace Xamarin.Android.Tasks
 
 		public string ExtraArguments { get; set; }
 
-		public D8 ()
-		{
-			CallBaseLogEventsFromTextOutput = false;
-		}
-
 		protected override string GenerateCommandLineCommands ()
 		{
 			return GetCommandLineBuilder ().ToString ();
@@ -128,6 +123,12 @@ namespace Xamarin.Android.Tasks
 			}
 
 			return cmd;
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			CheckForError (singleLine);
+			Log.LogMessage (messageImportance, singleLine);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
@@ -99,6 +99,7 @@ namespace Xamarin.Android.Tasks
 
 		protected override bool HandleTaskExecutionErrors ()
 		{
+			//System.Console.WriteLine ($"DEBUG!!! HandleTaskExecutionErrors called err:{foundError} has:{Log.HasLoggedErrors}");
 			if (foundError) {
 				AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
 				assemblyMap.Load (AssemblyIdentityMapFile);
@@ -142,6 +143,7 @@ namespace Xamarin.Android.Tasks
 		{
 			var match = CodeErrorRegEx.Match (singleLine);
 			var exceptionMatch = ExceptionRegEx.Match (singleLine);
+			//System.Console.WriteLine ($"DEBUG! code:{match.Success} ex:{exceptionMatch.Success} {singleLine}");
 			foreach (Match lp in lpRegex.Matches (singleLine)) {
 				var id = lp.Groups["identifier"].Value;
 				var asmName = assemblyMap.GetAssemblyNameForImportDirectory (id);
@@ -216,8 +218,9 @@ namespace Xamarin.Android.Tasks
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
 			errorLines.Add (singleLine);
-			base.LogEventsFromTextOutput (singleLine, messageImportance);  // not sure why/when we would skip this?
-
+			
+			Log.LogMessage (messageImportance, singleLine);
+			
 			if (foundError) {
 				return;
 			}
@@ -227,6 +230,7 @@ namespace Xamarin.Android.Tasks
 			foreach (var customRegex in GetCustomExpressions ()) {
 				customMatch |= customRegex.Match (singleLine).Success;
 			}
+			//System.Console.WriteLine ($"DEBUG!! code:{match.Success} ex:{exceptionMatch.Success} c:{customMatch} {singleLine}");
 			foundError = foundError || match.Success || exceptionMatch.Success || customMatch;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
@@ -89,8 +89,6 @@ namespace Xamarin.Android.Tasks
 
 		public string IntermediateOutputPath { get; set; }
 
-		protected bool CallBaseLogEventsFromTextOutput { get; set; } = true;
-
 		protected override string ToolName {
 			get { return OS.IsWindows ? "java.exe" : "java"; }
 		}
@@ -215,14 +213,9 @@ namespace Xamarin.Android.Tasks
 			errorText.AppendLine (text);
 		}
 
-		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		protected virtual void CheckForError (string singleLine)
 		{
 			errorLines.Add (singleLine);
-			
-			if (CallBaseLogEventsFromTextOutput)
-				base.LogEventsFromTextOutput (singleLine, messageImportance);
-			else
-				Log.LogMessage (messageImportance, singleLine);
 			
 			if (foundError) {
 				return;
@@ -234,6 +227,12 @@ namespace Xamarin.Android.Tasks
 				customMatch |= customRegex.Match (singleLine).Success;
 			}
 			foundError = foundError || match.Success || exceptionMatch.Success || customMatch;
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			CheckForError (singleLine);
+			base.LogEventsFromTextOutput (singleLine, messageImportance);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
@@ -89,6 +89,8 @@ namespace Xamarin.Android.Tasks
 
 		public string IntermediateOutputPath { get; set; }
 
+		protected bool CallBaseLogEventsFromTextOutput { get; set; } = true;
+
 		protected override string ToolName {
 			get { return OS.IsWindows ? "java.exe" : "java"; }
 		}
@@ -99,7 +101,6 @@ namespace Xamarin.Android.Tasks
 
 		protected override bool HandleTaskExecutionErrors ()
 		{
-			//System.Console.WriteLine ($"DEBUG!!! HandleTaskExecutionErrors called err:{foundError} has:{Log.HasLoggedErrors}");
 			if (foundError) {
 				AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
 				assemblyMap.Load (AssemblyIdentityMapFile);
@@ -143,7 +144,6 @@ namespace Xamarin.Android.Tasks
 		{
 			var match = CodeErrorRegEx.Match (singleLine);
 			var exceptionMatch = ExceptionRegEx.Match (singleLine);
-			//System.Console.WriteLine ($"DEBUG! code:{match.Success} ex:{exceptionMatch.Success} {singleLine}");
 			foreach (Match lp in lpRegex.Matches (singleLine)) {
 				var id = lp.Groups["identifier"].Value;
 				var asmName = assemblyMap.GetAssemblyNameForImportDirectory (id);
@@ -219,7 +219,10 @@ namespace Xamarin.Android.Tasks
 		{
 			errorLines.Add (singleLine);
 			
-			Log.LogMessage (messageImportance, singleLine);
+			if (CallBaseLogEventsFromTextOutput)
+				base.LogEventsFromTextOutput (singleLine, messageImportance);
+			else
+				Log.LogMessage (messageImportance, singleLine);
 			
 			if (foundError) {
 				return;
@@ -230,7 +233,6 @@ namespace Xamarin.Android.Tasks
 			foreach (var customRegex in GetCustomExpressions ()) {
 				customMatch |= customRegex.Match (singleLine).Success;
 			}
-			//System.Console.WriteLine ($"DEBUG!! code:{match.Success} ex:{exceptionMatch.Success} c:{customMatch} {singleLine}");
 			foundError = foundError || match.Success || exceptionMatch.Success || customMatch;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -38,6 +38,11 @@ namespace Xamarin.Android.Tasks
 
 		readonly List<string> tempFiles = new List<string> ();
 
+		public R8 ()
+		{
+			CallBaseLogEventsFromTextOutput = false;
+		}
+
 		public override bool RunTask ()
 		{
 			try {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -38,11 +38,6 @@ namespace Xamarin.Android.Tasks
 
 		readonly List<string> tempFiles = new List<string> ();
 
-		public R8 ()
-		{
-			CallBaseLogEventsFromTextOutput = false;
-		}
-
 		public override bool RunTask ()
 		{
 			try {
@@ -146,6 +141,12 @@ namespace Xamarin.Android.Tasks
 			}
 
 			return cmd;
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			CheckForError (singleLine);
+			Log.LogMessage (messageImportance, singleLine);
 		}
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -143,6 +143,8 @@ namespace Xamarin.Android.Tasks
 			return cmd;
 		}
 
+		// Note: We do not want to call the base.LogEventsFromTextOutput as it will incorrectly identify
+		// Warnings and Info messages as errors.
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
 			CheckForError (singleLine);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -34,6 +34,29 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void CheckR8InfoMessagesToNotBreakTheBuild ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidLinkTool, "r8");
+			proj.SetProperty (proj.ReleaseProperties, "AndroidCreateProguardMappingFile", true);
+			var packages = proj.PackageReferences;
+			packages.Add (KnownPackages.Xamarin_KotlinX_Coroutines_Android);
+			proj.OtherBuildItems.Add (new BuildItem ("ProguardConfiguration", "proguard.cfg") {
+				TextContent = () => @"-keepattributes Signature
+-keep class kotlinx.coroutines.channels.** { *; }
+"
+			});
+
+			using (var b = CreateApkBuilder ()) {
+				string mappingFile = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "mapping.txt");
+				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
+				FileAssert.Exists (mappingFile, $"'{mappingFile}' should have been generated.");
+			}
+		}
+
+		[Test]
 		[NonParallelizable] // Commonly fails NuGet restore
 		public void CheckIncludedAssemblies ([Values (false, true)] bool usesAssemblyStores)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -157,6 +157,10 @@ namespace Xamarin.ProjectTools
 			Id = "Xamarin.Kotlin.Reflect",
 			Version = "1.9.10.2"
 		};
+		public static Package Xamarin_KotlinX_Coroutines_Android = new Package {
+			Id = "Xamarin.KotlinX.Coroutines.Android",
+			Version = "1.8.1.1"
+		};
 		public static Package Acr_UserDialogs = new Package {
 			Id = "Acr.UserDialogs",
 			Version = "8.0.1",


### PR DESCRIPTION
Context https://github.com/dotnet/android/issues/7008#issuecomment-2343312847

When building with certain libraries we are seeing the following errors

```
4>  Invalid signature '(TT;)TV;' for method java.lang.Object kotlin.jvm.internal.PropertyReference1.get(java.lang.Object). (TaskId:792)
4>R8 : Validation error : A type variable is not in scope.
4>  Signature is ignored and will not be present in the output. (TaskId:792)
4>  Info in ...\.nuget\packages\xamarin.kotlin.stdlib\1.6.20.1\buildTransitive\monoandroid12.0\..\..\jar\org.jetbrains.kotlin.kotlin-stdlib-1.6.20.jar:kotlin/jvm/internal/PropertyReference0.class: (TaskId:792)
4>  Invalid signature '()TV;' for method java.lang.Object kotlin.jvm.internal.PropertyReference0.get(). (TaskId:792)
4>R8 : Validation error : A type variable is not in scope.
```

If you look carefully these are Info messages not errors. It turns out the call to `base.LogEventsFromTextOutput (singleLine, messageImportance);` is also including the default MSBuild error processing. This is mistaking this output for actual errors. So lets get around this by NOT calling `base.LogEventsFromTextOutput (singleLine, messageImportance);`. 
So lets add a new meethod `CheckForError` which does the actual check. By default `LogEventsFromTextOutput` will call this and `base.LogEventsFromTextOutput` . However to `R8` and `D8` we override `LogEventsFromTextOutput` and only call `CheckForError ` and `Log.LogMessage`. This fixing this issue.

Add a unit test which covers the error case.