### PR TITLE
[ci] Use xaSourcePath and other parameters in apk clean step

### DIFF
--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -44,7 +44,10 @@ steps:
 
 - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
   parameters:
+    configuration: ${{ parameters.buildConfiguration }}
+    xaSourcePath: ${{ parameters.xaSourcePath }}
     project: ${{ parameters.project }}
     arguments: -t:Clean -c ${{ parameters.configuration }} --no-restore
     displayName: Clean ${{ parameters.testName }}
+    condition: ${{ parameters.condition }}
     continueOnError: false


### PR DESCRIPTION
The apk-instrumentation template is also used by the monodroid repo,
where the xaSourcePath template parameter is set to the custom android
source path used there. This path (and other parameters) need to be
forwarded to the new clean step that was recently added.