### PR TITLE
[CI] Remove self annotation from apk-instrumentation.yaml

### DIFF
--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -42,7 +42,7 @@ steps:
     testRunTitle: ${{ parameters.testName }}
   condition: and(${{ parameters.condition }}, ne('${{ parameters.testResultsFiles }}', ''))
 
-- template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+- template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
   parameters:
     project: ${{ parameters.project }}
     arguments: -t:Clean -c ${{ parameters.configuration }} --no-restore


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/5cd9a267e20a19d796d521d67867a00fd67328ba
Context: https://github.com/dotnet/android/commit/e55c38f8eec2992899fc96528b9dcbc174aad585

The monodroid pipeline recently started failing to build with:

    /build-tools/automation/yaml-templates/apk-instrumentation.yaml@xa-yaml: Could not find /build-tools/automation/yaml-templates/run-dotnet-preview.yaml in repository self hosted on https://github.com/ using commit 0f5fd98ec70af48f03a67577e5ef9a360c2f0650. GitHub reported the error, "Not Found"

The @ self yaml template annotation should only be used in the pipeline
file, and not in nested templates.  This should fix potential issues
with other repos that use these templates.