### PR TITLE
Simplify and fix split configs detection

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Bundled.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Bundled.java
@@ -21,15 +21,12 @@ public class MonoRuntimeProvider
 		// Mono Runtime Initialization {{{
 		android.content.pm.ApplicationInfo applicationInfo = context.getApplicationInfo ();
 		String[] apks = null;
-		if (android.os.Build.VERSION.SDK_INT >= 21) {
-			String[] splitApks = applicationInfo.splitPublicSourceDirs;
-			if (splitApks != null && splitApks.length > 0) {
-				apks = new String[splitApks.length + 1];
-				apks [0] = applicationInfo.sourceDir;
-				System.arraycopy (splitApks, 0, apks, 1, splitApks.length);
-			}
-		}
-		if (apks == null) {
+		String[] splitApks = applicationInfo.splitSourceDirs;
+		if (splitApks != null && splitApks.length > 0) {
+			apks = new String[splitApks.length + 1];
+			apks [0] = applicationInfo.sourceDir;
+			System.arraycopy (splitApks, 0, apks, 1, splitApks.length);
+		} else {
 			apks = new String[] { applicationInfo.sourceDir };
 		}
 		mono.MonoPackageManager.LoadApplication (context, applicationInfo, apks);
@@ -67,4 +64,3 @@ public class MonoRuntimeProvider
 		throw new RuntimeException ("This operation is not supported.");
 	}
 }
-

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -58,13 +58,7 @@ public class MonoPackageManager {
 				// Should the order change here, src/monodroid/jni/SharedConstants.hh must be updated accordingly
 				//
 				String[] appDirs = new String[] {filesDir, cacheDir, dataDir};
-				boolean haveSplitApks = false;
-
-				if (android.os.Build.VERSION.SDK_INT >= 21) {
-					if (runtimePackage.splitSourceDirs != null) {
-						haveSplitApks = runtimePackage.splitSourceDirs.length > 1;
-					}
-				}
+				boolean haveSplitApks = runtimePackage.splitSourceDirs != null && runtimePackage.splitSourceDirs.length > 0;
 
 				//
 				// Preload DSOs libmonodroid.so depends on so that the dynamic


### PR DESCRIPTION
We use [`ApplicationInfo.splitSourceDirs`](https://developer.android.com/reference/android/content/pm/ApplicationInfo#splitSourceDirs) to detect whether the application uses split config files.
Those files are created by Android when an AAB is used to deploy application (e.g. via Google Play Store).

When they are present, the base APK file doesn't contain any `lib/` directories and we can simply skip
scanning it for those entries, thus saving on startup time.  We used to check whether there are more than
one entry in `splitSourceDirs`, which used to be the case, but it seems that the recent Android versions
(at least API 33 and newer) can have just a single entry in the array.  Because of that, we were scanning
all the APK files on those Android versions, wasting time at startup.

Fix the check by probing whether array exists and contains at least a single entry.  Additionally, remove
API 21 check, since this is our lowest supported API level.