### PR TITLE
Add retry ability to RemoveDirFixed

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "RDF";
 
 		const int DEFAULT_DIRECTORY_DELETE_RETRY_DELAY_MS = 1000;
-		const int DEFAULT_REMOVEDIRFIXED_RETRIES = 3;
+		const int DEFAULT_REMOVEDIRFIXED_RETRIES = 10;
 		const int ERROR_ACCESS_DENIED = -2147024891;
 		const int ERROR_SHARING_VIOLATION = -2147024864;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -71,10 +71,9 @@ namespace Xamarin.Android.Tasks
 									if (OS.IsWindows) {
 										fullPath = Files.ToLongPath (fullPath);
 										Log.LogDebugMessage ("Trying long path: " + fullPath);
+										break;
 									}
-									if (retryCount == DEFAULT_REMOVEDIRFIXED_RETRIES)
-										throw;
-									break;
+									throw;
 								case UnauthorizedAccessException:
 								case IOException:
 									int code = Marshal.GetHRForException(e);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -65,6 +65,7 @@ namespace Xamarin.Android.Tasks
 								Files.SetDirectoryWriteable (fullPath);
 							Directory.Delete (fullPath, true);
 							temporaryRemovedDirectories.Add (directory);
+							break;
 						} catch (Exception e) {
 							switch (e) {
 								case DirectoryNotFoundException:

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -72,6 +72,8 @@ namespace Xamarin.Android.Tasks
 										fullPath = Files.ToLongPath (fullPath);
 										Log.LogDebugMessage ("Trying long path: " + fullPath);
 									}
+									if (retryCount == DEFAULT_REMOVEDIRFIXED_RETRIES)
+										throw;
 									break;
 								case UnauthorizedAccessException:
 								case IOException:

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -40,8 +40,6 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "RDF";
 
-		const int DEFAULT_DIRECTORY_DELETE_RETRY_DELAY_MS = 1000;
-		const int DEFAULT_REMOVEDIRFIXED_RETRIES = 10;
 		const int ERROR_ACCESS_DENIED = -2147024891;
 		const int ERROR_SHARING_VIOLATION = -2147024864;
 
@@ -56,8 +54,10 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 				int retryCount = 0;
+				int attempts = Files.GetFileWriteRetryAttempts ();
+				int delay = Files.GetFileWriteRetryDelay ();
 				try {
-					while (retryCount <= DEFAULT_REMOVEDIRFIXED_RETRIES) {
+					while (retryCount <= attempts) {
 						try {
 							// try to do a normal "fast" delete of the directory.
 							// only do the set writable on the second attempt
@@ -78,14 +78,14 @@ namespace Xamarin.Android.Tasks
 								case UnauthorizedAccessException:
 								case IOException:
 									int code = Marshal.GetHRForException(e);
-									if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION) || retryCount == DEFAULT_REMOVEDIRFIXED_RETRIES) {
+									if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION) || retryCount >= attempts) {
 										throw;
 									};
 									break;
 								default:
 									throw;
 							}
-							Thread.Sleep(DEFAULT_DIRECTORY_DELETE_RETRY_DELAY_MS);
+							Thread.Sleep (delay);
 							retryCount++;
 						}
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -59,7 +59,14 @@ namespace Xamarin.Android.Tasks
 					// try to do a normal "fast" delete of the directory.
 					Directory.Delete (fullPath, true);
 					temporaryRemovedDirectories.Add (directory);
-				} catch (UnauthorizedAccessException ex) {
+				} catch (Exception ex) {
+					switch (ex) {
+						case UnauthorizedAccessException:
+						case IOException:
+							break;
+						default:
+							throw;
+					}
 					// if that fails we probably have readonly files (or locked files)
 					// so try to make them writable and try again.
 					Log.LogDebugMessage ("error: " + ex);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
@@ -119,7 +119,7 @@ namespace Xamarin.Android.Build.Tests
 				}
 			});
 			ev.WaitOne ();
