### PR TITLE
[nuget-msi-convert] Do not use new VS component IDs

### DIFF
--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -4,7 +4,7 @@
     <TargetName>Microsoft.NET.Sdk.Android.Workload.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@WORKLOAD_VERSION@</ManifestBuildVersion>
     <EnableSideBySideManifests>true</EnableSideBySideManifests>
-    <UseVisualStudioComponentPrefix>true</UseVisualStudioComponentPrefix>
+    <UseVisualStudioComponentPrefix>false</UseVisualStudioComponentPrefix>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/ab079718118e2b84d7b529a1155138cd7c855e19

We've decided hold off on this change until .NET 10.