### PR TITLE
Add Conditional Inputs for _GeneratePackageManagerJava and _GenerateJavaStubs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -242,10 +242,12 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 
 			// Check environment variable
-			var environmentFiles = EnvironmentHelper.GatherEnvironmentFiles (intermediate, "x86_64", required: true);
-			var environmentVariables = EnvironmentHelper.ReadEnvironmentVariables (environmentFiles);
-			Assert.IsTrue (environmentVariables.TryGetValue (env_var, out string actual), $"Environment should contain {env_var}");
-			Assert.AreEqual (env_val, actual, $"{env_var} should be {env_val}");
+			if (isRelease) {
+				var environmentFiles = EnvironmentHelper.GatherEnvironmentFiles (intermediate, "x86_64", required: true);
+				var environmentVariables = EnvironmentHelper.ReadEnvironmentVariables (environmentFiles);
+				Assert.IsTrue (environmentVariables.TryGetValue (env_var, out string actual), $"Environment should contain {env_var}");
+				Assert.AreEqual (env_val, actual, $"{env_var} should be {env_val}");
+			}
 
 			// Check Resource.designer.cs
 			if (!useDesignerAssembly) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1446,12 +1446,24 @@ because xbuild doesn't support framework reference assemblies.
     _PrepareAssemblies;
     _PrepareNativeAssemblySources;
     $(_AfterPrepareAssemblies);
+    _GetGenerateJavaStubsInputs;
   </_GenerateJavaStubsDependsOnTargets>
 </PropertyGroup>
 
+<Target Name="_GetGenerateJavaStubsInputs">
+  <ItemGroup>
+    <_GenerateJavaStubsInputs Include="@(_AndroidMSBuildAllProjects)" />
+    <_GenerateJavaStubsInputs Include="$(_ResolvedUserAssembliesHashFile)" />
+    <_GenerateJavaStubsInputs Include="@(_ResolvedUserMonoAndroidAssemblies)" />
+    <_GenerateJavaStubsInputs Include="$(_AndroidManifestAbs)" />
+    <_GenerateJavaStubsInputs Include="$(_AndroidBuildPropertiesCache)" />
+    <_GenerateJavaStubsInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(EmbedAssembliesIntoApk)' == 'true' " />
+  </ItemGroup>
+</Target>
+
 <Target Name="_GenerateJavaStubs"
     DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest)"
-    Inputs="@(_AndroidMSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
+    Inputs="@(_GenerateJavaStubsInputs)"
     Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
 
   <PropertyGroup>
@@ -1684,12 +1696,23 @@ because xbuild doesn't support framework reference assemblies.
     _GenerateAndroidRemapNativeCode;
     _GenerateEmptyAndroidRemapNativeCode;
     _IncludeNativeSystemLibraries;
+    _GetGeneratePackageManagerJavaInputs;
   </_GeneratePackageManagerJavaDependsOn>
 </PropertyGroup>
 
+<Target Name="_GetGeneratePackageManagerJavaInputs">
+  <ItemGroup>
+    <_GeneratePackageManagerJavaInputs Include="@(_AndroidMSBuildAllProjects)" />
+    <_GeneratePackageManagerJavaInputs Include="$(_ResolvedUserAssembliesHashFile)" />
+    <_GeneratePackageManagerJavaInputs Include="@(_ResolvedUserMonoAndroidAssemblies)" />
+    <_GeneratePackageManagerJavaInputs Include="$(_AndroidBuildPropertiesCache)" />
+    <_GeneratePackageManagerJavaInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(EmbedAssembliesIntoApk)' == 'true' " />
+  </ItemGroup>
+</Target>
+
 <Target Name="_GeneratePackageManagerJava"
   DependsOnTargets="$(_GeneratePackageManagerJavaDependsOn)"
-  Inputs="@(_AndroidMSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
+  Inputs="@(_GeneratePackageManagerJavaInputs)"
   Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp">
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -160,7 +160,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' And '$(Optimize)' != 'True' And '$(_XASupportsFastDev)' == 'True' ">False</EmbedAssembliesIntoApk>
 	<EmbedAssembliesIntoApk Condition=" '$(_XASupportsFastDev)' == 'False' ">True</EmbedAssembliesIntoApk>
 	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">True</EmbedAssembliesIntoApk>
