### PR TITLE
[release/9.0.1xx-rc2] [Xamarin.Android.Build.Tasks] Disable LLVM marshal methods (#9336)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,19 +5,19 @@
       "Size": 3036
     },
     "classes.dex": {
-      "Size": 22488
+      "Size": 389672
     },
     "lib/arm64-v8a/lib__Microsoft.Android.Resource.Designer.dll.so": {
       "Size": 1114
     },
     "lib/arm64-v8a/lib_Java.Interop.dll.so": {
-      "Size": 69279
+      "Size": 86256
     },
     "lib/arm64-v8a/lib_Mono.Android.dll.so": {
-      "Size": 98660
+      "Size": 115344
     },
     "lib/arm64-v8a/lib_Mono.Android.Runtime.dll.so": {
-      "Size": 5315
+      "Size": 22400
     },
     "lib/arm64-v8a/lib_System.Console.dll.so": {
       "Size": 7294
@@ -26,7 +26,7 @@
       "Size": 9390
     },
     "lib/arm64-v8a/lib_System.Private.CoreLib.dll.so": {
-      "Size": 616700
+      "Size": 633920
     },
     "lib/arm64-v8a/lib_System.Runtime.dll.so": {
       "Size": 2956
@@ -44,7 +44,7 @@
       "Size": 87432
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 484920
+      "Size": 485400
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3196336
@@ -62,10 +62,10 @@
       "Size": 160232
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 17912
+      "Size": 12648
     },
     "META-INF/BNDLTOOL.RSA": {
-      "Size": 1221
+      "Size": 1223
     },
     "META-INF/BNDLTOOL.SF": {
       "Size": 3266
@@ -98,5 +98,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2783765
+  "PackageSize": 2865685
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -11,28 +11,28 @@
       "Size": 1114
     },
     "lib/arm64-v8a/lib_Java.Interop.dll.so": {
-      "Size": 86256
+      "Size": 69163
     },
     "lib/arm64-v8a/lib_Mono.Android.dll.so": {
-      "Size": 115344
+      "Size": 98246
     },
     "lib/arm64-v8a/lib_Mono.Android.Runtime.dll.so": {
-      "Size": 22400
+      "Size": 5310
     },
     "lib/arm64-v8a/lib_System.Console.dll.so": {
-      "Size": 7294
+      "Size": 7291
     },
     "lib/arm64-v8a/lib_System.Linq.dll.so": {
-      "Size": 9390
+      "Size": 9388
     },
     "lib/arm64-v8a/lib_System.Private.CoreLib.dll.so": {
-      "Size": 633920
+      "Size": 616826
     },
     "lib/arm64-v8a/lib_System.Runtime.dll.so": {
-      "Size": 2956
+      "Size": 2954
     },
     "lib/arm64-v8a/lib_System.Runtime.InteropServices.dll.so": {
-      "Size": 4502
+      "Size": 4498
     },
     "lib/arm64-v8a/lib_UnnamedProject.dll.so": {
       "Size": 2932
@@ -44,7 +44,7 @@
       "Size": 87432
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 485400
+      "Size": 484568
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3196336
@@ -62,7 +62,7 @@
       "Size": 160232
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 12648
+      "Size": 12536
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1223
@@ -98,5 +98,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2865685
+  "PackageSize": 2857493
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -35,169 +35,169 @@
       "Size": 2363
     },
     "lib/arm64-v8a/lib_FormsViewGroup.dll.so": {
-      "Size": 25184
+      "Size": 8090
     },
     "lib/arm64-v8a/lib_Java.Interop.dll.so": {
-      "Size": 94640
+      "Size": 77546
     },
     "lib/arm64-v8a/lib_Mono.Android.dll.so": {
-      "Size": 521824
+      "Size": 504730
     },
     "lib/arm64-v8a/lib_Mono.Android.Runtime.dll.so": {
-      "Size": 22400
+      "Size": 5310
     },
     "lib/arm64-v8a/lib_mscorlib.dll.so": {
-      "Size": 21440
+      "Size": 4345
     },
     "lib/arm64-v8a/lib_netstandard.dll.so": {
       "Size": 5985
     },
     "lib/arm64-v8a/lib_System.Collections.Concurrent.dll.so": {
-      "Size": 29800
+      "Size": 12712
     },
     "lib/arm64-v8a/lib_System.Collections.dll.so": {
-      "Size": 19198
+      "Size": 19195
     },
     "lib/arm64-v8a/lib_System.Collections.NonGeneric.dll.so": {
-      "Size": 8668
+      "Size": 8665
     },
     "lib/arm64-v8a/lib_System.Collections.Specialized.dll.so": {
-      "Size": 6756
+      "Size": 6755
     },
     "lib/arm64-v8a/lib_System.ComponentModel.dll.so": {
       "Size": 2496
     },
     "lib/arm64-v8a/lib_System.ComponentModel.Primitives.dll.so": {
-      "Size": 21296
+      "Size": 4208
     },
     "lib/arm64-v8a/lib_System.ComponentModel.TypeConverter.dll.so": {
-      "Size": 42448
+      "Size": 25360
     },
     "lib/arm64-v8a/lib_System.Console.dll.so": {
-      "Size": 24416
+      "Size": 7327
     },
     "lib/arm64-v8a/lib_System.Core.dll.so": {
-      "Size": 2365
+      "Size": 2364
     },
     "lib/arm64-v8a/lib_System.Diagnostics.DiagnosticSource.dll.so": {
-      "Size": 11349
+      "Size": 11351
     },
     "lib/arm64-v8a/lib_System.Diagnostics.TraceSource.dll.so": {
-      "Size": 24688
+      "Size": 7597
     },
     "lib/arm64-v8a/lib_System.dll.so": {
-      "Size": 2765
+      "Size": 2764
     },
     "lib/arm64-v8a/lib_System.Drawing.dll.so": {
-      "Size": 2342
+      "Size": 2340
     },
     "lib/arm64-v8a/lib_System.Drawing.Primitives.dll.so": {
-      "Size": 12959
+      "Size": 12957
     },
     "lib/arm64-v8a/lib_System.Formats.Asn1.dll.so": {
-      "Size": 32843
+      "Size": 32845
     },
     "lib/arm64-v8a/lib_System.IO.Compression.Brotli.dll.so": {
-      "Size": 29480
+      "Size": 12389
     },
     "lib/arm64-v8a/lib_System.IO.Compression.dll.so": {
-      "Size": 16696
+      "Size": 16695
     },
     "lib/arm64-v8a/lib_System.IO.IsolatedStorage.dll.so": {
-      "Size": 11196
+      "Size": 11194
     },
     "lib/arm64-v8a/lib_System.Linq.dll.so": {
-      "Size": 21645
+      "Size": 21643
     },
     "lib/arm64-v8a/lib_System.Linq.Expressions.dll.so": {
-      "Size": 185808
+      "Size": 168719
     },
     "lib/arm64-v8a/lib_System.Net.Http.dll.so": {
-      "Size": 89496
+      "Size": 72404
     },
     "lib/arm64-v8a/lib_System.Net.Primitives.dll.so": {
-      "Size": 41120
+      "Size": 24027
     },
     "lib/arm64-v8a/lib_System.Net.Requests.dll.so": {
-      "Size": 4461
+      "Size": 4459
     },
     "lib/arm64-v8a/lib_System.ObjectModel.dll.so": {
-      "Size": 9981
+      "Size": 9979
     },
     "lib/arm64-v8a/lib_System.Private.CoreLib.dll.so": {
-      "Size": 956408
+      "Size": 939319
     },
     "lib/arm64-v8a/lib_System.Private.DataContractSerialization.dll.so": {
-      "Size": 199596
+      "Size": 199599
     },
     "lib/arm64-v8a/lib_System.Private.Uri.dll.so": {
-      "Size": 62192
+      "Size": 45102
     },
     "lib/arm64-v8a/lib_System.Private.Xml.dll.so": {
-      "Size": 237104
+      "Size": 220011
     },
     "lib/arm64-v8a/lib_System.Private.Xml.Linq.dll.so": {
-      "Size": 35584
+      "Size": 18496
     },
     "lib/arm64-v8a/lib_System.Runtime.dll.so": {
-      "Size": 3111
+      "Size": 3108
     },
     "lib/arm64-v8a/lib_System.Runtime.InteropServices.dll.so": {
-      "Size": 4502
+      "Size": 4498
     },
     "lib/arm64-v8a/lib_System.Runtime.Numerics.dll.so": {
-      "Size": 54408
+      "Size": 37318
     },
     "lib/arm64-v8a/lib_System.Runtime.Serialization.dll.so": {
-      "Size": 19352
+      "Size": 2264
     },
     "lib/arm64-v8a/lib_System.Runtime.Serialization.Formatters.dll.so": {
-      "Size": 3243
+      "Size": 3242
     },
     "lib/arm64-v8a/lib_System.Runtime.Serialization.Primitives.dll.so": {
-      "Size": 21448
+      "Size": 4359
     },
     "lib/arm64-v8a/lib_System.Security.Cryptography.dll.so": {
-      "Size": 80504
+      "Size": 63412
     },
     "lib/arm64-v8a/lib_System.Text.RegularExpressions.dll.so": {
-      "Size": 183592
+      "Size": 166503
     },
     "lib/arm64-v8a/lib_System.Xml.dll.so": {
-      "Size": 2167
+      "Size": 2166
     },
     "lib/arm64-v8a/lib_System.Xml.Linq.dll.so": {
-      "Size": 2181
+      "Size": 2179
     },
     "lib/arm64-v8a/lib_UnnamedProject.dll.so": {
-      "Size": 5007
+      "Size": 5006
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 34760
+      "Size": 17665
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.AppCompat.AppCompatResources.dll.so": {
-      "Size": 24296
+      "Size": 7203
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 163072
+      "Size": 145980
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.CardView.dll.so": {
-      "Size": 7469
+      "Size": 7472
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 35680
+      "Size": 18592
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.Core.dll.so": {
-      "Size": 151216
+      "Size": 134121
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.CursorAdapter.dll.so": {
       "Size": 10076
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 33760
+      "Size": 16666
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 72224
+      "Size": 55131
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.Legacy.Support.Core.UI.dll.so": {
       "Size": 6806
@@ -215,22 +215,22 @@
       "Size": 14499
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 111896
+      "Size": 94806
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.SavedState.dll.so": {
-      "Size": 6050
+      "Size": 6051
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 31672
+      "Size": 14578
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 37752
+      "Size": 20659
     },
     "lib/arm64-v8a/lib_Xamarin.Forms.Core.dll.so": {
       "Size": 563905
     },
     "lib/arm64-v8a/lib_Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 373374
