### PR TITLE
Bump cmake to version 3.30.3

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -80,7 +80,7 @@
     <AndroidSdkDirectory Condition=" '$(AndroidSdkDirectory)' == '' ">$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory Condition=" '$(AndroidNdkDirectory)' == '' And Exists($(ANDROID_NDK_LATEST_HOME)) ">$(ANDROID_NDK_LATEST_HOME)</AndroidNdkDirectory>
     <AndroidNdkDirectory Condition=" '$(AndroidNdkDirectory)' == '' ">$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
-    <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.22.1</AndroidCmakeVersion>
+    <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.30.3</AndroidCmakeVersion>
     <AndroidCmakeUrlPrefix Condition=" '$(HostOS)' == 'Windows' And '$(AndroidCmakeUrlPrefix)' == '' "></AndroidCmakeUrlPrefix>
     <AndroidCmakeUrlPrefix Condition=" '$(HostOS)' == 'Darwin' And '$(AndroidCmakeUrlPrefix)' == '' "></AndroidCmakeUrlPrefix>
     <AndroidCmakeUrlPrefix Condition=" '$(HostOS)' == 'Linux' And '$(AndroidCmakeUrlPrefix)' == '' "></AndroidCmakeUrlPrefix>


### PR DESCRIPTION
Changes: https://cmake.org/cmake/help/latest/release/index.html

Android SDK recently added cmake v3.30.3.  Bridge the gap of 60+ releases
between 3.21.1 and the 3.30.3 and use the latest and the greatest.

This PR doesn't contain any changes to script files.  A review of changes 
in cmake is required in order to modify our scripts accordingly.