### PR TITLE
Fix thread state transition in get_function_pointer

### DIFF
--- a/src/native/monodroid/xamarin-android-app-context.cc
+++ b/src/native/monodroid/xamarin-android-app-context.cc
@@ -58,7 +58,7 @@ MonodroidRuntime::get_function_pointer (uint32_t mono_image_index, uint32_t clas
 	}
 
 	// We need to do that, as Mono APIs cannot be invoked from threads that aren't attached to the runtime.
-	mono_thread_attach (mono_get_root_domain ());
+	mono_jit_thread_attach (mono_get_root_domain ());
 
 	MonoImage *image = MonoImageLoader::get_from_index (mono_image_index);
 	MarshalMethodsManagedClass &klass = marshal_methods_class_cache[class_index];


### PR DESCRIPTION
`get_function_pointer` can be called from any thread. In particular, it can be called from Android thread pool thread when method marshaling is used. We need to ensure those threads stay in the GC safe mode from the runtime perspective once we stop executing user code on those threads. `mono_thread_attach` switches the thread to GC unsafe mode and it stays there after we stop executing user code. The next GC will try to suspend the thread which cannot succeed since there's no cooperative runtime code running on that thread anymore.

The fix is to use `mono_jit_thread_attach` which mimics what the iOS/macOS interop does. It creates the necessary MonoVM thread structures for JIT to work but doesn't transition the thread state.

Fixes #8253