### PR TITLE
[Mono.Android] Use X509TrustManagerExtensions to allow using domain-config in network_security_config.xml

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs
@@ -6,6 +6,7 @@ using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
 using Android.OS;
+using Android.Net.Http;
 using Android.Runtime;
 using Javax.Net.Ssl;
 
@@ -53,7 +54,8 @@ namespace Xamarin.Android.Net
 				var sslPolicyErrors = SslPolicyErrors.None;
 
 				try {
-					_internalTrustManager.CheckServerTrusted (javaChain, authType);
+					var trustManagerExtensions = new X509TrustManagerExtensions (_internalTrustManager);
+					trustManagerExtensions.CheckServerTrusted (javaChain, authType, _request.RequestUri.Host);
 				} catch (JavaCertificateException) {
 					sslPolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
 				}


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/107695

When `<domain-config ...>` is used in `network_security_config.xml` then all calls to `_internalTrustManager.CheckServerTrusted (javaChain, authType);` will throw an exception and we will always pass `SslPolicyErrors.RemoteCertificateChainErrors` to the custom server certificate validation callback. To fix this, it is necessary to use hostname-specific certificate check via `X509TrustManagerExtensions`.