### PR TITLE
Move all of assembly store building code to a separate class

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -501,6 +501,14 @@ namespace Xamarin.Android.Tasks
 				);
 			}
 
+			void EnsureCompressedAssemblyData (string sourcePath, uint descriptorIndex)
+			{
+				if (compressedAssembly == null)
+					compressedAssembly = new AssemblyCompression.AssemblyData (sourcePath, descriptorIndex);
+				else
+					compressedAssembly.SetData (sourcePath, descriptorIndex);
+			}
+
 			string CompressAssembly (ITaskItem assembly)
 			{
 				if (!compress) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -432,10 +432,10 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Add user assemblies
-			AddAssembliesFromCollection (ResolvedUserAssemblies);
+			AssemblyPackagingHelper.AddAssembliesFromCollection (Log, SupportedAbis, ResolvedUserAssemblies, DoAddAssembliesFromArchCollection);
 
 			// Add framework assemblies
-			AddAssembliesFromCollection (ResolvedFrameworkAssemblies);
+			AssemblyPackagingHelper.AddAssembliesFromCollection (Log, SupportedAbis, ResolvedFrameworkAssemblies, DoAddAssembliesFromArchCollection);
 
 			if (!UseAssemblyStore) {
 				return;
@@ -457,28 +457,6 @@ namespace Xamarin.Android.Tasks
 				inArchivePath = MakeArchiveLibPath (abi, "lib" + Path.GetFileName (kvp.Value));
 				string wrappedSourcePath = DSOWrapperGenerator.WrapIt (kvp.Key, kvp.Value, Path.GetFileName (inArchivePath), this);
 				AddFileToArchiveIfNewer (apk, wrappedSourcePath, inArchivePath, GetCompressionMethod (inArchivePath));
-			}
-
-			void AddAssembliesFromCollection (ITaskItem[] assemblies)
-			{
-				Dictionary<AndroidTargetArch, Dictionary<string, ITaskItem>> perArchAssemblies = MonoAndroidHelper.GetPerArchAssemblies (
-					assemblies,
-					SupportedAbis,
-					validate: true,
-					shouldSkip: (ITaskItem asm) => {
-						if (bool.TryParse (asm.GetMetadata ("AndroidSkipAddToPackage"), out bool value) && value) {
-							Log.LogDebugMessage ($"Skipping {asm.ItemSpec} due to 'AndroidSkipAddToPackage' == 'true' ");
-							return true;
-						}
-
-						return false;
-					}
-				);
-
-				foreach (var kvp in perArchAssemblies) {
-					Log.LogDebugMessage ($"Adding assemblies for architecture '{kvp.Key}'");
-					DoAddAssembliesFromArchCollection (kvp.Key, kvp.Value);
-				}
 			}
 
 			void DoAddAssembliesFromArchCollection (AndroidTargetArch arch, Dictionary<string, ITaskItem> assemblies)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -515,15 +515,17 @@ namespace Xamarin.Android.Tasks
 
 					string symbols = Path.ChangeExtension (assembly.ItemSpec, "pdb");
 					if (!File.Exists (symbols)) {
-						string archiveSymbolsPath = assemblyDirectory + MonoAndroidHelper.MakeDiscreteAssembliesEntryName (Path.GetFileName (symbols));
-						string wrappedSymbolsPath = DSOWrapperGenerator.WrapIt (arch, symbols, Path.GetFileName (archiveSymbolsPath), this);
-						AddFileToArchiveIfNewer (
-							apk,
-							wrappedSymbolsPath,
-							archiveSymbolsPath,
-							compressionMethod: GetCompressionMethod (archiveSymbolsPath)
-						);
+						continue;
 					}
+
+					string archiveSymbolsPath = assemblyDirectory + MonoAndroidHelper.MakeDiscreteAssembliesEntryName (Path.GetFileName (symbols));
+					string wrappedSymbolsPath = DSOWrapperGenerator.WrapIt (arch, symbols, Path.GetFileName (archiveSymbolsPath), this);
+					AddFileToArchiveIfNewer (
+						apk,
+						wrappedSymbolsPath,
+						archiveSymbolsPath,
+						compressionMethod: GetCompressionMethod (archiveSymbolsPath)
+					);
 				}
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyPackagingHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyPackagingHelper.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks;
+
+static class AssemblyPackagingHelper
+{
+	public static void AddAssembliesFromCollection (TaskLoggingHelper Log, ICollection<string> SupportedAbis, ICollection<ITaskItem> assemblies, Action<AndroidTargetArch, Dictionary<string, ITaskItem>> doAddAssemblies)
+	{
+		Dictionary<AndroidTargetArch, Dictionary<string, ITaskItem>> perArchAssemblies = MonoAndroidHelper.GetPerArchAssemblies (
+			assemblies,
+			SupportedAbis,
+			validate: true,
+			shouldSkip: (ITaskItem asm) => {
+				if (bool.TryParse (asm.GetMetadata ("AndroidSkipAddToPackage"), out bool value) && value) {
+					Log.LogDebugMessage ($"Skipping {asm.ItemSpec} due to 'AndroidSkipAddToPackage' == 'true' ");
+					return true;
+				}
+
+				return false;
+			}
+		);
+
+		foreach (var kvp in perArchAssemblies) {
+			Log.LogDebugMessage ($"Adding assemblies for architecture '{kvp.Key}'");
+			doAddAssemblies (kvp.Key, kvp.Value);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyPackagingHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyPackagingHelper.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Android.Tasks;
 
 static class AssemblyPackagingHelper
 {
-	public static void AddAssembliesFromCollection (TaskLoggingHelper Log, ICollection<string> SupportedAbis, ICollection<ITaskItem> assemblies, Action<AndroidTargetArch, Dictionary<string, ITaskItem>> doAddAssemblies)
+	public static void AddAssembliesFromCollection (TaskLoggingHelper Log, ICollection<string> SupportedAbis, ICollection<ITaskItem> assemblies, Action<TaskLoggingHelper, AndroidTargetArch, ITaskItem> doAddAssembly)
 	{
 		Dictionary<AndroidTargetArch, Dictionary<string, ITaskItem>> perArchAssemblies = MonoAndroidHelper.GetPerArchAssemblies (
 			assemblies,
@@ -28,7 +28,18 @@ static class AssemblyPackagingHelper
 
 		foreach (var kvp in perArchAssemblies) {
 			Log.LogDebugMessage ($"Adding assemblies for architecture '{kvp.Key}'");
-			doAddAssemblies (kvp.Key, kvp.Value);
+			DoAddAssembliesFromArchCollection (Log, kvp.Key, kvp.Value, doAddAssembly);
+		}
+	}
+
+	static void DoAddAssembliesFromArchCollection (TaskLoggingHelper Log, AndroidTargetArch arch, Dictionary<string, ITaskItem> assemblies, Action<TaskLoggingHelper, AndroidTargetArch, ITaskItem> doAddAssembly)
+	{
+		foreach (ITaskItem assembly in assemblies.Values) {
+			if (MonoAndroidHelper.IsReferenceAssembly (assembly.ItemSpec, Log)) {
+				Log.LogCodedWarning ("XA0107", assembly.ItemSpec, 0, Properties.Resources.XA0107, assembly.ItemSpec);
+			}
+
+			doAddAssembly (Log, arch, assembly);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreBuilder.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks;
+
+class AssemblyStoreBuilder
+{
+	readonly TaskLoggingHelper log;
+	readonly AssemblyStoreGenerator storeGenerator;
+
+	public AssemblyStoreBuilder (TaskLoggingHelper log)
+	{
+		this.log = log;
+		storeGenerator = new (log);
+	}
+
+	public void AddAssembly (string assemblySourcePath, ITaskItem assemblyItem, bool includeDebugSymbols)
+	{
+		var storeAssemblyInfo = new AssemblyStoreAssemblyInfo (assemblySourcePath, assemblyItem);
+
+		// Try to add config if exists.  We use assemblyItem, because `sourcePath` might refer to a compressed
+		// assembly file in a different location.
+		var config = Path.ChangeExtension (assemblyItem.ItemSpec, "dll.config");
+		if (File.Exists (config)) {
+			storeAssemblyInfo.ConfigFile = new FileInfo (config);
+		}
+
+		if (includeDebugSymbols) {
+			string debugSymbolsPath = Path.ChangeExtension (assemblyItem.ItemSpec, "pdb");
+			if (File.Exists (debugSymbolsPath)) {
+				storeAssemblyInfo.SymbolsFile = new FileInfo (debugSymbolsPath);
+			}
+		}
+
+		storeGenerator.Add (storeAssemblyInfo);
+	}
+
+	public Dictionary<AndroidTargetArch, string> Generate (string outputDirectoryPath) => storeGenerator.Generate (outputDirectoryPath);
+}


### PR DESCRIPTION
Simplify the task of constructing assembly stores by moving all the code
which actually stashes assemblies (and their config and debug files, if found
and required) in the assembly store to a separate utility class, `AssemblyStoreBuilder`.  

Additionally, move a portion of assembly packaging code from `BuildApk` to a helper class.

This makes it easier to build the stores outside of the `BuildApk` task and further 
simplifies `BuildApk` code.
