### PR TITLE
Handle more Attribute Types when Filtering Assemblies

### DIFF
--- a/samples/HelloWorld/HelloLibrary/LibraryActivity.cs
+++ b/samples/HelloWorld/HelloLibrary/LibraryActivity.cs
@@ -16,8 +16,12 @@ using Android.Util;
 using Android.Views;
 using Android.Widget;
 
+[assembly: HelloLibrary.GenericTest<string>]
 namespace HelloLibrary
 {
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+    public class GenericTestAttribute<T> : Attribute { }
+
     [Activity(Label = "Library Activity", Name="mono.samples.hello.LibraryActivity")]
     public class LibraryActivity : Activity
     {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -493,7 +493,7 @@ namespace Xamarin.Android.Tasks
 				// Thus, we no longer just store them in the apk but we call the `GetCompressionMethod` method to find out whether
 				// or not we're supposed to compress .so files.
 				foreach (ITaskItem assembly in assemblies.Values) {
-					if (MonoAndroidHelper.IsReferenceAssembly (assembly.ItemSpec)) {
+					if (MonoAndroidHelper.IsReferenceAssembly (assembly.ItemSpec, Log)) {
 						Log.LogCodedWarning ("XA0107", assembly.ItemSpec, 0, Properties.Resources.XA0107, assembly.ItemSpec);
 					}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
@@ -102,7 +102,7 @@ namespace Xamarin.Android.Tasks
 		{
 			foreach (var handle in assembly.GetCustomAttributes ()) {
 				var attribute = reader.GetCustomAttribute (handle);
-				var name = reader.GetCustomAttributeFullName (attribute);
+				var name = reader.GetCustomAttributeFullName (attribute, Log);
 				switch (name) {
 					case "System.Runtime.Versioning.TargetFrameworkAttribute":
 						string targetFrameworkIdentifier = null;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
@@ -26,13 +26,12 @@ namespace Xamarin.Android.Tasks
 						TypeReference typeRef = reader.GetTypeReference ((TypeReferenceHandle)typeHandle);
 						return reader.GetString (typeRef.Namespace) + "." + reader.GetString (typeRef.Name);
 					} else {
-						log.LogDebugMessage($"Unknown EntityHandle.Kind: {ctor.Parent.Kind}");
+						log.LogDebugMessage ($"Unsupported EntityHandle.Kind: {ctor.Parent.Kind}");
 						return null;
 					}
 				}
-				catch (InvalidCastException ex)
-				{
-					log.LogDebugMessage($"Unknown EntityHandle.Kind: {ex}");
+				catch (InvalidCastException ex) {
+					log.LogDebugMessage ($"Unsupported EntityHandle.Kind `{ctor?.Parent?.Kind?.ToString () ?? "<null>"}`: {ex}");
 					return null;
 				}
 			} else if (attribute.Constructor.Kind == HandleKind.MethodDefinition) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
@@ -3,12 +3,14 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using Microsoft.Build.Utilities;
+using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks
 {
 	public static class MetadataExtensions
 	{
-		public static string GetCustomAttributeFullName (this MetadataReader reader, CustomAttribute attribute)
+		public static string GetCustomAttributeFullName (this MetadataReader reader, CustomAttribute attribute, TaskLoggingHelper log)
 		{
 			if (attribute.Constructor.Kind == HandleKind.MemberReference) {
 				var ctor = reader.GetMemberReference ((MemberReferenceHandle)attribute.Constructor);
@@ -23,10 +25,14 @@ namespace Xamarin.Android.Tasks
 						EntityHandle typeHandle = blobReader.ReadTypeHandle ();
 						TypeReference typeRef = reader.GetTypeReference ((TypeReferenceHandle)typeHandle);
 						return reader.GetString (typeRef.Namespace) + "." + reader.GetString (typeRef.Name);
+					} else {
+						log.LogDebugMessage($"Unknown EntityHandle.Kind: {ctor.Parent.Kind}");
+						return null;
 					}
 				}
-				catch (InvalidCastException)
+				catch (InvalidCastException ex)
 				{
+					log.LogDebugMessage($"Unknown EntityHandle.Kind: {ex}");
 					return null;
 				}
 			} else if (attribute.Constructor.Kind == HandleKind.MethodDefinition) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
@@ -12,8 +12,23 @@ namespace Xamarin.Android.Tasks
 		{
 			if (attribute.Constructor.Kind == HandleKind.MemberReference) {
 				var ctor = reader.GetMemberReference ((MemberReferenceHandle)attribute.Constructor);
-				var type = reader.GetTypeReference ((TypeReferenceHandle)ctor.Parent);
-				return reader.GetString (type.Namespace) + "." + reader.GetString (type.Name);
+				try {
+					if (ctor.Parent.Kind == HandleKind.TypeReference) {
+						var type = reader.GetTypeReference ((TypeReferenceHandle)ctor.Parent);
+						return reader.GetString (type.Namespace) + "." + reader.GetString (type.Name);
+					} else if (ctor.Parent.Kind == HandleKind.TypeSpecification) {
+						var type = reader.GetTypeSpecification ((TypeSpecificationHandle)ctor.Parent);
+						BlobReader blobReader = reader.GetBlobReader (type.Signature);
+						SignatureTypeCode typeCode = blobReader.ReadSignatureTypeCode ();
+						EntityHandle typeHandle = blobReader.ReadTypeHandle ();
+						TypeReference typeRef = reader.GetTypeReference ((TypeReferenceHandle)typeHandle);
+						return reader.GetString (typeRef.Namespace) + "." + reader.GetString (typeRef.Name);
+					}
+				}
+				catch (InvalidCastException)
+				{
+					return null;
+				}
 			} else if (attribute.Constructor.Kind == HandleKind.MethodDefinition) {
 				var ctor = reader.GetMethodDefinition ((MethodDefinitionHandle)attribute.Constructor);
 				var type = reader.GetTypeDefinition (ctor.GetDeclaringType ());

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 				catch (InvalidCastException ex) {
-					log.LogDebugMessage ($"Unsupported EntityHandle.Kind `{ctor?.Parent?.Kind?.ToString () ?? "<null>"}`: {ex}");
+					log.LogDebugMessage ($"Unsupported EntityHandle.Kind `{ctor.Parent.Kind}`: {ex}");
 					return null;
 				}
 			} else if (attribute.Constructor.Kind == HandleKind.MethodDefinition) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -364,7 +364,7 @@ namespace Xamarin.Android.Tasks
 			return false;
 		}
 
-		public static bool IsReferenceAssembly (string assembly)
+		public static bool IsReferenceAssembly (string assembly, TaskLoggingHelper log)
 		{
 			using (var stream = File.OpenRead (assembly))
 			using (var pe = new PEReader (stream)) {
@@ -372,7 +372,7 @@ namespace Xamarin.Android.Tasks
 				var assemblyDefinition = reader.GetAssemblyDefinition ();
 				foreach (var handle in assemblyDefinition.GetCustomAttributes ()) {
 					var attribute = reader.GetCustomAttribute (handle);
-					var attributeName = reader.GetCustomAttributeFullName (attribute);
+					var attributeName = reader.GetCustomAttributeFullName (attribute, log);
 					if (attributeName == "System.Runtime.CompilerServices.ReferenceAssemblyAttribute")
 						return true;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Android.Tasks
 			var assembly = reader.GetAssemblyDefinition ();
 			foreach (var handle in assembly.GetCustomAttributes ()) {
 				var attribute = reader.GetCustomAttribute (handle);
-				var fullName = reader.GetCustomAttributeFullName (attribute);
+				var fullName = reader.GetCustomAttributeFullName (attribute, Log);
 				if (fullName == "Android.Runtime.ResourceDesignerAttribute") {
 					var values = attribute.GetCustomAttributeArguments ();
 					foreach (var arg in values.NamedArguments) {


### PR DESCRIPTION
Fixes #9369

When System.Reflection.Metadata comes across an Attribute which has a generic, it does NOT return a `TypeReferenceHandle`. It returns a `TypeSpecificationHandle`.

Tying to cast the type results in the following error

```
System.InvalidCastException: Die angegebene Umwandlung ist ungültig.
error XAFLT7007:    bei System.Reflection.Throw.InvalidCast()
error XAFLT7007:    bei System.Reflection.Metadata.TypeReferenceHandle.op_Explicit(EntityHandle handle)
error XAFLT7007:    bei Xamarin.Android.Tasks.MetadataExtensions.GetCustomAttributeFullName(MetadataReader reader, CustomAttribute attribute)
error XAFLT7007:    bei Xamarin.Android.Tasks.FilterAssemblies.IsAndroidAssembly(AssemblyDefinition assembly, MetadataReader reader)
error XAFLT7007:    bei Xamarin.Android.Tasks.FilterAssemblies.ProcessAssembly(ITaskItem assemblyItem, List`1 output)
error XAFLT7007:    bei Xamarin.Android.Tasks.FilterAssemblies.RunTask()
error XAFLT7007:    bei Microsoft.Android.Build.Tasks.AndroidTask.Execute()
```

So we need to handle this case, and put in place a backup to handle an `InvalidCastException` so that we never hit this issue again.