### PR TITLE
$(AndroidPackVersionSuffix)=rtm; Stable 35.0.x branding

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,8 +35,8 @@
          * Major/Minor match Android stable API level, such as 30.0 for API 30.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>35.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
+    <AndroidPackVersion>35.0.1</AndroidPackVersion>
+    <AndroidPackVersionSuffix>rtm</AndroidPackVersionSuffix>
     <IsStableBuild>false</IsStableBuild>
     <IsStableBuild Condition=" '$(AndroidPackVersionSuffix)' == 'rtm' ">true</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/4ea5dbb921ccebb93f2a03d33169d2ebb6248936

We branched for .NET 9 RC 2 from 118e8943 into release/9.0.1xx-rc2; the main branch is now .NET 9 "GA" or "rtm".

Update dotnet/android/main's version number to 35.0.1, which should auto-increment for each commit.