### PR TITLE
Move Debug Test first and Clean after runs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -156,15 +156,6 @@ extends:
 
         - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
           parameters:
-            configuration: $(XA.Build.Configuration)
-            testName: Mono.Android.NET_Tests-$(XA.Build.Configuration)
-            project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
-            testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration).xml
-            artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
-            artifactFolder: $(DotNetTargetFramework)-$(XA.Build.Configuration)
-
-        - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
-          parameters:
             buildConfiguration: $(XA.Build.Configuration)
             configuration: Debug
             testName: Mono.Android.NET_Tests-Debug
@@ -172,6 +163,15 @@ extends:
             testResultsFiles: TestResult-Mono.Android.NET_Tests-Debug.xml
             artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.apk
             artifactFolder: $(DotNetTargetFramework)-Debug
+
+        - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
+          parameters:
+            configuration: $(XA.Build.Configuration)
+            testName: Mono.Android.NET_Tests-$(XA.Build.Configuration)
+            project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+            testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration).xml
+            artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
+            artifactFolder: $(DotNetTargetFramework)-$(XA.Build.Configuration)
 
         - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
           parameters:

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -41,3 +41,10 @@ steps:
     testResultsFiles: ${{ parameters.testResultsFiles }}
     testRunTitle: ${{ parameters.testName }}
   condition: and(${{ parameters.condition }}, ne('${{ parameters.testResultsFiles }}', ''))
+
+- template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+  parameters:
+    project: ${{ parameters.project }}
+    arguments: -t:Clean -c ${{ parameters.configuration }} --no-restore
+    displayName: Clean ${{ parameters.testName }}
+    continueOnError: false


### PR DESCRIPTION
There is some odd build issue were Release artifacts are making into a Debug build of `tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj`. This only happens in this test project.

I suspect it is because we are overriding the `$(Configuration)` in the project, but not always since we are also building in a `Release` environment. Both the top level `Configuration.props` is using `$(Configuration)` as well as the test project, but the test project gets a value of `Debug` from the build yaml. I think it is confusing things, but I have not been able to track it down.


So lets try to clean up the `tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj` test project after it has been built and run. To make sure any old outputs are not there. 
Also try running the `Debug` test first, so its running in a clean environment. 