### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 17928: Build ID 10286032

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.cs.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.cs.resx
@@ -1076,4 +1076,14 @@ Pokud chcete pro sestavení z příkazového řádku použít vlastní cestu JDK
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.de.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.de.resx
@@ -1076,4 +1076,14 @@ Um einen benutzerdefinierten JDK-Pfad für einen Befehlszeilenbuild zu verwenden
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.es.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.es.resx
@@ -1076,4 +1076,14 @@ Para usar una ruta de acceso de JDK personalizada para una compilación de líne
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.fr.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.fr.resx
@@ -1076,4 +1076,14 @@ Pour utiliser un chemin JDK personnalisé pour une build de ligne de commande, d
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.it.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.it.resx
@@ -1076,4 +1076,14 @@ Per usare un percorso JDK personalizzato per una compilazione della riga di coma
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ja.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ja.resx
@@ -1077,4 +1077,14 @@ In this message, the term "handheld app" means "app for handheld devices."
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ko.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ko.resx
@@ -1076,4 +1076,14 @@ In this message, the term "handheld app" means "app for handheld devices."
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.pl.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.pl.resx
@@ -1076,4 +1076,14 @@ Aby użyć niestandardowej ścieżki zestawu JDK dla kompilacji wiersza poleceni
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.pt-BR.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.pt-BR.resx
@@ -1076,4 +1076,14 @@ Para usar um caminho JDK personalizado para um build de linha de comando, defina
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ru.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ru.resx
@@ -1076,4 +1076,14 @@ In this message, the term "handheld app" means "app for handheld devices."
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.tr.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.tr.resx
@@ -1076,4 +1076,14 @@ Bir komut satırı derlemesi için özel bir SDK yolu kullanmak için 'JavaSdkDi
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hans.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hans.resx
@@ -1076,4 +1076,14 @@ In this message, the term "handheld app" means "app for handheld devices."
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hant.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hant.resx
@@ -1076,4 +1076,14 @@ In this message, the term "handheld app" means "app for handheld devices."
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XAGRDL1000" xml:space="preserve">
+    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
+{0} - The value of the AndroidGradleProject item</comment>
+  </data>
+  <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
+    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
+{0} - The path to the library output that will be referenced</comment>
+  </data>
 </root>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.