-	<AndroidPreferNativeLibrariesWithDebugSymbols Condition=" '$(AndroidPreferNativeLibrariesWithDebugSymbols)' == '' ">False</AndroidPreferNativeLibrariesWithDebugSymbols>
+  <AndroidPreferNativeLibrariesWithDebugSymbols Condition=" '$(AndroidPreferNativeLibrariesWithDebugSymbols)' == '' ">False</AndroidPreferNativeLibrariesWithDebugSymbols>
 	<AndroidSkipJavacVersionCheck Condition="'$(AndroidSkipJavacVersionCheck)' == ''">False</AndroidSkipJavacVersionCheck>
 	<AndroidBuildApplicationPackage Condition=" '$(AndroidBuildApplicationPackage)' == ''">False</AndroidBuildApplicationPackage>
 	<AndroidGenerateLayoutBindings Condition=" '$(AndroidGenerateLayoutBindings)' == '' ">False</AndroidGenerateLayoutBindings>
@@ -288,6 +288,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_NativeAssemblySourceDir>$(IntermediateOutputPath)android\</_NativeAssemblySourceDir>
 	<_AndroidUseNewTypemaps>True</_AndroidUseNewTypemaps>
 	<_SkipJniAddNativeMethodRegistrationAttributeScan Condition=" '$(_SkipJniAddNativeMethodRegistrationAttributeScan)' == '' ">False</_SkipJniAddNativeMethodRegistrationAttributeScan>
+
+	<_AndroidFastDeployEnvironmentFiles Condition=" '$(_AndroidFastDeployEnvironmentFiles)' == '' And '$(EmbedAssembliesIntoApk)' == 'true' ">True</_AndroidFastDeployEnvironmentFiles>
+	<_AndroidFastDeployEnvironmentFiles Condition=" '$(_AndroidFastDeployEnvironmentFiles)' == '' ">False</_AndroidFastDeployEnvironmentFiles>
+	
 </PropertyGroup>
 
 <Choose>
@@ -1457,7 +1461,7 @@ because xbuild doesn't support framework reference assemblies.
     <_GenerateJavaStubsInputs Include="@(_ResolvedUserMonoAndroidAssemblies)" />
     <_GenerateJavaStubsInputs Include="$(_AndroidManifestAbs)" />
     <_GenerateJavaStubsInputs Include="$(_AndroidBuildPropertiesCache)" />
-    <_GenerateJavaStubsInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(EmbedAssembliesIntoApk)' == 'true' " />
+    <_GenerateJavaStubsInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' == 'false' " />
   </ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -289,7 +289,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidUseNewTypemaps>True</_AndroidUseNewTypemaps>
 	<_SkipJniAddNativeMethodRegistrationAttributeScan Condition=" '$(_SkipJniAddNativeMethodRegistrationAttributeScan)' == '' ">False</_SkipJniAddNativeMethodRegistrationAttributeScan>
 
-	<_AndroidFastDeployEnvironmentFiles Condition=" '$(_AndroidFastDeployEnvironmentFiles)' == '' And '$(EmbedAssembliesIntoApk)' == 'true' ">True</_AndroidFastDeployEnvironmentFiles>
+	<_AndroidFastDeployEnvironmentFiles Condition=" '$(_AndroidFastDeployEnvironmentFiles)' == '' And '$(EmbedAssembliesIntoApk)' == 'False' ">True</_AndroidFastDeployEnvironmentFiles>
 	<_AndroidFastDeployEnvironmentFiles Condition=" '$(_AndroidFastDeployEnvironmentFiles)' == '' ">False</_AndroidFastDeployEnvironmentFiles>
 	
 </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1703,11 +1703,6 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GetGeneratePackageManagerJavaInputs">
   <ItemGroup>
     <_GeneratePackageManagerJavaInputs Include="@(_GenerateJavaStubsInputs)" />
-    <!-- <_GeneratePackageManagerJavaInputs Include="@(_AndroidMSBuildAllProjects)" />
-    <_GeneratePackageManagerJavaInputs Include="$(_ResolvedUserAssembliesHashFile)" />
-    <_GeneratePackageManagerJavaInputs Include="@(_ResolvedUserMonoAndroidAssemblies)" />
-    <_GeneratePackageManagerJavaInputs Include="$(_AndroidBuildPropertiesCache)" />
-    <_GeneratePackageManagerJavaInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(EmbedAssembliesIntoApk)' == 'true' " /> -->
   </ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1702,11 +1702,12 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GetGeneratePackageManagerJavaInputs">
   <ItemGroup>
