### PR TITLE
[XABT] Update AndroidGradleProject Bind and Pack defaults

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Microsoft.Android.Sdk.Bindings.Gradle.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Microsoft.Android.Sdk.Bindings.Gradle.targets
@@ -19,11 +19,11 @@ This file contains MSBuild targets that support building and operating on Androi
 
   <ItemDefinitionGroup>
     <AndroidGradleProject>
-      <Bind></Bind>
+      <Bind>true</Bind>
       <Configuration>Release</Configuration>
       <ModuleName></ModuleName>
       <OutputPath></OutputPath>
-      <Pack></Pack>
+      <Pack>true</Pack>
       <CreateAndroidLibrary>true</CreateAndroidLibrary>
       <Visible></Visible>
     </AndroidGradleProject>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/dbdc5fadca60b79518739fea49bdfee58a748bf0

Updates the default values of the `%(Bind)` and `%(Pack)` metadata
forwarded to the created `@(AndroidLibrary)` item to better match the
defaults on that item. Leaving these empty did not allow the defaults
declared in the `AndroidLibrary` ItemDefinitionGroup to be used as
expected in commit https://github.com/dotnet/android/commit/dbdc5fadca60b79518739fea49bdfee58a748bf0.