### PR TITLE
[tests] ignore `BuildAppCheckDebugSymbols()` test on non-commercial builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1291,7 +1291,7 @@ GVuZHNDbGFzc1ZhbHVlLmNsYXNzUEsFBgAAAAADAAMAwgAAAMYBAAAAAA==
 		}
 
 		[Test]
-		public void BuildAppCheckDebugSymbols ()
+		public void BuildAppCheckDebugSymbols ([Values(true, false)] bool embedAssembliesIntoApk)
 		{
 			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
 			var lib = new XamarinAndroidLibraryProject () {
@@ -1332,6 +1332,7 @@ namespace App1
 					},
 				},
 			};
+			proj.EmbedAssembliesIntoApk = embedAssembliesIntoApk;
 			proj.SetProperty (KnownProperties.AndroidLinkMode, AndroidLinkMode.None.ToString ());
 			using (var libb = CreateDllBuilder (Path.Combine (path, "Library1"))) {
 				Assert.IsTrue (libb.Build (lib), "Library1 Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1291,8 +1291,10 @@ GVuZHNDbGFzc1ZhbHVlLmNsYXNzUEsFBgAAAAADAAMAwgAAAMYBAAAAAA==
 		}
 
 		[Test]
-		public void BuildAppCheckDebugSymbols ([Values(true, false)] bool embedAssembliesIntoApk)
+		public void BuildAppCheckDebugSymbols ()
 		{
+			AssertCommercialBuild (); // FIXME: when Fast Deployment isn't available, we would need to use `llvm-objcopy` to extract the debug symbols
+
 			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
 			var lib = new XamarinAndroidLibraryProject () {
 				IsRelease = false,
@@ -1332,7 +1334,6 @@ namespace App1
 					},
 				},
 			};
-			proj.EmbedAssembliesIntoApk = embedAssembliesIntoApk;
 			proj.SetProperty (KnownProperties.AndroidLinkMode, AndroidLinkMode.None.ToString ());
 			using (var libb = CreateDllBuilder (Path.Combine (path, "Library1"))) {
 				Assert.IsTrue (libb.Build (lib), "Library1 Build should have succeeded.");


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10272296&view=ms.vss-test-web.build-test-results-tab&runId=111431847&resultId=100127&paneView=debug

With Fast Dev disabled, this test fails with:
```
'assemblies/arm64-v8a/App1.pdb' and 'D:\a_work\1\a\TestRelease\09-24_17.47.53\temp\BuildAppCheckDebugSymbols\App1\obj\Debug\android\assets\arm64-v8a\App1.pdb' should not differ
Expected Stream length 13136 but was 12432.
```

We can eventually fix the test, but we'd have to shell out to:

    llvm-objcopy --dump-section=payload=payload.bin libassemblies.arm64-v8a.blob.so