### PR TITLE
[build] add feeds to fix `MAUI Integration`

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -20,8 +20,8 @@
     <!-- Android binary, to support delta APK install -->
     <add key="xamarin.android util" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/Xamarin.Android/nuget/v3/index.json" />
     <!-- Added manually for dotnet/runtime 8.0.10 -->
-    <add key="darc-pub-dotnet-emsdk-d667257" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-d6672570/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-runtime-b5f5349" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-b5f53494/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-91b783e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-91b783ed/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-eeb6f52" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-eeb6f525/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -91,14 +91,13 @@
 
     <!-- Parse NuGet.config -->
     <XmlPeek
-        Condition=" '$(MauiUseLocalPacks)' != 'true' "
-        XmlInputPath="$(XamarinAndroidSourcePath)NuGet.config"
+        Condition=" '$(MauiUseLocalPacks)' == 'true' "
+        XmlInputPath="$(MauiSourcePath)\NuGet.config"
         Query="/configuration/packageSources/add/@value">
       <Output TaskParameter="Result" ItemName="_NuGetSources" />
     </XmlPeek>
     <XmlPeek
-        Condition=" '$(MauiUseLocalPacks)' == 'true' "
-        XmlInputPath="$(MauiSourcePath)\NuGet.config"
+        XmlInputPath="$(XamarinAndroidSourcePath)NuGet.config"
         Query="/configuration/packageSources/add/@value">
       <Output TaskParameter="Result" ItemName="_NuGetSources" />
     </XmlPeek>


### PR DESCRIPTION
Trying to fix the error:

    ##[error]build-tools\scripts\DotNet.targets(115,5): Error MSB3073: The command ""bin\Release\dotnet\dotnet" workload install maui --skip-manifest-update --skip-sign-check --verbosity diag --source "build-tools\scripts\..\..\..\maui\artifacts" --source "D:\a\_work\1\a\android-packs" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-2674f580/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-ed13b351/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-45bb7f36/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-xamarin-xamarin-macios-bc01f5e0/nuget/v3/index.json" --temp-dir "bin\Release\dotnet\..\.xa-workload-temp-at32pghi.3t5"" exited with code 1.
     1>build-tools\scripts\DotNet.targets(115,5): error MSB3073: The command ""bin\Release\dotnet\dotnet" workload install maui --skip-manifest-update --skip-sign-check --verbosity diag --source "build-tools\scripts\..\..\..\maui\artifacts" --source "D:\a\_work\1\a\android-packs" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-2674f580/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-ed13b351/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-45bb7f36/nuget/v3/index.json" --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-xamarin-xamarin-macios-bc01f5e0/nuget/v3/index.json" --temp-dir "bin\Release\dotnet\..\.xa-workload-temp-at32pghi.3t5"" exited with code 1.
     1>Done Building Project "Xamarin.Android.sln" (InstallMaui target(s)) -- FAILED.

Using the latest 8.0.10 feeds from dotnet/runtime.

We also can update the two `<XmlPeek/>` calls on the `NuGet.config` in order to:

* Add `$(MauiSourcePath)\NuGet.config` to the `@(_NuGetSources)` item group.

* Add `$(XamarinAndroidSourcePath)NuGet.config` to the `@(_NuGetSources)` item group.

So, we end up using the MAUI feeds + our feeds second, which is more likely to work when both repos are not aligned.