### PR TITLE
[tests] skip performance tests (w/ `.apk` changes) on non-commercial builds

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -185,6 +185,8 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Build_AndroidResource_Change ()
 		{
+			AssertCommercialBuild (); // If <BuildApk/> runs, this test will fail without Fast Deployment
+
 			var proj = CreateApplicationProject ();
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";
@@ -202,6 +204,8 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Build_AndroidAsset_Change ()
 		{
+			AssertCommercialBuild (); // If <BuildApk/> runs, this test will fail without Fast Deployment
+
 			var bytes = new byte [1024*1024*10];
 			var rnd = new Random ();
 			rnd.NextBytes (bytes);
@@ -260,6 +264,8 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Build_AndroidManifest_Change ()
 		{
+			AssertCommercialBuild (); // If <BuildApk/> runs, this test will fail without Fast Deployment
+
 			var proj = CreateApplicationProject ();
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";


### PR DESCRIPTION
Some of the `PerformanceTest` would result in `<BuildApk/>` running for non-commercial (open source) builds and *skipped* in commercial builds. This makes the build much slower, and the test will likely fail on PRs from forks.

For now, let's skip these specific tests for non-commercial builds.