+      "Size": 373373
     },
     "lib/arm64-v8a/lib_Xamarin.Forms.Platform.dll.so": {
       "Size": 18753
@@ -239,7 +239,7 @@
       "Size": 63542
     },
     "lib/arm64-v8a/lib_Xamarin.Google.Android.Material.dll.so": {
-      "Size": 84400
+      "Size": 67309
     },
     "lib/arm64-v8a/libarc.bin.so": {
       "Size": 1685
@@ -248,7 +248,7 @@
       "Size": 87432
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 485400
+      "Size": 484568
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3196336
@@ -266,7 +266,7 @@
       "Size": 160232
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 119928
+      "Size": 119816
     },
     "META-INF/androidx.activity_activity.version": {
       "Size": 6
@@ -419,7 +419,7 @@
       "Size": 6
     },
     "META-INF/BNDLTOOL.RSA": {
-      "Size": 1223
+      "Size": 1221
     },
     "META-INF/BNDLTOOL.SF": {
       "Size": 98661
@@ -2489,5 +2489,5 @@
       "Size": 812848
     }
   },
-  "PackageSize": 10673477
+  "PackageSize": 10624325
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -5,7 +5,10 @@
       "Size": 6652
     },
     "classes.dex": {
-      "Size": 9172800
+      "Size": 9448924
+    },
+    "classes2.dex": {
+      "Size": 154180
     },
     "kotlin/annotation/annotation.kotlin_builtins": {
       "Size": 928
@@ -32,25 +35,25 @@
       "Size": 2363
     },
     "lib/arm64-v8a/lib_FormsViewGroup.dll.so": {
-      "Size": 8330
+      "Size": 25184
     },
     "lib/arm64-v8a/lib_Java.Interop.dll.so": {
-      "Size": 77673
+      "Size": 94640
     },
     "lib/arm64-v8a/lib_Mono.Android.dll.so": {
-      "Size": 506473
+      "Size": 521824
     },
     "lib/arm64-v8a/lib_Mono.Android.Runtime.dll.so": {
-      "Size": 5315
+      "Size": 22400
     },
     "lib/arm64-v8a/lib_mscorlib.dll.so": {
-      "Size": 4344
+      "Size": 21440
     },
     "lib/arm64-v8a/lib_netstandard.dll.so": {
       "Size": 5985
     },
     "lib/arm64-v8a/lib_System.Collections.Concurrent.dll.so": {
-      "Size": 12714
+      "Size": 29800
     },
     "lib/arm64-v8a/lib_System.Collections.dll.so": {
       "Size": 19198
@@ -65,13 +68,13 @@
       "Size": 2496
     },
     "lib/arm64-v8a/lib_System.ComponentModel.Primitives.dll.so": {
-      "Size": 4212
+      "Size": 21296
     },
     "lib/arm64-v8a/lib_System.ComponentModel.TypeConverter.dll.so": {
-      "Size": 25362
+      "Size": 42448
     },
     "lib/arm64-v8a/lib_System.Console.dll.so": {
-      "Size": 7331
+      "Size": 24416
     },
     "lib/arm64-v8a/lib_System.Core.dll.so": {
       "Size": 2365
@@ -80,7 +83,7 @@
       "Size": 11349
     },
     "lib/arm64-v8a/lib_System.Diagnostics.TraceSource.dll.so": {
-      "Size": 7601
+      "Size": 24688
     },
     "lib/arm64-v8a/lib_System.dll.so": {
       "Size": 2765
@@ -95,7 +98,7 @@
       "Size": 32843
     },
     "lib/arm64-v8a/lib_System.IO.Compression.Brotli.dll.so": {
-      "Size": 12393
+      "Size": 29480
     },
     "lib/arm64-v8a/lib_System.IO.Compression.dll.so": {
       "Size": 16696
@@ -107,13 +110,13 @@
       "Size": 21645
     },
     "lib/arm64-v8a/lib_System.Linq.Expressions.dll.so": {
-      "Size": 168722
+      "Size": 185808
     },
     "lib/arm64-v8a/lib_System.Net.Http.dll.so": {
-      "Size": 72400
+      "Size": 89496
     },
     "lib/arm64-v8a/lib_System.Net.Primitives.dll.so": {
-      "Size": 24022
+      "Size": 41120
     },
     "lib/arm64-v8a/lib_System.Net.Requests.dll.so": {
       "Size": 4461
@@ -122,19 +125,19 @@
       "Size": 9981
     },
     "lib/arm64-v8a/lib_System.Private.CoreLib.dll.so": {
-      "Size": 939274
+      "Size": 956408
     },
     "lib/arm64-v8a/lib_System.Private.DataContractSerialization.dll.so": {
       "Size": 199596
     },
     "lib/arm64-v8a/lib_System.Private.Uri.dll.so": {
-      "Size": 45095
+      "Size": 62192
     },
     "lib/arm64-v8a/lib_System.Private.Xml.dll.so": {
-      "Size": 220007
+      "Size": 237104
     },
     "lib/arm64-v8a/lib_System.Private.Xml.Linq.dll.so": {
-      "Size": 18497
+      "Size": 35584
     },
     "lib/arm64-v8a/lib_System.Runtime.dll.so": {
       "Size": 3111
@@ -143,22 +146,22 @@
       "Size": 4502
     },
     "lib/arm64-v8a/lib_System.Runtime.Numerics.dll.so": {
-      "Size": 37312
+      "Size": 54408
     },
     "lib/arm64-v8a/lib_System.Runtime.Serialization.dll.so": {
-      "Size": 2265
+      "Size": 19352
     },
     "lib/arm64-v8a/lib_System.Runtime.Serialization.Formatters.dll.so": {
       "Size": 3243
     },
     "lib/arm64-v8a/lib_System.Runtime.Serialization.Primitives.dll.so": {
-      "Size": 4361
+      "Size": 21448
     },
     "lib/arm64-v8a/lib_System.Security.Cryptography.dll.so": {
-      "Size": 63408
+      "Size": 80504
     },
     "lib/arm64-v8a/lib_System.Text.RegularExpressions.dll.so": {
-      "Size": 166506
+      "Size": 183592
     },
     "lib/arm64-v8a/lib_System.Xml.dll.so": {
       "Size": 2167
@@ -170,31 +173,31 @@
       "Size": 5007
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 17872
+      "Size": 34760
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.AppCompat.AppCompatResources.dll.so": {
-      "Size": 7425
+      "Size": 24296
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 146152
+      "Size": 163072
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.CardView.dll.so": {
       "Size": 7469
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 18823
+      "Size": 35680
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.Core.dll.so": {
-      "Size": 134318
+      "Size": 151216
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.CursorAdapter.dll.so": {
       "Size": 10076
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 16856
+      "Size": 33760
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 55435
+      "Size": 72224
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.Legacy.Support.Core.UI.dll.so": {
       "Size": 6806
@@ -212,16 +215,16 @@
       "Size": 14499
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 95162
+      "Size": 111896
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.SavedState.dll.so": {
       "Size": 6050
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 14858
+      "Size": 31672
     },
     "lib/arm64-v8a/lib_Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 20961
