### PR TITLE
[trimming] `TrimMode=full` in debug mode, should enable analyzers

### DIFF
--- a/src/Microsoft.Android.Templates/android-wear/AndroidApp1.csproj
+++ b/src/Microsoft.Android.Templates/android-wear/AndroidApp1.csproj
@@ -10,12 +10,10 @@
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);XA4218</MSBuildWarningsAsMessages>
-  </PropertyGroup>
-  <!--
-    Enable full trimming in Release mode.
-    To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
-  -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <!--
+      Enables trim analyzers and full trimming during Release mode.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
+    -->
     <TrimMode>full</TrimMode>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Android.Templates/android/AndroidApp1.csproj
+++ b/src/Microsoft.Android.Templates/android/AndroidApp1.csproj
@@ -9,12 +9,10 @@
     <ApplicationId>com.companyname.AndroidApp1</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-  </PropertyGroup>
-  <!--
-    Enable full trimming in Release mode.
-    To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
-  -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <!--
+      Enables trim analyzers and full trimming during Release mode.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
+    -->
     <TrimMode>full</TrimMode>
   </PropertyGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -123,6 +123,7 @@
     <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == '' and '$(PublishTrimmed)' == 'true'">false</VerifyDependencyInjectionOpenGenericServiceTrimmability>
     <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == ''">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
     <EnableSingleFileAnalyzer Condition="'$(EnableSingleFileAnalyzer)' == ''">true</EnableSingleFileAnalyzer>
+    <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' and '$(TrimMode)' == 'full'">true</EnableTrimAnalyzer>
 
     <!-- XA feature switches defaults -->
     <VSAndroidDesigner Condition="'$(VSAndroidDesigner)' == ''">false</VSAndroidDesigner>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -269,7 +269,7 @@ namespace Xamarin.Android.Build.Tests
 		[TestCase ("", new string [0], false)]
 		[TestCase ("", new string [0], true)]
 		[TestCase ("SuppressTrimAnalysisWarnings=false", new string [] { "IL2055" }, true, 2)]
-		[TestCase ("TrimMode=full", new string [0], false)]
+		[TestCase ("TrimMode=full", new string [] { "IL2055" }, false, 1)]
 		[TestCase ("TrimMode=full", new string [] { "IL2055" }, true, 2)]
 		[TestCase ("IsAotCompatible=true", new string [] { "IL2055", "IL3050" }, false)]
 		[TestCase ("IsAotCompatible=true", new string [] { "IL2055", "IL3050" }, true, 3)]


### PR DESCRIPTION
For NativeAOT scenarios, projects would set:

    <PublishAot>true</PublishAot>

For both `Debug` and `Release`, this allows you to get the same set of analyzers in both configurations. You'd want to see the same warnings for both.

For Android, the project template is currently doing:

    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
        <TrimMode>Full</TrimMode>
    </PropertyGroup>

But this would result in a *different* set of warnings between `Debug` and `Release` mode!

Instead, we can do:

    <PropertyGroup>
        <TrimMode>Full</TrimMode>
    </PropertyGroup>

And then add a new default, such as:

    <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' and '$(TrimMode)' == 'full'">true</EnableTrimAnalyzer>

`TrimMode=Full` does *not* enable the trimmer, so other defaults in `Debug` should remain unchanged.

So, the new behavior is:

* `Configuration=Debug`
* `PublishTrimmed=false` (default, no trimmer)
* `TrimMode=Full` (project template)
* `EnableTrimAnalyzer=true` (new default)
* You get the same warnings in `Debug` and `Release` mode.

I also reworded the commend in the project template slightly, to mention it enables analyzers.