### PR TITLE
[tests] run `sdkmanager update` before installing emulators

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -377,6 +377,11 @@
   </Target>
 
   <Target Name="InstallAvdImage" >
+    <!-- Try updating the index first -->
+    <Exec
+        Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; update"
+        ContinueOnError="true"
+    />
     <!-- SDK component installation can be frail, try a few times. -->
     <Exec
         Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"


### PR DESCRIPTION
Seeing if we can get a newer image than:

    $ "/Users/runner/Library/Android/sdk/cmdline-tools/12.0/bin/sdkmanager" "system-images;android-23;default;x86"
    ...
    [===                                    ] 10% Downloading x86-23_r10.zip...