### PR TITLE
Fix DSO name hash generation on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
@@ -986,7 +986,7 @@ namespace Xamarin.Android.Tasks
 			foreach (string name in uniqueAssemblyNames) {
 				// We must make sure we keep the possible culture prefix, which will be treated as "directory" path here
 				string cultureName = Path.GetDirectoryName (name) ?? String.Empty;
-				string clippedName = Path.Combine (cultureName, Path.GetFileNameWithoutExtension (name));
+				string clippedName = Path.Combine (cultureName, Path.GetFileNameWithoutExtension (name)).Replace (@"\", "/");
 				string inArchiveName;
 
 				if (cultureName.Length == 0) {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9200
    
@jonpryor found that on Windows, shared library name hashes are
generated using the Windows path separator character, while the
runtime expects a Unix one.  This discrepancy leads to different
hashes for the same satellite assembly on Linux/macOS and Windows.

Fix by explicitly converting any `\` characters in the satellite
assembly name to `/` prior to hash generation.