### PR TITLE
[release/8.0.4xx] [tests] add test for `$(AdbTargetArchitecture)` (#9227)

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:release/8.0.4xx@1a9ee3733285238e0630f230c383cf3df1a6736d
+xamarin/monodroid:release/8.0.4xx@352bcbe8cc06aeba358450f57846218ef274bf01
 mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -634,6 +634,22 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void AdbTargetArchitecture ()
+		{
+			AssertCommercialBuild ();
+			AssertHasDevices ();
+
+			const string abi = "x86_64";
+			var proj = new XamarinAndroidApplicationProject ();
+
+			using var b = CreateApkBuilder ();
+			b.Verbosity = LoggerVerbosity.Diagnostic;
+			Assert.IsTrue (b.Install (proj, parameters: [ $"AdbTargetArchitecture={abi}" ]), "install should have succeeded.");
+			Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, $"Using $(AdbTargetArchitecture): {abi}"),
+				$"`_GetPrimaryCpuAbi` should be skipped for $(AdbTargetArchitecture)!");
+		}
+
+		[Test]
 		public void AppWithAndroidJavaSource ()
 		{
 			var path = Path.Combine ("temp", TestName);


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/8662
Context: https://github.com/xamarin/monodroid/pull/1537

* Bump to xamarin/monodroid/release/8.0.4xx@352bcbe8

Changes: https://github.com/xamarin/monodroid/compare/1a9ee373...352bcbe8

* [tools/msbuild] implement $(AdbTargetArchitecture) for IDEs

* Bump to dotnet/android/release/8.0.4xx@c158adfd6f