### PR TITLE
[Xamarin.Android.Build.Tasks] use `ProjectSpecificTaskObjectKey` in `<PrepareDSOWrapperState/>`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareDSOWrapperState.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareDSOWrapperState.cs
@@ -47,7 +47,7 @@ public class PrepareDSOWrapperState : AndroidTask
 		}
 
 		var config = new DSOWrapperGenerator.Config (stubPaths, AndroidBinUtilsDirectory, BaseOutputDirectory);
-		BuildEngine4.RegisterTaskObjectAssemblyLocal (DSOWrapperGenerator.RegisteredConfigKey, config, RegisteredTaskObjectLifetime.Build);
+		BuildEngine4.RegisterTaskObjectAssemblyLocal (ProjectSpecificTaskObjectKey (DSOWrapperGenerator.RegisteredConfigKey), config, RegisteredTaskObjectLifetime.Build);
 
 		return !Log.HasLoggedErrors;
 	}


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/24539#issuecomment-2377671832

In .NET MAUI's build, they failed to bump .NET for Android because of the following error:

    dotnet\packs\Microsoft.Android.Sdk.Windows\35.0.0-rc.2.130\tools\Xamarin.Android.Common.Debugging.targets(139,2): error XABLD7009: System.InvalidOperationException: Internal error: archive DSO stub location not known for architecture 'X86'
    at Xamarin.Android.Tasks.DSOWrapperGenerator.WrapIt(AndroidTargetArch targetArch, String payloadFilePath, String outputFileName, IBuildEngine4 buildEngine, TaskLoggingHelper log) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Utilities/DSOWrapperGenerator.cs:line 86
    at Xamarin.Android.Tasks.BuildApk.AddRuntimeConfigBlob(ZipArchiveEx apk) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs:line 404
    at Xamarin.Android.Tasks.BuildApk.ExecuteWithAbi(String[] supportedAbis, String apkInputPath, String apkOutputPath, Boolean debug, Boolean compress, IDictionary`2 compressedAssembliesInfo, String assemblyStoreApkName) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs:line 215
    at Xamarin.Android.Tasks.BuildApk.RunTask() in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs:line 357
    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 25

In 5ebcb1dd, we introduced some MSBuild `RegisterTaskObject()` usage that failed in specific way:

* MAUI has a `.sln` with multiple "app" projects: device tests, samples, etc. building in parallel

* The `<PrepareDSOWrapperState/>` MSBuild task runs for project A, saving x64 and arm64 values.

* Project B goes to run `<BuildApk/>` but x86 is missing.

For now, we can fix this by using `ProjectSpecificTaskObjectKey()` that wraps the key with a `Tuple` such as:

    (key, WorkingDirectory)

Which, should result in a unique key per project.

In a future PR, we could consider removing this `RegisterTaskObject()` usage completely, and doing all the work inside the `<BuildApk/>` MSBuild task instead.