-    <_GeneratePackageManagerJavaInputs Include="@(_AndroidMSBuildAllProjects)" />
+    <_GeneratePackageManagerJavaInputs Include="@(_GetGenerateJavaStubsInputs)" />
+    <!-- <_GeneratePackageManagerJavaInputs Include="@(_AndroidMSBuildAllProjects)" />
     <_GeneratePackageManagerJavaInputs Include="$(_ResolvedUserAssembliesHashFile)" />
     <_GeneratePackageManagerJavaInputs Include="@(_ResolvedUserMonoAndroidAssemblies)" />
     <_GeneratePackageManagerJavaInputs Include="$(_AndroidBuildPropertiesCache)" />
-    <_GeneratePackageManagerJavaInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(EmbedAssembliesIntoApk)' == 'true' " />
+    <_GeneratePackageManagerJavaInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(EmbedAssembliesIntoApk)' == 'true' " /> -->
   </ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1462,6 +1462,7 @@ because xbuild doesn't support framework reference assemblies.
     <_GenerateJavaStubsInputs Include="$(_AndroidManifestAbs)" />
     <_GenerateJavaStubsInputs Include="$(_AndroidBuildPropertiesCache)" />
     <_GenerateJavaStubsInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
+    <_EnvironmentFiles Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
   </ItemGroup>
 </Target>
 
@@ -1517,7 +1518,7 @@ because xbuild doesn't support framework reference assemblies.
       LinkingEnabled="$(_LinkingEnabled)"
       HaveMultipleRIDs="$(_HaveMultipleRIDs)"
       IntermediateOutputDirectory="$(IntermediateOutputPath)"
-      Environments="@(AndroidEnvironment);@(LibraryEnvironments)">
+      Environments="@(_EnvironmentFiles)">
   </GenerateJavaStubs>
 
   <ItemGroup>
@@ -1726,7 +1727,7 @@ because xbuild doesn't support framework reference assemblies.
     EnvironmentOutputDirectory="$(IntermediateOutputPath)android"
     TargetFrameworkVersion="$(TargetFrameworkVersion)"
     Manifest="$(IntermediateOutputPath)android\AndroidManifest.xml"
-    Environments="@(AndroidEnvironment);@(LibraryEnvironments)"
+    Environments="@(_EnvironmentFiles)"
     AndroidAotMode="$(AndroidAotMode)"
     AndroidAotEnableLazyLoad="$(AndroidAotEnableLazyLoad)"
     EnableLLVM="$(EnableLLVM)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1461,7 +1461,7 @@ because xbuild doesn't support framework reference assemblies.
     <_GenerateJavaStubsInputs Include="@(_ResolvedUserMonoAndroidAssemblies)" />
     <_GenerateJavaStubsInputs Include="$(_AndroidManifestAbs)" />
     <_GenerateJavaStubsInputs Include="$(_AndroidBuildPropertiesCache)" />
-    <_GenerateJavaStubsInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' == 'false' " />
+    <_GenerateJavaStubsInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
   </ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1702,7 +1702,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GetGeneratePackageManagerJavaInputs">
   <ItemGroup>
-    <_GeneratePackageManagerJavaInputs Include="@(_GetGenerateJavaStubsInputs)" />
+    <_GeneratePackageManagerJavaInputs Include="@(_GenerateJavaStubsInputs)" />
     <!-- <_GeneratePackageManagerJavaInputs Include="@(_AndroidMSBuildAllProjects)" />
     <_GeneratePackageManagerJavaInputs Include="$(_ResolvedUserAssembliesHashFile)" />
     <_GeneratePackageManagerJavaInputs Include="@(_ResolvedUserMonoAndroidAssemblies)" />

--- a/src/native/monodroid/monodroid-glue.cc
+++ b/src/native/monodroid/monodroid-glue.cc
@@ -1405,6 +1405,7 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	set_environment_variable_for_directory ("HOME", home);
 	create_xdg_directories_and_environment (home);
 	AndroidSystem::set_primary_override_dir (home);
+	AndroidSystem::create_update_dir (AndroidSystem::get_primary_override_dir ());
 
 	AndroidSystem::setup_environment ();
 
@@ -1412,7 +1413,6 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	AndroidSystem::setup_app_library_directories (runtimeApks, applicationDirs, haveSplitApks);
 
 	Logger::init_reference_logging (AndroidSystem::get_primary_override_dir ());
