### PR TITLE
[ci] Use latest macOS-14 image

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -30,7 +30,7 @@ variables:
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage
-  value: macOS-13
+  value: macOS-14
 - name: HostedWinImage
   value: windows-2022
 - name: WindowsPoolImage1ESPT


### PR DESCRIPTION
Context: https://github.com/actions/runner-images/blob/768c45609155f3d115ea5c2c23ce129af4d17a9e/images/macos/macos-14-Readme.md

Updates the hosted macOS pool used for build and test stages to the
latest macOS 14 Sonoma images.