### PR TITLE
[Xamarin.Android.Build.Tasks] move `Console.WriteLine()` messages to MSBuild log

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreGenerator.cs
@@ -149,15 +149,15 @@ partial class AssemblyStoreGenerator
 		WriteIndex (writer, mw, index, descriptors, is64Bit);
 		mw.Flush ();
 
-		Console.WriteLine ($"Number of descriptors: {descriptors.Count}; index entries: {index.Count}");
-		Console.WriteLine ($"Header size: {AssemblyStoreHeader.NativeSize}; index entry size: {IndexEntrySize ()}; descriptor size: {AssemblyStoreEntryDescriptor.NativeSize}");
+		log.LogDebugMessage ($"Number of descriptors: {descriptors.Count}; index entries: {index.Count}");
+		log.LogDebugMessage ($"Header size: {AssemblyStoreHeader.NativeSize}; index entry size: {IndexEntrySize ()}; descriptor size: {AssemblyStoreEntryDescriptor.NativeSize}");
 
 		WriteDescriptors (writer, descriptors);
 		WriteNames (writer, infos);
 		writer.Flush ();
 
 		if (fs.Position != (long)assemblyDataStart) {
-			Console.WriteLine ($"fs.Position == {fs.Position}; assemblyDataStart == {assemblyDataStart}");
+			log.LogDebugMessage ($"fs.Position == {fs.Position}; assemblyDataStart == {assemblyDataStart}");
 			throw new InvalidOperationException ($"Internal error: store '{storePath}' position is different than metadata size after header write");
 		}
 


### PR DESCRIPTION
When running builds at the command-line (with the default, new "MSBuild Terminal Logger"), `Console.WriteLine()` output can make the text not look so great:

    > dotnet build -c Release -bl
    Restore complete (0.6s)
    You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
    hellomaui                                                                                      _BuildApkEmbed (18.9s)
    Number of descriptors: 116; index entries: 232
    hellomaui succeeded (33.3s) → bin\Release\net9.0-android\android-arm64\hellomaui.dll
    Build succeeded in 46.8s

The message `Number of descriptors: 116; index entries: 232` appears, but so does another one. You can watch the terminal logger clear and rewrite messages, which is not ideal.

Let's move these to the MSBuild logger, so they will show up in `.binlog` files, but not in the console output.