-	AndroidSystem::create_update_dir (AndroidSystem::get_primary_override_dir ());
 
 #if DEBUG
 	setup_gc_logging ();

--- a/src/native/monodroid/monodroid-glue.cc
+++ b/src/native/monodroid/monodroid-glue.cc
@@ -1401,12 +1401,12 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	jstring_wrapper jstr (env, lang);
 	set_environment_variable ("LANG", jstr);
 
-	AndroidSystem::setup_environment ();
-
 	set_environment_variable_for_directory ("TMPDIR", applicationDirs[SharedConstants::APP_DIRS_CACHE_DIR_INDEX]);
 	set_environment_variable_for_directory ("HOME", home);
 	create_xdg_directories_and_environment (home);
 	AndroidSystem::set_primary_override_dir (home);
+
+	AndroidSystem::setup_environment ();
 
 	jstring_array_wrapper runtimeApks (env, runtimeApksJava);
 	AndroidSystem::setup_app_library_directories (runtimeApks, applicationDirs, haveSplitApks);

--- a/src/native/runtime-base/android-system.cc
+++ b/src/native/runtime-base/android-system.cc
@@ -552,6 +552,7 @@ AndroidSystem::setup_environment_from_override_file (const char *path) noexcept
 		log_warn (LOG_DEFAULT, "Malformed header of the environment override file %s: value width has invalid format", path);
 		return;
 	}
+	log_debug(LOG_DEFAULT, "name_width: %d value_width: %d", name_width, value_width);
 
 	uint64_t data_width = name_width + value_width;
 	if (data_width > file_size - OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE || (file_size - OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE) % data_width != 0) {

--- a/src/native/runtime-base/android-system.cc
+++ b/src/native/runtime-base/android-system.cc
@@ -612,8 +612,8 @@ AndroidSystem::setup_environment () noexcept
 		}
 	}
 
-	if (application_config.environment_variable_count == 0)
-		return;
+	//if (application_config.environment_variable_count == 0)
+	//	return;
 
 	if (application_config.environment_variable_count % 2 != 0) {
 		log_warn (LOG_DEFAULT, "Corrupted environment variable array: does not contain an even number of entries (%u)", application_config.environment_variable_count);
@@ -638,10 +638,12 @@ AndroidSystem::setup_environment () noexcept
 			log_warn (LOG_DEFAULT, "Failed to set environment variable: %s", strerror (errno));
 	}
 #if defined (DEBUG)
-	// TODO: for debug read from file in the override directory named `environment`
+	log_info (LOG_DEFAULT, "Loading environment from  override directories.");
 	for (const char *od : override_dirs) {
+		log_info (LOG_DEFAULT, "%s", od);
 		std::unique_ptr<char[]> env_override_file {Util::path_combine (od, OVERRIDE_ENVIRONMENT_FILE_NAME.data ())};
 		if (Util::file_exists (env_override_file.get ())) {
+			log_info (LOG_DEFAULT, "Loading %s", env_override_file.get ());
 			setup_environment_from_override_file (env_override_file.get ());
 		}
 	}

--- a/src/native/runtime-base/android-system.cc
+++ b/src/native/runtime-base/android-system.cc
@@ -552,7 +552,7 @@ AndroidSystem::setup_environment_from_override_file (const char *path) noexcept
 		log_warn (LOG_DEFAULT, "Malformed header of the environment override file %s: value width has invalid format", path);
 		return;
 	}