+      "Size": 37752
     },
     "lib/arm64-v8a/lib_Xamarin.Forms.Core.dll.so": {
       "Size": 563905
@@ -236,7 +239,7 @@
       "Size": 63542
     },
     "lib/arm64-v8a/lib_Xamarin.Google.Android.Material.dll.so": {
-      "Size": 67675
+      "Size": 84400
     },
     "lib/arm64-v8a/libarc.bin.so": {
       "Size": 1685
@@ -245,7 +248,7 @@
       "Size": 87432
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 484920
+      "Size": 485400
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3196336
@@ -263,7 +266,7 @@
       "Size": 160232
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 349352
+      "Size": 119928
     },
     "META-INF/androidx.activity_activity.version": {
       "Size": 6
@@ -419,7 +422,7 @@
       "Size": 1223
     },
     "META-INF/BNDLTOOL.SF": {
-      "Size": 98577
+      "Size": 98661
     },
     "META-INF/com.android.tools/proguard/coroutines.pro": {
       "Size": 1345
@@ -446,7 +449,7 @@
       "Size": 5
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 98450
+      "Size": 98534
     },
     "META-INF/maven/com.google.guava/listenablefuture/pom.properties": {
       "Size": 96
@@ -2486,5 +2489,5 @@
       "Size": 812848
     }
   },
