### PR TITLE
[tests] Bump System.Text.Json test package to 8.0.*

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -38,10 +38,10 @@ namespace Xamarin.Android.Build.Tests
 				PackageReferences = {
 					new Package { Id = "Xamarin.AndroidX.AppCompat", Version = "1.3.1.1" },
 					// Using * here, so we explicitly get newer packages
-					new Package { Id = "Microsoft.AspNetCore.Components.WebView", Version = "6.0.0-*" },
-					new Package { Id = "Microsoft.Extensions.FileProviders.Embedded", Version = "6.0.0-*" },
-					new Package { Id = "Microsoft.JSInterop", Version = "6.0.0-*" },
-					new Package { Id = "System.Text.Json", Version = "6.0.0-*" },
+					new Package { Id = "Microsoft.AspNetCore.Components.WebView", Version = "8.0.*" },
+					new Package { Id = "Microsoft.Extensions.FileProviders.Embedded", Version = "8.0.*" },
+					new Package { Id = "Microsoft.JSInterop", Version = "8.0.*" },
+					new Package { Id = "System.Text.Json", Version = "8.0.*" },
 				},
 				Sources = {
 					new BuildItem ("EmbeddedResource", "Foo.resx") {


### PR DESCRIPTION
Some tests on the release/8.0.4xx branch have recently started failing
due to the following warning:

    warning NU1903: Package 'System.Text.Json' 6.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4

We've bumped these packages to 8.0.x in main, and should do the same
here to get the latest versions.