### PR TITLE
[build] fix incremental build for `RuntimeLists.xml`

### DIFF
--- a/build-tools/create-packs/ConfigureLocalWorkload.targets
+++ b/build-tools/create-packs/ConfigureLocalWorkload.targets
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <Target Name="CreateLocalRuntimeLists"
-      Inputs="$(MSBuildThisFile);@(_RuntimeListInputs)"
+      Inputs="$(MSBuildAllProjects);@(_RuntimeListInputs)"
       Outputs="@(_RuntimeListOutputs)">
     <MSBuild
         Projects="$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj"
@@ -27,7 +27,7 @@
   </Target>
 
   <Target Name="CreateLocalFrameworkLists"
-      Inputs="$(MSBuildThisFile);@(_FrameworkListInputs)"
+      Inputs="$(MSBuildAllProjects);@(_FrameworkListInputs)"
       Outputs="@(_FrameworkListOutputs)">
     <MSBuild
         Projects="$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj"


### PR DESCRIPTION
In 5ebcb1dd1, a new `libarchive-dso-stub.so` file was added to `Microsoft.Android.Runtime.proj` and runtime packs, but I started getting build failures for any app, such as:

    bin\Debug\lib\packs\Microsoft.Android.Sdk.Windows\35.0.0\tools\Xamarin.Android.Common.Debugging.targets(139,2): error XABLD7009: System.InvalidOperationException: Internal error: archive DSO stub location not known for architecture 'Arm64'
    at Xamarin.Android.Tasks.DSOWrapperGenerator.WrapIt(AndroidTargetArch targetArch, String payloadFilePath, String outputFileName, IBuildEngine4 buildEngine, TaskLoggingHelper log) in src\Xamarin.Android.Build.Tasks\Utilities\DSOWrapperGenerator.cs:line 86
    at Xamarin.Android.Tasks.BuildApk.AddRuntimeConfigBlob(ZipArchiveEx apk) in src\Xamarin.Android.Build.Tasks\Tasks\BuildApk.cs:line 408
    at Xamarin.Android.Tasks.BuildApk.ExecuteWithAbi(String[] supportedAbis, String apkInputPath, String apkOutputPath, Boolean debug, Boolean compress, IDictionary`2 compressedAssembliesInfo, String assemblyStoreApkName) in src\Xamarin.Android.Build.Tasks\Tasks\BuildApk.cs:line 215
    at Xamarin.Android.Tasks.BuildApk.RunTask() in src\Xamarin.Android.Build.Tasks\Tasks\BuildApk.cs:line 357
    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\AndroidTask.cs:line 25

Reviewing a build log and files on disk, I saw this line was missing from `RuntimeList.xml`:

    <File Type="Native" Path="runtimes/android-x64/native/libarchive-dso-stub.so" FileVersion="0.0.0.0" Profile="Android" />

This causes the build to not include the `.so` file, as this is the general logic for .NET workloads and runtime packs.

To fix this, we need to change the `Inputs` of the `CreateLocalRuntimeLists` target that generates this file:

    --$(MSBuildThisFile)
    ++$(MSBuildAllProjects)

This way if `Microsoft.Android.Runtime.proj` changes in the future, the targets will run.

I also fixed `CreateLocalFrameworkLists` for `FrameworkList.xml`.