### PR TITLE
[tests] fix nightly APK tests for 32-bit emulators

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -17,6 +17,8 @@
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessApkSizes" />
 
   <PropertyGroup>
+    <!-- APK tests might run on 32-bit emulators -->
+    <RuntimeIdentifiers>android-arm64;android-x86;android-x64;</RuntimeIdentifiers>
     <TestAvdApiLevel Condition=" '$(TestAvdApiLevel)' == '' ">29</TestAvdApiLevel>
     <TestAvdAbi Condition=" '$(TestAvdAbi)' == '' and '$(HostOS)' == 'Darwin' and  '$(HostOSArchitecture)' == 'Arm64' ">arm64-v8a</TestAvdAbi>
     <TestAvdAbi Condition=" '$(TestAvdAbi)' == '' ">x86_64</TestAvdAbi>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10233028&view=logs&j=16e8a400-d09b-57ea-d2d5-3b6e79259973&t=469522d3-478a-58c1-dd99-cef151b877ac&l=4872

The APK tests on API 21 & 23 (maybe more) emulators fail with:

    [BT The app doesn't support ABI architectures of the device. Device ABIs: [x86], app ABIs: [arm64-v8a, x86_64].

Let's build `android-x86` as well for all APK tests, to fix this issue.