### PR TITLE
Bump to Android NDK r27b

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "27";
-		public const string AndroidNdkPkgRevision = "27.0.12077973";
+		public const string AndroidNdkVersion = "27b";
+		public const string AndroidNdkPkgRevision = "27.1.12297006";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 21;
 


### PR DESCRIPTION
Changes: https://github.com/android/ndk/wiki/Changelog-r27#r27b

Contains a handful of toolchain fixes which don't affect us.  Updating
the version to track the latest LTS release.