### PR TITLE
[templates] Update to latest NuGet version of `Xamarin.AndroidX.Wear`

### DIFF
--- a/src/Microsoft.Android.Templates/android-wear/AndroidApp1.csproj
+++ b/src/Microsoft.Android.Templates/android-wear/AndroidApp1.csproj
@@ -19,6 +19,6 @@
     <TrimMode>full</TrimMode>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Wear" Version="1.2.0.5" />
+    <PackageReference Include="Xamarin.AndroidX.Wear" Version="1.3.0.10" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/9161

Update our `android-wear` template to reference the latest NuGet of `Xamarin.AndroidX.Wear` (`1.3.0.10`).