-  "PackageSize": 10579211
+  "PackageSize": 10673477
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -324,7 +324,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <AndroidUseAssemblyStore Condition=" '$(AndroidUseAssemblyStore)' == '' ">true</AndroidUseAssemblyStore>
   <AndroidAotEnableLazyLoad Condition=" '$(AndroidAotEnableLazyLoad)' == '' And '$(AotAssemblies)' == 'true' And '$(AndroidIncludeDebugSymbols)' != 'true' ">True</AndroidAotEnableLazyLoad>
   <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and ('$(UsingMicrosoftNETSdkRazor)' == 'true') ">False</AndroidEnableMarshalMethods>
-  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' ">True</AndroidEnableMarshalMethods>
+  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' ">False</AndroidEnableMarshalMethods>
   <_AndroidUseMarshalMethods Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' ">False</_AndroidUseMarshalMethods>
   <_AndroidUseMarshalMethods Condition=" '$(AndroidIncludeDebugSymbols)' != 'True' ">$(AndroidEnableMarshalMethods)</_AndroidUseMarshalMethods>
 </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/8253
Context: https://github.com/dotnet/android/pull/9343

We've had a number of reports about *hangs* when LLVM Marshal Methods are enabled (see also dotnet/android#8253), but we had been willing to accept having LLVM Marshal Methods enabled by default as it helps improve app startup time.

