### PR TITLE
[nuget-msi-convert] Support improved VS component IDs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -18,7 +18,7 @@ resources:
   - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/pjc/msi-arcade-05c72bb
     endpoint: xamarin
   - repository: sdk-insertions
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -18,7 +18,7 @@ resources:
   - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/dev/pjc/msi-arcade-05c72bb
+    ref: refs/heads/main
     endpoint: xamarin
   - repository: sdk-insertions
     type: github

--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -4,6 +4,7 @@
     <TargetName>Microsoft.NET.Sdk.Android.Workload.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@WORKLOAD_VERSION@</ManifestBuildVersion>
     <EnableSideBySideManifests>true</EnableSideBySideManifests>
+    <UseVisualStudioComponentPrefix>true</UseVisualStudioComponentPrefix>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->


### PR DESCRIPTION
Context: https://github.com/dotnet/arcade/commit/b2d3a3a35526b529490e8f7e410b3777b3f20bd6
Context: https://github.com/xamarin/yaml-templates/pull/339

The VS insertion manifest generation has been updated to use new VS
component IDs required for .NET 9+.