-			Assert.IsTrue (task.Execute (), "task.Execute() should have failed.");
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
 			Assert.AreEqual (1, task.RemovedDirectories.Length, "Changes should have been made.");
 			DirectoryAssert.DoesNotExist (tempDirectory);
 			await t;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Android.Build.Tests
 			DirectoryAssert.DoesNotExist (tempDirectory);
 		}
 
-		[Test]
+		[Test, Category ("SmokeTests")]
 		public void DirectoryInUse ()
 		{
 			var file = NewFile ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 using Xamarin.Android.Tasks;
 using Xamarin.Android.Tools;
 using Microsoft.Android.Build.Tasks;
+using TPL = System.Threading.Tasks;
+using System.Threading;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -87,6 +89,10 @@ namespace Xamarin.Android.Build.Tests
 		[Test, Category ("SmokeTests")]
 		public void DirectoryInUse ()
 		{
+			if (OS.IsMac) {
+				Assert.Ignore ("This is not an issue on macos.");
+				return;
+			}
 			var file = NewFile ();
 			var task = CreateTask ();
 			using (var f = File.OpenWrite (file)) {
@@ -94,6 +100,29 @@ namespace Xamarin.Android.Build.Tests
 				Assert.AreEqual (0, task.RemovedDirectories.Length, "Changes should not have been made.");
 				DirectoryAssert.Exists (tempDirectory);
 			}
+		}
+
+		[Test, Category ("SmokeTests")]
+		public async TPL.Task DirectoryInUseWithRetry ()
+		{
+			if (OS.IsMac) {
+				Assert.Ignore ("This is not an issue on macos.");
+				return;
+			}
+			var file = NewFile ();
+			var task = CreateTask ();
+			var ev = new ManualResetEvent (false);
+			var t = TPL.Task.Run (async () => {
+				using (var f = File.OpenWrite (file)) {
+					ev.Set ();
+					await TPL.Task.Delay (2500);
+				}
+			});
+			ev.WaitOne ();
+			Assert.IsTrue (task.Execute (), "task.Execute() should have failed.");
+			Assert.AreEqual (1, task.RemovedDirectories.Length, "Changes should have been made.");
+			DirectoryAssert.DoesNotExist (tempDirectory);
+			await t;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
@@ -83,5 +83,17 @@ namespace Xamarin.Android.Build.Tests
 			Assert.AreEqual (1, task.RemovedDirectories.Length, "Changes should have been made.");
 			DirectoryAssert.DoesNotExist (tempDirectory);
 		}
+
+		[Test]
+		public void DirectoryInUse ()
+		{
+			var file = NewFile ();
+			var task = CreateTask ();
+			using (var f = File.OpenWrite (file)) {
+				Assert.IsFalse (task.Execute (), "task.Execute() should have failed.");
+				Assert.AreEqual (0, task.RemovedDirectories.Length, "Changes should not have been made.");
+				DirectoryAssert.Exists (tempDirectory);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/android/issues/9133
Context: https://learn.microsoft.com/visualstudio/msbuild/copy-task?view=vs-2022

The Design Time Build (DTB) seems to lock files and directories during its build process. 
This is not by design it is just that sometimes a build will try to do something with a 
file that the DTB already has open.

Users will sometimes see this error.

```
Error (active)	XARDF7019	System.UnauthorizedAccessException: Access to the path 'GoogleGson.dll' is denied.
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
   at Xamarin.Android.Tasks.RemoveDirFixed.RunTask() in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs:line 54	MauiApp2 (net9.0-android)	C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.99.0-preview.6.340\tools\Xamarin.Android.Common.targets	2503
```

PR https://github.com/dotnet/android-tools/pull/245 introduced the concept on a "Retry" in the cases of `UnauthorizedAccessException` or `IOException` when the code is `ACCESS_DENIED` or
`ERROR_SHARING_VIOLATION`.  This commit builds on that work to use the API's added to add retry semantics to the `RemoveDirFixed` task. 

This also simplifys the Task somewhat as it had quite complete exception handling. 