However, [a customer reported a native crash][0] when LLVM Marshal Methods are enabled:

> ![Thread Stack Trace][1]

	syscall at line 28 within libc
	__futex_wait_ex(void volatile*, bool, int, bool, timespec const*) at line 144 within libc
	sem_wait at line 108 within libc
	within libmonosgen-2.0.so (Build Id: …)
	within <anonymous:…>

This native crash suggests "something going wrong" within MonoVM. We find this "scary" enough that we feel it is once again prudent to disable LLVM Marshal Methods by default in .NET 9, by setting the default value of `$(AndroidEnableMarshalMethods)`=False.

Even though #9343 has a potential fix for the hang, we feel that we're too close to .NET 9 GA to validate in the wild.  This feature will need to wait for .NET 10.  🙁

To explicitly enable LLVM Marshal Methods, set
`$(AndroidEnableMarshalMethods)`=True in your App `.csproj`.

[0]: https://discord.com/channels/732297728826277939/732297837953679412/1288758900627345463
[1]: https://cdn.discordapp.com/attachments/732297837953679412/1288758900522483712/05F6ED48-2BBA-4FC0-A54F-81BB57606500.png?ex=66f659c1&is=66f50841&hm=8f6f78f283f8c03e9fb37a452ad5d0babaaad3dd4bcc1b4887f4dcf60f651c12&