### PR TITLE
[tests] remove Xamarin.Legacy.Sdk

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -264,37 +264,6 @@ public class JavaSourceTest {
 		}
 
 		[Test]
-		public void XamarinLegacySdk ([Values ("net8.0-android34.0", "net9.0-android35.0")] string dotnetTargetFramework)
-		{
-			var proj = new XamarinAndroidLibraryProject {
-				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha4",
-				EnableDefaultItems = true,
-				Sources = {
-					new AndroidItem.AndroidLibrary ("javaclasses.jar") {
-						BinaryContent = () => ResourceData.JavaSourceJarTestJar,
-					}
-				}
-			};
-
-			// NOTE: keep this on the latest Xamarin.Android shipped
-			var legacyTargetFrameworkVersion = "13.0";
-			var legacyTargetFramework = $"monoandroid{legacyTargetFrameworkVersion}";
-			proj.SetProperty ("TargetFramework",  value: "");
-			proj.SetProperty ("TargetFrameworks", value: $"{dotnetTargetFramework};{legacyTargetFramework}");
-
-			var projBuilder = CreateDllBuilder ();
-			projBuilder.Save (proj);
-			var dotnet = new DotNetCLI (Path.Combine (Root, projBuilder.ProjectDirectory, proj.ProjectFilePath));
-			Assert.IsTrue (dotnet.Pack (parameters: new [] { "Configuration=Debug" }), "`dotnet pack` should succeed");
-
-			var nupkgPath = Path.Combine (Root, projBuilder.ProjectDirectory, proj.OutputPath, $"{proj.ProjectName}.1.0.0.nupkg");
-			FileAssert.Exists (nupkgPath);
-			using var nupkg = ZipHelper.OpenZip (nupkgPath);
-			nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetTargetFramework}/{proj.ProjectName}.dll");
-			nupkg.AssertContainsEntry (nupkgPath, $"lib/{legacyTargetFramework}/{proj.ProjectName}.dll");
-		}
-
-		[Test]
 		[TestCaseSource (nameof (DotNetTargetFrameworks))]
 		public void MauiTargetFramework (string dotnetVersion, string platform, int apiLevel)
 		{

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -496,61 +496,6 @@ using System.Runtime.Serialization.Json;
 		}
 
 		[Test]
-		public void ResourceDesignerWithNuGetReference ([Values ("net8.0-android", "net9.0-android")] string dotnetTargetFramework)
-		{
-			// Build a NuGet Package
-			var nuget = new XamarinAndroidLibraryProject () {
-				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha4",
-				ProjectName = "Test.Nuget.Package",
-				IsRelease = true,
-				ExtraNuGetConfigSources = {
-					"https://api.nuget.org/v3/index.json",
-				},
-			};
-			nuget.Sources.Clear ();
-			nuget.Sources.Add (new AndroidItem.AndroidResource ("Resources/values/Strings.xml") {
-						TextContent = () => @"<resources>
-    <string name='library_resouce_from_nuget'>Library Resource From Nuget</string>
-</resources>",
-			});
-			nuget.SetProperty ("PackageName", "Test.Nuget.Package");
-			var legacyTargetFrameworkVersion = "13.0";
-			var legacyTargetFramework = $"monoandroid{legacyTargetFrameworkVersion}";
-			nuget.TargetFramework = "";
-			nuget.TargetFrameworks = $"{dotnetTargetFramework};{legacyTargetFramework}";
-
-			var rootPath = Path.Combine (Root, "temp", TestName);
-			var nugetBuilder = CreateDllBuilder (Path.Combine (rootPath, nuget.ProjectName));
-			nugetBuilder.Save (nuget);
-			var dotnet = new DotNetCLI (Path.Combine (rootPath, nuget.ProjectName, nuget.ProjectFilePath));
-			Assert.IsTrue (dotnet.Pack (parameters: new [] { "Configuration=Release" }), "`dotnet pack` should succeed");
-
-			// Build an app which references it.
-			var proj = new XamarinAndroidApplicationProject () {
-				ProjectName = "App1",
-				IsRelease = true,
-			};
-			proj.SetAndroidSupportedAbis (DeviceAbi);
-			proj.OtherBuildItems.Add (new BuildItem ("None", "NuGet.config") {
-				TextContent = () => @"<?xml version='1.0' encoding='utf-8'?>
-<configuration>
-  <packageSources>
-	<add key='local' value='" + Path.Combine (Root, nugetBuilder.ProjectDirectory, "bin", "Release") + @"' />
-  </packageSources>
-</configuration>",
-			});
-			proj.PackageReferences.Add (new Package {
-					Id = "Test.Nuget.Package",
-					Version = "1.0.0",
-				});
-			builder = CreateApkBuilder (Path.Combine (rootPath, proj.ProjectName));
-			Assert.IsTrue (builder.Install (proj, doNotCleanupOnUpdate: true), "Install should have succeeded.");
-			string resource_designer = GetResourceDesignerPath (builder, proj);
-			var contents = GetResourceDesignerText (proj, resource_designer);
-			StringAssert.Contains ("public const int library_resouce_from_nuget =", contents);
-		}
-
-		[Test]
 		public void SingleProject_ApplicationId ([Values (false, true)] bool testOnly)
 		{
 			AssertCommercialBuild ();


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10234371&view=ms.vss-test-web.build-test-results-tab&runId=110872727&resultId=100056&paneView=debug

The `Xamarin.Legacy.Sdk` GitHub repo is archived, and no longer supported.

We still have a few tests using `Xamarin.Legacy.Sdk` that fail with:

    error MSB4057: The target "_GetRestoreSettingsPerFramework" does not exist in the project.

It's probably related to Mono now longer installed on CI agents.

Let's remove usage of `Xamarin.Legacy.Sdk` from our tests.