### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 17928: Build ID 10317670

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.cs.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.cs.resx
@@ -1082,12 +1082,12 @@ Pokud chcete pro sestavení z příkazového řádku použít vlastní cestu JDK
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>Spustitelný soubor gradlew nebyl v adresáři projektu {0} nalezen. Ujistěte se prosím, že cesta ke složce projektu Gradle je správná a že obsahuje skripty Gradle Wrapper.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Přidává se odkaz na výstup Gradle: {0}. S tímto chováním lze vyjádřit výslovný nesouhlas nastavením metadat %(CreateAndroidLibrary) na hodnotu false.</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.de.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.de.resx
@@ -1082,12 +1082,12 @@ Um einen benutzerdefinierten JDK-Pfad für einen Befehlszeilenbuild zu verwenden
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>Die ausführbare Datei „gradlew“ wurde im Projektverzeichnis „{0}“ nicht gefunden. Stellen Sie sicher, dass der Pfad zu Ihrem Gradle-Projektordner korrekt ist und dass er Gradle Wrapper-Skripts enthält.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Verweis auf Gradle-Ausgabe wird hinzugefügt: „{0}“. Die %(CreateAndroidLibrary)-Metadaten können auf FALSE festgelegt werden, um dieses Verhalten zu deaktivieren.</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.es.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.es.resx
@@ -1082,12 +1082,12 @@ Para usar una ruta de acceso de JDK personalizada para una compilación de líne
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>No se encontró el ejecutable 'gradlew' en el directorio del proyecto '{0}'. Asegúrese de que la ruta de acceso a la carpeta del proyecto de Gradle es correcta y que contiene scripts de contenedores de Gradle.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Agregando referencia a la salida de Gradle: '{0}'. Los metadatos '%(CreateAndroidLibrary)' se pueden establecer en 'false' para no participar en este comportamiento.</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.fr.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.fr.resx
@@ -1082,12 +1082,12 @@ Pour utiliser un chemin JDK personnalisé pour une build de ligne de commande, d
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>L’exécutable « gradlew » est introuvable dans le répertoire du projet « {0} ». Veuillez vérifier que le chemin d’accès au dossier de votre projet Gradle est correct et qu’il contient des scripts Wrapper Gradle.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Ajout d’une référence à la sortie Gradle : « {0} ». Les métadonnées « %(CreateAndroidLibrary) » peuvent avoir la valeur « false » pour refuser ce comportement.</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.it.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.it.resx
@@ -1082,12 +1082,12 @@ Per usare un percorso JDK personalizzato per una compilazione della riga di coma
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>Il file eseguibile 'gradlew' non è stato trovato nella directory di progetto '{0}'. Assicurarsi che il percorso della cartella di progetto Gradle sia corretto e che contenga script wrapper di Gradle.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Aggiunta del riferimento all'output di Gradle: '{0}'. I metadati '%(CreateAndroidLibrary)' possono essere impostati su 'false' per rifiutare esplicitamente questo comportamento.</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ja.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ja.resx
@@ -1083,12 +1083,12 @@ In this message, the term "handheld app" means "app for handheld devices."
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>プロジェクト ディレクトリ '{0}' に実行可能ファイル 'gradlew' が見つかりません。Gradle プロジェクト フォルダーへのパスが正しいこと、Gradle ラッパー スクリプトが含まれていることを確認してください。</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Gradle 出力への参照を追加しています: '{0}'。'%(CreateAndroidLibrary)' メタデータを 'false' に設定して、この動作をオプトアウトすることができます。</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ko.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ko.resx
@@ -1082,12 +1082,12 @@ In this message, the term "handheld app" means "app for handheld devices."
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>프로젝트 디렉터리 '{0}'에서 실행 파일 'gradlew'를 찾을 수 없습니다. Gradle 프로젝트 폴더의 경로가 올바르고 Gradle Wrapper 스크립트가 포함되어 있는지 확인하세요.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Gradle 출력에 참조를 추가하는 중: '{0}'. 이 동작을 옵트아웃하려면 '%(CreateAndroidLibrary)' 메타데이터를 'false'로 설정할 수 있습니다.</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.pl.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.pl.resx
@@ -1082,12 +1082,12 @@ Aby użyć niestandardowej ścieżki zestawu JDK dla kompilacji wiersza poleceni
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>Nie znaleziono pliku wykonywalnego „gradlew” w katalogu projektu „{0}”. Upewnij się, że ścieżka do folderu projektu Gradle jest poprawna i że zawiera skrypty Gradle Wrapper.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Dodawanie odwołania do danych wyjściowych Gradle: „{0}”. Metadane „%(CreateAndroidLibrary)” można ustawić na wartość „false”, aby zrezygnować z tego zachowania.</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.pt-BR.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.pt-BR.resx
@@ -1082,12 +1082,12 @@ Para usar um caminho JDK personalizado para um build de linha de comando, defina
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>Executável 'gradlew' não encontrado no diretório do projeto '{0}'. Verifique se o caminho para a pasta do projeto Gradle está correto e se ele contém scripts do Gradle Wrapper.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Adicionando referência à saída do Gradle: '{0}'. Os metadados '%(CreateAndroidLibrary)' podem ser definidos como 'falso' para recusar esse comportamento.</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ru.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ru.resx
@@ -1082,12 +1082,12 @@ In this message, the term "handheld app" means "app for handheld devices."
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>Исполняемый файл "gradlew" не найден в каталоге проекта "{0}". Убедитесь, что путь к папке проекта Gradle указан правильно и что она содержит сценарии Gradle Wrapper.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Добавление ссылки на выходные данные Gradle: "{0}". Чтобы отказаться от этого поведения, метаданным "%(CreateAndroidLibrary)" можно присвоить значение "false".</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.tr.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.tr.resx
@@ -1082,12 +1082,12 @@ Bir komut satırı derlemesi için özel bir SDK yolu kullanmak için 'JavaSdkDi
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>'Gradlew' yürütülebilir dosyası '{0}' proje dizininde bulunamadı. Lütfen Gradle proje klasör yolunun doğru olduğundan ve Gradle Sarmalayıcı betikleri içerdiğinden emin olun.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>Gradle çıkışına başvuru ekleniyor: '{0}'. Bu davranıştan çıkmak için '%(CreateAndroidLibrary)' meta verileri 'false' olarak ayarlanabilir.</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hans.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hans.resx
@@ -1082,12 +1082,12 @@ In this message, the term "handheld app" means "app for handheld devices."
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
   <data name="XAGRDL1000" xml:space="preserve">
-    <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
+    <value>在项目目录 ‘{0}’ 中找不到可执行的 ‘gradlew’。请确保 Gradle 项目文件夹的路径正确无误，并且包含 Gradle 包装器脚本。</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper
 {0} - The value of the AndroidGradleProject item</comment>
   </data>
   <data name="XAGRDLRefLibraryOutputs" xml:space="preserve">
-    <value>Adding reference to Gradle output: '{0}'. The '%(CreateAndroidLibrary)' metadata can be set to 'false' to opt out of this behavior.</value>
+    <value>正在添加对 Gradle 输出 ‘{0}’ 的引用。可以将 ‘%(CreateAndroidLibrary)’ 元数据设置为 ‘false’ 以选择退出此行为。</value>
     <comment>The following are literal names and should not be translated: Gradle, '%(CreateAndroidLibrary)', metadata, 'false'
 {0} - The path to the library output that will be referenced</comment>
   </data>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.