-	
+
 	uint64_t data_width = name_width + value_width;
 	if (data_width > file_size - OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE || (file_size - OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE) % data_width != 0) {
 		log_warn (LOG_DEFAULT, "Malformed environment override file %s: invalid data size", path);

--- a/src/native/runtime-base/android-system.cc
+++ b/src/native/runtime-base/android-system.cc
@@ -578,7 +578,7 @@ AndroidSystem::setup_environment_from_override_file (const char *path) noexcept
 void
 AndroidSystem::setup_environment () noexcept
 {
-	log_info (LOG_DEFAULT, "DEBUGG!!! setup_environment");
+	log_debug (LOG_DEFAULT, "DEBUGG!!! setup_environment");
 	if (is_mono_aot_enabled () && *mono_aot_mode_name != '\0') {
 		switch (mono_aot_mode_name [0]) {
 			case 'n':
@@ -621,7 +621,7 @@ AndroidSystem::setup_environment () noexcept
 		return;
 	}
 
-	log_info (LOG_DEFAULT, "DEBUGG!!! for loop");
+	log_debug (LOG_DEFAULT, "DEBUGG!!! for loop");
 	const char *var_name;
 	const char *var_value;
 	for (size_t i = 0; i < application_config.environment_variable_count; i += 2) {
@@ -639,14 +639,14 @@ AndroidSystem::setup_environment () noexcept
 		if (setenv (var_name, var_value, 1) < 0)
 			log_warn (LOG_DEFAULT, "Failed to set environment variable: %s", strerror (errno));
 	}
-	log_info (LOG_DEFAULT, "DEBUGG!!! Loading");
+	log_debug (LOG_DEFAULT, "DEBUGG!!! Loading");
 #if defined (DEBUG)
-	log_info (LOG_DEFAULT, "Loading environment from  override directories.");
+	log_debug (LOG_DEFAULT, "Loading environment from  override directories.");
 	for (const char *od : override_dirs) {
-		log_info (LOG_DEFAULT, "%s", od);
+		log_debug (LOG_DEFAULT, "%s", od);
 		std::unique_ptr<char[]> env_override_file {Util::path_combine (od, OVERRIDE_ENVIRONMENT_FILE_NAME.data ())};
 		if (Util::file_exists (env_override_file.get ())) {
-			log_info (LOG_DEFAULT, "Loading %s", env_override_file.get ());
+			log_debug (LOG_DEFAULT, "Loading %s", env_override_file.get ());
 			setup_environment_from_override_file (env_override_file.get ());
 		}
 	}

--- a/src/native/runtime-base/android-system.cc
+++ b/src/native/runtime-base/android-system.cc
@@ -552,11 +552,10 @@ AndroidSystem::setup_environment_from_override_file (const char *path) noexcept
 		log_warn (LOG_DEFAULT, "Malformed header of the environment override file %s: value width has invalid format", path);
 		return;
 	}
-	log_debug(LOG_DEFAULT, "name_width: %d value_width: %d", name_width, value_width);
-
+	
 	uint64_t data_width = name_width + value_width;
 	if (data_width > file_size - OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE || (file_size - OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE) % data_width != 0) {
-		log_warn (LOG_DEFAULT, "Malformed environment override file %s: invalid data size '%d', '%d'", path, data_width, file_size);
+		log_warn (LOG_DEFAULT, "Malformed environment override file %s: invalid data size", path);
 		return;
 	}
 

--- a/src/native/runtime-base/android-system.cc
+++ b/src/native/runtime-base/android-system.cc
@@ -555,7 +555,7 @@ AndroidSystem::setup_environment_from_override_file (const char *path) noexcept
 
 	uint64_t data_width = name_width + value_width;
 	if (data_width > file_size - OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE || (file_size - OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE) % data_width != 0) {
-		log_warn (LOG_DEFAULT, "Malformed environment override file %s: invalid data size", path);
+		log_warn (LOG_DEFAULT, "Malformed environment override file %s: invalid data size '%d', '%d'", path, data_width, file_size);
 		return;
 	}
 

--- a/src/native/runtime-base/android-system.cc
+++ b/src/native/runtime-base/android-system.cc
@@ -637,6 +637,9 @@ AndroidSystem::setup_environment () noexcept
 #if defined (DEBUG)
 	log_debug (LOG_DEFAULT, "Loading environment from  override directories.");
 	for (const char *od : override_dirs) {
+		if (od == nullptr) {
+			continue;
+		}
 		std::unique_ptr<char[]> env_override_file {Util::path_combine (od, OVERRIDE_ENVIRONMENT_FILE_NAME.data ())};
 		log_debug (LOG_DEFAULT, "%s", env_override_file.get ());
 		if (Util::file_exists (env_override_file.get ())) {

--- a/src/native/runtime-base/android-system.cc
+++ b/src/native/runtime-base/android-system.cc
@@ -578,7 +578,6 @@ AndroidSystem::setup_environment_from_override_file (const char *path) noexcept
 void
 AndroidSystem::setup_environment () noexcept
 {
-	log_debug (LOG_DEFAULT, "DEBUGG!!! setup_environment");
 	if (is_mono_aot_enabled () && *mono_aot_mode_name != '\0') {
 		switch (mono_aot_mode_name [0]) {
 			case 'n':
@@ -613,15 +612,11 @@ AndroidSystem::setup_environment () noexcept
 		}
 	}
 
-	//if (application_config.environment_variable_count == 0)
-	//	return;
-
 	if (application_config.environment_variable_count % 2 != 0) {
 		log_warn (LOG_DEFAULT, "Corrupted environment variable array: does not contain an even number of entries (%u)", application_config.environment_variable_count);
 		return;
 	}
 
-	log_debug (LOG_DEFAULT, "DEBUGG!!! for loop");
 	const char *var_name;
 	const char *var_value;
 	for (size_t i = 0; i < application_config.environment_variable_count; i += 2) {
@@ -639,12 +634,11 @@ AndroidSystem::setup_environment () noexcept
 		if (setenv (var_name, var_value, 1) < 0)
 			log_warn (LOG_DEFAULT, "Failed to set environment variable: %s", strerror (errno));
 	}
-	log_debug (LOG_DEFAULT, "DEBUGG!!! Loading");
 #if defined (DEBUG)
 	log_debug (LOG_DEFAULT, "Loading environment from  override directories.");
 	for (const char *od : override_dirs) {
-		log_debug (LOG_DEFAULT, "%s", od);
 		std::unique_ptr<char[]> env_override_file {Util::path_combine (od, OVERRIDE_ENVIRONMENT_FILE_NAME.data ())};
+		log_debug (LOG_DEFAULT, "%s", env_override_file.get ());
 		if (Util::file_exists (env_override_file.get ())) {
 			log_debug (LOG_DEFAULT, "Loading %s", env_override_file.get ());
 			setup_environment_from_override_file (env_override_file.get ());

--- a/src/native/runtime-base/android-system.cc
+++ b/src/native/runtime-base/android-system.cc
@@ -578,6 +578,7 @@ AndroidSystem::setup_environment_from_override_file (const char *path) noexcept
 void
 AndroidSystem::setup_environment () noexcept
 {
+	log_info (LOG_DEFAULT, "DEBUGG!!! setup_environment");
 	if (is_mono_aot_enabled () && *mono_aot_mode_name != '\0') {
 		switch (mono_aot_mode_name [0]) {
 			case 'n':
@@ -620,6 +621,7 @@ AndroidSystem::setup_environment () noexcept
 		return;
 	}
 
+	log_info (LOG_DEFAULT, "DEBUGG!!! for loop");
 	const char *var_name;
 	const char *var_value;
 	for (size_t i = 0; i < application_config.environment_variable_count; i += 2) {
@@ -637,6 +639,7 @@ AndroidSystem::setup_environment () noexcept
 		if (setenv (var_name, var_value, 1) < 0)
 			log_warn (LOG_DEFAULT, "Failed to set environment variable: %s", strerror (errno));
 	}
+	log_info (LOG_DEFAULT, "DEBUGG!!! Loading");
 #if defined (DEBUG)
 	log_info (LOG_DEFAULT, "Loading environment from  override directories.");
 	for (const char *od : override_dirs) {

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -965,12 +965,13 @@ namespace UnnamedProject
 				OtherBuildItems = {
 					new BuildItem("AndroidEnvironment", "env.txt") {
 						TextContent = () => @"Foo=Bar
-Bar=Foo",
+Bar34=Foo55",
 					}
 				}
 			};
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", @"
-		Console.WriteLine (""Foo="" + Environment.GetEnvironmentVariable(""Foo""));");
+		Console.WriteLine (""Foo="" + Environment.GetEnvironmentVariable(""Foo""));
+		Console.WriteLine (""Bar34="" + Environment.GetEnvironmentVariable(""Bar34""));");
 			var builder = CreateApkBuilder ();
 			Assert.IsTrue (builder.Build (proj), "`dotnet build` should succeed");
 			RunProjectAndAssert (proj, builder);
@@ -986,6 +987,11 @@ Bar=Foo",
 					"Foo=Bar",
 					logcatOutput,
 					"The Environment variable \"Foo\" was not set."
+			);
+			StringAssert.Contains (
+					"Bar34=Foo55",
+					logcatOutput,
+					"The Environment variable \"Bar34\" was not set."
 			);
 		}
 


### PR DESCRIPTION
This commit updates the inputs for `_GenerateJavaStubs` and `_GeneratePackageManagerJava` so that the `@(AndroidEnvironment)` and `@(LibraryEnvironments)` items are only included if we are building a release build. Or a build which embeds the assemblies into the apk. 

This is so that we can evantually fast deploy these files to the device via https://github.com/xamarin/monodroid/pull/1547. 
A new unit test has been added to make sure that the environment values can be used correctly on device.