### PR TITLE
Rework Design Time Build to use .aar files directly.

### DIFF
--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -21,5 +21,7 @@ steps:
   continueOnError: true
   timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
   retryCountOnTaskFailure: ${{ parameters.retryCountOnTaskFailure }}
+  env:
+    RunningOnCI: true
 
 - template: /build-tools/automation/yaml-templates/kill-processes.yaml

--- a/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
@@ -90,6 +90,7 @@ namespace Xamarin.Android.Prepare
 			"*log",
 			"TestOutput-*.txt",
 			"Timing_*",
+			"*.runsettings",
 		};
 
 		void CopyExtraTestFiles (string destinationRoot, Context context)

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -27,7 +27,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 
 <Target Name="_InjectAaptDependencies">
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(DesignTimeBuild)' != 'True' Or ('$(DesignTimeBuild)' == 'True' And '$(AndroidUseManagedDesignTimeResourceGenerator)' == 'False') ">
     <_SetLatestTargetFrameworkVersionDependsOnTargets>
       $(_SetLatestTargetFrameworkVersionDependsOnTargets);
       _CreateAapt2VersionCache;

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
@@ -45,6 +45,8 @@ Copyright (C) 2016 Xamarin. All rights reserved.
     per TargetFramework.
     -->
     <_DesignerIntermediateOutputPath Condition=" '$(_DesignerIntermediateOutputPath)' == '' And '$(_OuterIntermediateOutputPath)' != '' ">$(_OuterIntermediateOutputPath)</_DesignerIntermediateOutputPath>
+    <_DesignerIntermediateOutputPath Condition=" '$(_DesignerIntermediateOutputPath)' == '' And '$(_OuterIntermediateOutputPath)' != '' And '$(AndroidUseDesignerAssembly)' == 'True' And '$(DesignTimeBuild)' == 'true' ">$(_OuterIntermediateOutputPath)designtime\</_DesignerIntermediateOutputPath>
+    <_DesignerIntermediateOutputPath Condition=" '$(_DesignerIntermediateOutputPath)' == '' And '$(AndroidUseDesignerAssembly)' == 'True' And '$(DesignTimeBuild)' == 'true' ">$(IntermediateOutputPath)designtime\</_DesignerIntermediateOutputPath>
     <_DesignerIntermediateOutputPath Condition=" '$(_DesignerIntermediateOutputPath)' == '' ">$(IntermediateOutputPath)</_DesignerIntermediateOutputPath>
     <_GenerateResourceDesignerAssemblyOutput>$(_DesignerIntermediateOutputPath)$(_DesignerAssemblyName).dll</_GenerateResourceDesignerAssemblyOutput>
     <_GenerateResourceDesignerClassFile Condition=" '$(Language)' == 'F#' ">$(_DesignerIntermediateOutputPath)_$(_DesignerAssemblyName).fs</_GenerateResourceDesignerClassFile>
@@ -56,15 +58,44 @@ Copyright (C) 2016 Xamarin. All rights reserved.
   <Message Text="IntermediateOutputPath: $(IntermediateOutputPath)" />
 </Target>
 
+<Target Name="_GetProjectResourceDirectory" Returns="@(_ProjectReferenceResourceDirectory)">
+  <ItemGroup>
+    <_ProjectReferenceResourceDirectory Include="$(MSBuildProjectDirectory)\$(MonoAndroidResourcePrefix)"
+      StampFile="$(MSBuildProjectFile)"
+      Condition="!Exists('$(OutputPath)$(TargetName).aar')"
+    />
+  </ItemGroup>
+</Target>
+
+<Target Name="_CollectProjectReferenceResources"
+    Condition="'$(AndroidUseDesignerAssembly)' == 'True' And '$(DesignTimeBuild)' == 'True' "
+>
+  <MSBuild
+      Projects="@(ProjectReference)"
+      Targets="_GetProjectResourceDirectory"
+      SkipNonexistentTargets="true"
+  >
+    <Output TaskParameter="TargetOutputs" ItemName="LibraryResourceDirectories" />
+  </MSBuild>
+</Target>
+
+<Target Name="_CalculateDesignTimeAars" Condition=" '$(DesignTimeBuild)' == 'True' ">
+  <ItemGroup>
+    <!-- Only use the aar files if we have not extracted the data -->
+    <_DesignTimeAarFiles Include="@(AndroidAarLibrary)" Condition=" '@(LibraryResourceDirectories->Count())' == '0' " />
+  </ItemGroup>
+</Target>
+
 <Target Name="_GenerateRtxt"
     Condition="'$(AndroidUseDesignerAssembly)' == 'True' And '$(DesignTimeBuild)' == 'True' "
-    DependsOnTargets="_CreatePropertiesCache;_ResolveSdks;_ResolveAndroidTooling;_GetJavaPlatformJar;_GenerateAndroidResourceDir;_SetupDesignerProperties"
+    DependsOnTargets="_CreatePropertiesCache;_ResolveSdks;_ResolveAndroidTooling;_GetJavaPlatformJar;_GenerateAndroidResourceDir;_SetupDesignerProperties;_CollectProjectReferenceResources;_CalculateDesignTimeAars"
     Inputs="$(_AndroidResFlagFile);@(_AndroidResourceDest);@(LibraryResourceDirectories->'%(StampFile)')"
     Outputs="$(_DesignerIntermediateOutputPath)R.txt"
   >
   <!-- Generate an R.txt file using the Managed Parser -->
   <GenerateRtxt
       AdditionalResourceDirectories="@(LibraryResourceDirectories)"
+      AarLibraries="@(_DesignTimeAarFiles)"
       CaseMapFile="$(_GenerateResourceCaseMapFile)"
       JavaPlatformJarPath="$(JavaPlatformJarPath)"
       ResourceDirectory="$(MonoAndroidResDirIntermediate)"
@@ -75,13 +106,14 @@ Copyright (C) 2016 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_GenerateResourceCaseMap"
-    DependsOnTargets="_ComputeAndroidResourcePaths;_SetupDesignerProperties;_GetLibraryImports"
+    DependsOnTargets="_ComputeAndroidResourcePaths;_SetupDesignerProperties;_GetLibraryImports;_CollectProjectReferenceResources;_CalculateDesignTimeAars"
     Inputs="@(_AndroidResourceDest);@(LibraryResourceDirectories->'%(StampFile)')"
     Outputs="$(_GenerateResourceCaseMapFile)"
   >
   <!-- Generate a ResourceMap file for the project and its resources -->
   <GenerateResourceCaseMap
       AdditionalResourceDirectories="@(LibraryResourceDirectories)"
+      AarLibraries="@(_DesignTimeAarFiles)"
       OutputFile="$(_GenerateResourceCaseMapFile)"
       ProjectDir="$(ProjectDir)"
       ResourceDirectory="$(MonoAndroidResDirIntermediate)"
@@ -159,6 +191,8 @@ Copyright (C) 2016 Xamarin. All rights reserved.
 <PropertyGroup>
   <_BuildResourceDesignerDependsOn>
     _SetupDesignerProperties;
+    _ResolveAars;
+    _CalculateDesignTimeAars;
     _GenerateResourceCaseMap;
     _GenerateRtxt;
     _GenerateResourceDesignerIntermediateClass;

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
@@ -83,6 +83,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
   <ItemGroup>
     <!-- Only use the aar files if we have not extracted the data -->
     <_DesignTimeAarFiles Include="@(AndroidAarLibrary)" Condition=" '@(LibraryResourceDirectories->Count())' == '0' " />
+    <_DesignTimeAarFiles Include="@(LibraryProjectZip)" Condition="'%(LibraryProjectZip.Extension)' == '.aar' and '@(LibraryResourceDirectories->Count())' == '0'" />
   </ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -18,7 +18,7 @@ projects.
     <_AarOutputPath>$(OutputPath)$(TargetName).aar</_AarOutputPath>
   </PropertyGroup>
 
-  <Target Name="_ResolveAars">
+  <Target Name="_ResolveAars" AfterTargets="ResolveReferences">
     <ItemGroup>
       <_AarSearchDirectory   Include="@(_ReferencePath->'%(RootDir)%(Directory)')" />
       <_AarSearchDirectory   Include="@(_ReferenceDependencyPaths->'%(RootDir)%(Directory)')" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -90,6 +90,7 @@ _ResolveAssemblies MSBuild target.
       <_AdditionalProperties>
         _ComputeFilesToPublishForRuntimeIdentifiers=true
         ;SelfContained=true
+        ;DesignTimeBuild=$(DesignTimeBuild)
         ;AppendRuntimeIdentifierToOutputPath=true
         ;ResolveAssemblyReferencesFindRelatedSatellites=false
         ;SkipCompilerExecution=true
@@ -105,6 +106,7 @@ _ResolveAssemblies MSBuild target.
       <_ProjectToBuild Include="$(MSBuildProjectFile)" AdditionalProperties="RuntimeIdentifier=%(_RIDs.Identity);$(_AdditionalProperties)" />
     </ItemGroup>
     <MSBuild
+        Condition=" '$(DesignTimeBuild)' != 'true' "
         Projects="@(_ProjectToBuild)"
         BuildInParallel="$(_AndroidBuildRuntimeIdentifiersInParallel)"
         Targets="_ComputeFilesToPublishForRuntimeIdentifiers">

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -165,6 +165,7 @@ properties that determine build ordering.
     </CleanDependsOn>
     <ExportJarToXmlDependsOnTargets>
       _ResolveMonoAndroidSdks;
+      ResolveAssemblyReferences;
       _ExtractLibraryProjectImports;
       _GetLibraryImports;
       _ExtractAar;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -112,14 +112,9 @@ properties that determine build ordering.
     <ResolveReferencesDependsOn>
       $(CoreResolveReferencesDependsOn);
       UpdateAndroidResources;
-      _BuildResourceDesigner;
       UpdateAndroidInterfaceProxies;
       _CheckForInvalidDesignerConfig;
     </ResolveReferencesDependsOn>
-    <DesignTimeResolveAssemblyReferencesDependsOn>
-      $(DesignTimeResolveAssemblyReferencesDependsOn);
-      _BuildResourceDesigner;
-    </DesignTimeResolveAssemblyReferencesDependsOn>
     <_UpdateAndroidResourcesDependsOn>
       $(CoreResolveReferencesDependsOn);
       _CreatePropertiesCache;
@@ -127,7 +122,6 @@ properties that determine build ordering.
       _ComputeAndroidResourcePaths;
       _UpdateAndroidResgen;
       _CreateAar;
-      _BuildResourceDesigner;
     </_UpdateAndroidResourcesDependsOn>
     <CompileDependsOn>
       _SetupMSBuildAllProjects;
@@ -142,9 +136,9 @@ properties that determine build ordering.
       _CollectGeneratedManagedBindingFiles;
       _ClearGeneratedManagedBindings;
       AddBindingsToCompile;
+      $(CompileDependsOn);
       _BuildResourceDesigner;
       _AddResourceDesignerFiles;
-      $(CompileDependsOn);
       _CheckAndroidHttpClientHandlerType;
     </CompileDependsOn>
     <CoreCompileDependsOn>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -27,6 +27,7 @@
   <Import Project="Microsoft.Android.Sdk.DefaultProperties.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props"
       Condition="Exists('$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props')"/>
-  <Import Project="Microsoft.Android.Sdk.NativeAOT.targets" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' " />
+  <Import Project="Microsoft.Android.Sdk.NativeAOT.targets" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' "
+      Condition=" '$(DesignTimeBuild)' != 'true' " />
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -26,8 +26,7 @@
   <Import Project="Microsoft.Android.Sdk.BundledVersions.targets" />
   <Import Project="Microsoft.Android.Sdk.DefaultProperties.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props"
-      Condition="Exists('$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props')"/>
-  <Import Project="Microsoft.Android.Sdk.NativeAOT.targets" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' "
-      Condition=" '$(DesignTimeBuild)' != 'true' " />
+      Condition="Exists('$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props') And '$(DesignTimeBuild)' != 'true' "/>
+  <Import Project="Microsoft.Android.Sdk.NativeAOT.targets" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' And '$(DesignTimeBuild)' != 'true' " />
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Android.Build.Tasks;
@@ -90,7 +91,7 @@ namespace Xamarin.Android.Tasks
 							entryStream.CopyTo (ms);
 						}
 						ms.Position = 0;
-						using (var reader = new StreamReader (ms)) {
+						using (var reader = new StreamReader (ms, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: -1, leaveOpen: true)) {
 							string line;
 							// Read each line until the end of the file
 							while ((line = reader.ReadLine()) != null) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs
@@ -90,14 +90,15 @@ namespace Xamarin.Android.Tasks
 							entryStream.CopyTo (ms);
 						}
 						ms.Position = 0;
-						using var reader = new StreamReader (ms);
-						string line;
-						// Read each line until the end of the file
-						while ((line = reader.ReadLine()) != null) {
-							if (string.IsNullOrEmpty (line))
-								continue;
-							string [] tok = line.Split (';');
-							AddRename (tok [1].Replace ('/', Path.DirectorySeparatorChar), tok [0].Replace ('/', Path.DirectorySeparatorChar));
+						using (var reader = new StreamReader (ms)) {
+							string line;
+							// Read each line until the end of the file
+							while ((line = reader.ReadLine()) != null) {
+								if (string.IsNullOrEmpty (line))
+									continue;
+								string [] tok = line.Split (';');
+								AddRename (tok [1].Replace ('/', Path.DirectorySeparatorChar), tok [0].Replace ('/', Path.DirectorySeparatorChar));
+							}
 						}
 					} finally {
 						MemoryStreamPool.Shared.Return (ms);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateRtxt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateRtxt.cs
@@ -17,6 +17,8 @@ namespace Xamarin.Android.Tasks
 		public string ResourceDirectory { get; set; }
 		public string[] AdditionalResourceDirectories { get; set; }
 
+		public string[] AarLibraries { get; set; }
+
 		public string JavaPlatformJarPath { get; set; }
 
 		public string ResourceFlagFile { get; set; }
@@ -31,7 +33,7 @@ namespace Xamarin.Android.Tasks
 
 			var javaPlatformDirectory = string.IsNullOrEmpty (JavaPlatformJarPath) ? "" : Path.GetDirectoryName (JavaPlatformJarPath);
 			var parser = new FileResourceParser () { Log = Log, JavaPlatformDirectory = javaPlatformDirectory, ResourceFlagFile = ResourceFlagFile};
-			var resources = parser.Parse (ResourceDirectory, AdditionalResourceDirectories, resource_fixup);
+			var resources = parser.Parse (ResourceDirectory, AdditionalResourceDirectories, AarLibraries, resource_fixup);
 
 			// only update if it changed.
 			writer.Write (RTxtFile, resources);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1029,7 +1029,7 @@ namespace Lib1 {
 					Assert.LessOrEqual (libBuilder.LastBuildTime.TotalMilliseconds, maxBuildTimeMs, $"DesignTime build should be less than {maxBuildTimeMs} milliseconds.");
 					Assert.IsFalse (libProj.CreateBuildOutput (libBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen"),
 						"Target '_ManagedUpdateAndroidResgen' should have run.");
-					Assert.IsFalse (appBuilder.DesignTimeBuild (appProj), "Application project should have built");
+					Assert.IsTrue (appBuilder.DesignTimeBuild (appProj), "Application project should have built");
 					Assert.LessOrEqual (appBuilder.LastBuildTime.TotalMilliseconds, maxBuildTimeMs, $"DesignTime build should be less than {maxBuildTimeMs} milliseconds.");
 					Assert.IsFalse (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen"),
 						"Target '_ManagedUpdateAndroidResgen' should have run.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -547,7 +547,7 @@ namespace Foo {
 				var assemblyFile = Path.Combine (intermediate, proj.ProjectName + ".dll");
 				using (var assembly = AssemblyDefinition.ReadAssembly (assemblyFile)) {
 					var typeName = "Com.Balysv.Material.Drawable.Menu.MaterialMenuView";
-					Assert.IsTrue (assembly.MainModule.Types.Any (t => t.FullName == typeName), $"Type `{typeName}` should exist!");
+					Assert.IsTrue (assembly.MainModule.Types.Any (t => t.FullName == typeName), $"Type `{typeName}` should exist in '{assemblyFile}'!");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -544,11 +544,8 @@ namespace Foo {
 				Assert.IsNotNull (element, "api.xml should contain an `api` element!");
 				Assert.IsTrue (element.HasElements, "api.xml should contain elements!");
 
-				var assemblyFile = Path.Combine (intermediate, proj.ProjectName + ".dll");
-				using (var assembly = AssemblyDefinition.ReadAssembly (assemblyFile)) {
-					var typeName = "Com.Balysv.Material.Drawable.Menu.MaterialMenuView";
-					Assert.IsTrue (assembly.MainModule.Types.Any (t => t.FullName == typeName), $"Type `{typeName}` should exist in '{assemblyFile}'!");
-				}
+				var sourceFile = Path.Combine (intermediate, "generated", "src", "Com.Balysv.Material.Drawable.Menu.MaterialMenuView.cs");
+				FileAssert.Exists (sourceFile, $"'{sourceFile}' should have been generated.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -752,6 +752,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void BuildInDesignTimeMode ([Values(false, true)] bool useManagedParser)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -762,20 +763,20 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				builder.Target = "UpdateAndroidResources";
 				builder.Build (proj, parameters: new string[] { "DesignTimeBuild=true" });
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_CreatePropertiesCache"), "target \"_CreatePropertiesCache\" should have been run.");
-				Assert.IsFalse (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"), "target \"_ResolveLibraryProjectImports\' should have been run.");
+				Assert.IsFalse (builder.Output.IsTargetSkipped ("_GenerateRtxt"), "target \"_GenerateRtxt\' should have been run.");
 				var intermediate = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath);
-				var librarycache = Path.Combine (intermediate, "designtime", "libraryprojectimports.cache");
-				Assert.IsTrue (File.Exists (librarycache), $"'{librarycache}' should exist.");
-				librarycache = Path.Combine (intermediate, "libraryprojectimports.cache");
-				Assert.IsFalse (File.Exists (librarycache), $"'{librarycache}' should not exist.");
+				var rTxtFile = Path.Combine (intermediate, "designtime", "R.txt");
+				Assert.IsTrue (File.Exists (rTxtFile), $"'{rTxtFile}' should exist.");
+				rTxtFile = Path.Combine (intermediate, "R.txt");
+				Assert.IsFalse (File.Exists (rTxtFile), $"'{rTxtFile}' should not exist.");
 				builder.Build (proj, parameters: new string[] { "DesignTimeBuild=true" });
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_CreatePropertiesCache"), "target \"_CreatePropertiesCache\" should have been run.");
-				Assert.IsTrue (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"), "target \"_ResolveLibraryProjectImports\' should have been skipped.");
+				Assert.IsTrue (builder.Output.IsTargetSkipped ("_GenerateRtxt"), "target \"_GenerateRtxt\' should have been skipped.");
 				Assert.IsTrue (builder.Clean (proj), "Clean Should have succeeded");
 				builder.Target = "_CleanDesignTimeIntermediateDir";
 				Assert.IsTrue (builder.Build (proj), "_CleanDesignTimeIntermediateDir should have succeeded");
-				librarycache = Path.Combine (intermediate, "designtime", "libraryprojectimports.cache");
-				Assert.IsFalse (File.Exists (librarycache), $"'{librarycache}' should not exist.");
+				rTxtFile = Path.Combine (intermediate, "designtime", "R.txt");
+				Assert.IsFalse (File.Exists (rTxtFile), $"'{rTxtFile}' should not exist.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -35,7 +35,9 @@ namespace Xamarin.Android.Build.Tests
 		{
 			if (!TestEnvironment.CommercialBuildAvailable) {
 				var message = $"'{TestName}' requires a commercial build of .NET for Android.";
-				if (fail) {
+				var runningOnCI = false;
+				bool.TryParse (Environment.GetEnvironmentVariable ("RunningOnCI"), out runningOnCI);
+				if (fail || runningOnCI) {
 					Assert.Fail (message);
 				} else {
 					Assert.Ignore (message);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -101,11 +101,12 @@ namespace Xamarin.ProjectTools
 		public bool DesignTimeBuild (XamarinProject project, string target = "Compile", bool doNotCleanupOnUpdate = false, string [] parameters = null)
 		{
 			if (parameters == null) {
-				return RunTarget (project, target, doNotCleanupOnUpdate, parameters: new string [] { "DesignTimeBuild=True" });
+				return RunTarget (project, target, doNotCleanupOnUpdate, parameters: new string [] { "DesignTimeBuild=True", "SkipCompilerExecution=true" });
 			} else {
-				var designTimeParameters = new string [parameters.Length + 1];
+				var designTimeParameters = new string [parameters.Length + 2];
 				parameters.CopyTo (designTimeParameters, 0);
-				designTimeParameters [parameters.Length] = "DesignTimeBuild=True";
+				designTimeParameters [designTimeParameters.Length - 2] = "DesignTimeBuild=True";
+				designTimeParameters [designTimeParameters.Length - 1] = "SkipCompilerExecution=true";
 				return RunTarget (project, target, doNotCleanupOnUpdate, parameters: designTimeParameters);
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -153,8 +153,8 @@ namespace Xamarin.ProjectTools
 				var result = File.Exists (Path.Combine (AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
 				Console.WriteLine ($"DEBUG! checking `{AndroidMSBuildDirectory}` for `Xamarin.Android.Common.Debugging.targets`: {result}.");
 				if (!result) {
-					Console.WriteLine ($"DEBUG! checking `{LocalDotNetAndroidSdkDirectory}\tools` for `Xamarin.Android.Common.Debugging.targets`: {result}.");
 					result = File.Exists (Path.Combine (LocalDotNetAndroidSdkDirectory, "tools", "Xamarin.Android.Common.Debugging.targets"));
+					Console.WriteLine ($"DEBUG! checking `{LocalDotNetAndroidSdkDirectory}/tools` for `Xamarin.Android.Common.Debugging.targets`: {result}.");
 				}
 				return result;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -125,13 +125,19 @@ namespace Xamarin.ProjectTools
 				"Microsoft.Android.Sdk.Linux";
 
 			var sdkDir = Path.Combine (packsDirectory, sdkName);
-			if (!Directory.Exists (sdkDir))
+			if (!Directory.Exists (sdkDir)) {
+				Console.WriteLine ($"Unable to locate a Microsoft.Android.Sdk in '{sdkDir}'.");
 				return string.Empty;
+			}
 
 			var dirs = from d in Directory.GetDirectories (sdkDir)
 				   let version = ParseVersion (d)
 				   orderby version descending
 				   select d;
+
+			foreach (var dir in dirs) {
+				Console.WriteLine ($"DEBUG! found'{dir}'.");
+			}
 
 			return dirs.FirstOrDefault ();
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -148,7 +148,12 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		public static bool CommercialBuildAvailable => File.Exists (Path.Combine (AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
+		public static bool CommercialBuildAvailable {
+			get {
+				Console.WriteLine ("DEBUG! checking `{AndroidMSBuildDirectory}` for `Xamarin.Android.Common.Debugging.targets`.")
+				return File.Exists (Path.Combine (AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
+			}
+		}
 
 		public static string OSBinDirectory {
 			get {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -150,8 +150,13 @@ namespace Xamarin.ProjectTools
 
 		public static bool CommercialBuildAvailable {
 			get {
-				Console.WriteLine ("DEBUG! checking `{AndroidMSBuildDirectory}` for `Xamarin.Android.Common.Debugging.targets`.");
-				return File.Exists (Path.Combine (AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
+				var result = File.Exists (Path.Combine (AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
+				Console.WriteLine ($"DEBUG! checking `{AndroidMSBuildDirectory}` for `Xamarin.Android.Common.Debugging.targets`: {result}.");
+				if (!result) {
+					Console.WriteLine ($"DEBUG! checking `{LocalDotNetAndroidSdkDirectory}\tools` for `Xamarin.Android.Common.Debugging.targets`: {result}.");
+					result = File.Exists (Path.Combine (LocalDotNetAndroidSdkDirectory, "tools", "Xamarin.Android.Common.Debugging.targets"));
+				}
+				return result;
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -150,7 +150,7 @@ namespace Xamarin.ProjectTools
 
 		public static bool CommercialBuildAvailable {
 			get {
-				Console.WriteLine ("DEBUG! checking `{AndroidMSBuildDirectory}` for `Xamarin.Android.Common.Debugging.targets`.")
+				Console.WriteLine ("DEBUG! checking `{AndroidMSBuildDirectory}` for `Xamarin.Android.Common.Debugging.targets`.");
 				return File.Exists (Path.Combine (AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs
@@ -96,9 +96,8 @@ namespace Xamarin.Android.Tasks
 										entryStream.CopyTo (ms);
 									}
 									ms.Position = 0;
-									using (XmlReader reader = XmlReader.Create (ms)) {
-										ProcessXmlFile (reader, resources);
-									}
+									using XmlReader reader = XmlReader.Create (ms);
+									ProcessXmlFile (reader, resources);
 								} finally {
 									MemoryStreamPool.Shared.Return (ms);
 								}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs
@@ -96,8 +96,9 @@ namespace Xamarin.Android.Tasks
 										entryStream.CopyTo (ms);
 									}
 									ms.Position = 0;
-									using XmlReader reader = XmlReader.Create (ms);
-									ProcessXmlFile (reader, resources);
+									using (XmlReader reader = XmlReader.Create (ms)) {
+										ProcessXmlFile (reader, resources);
+									}
 								} finally {
 									MemoryStreamPool.Shared.Return (ms);
 								}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.CodeDom;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,6 +12,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Utilities;
 using Microsoft.Android.Build.Tasks;
+using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Tasks
 {
@@ -43,7 +45,7 @@ namespace Xamarin.Android.Tasks
 			return null;
 		}
 
-		public IList<R> Parse (string resourceDirectory, IEnumerable<string> additionalResourceDirectories, Dictionary<string, string> resourceMap)
+		public IList<R> Parse (string resourceDirectory, IEnumerable<string> additionalResourceDirectories, IEnumerable<string> aarLibraries, Dictionary<string, string> resourceMap)
 		{
 			Log.LogDebugMessage ($"Parsing Directory {resourceDirectory}");
 			publicXml = LoadPublicXml ();
@@ -69,6 +71,38 @@ namespace Xamarin.Android.Tasks
 					}
 				} else {
 					Log.LogDebugMessage ($"Skipping non-existent directory: {dir}");
+				}
+			}
+			foreach (var aar in aarLibraries ??  Array.Empty<string>()) {
+				Log.LogDebugMessage ($"Processing Aar file {aar}");
+				if (!File.Exists (aar)) {
+					Log.LogDebugMessage ($"Skipping non-existent aar: {aar}");
+					continue;
+				}
+				using (var file = File.Open (aar, FileMode.Open, FileAccess.ReadWrite, FileShare.Read)) {
+					using var zip = ZipArchive.Open (file);
+					foreach (var entry in zip) {
+						if (entry.IsDirectory)
+							continue;
+						if (!entry.FullName.StartsWith ("res"))
+							continue;
+						var ext = Path.GetExtension (entry.FullName);
+						var path = Directory.GetParent (entry.FullName).Name;
+						if (ext == ".xml" || ext == ".axml") {
+							if (string.Compare (path, "raw", StringComparison.OrdinalIgnoreCase) != 0) {
+								var ms = MemoryStreamPool.Shared.Rent ();
+								try {
+									entry.Extract (ms);
+									ms.Position = 0;
+									using XmlReader reader = XmlReader.Create (ms);
+									ProcessXmlFile (reader, resources);
+								} finally {
+									MemoryStreamPool.Shared.Return (ms);
+								}
+							}
+						}
+						ProcessResourceFile (entry.FullName, resources, processXml: false);
+					}
 				}
 			}
 
@@ -172,7 +206,7 @@ namespace Xamarin.Android.Tasks
 			return -1;
 		}
 
-		void ProcessResourceFile (string file, Dictionary<string, ICollection<R>> resources)
+		void ProcessResourceFile (string file, Dictionary<string, ICollection<R>> resources, bool processXml = true)
 		{
 			Log.LogDebugMessage ($"{nameof(ProcessResourceFile)} {file}");
 			var fileName = Path.GetFileNameWithoutExtension (file);
@@ -181,6 +215,10 @@ namespace Xamarin.Android.Tasks
 			if (fileName.EndsWith (".9", StringComparison.OrdinalIgnoreCase))
 				fileName = Path.GetFileNameWithoutExtension (fileName);
 			var path = Directory.GetParent (file).Name;
+			if (!processXml) {
+				CreateResourceField (path, fileName, resources);
+				return;
+			}
 			var ext = Path.GetExtension (file);
 			switch (ext) {
 				case ".xml":
@@ -299,8 +337,6 @@ namespace Xamarin.Android.Tasks
 						fields.Add (r);
 					}
 				}
-				if (field.Type != RType.Array)
-					return;
 				arrayMapping.Add (field, fields.ToArray ());
 
 				field.Ids = new int [attribs.Count];
@@ -321,71 +357,80 @@ namespace Xamarin.Android.Tasks
 
 		void ProcessXmlFile (string file, Dictionary<string, ICollection<R>> resources)
 		{
-			Log.LogDebugMessage ($"{nameof(ProcessXmlFile)}");
 			using (var reader = XmlReader.Create (file)) {
-				while (reader.Read ()) {
-					if (reader.NodeType == XmlNodeType.Whitespace || reader.NodeType == XmlNodeType.Comment)
-						continue;
-					if (reader.IsStartElement ()) {
-						var elementName = reader.Name;
-						var elementNS = reader.NamespaceURI;
-						if (!string.IsNullOrEmpty (elementNS)) {
-							if (elementNS != "http://schemas.android.com/apk/res/android")
-								continue;
-						}
-						if (elementName == "declare-styleable" || elementName == "configVarying" || elementName == "add-resource") {
-							ProcessStyleable (reader.ReadSubtree (), resources);
-							continue;
-						}
-						if (reader.HasAttributes) {
-							string name = null;
-							string type = null;
-							string id = null;
-							string custom_id = null;
-							while (reader.MoveToNextAttribute ()) {
-								if (reader.LocalName == "name")
-									name = reader.Value;
-								if (reader.LocalName == "type")
-									type = reader.Value;
-								if (reader.LocalName == "id") {
-									string[] values = reader.Value.Split ('/');
-									if (values.Length != 2) {
-										id = reader.Value.Replace ("@+id/", "").Replace ("@id/", "");
-									} else {
-										if (values [0] != "@+id" && values [0] != "@id" && !values [0].Contains ("android:")) {
-											custom_id = values [0].Replace ("@", "").Replace ("+", "");
-										}
-										id = values [1];
-									}
+				ProcessXmlFile (reader, resources);
+			}
+		}
 
+		void ProcessXmlFile (XmlReader reader, Dictionary<string, ICollection<R>> resources)
+		{
+			Log.LogDebugMessage ($"{nameof(ProcessXmlFile)}");
+			while (reader.Read ()) {
+				if (reader.NodeType == XmlNodeType.Whitespace || reader.NodeType == XmlNodeType.Comment)
+					continue;
+				if (reader.IsStartElement ()) {
+					var elementName = reader.Name;
+					var elementNS = reader.NamespaceURI;
+					if (!string.IsNullOrEmpty (elementNS)) {
+						if (elementNS != "http://schemas.android.com/apk/res/android")
+							continue;
+					}
+					if (elementName == "declare-styleable" || elementName == "configVarying" || elementName == "add-resource") {
+						try {
+							ProcessStyleable (reader.ReadSubtree (), resources);
+						} catch (Exception ex) {
+							Log.LogErrorFromException (ex);
+						}
+						continue;
+					}
+					if (reader.HasAttributes) {
+						string name = null;
+						string type = null;
+						string id = null;
+						string custom_id = null;
+						while (reader.MoveToNextAttribute ()) {
+							if (reader.LocalName == "name")
+								name = reader.Value;
+							if (reader.LocalName == "type")
+								type = reader.Value;
+							if (reader.LocalName == "id") {
+								string[] values = reader.Value.Split ('/');
+								if (values.Length != 2) {
+									id = reader.Value.Replace ("@+id/", "").Replace ("@id/", "");
+								} else {
+									if (values [0] != "@+id" && values [0] != "@id" && !values [0].Contains ("android:")) {
+										custom_id = values [0].Replace ("@", "").Replace ("+", "");
+									}
+									id = values [1];
 								}
-								if (reader.LocalName == "inflatedId") {
-									string inflateId = reader.Value.Replace ("@+id/", "").Replace ("@id/", "");
-									var r = new R () {
-										ResourceTypeName = "id",
-										Identifier = inflateId,
-										Id = -1,
-									};
-									Log.LogDebugMessage ($"Adding 1 {r}");
-									resources[r.ResourceTypeName].Add (r);
-								}
+
 							}
-							if (name?.Contains ("android:") ?? false)
-								continue;
-							if (id?.Contains ("android:") ?? false)
-								continue;
-							// Move the reader back to the element node.
-							reader.MoveToElement ();
-							if (!string.IsNullOrEmpty (name)) {
-								CreateResourceField (type ?? elementName, name, resources);
+							if (reader.LocalName == "inflatedId") {
+								string inflateId = reader.Value.Replace ("@+id/", "").Replace ("@id/", "");
+								var r = new R () {
+									ResourceTypeName = "id",
+									Identifier = inflateId,
+									Id = -1,
+								};
+								Log.LogDebugMessage ($"Adding 1 {r}");
+								resources[r.ResourceTypeName].Add (r);
 							}
-							if (!string.IsNullOrEmpty (custom_id) && !resources.ContainsKey (custom_id)) {
-								resources.Add (custom_id, new SortedSet<R> (new RComparer ()));
-								custom_types.Add (custom_id);
-							}
-							if (!string.IsNullOrEmpty (id)) {
-								CreateResourceField (custom_id ?? "id", id.Replace ("-", "_").Replace (".", "_"), resources);
-							}
+						}
+						if (name?.Contains ("android:") ?? false)
+							continue;
+						if (id?.Contains ("android:") ?? false)
+							continue;
+						// Move the reader back to the element node.
+						reader.MoveToElement ();
+						if (!string.IsNullOrEmpty (name)) {
+							CreateResourceField (type ?? elementName, name, resources);
+						}
+						if (!string.IsNullOrEmpty (custom_id) && !resources.ContainsKey (custom_id)) {
+							resources.Add (custom_id, new SortedSet<R> (new RComparer ()));
+							custom_types.Add (custom_id);
+						}
+						if (!string.IsNullOrEmpty (id)) {
+							CreateResourceField (custom_id ?? "id", id.Replace ("-", "_").Replace (".", "_"), resources);
 						}
 					}
 				}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEntryExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEntryExtensions.cs
@@ -1,0 +1,8 @@
+using System;
+using System.IO.Compression;
+public static class ZipArchiveEntryExtensions {
+    public static bool IsDirectory (this ZipArchiveEntry entry)
+    {
+        return entry.Length == 0 && entry.FullName.EndsWith ("/", StringComparison.Ordinal);
+    }
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -548,11 +548,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       FormatArguments="AndroidFastDeploymentType;9"
       Condition=" '$(AndroidFastDeploymentType)' != '' "
   />
-  <AndroidWarning Code="XA1037"
-      ResourceName="XA1037"
-      FormatArguments="AndroidUseManagedDesignTimeResourceGenerator;11"
-      Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' != '' "
-  />
 </Target>
 
 <Target Name="_CheckNonIdealConfigurations"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -118,7 +118,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 -->
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Installer.Common.props"
-	Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Installer.Common.props')"/>
+	Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Installer.Common.props') And '$(DesignTimeBuild)' != 'true'"/>
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.props"
 	Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Android.Common.props')" />
@@ -361,7 +361,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <!-- As we split up/refactor this file, put new imports here -->
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.D8.targets" Condition=" '$(AndroidDexTool)' == 'd8' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
-<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Assets.targets" />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Assets.targets" Condition=" '$(DesignTimeBuild)' != 'true' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DesignTime.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.EmbeddedResource.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Javac.targets" />
@@ -2865,14 +2865,14 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets"
-        Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets')"/>
+        Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets') And '$(DesignTimeBuild)' != 'true' "/>
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Application.targets"
         Condition=" '$(AndroidApplication)' == 'True' "/>
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Designer.targets" />
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Installer.Common.targets"
-        Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Installer.Common.targets')"/>
+        Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Installer.Common.targets') And '$(DesignTimeBuild)' != 'true' "/>
 <!--
 *******************************************
   Extensibility hook that allows VS to

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -364,7 +364,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Assets.targets" Condition=" '$(DesignTimeBuild)' != 'true' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DesignTime.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.EmbeddedResource.targets" />
-<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Javac.targets" />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Javac.targets" Condition=" '$(DesignTimeBuild)' != 'true' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Resource.Designer.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Tooling.targets" />
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -364,7 +364,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Assets.targets" Condition=" '$(DesignTimeBuild)' != 'true' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DesignTime.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.EmbeddedResource.targets" />
-<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Javac.targets" Condition=" '$(DesignTimeBuild)' != 'true' " />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Javac.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Resource.Designer.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Tooling.targets" />
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -548,6 +548,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       FormatArguments="AndroidFastDeploymentType;9"
       Condition=" '$(AndroidFastDeploymentType)' != '' "
   />
+  <AndroidWarning Code="XA1037"
+      ResourceName="XA1037"
+      FormatArguments="AndroidUseManagedDesignTimeResourceGenerator;11"
+      Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' != '' "
+  />
 </Target>
 
 <Target Name="_CheckNonIdealConfigurations"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -33,6 +33,7 @@ This file is used by all project types, including binding projects.
   </PropertyGroup>
 
   <Target Name="_ResolveLibraryProjectImports"
+      Condition="'$(DesignTimeBuild)' != 'true'"
       DependsOnTargets="$(CoreResolveReferencesDependsOn)"
       Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths);@(AndroidAarLibrary);$(_AndroidBuildPropertiesCache)"
       Outputs="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -33,7 +33,7 @@ This file is used by all project types, including binding projects.
   </PropertyGroup>
 
   <Target Name="_ResolveLibraryProjectImports"
-      Condition="'$(DesignTimeBuild)' != 'true'"
+      Condition="'$(DesignTimeBuild)' != 'true' or ('$(DesignTimeBuild)' == 'true' and '$(AndroidUseManagedDesignTimeResourceGenerator)' == 'true') "
       DependsOnTargets="$(CoreResolveReferencesDependsOn)"
       Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths);@(AndroidAarLibrary);$(_AndroidBuildPropertiesCache)"
       Outputs="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp">

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -395,5 +395,26 @@ namespace Xamarin.Android.Build.Tests
 				});
 			}
 		}
+
+		[Test]
+		public void DesignTimeBuild_CSharp_From_Clean ()
+		{
+			AssertCommercialBuild (); // This test will fail without Fast Deployment
+
+			var proj = CreateApplicationProject ();
+			proj.PackageName = "com.xamarin.designtimebuild_csharp_from_clean";
+			proj.PackageReferences.Add (KnownPackages.AndroidXAppCompat);
+			proj.MainActivity = proj.DefaultMainActivity;
+			using (var builder = CreateBuilderWithoutLogFile ()) {
+				builder.BuildLogFile = "designtimebuild.log";
+				builder.Verbosity = LoggerVerbosity.Quiet;
+				builder.Clean (proj);
+				builder.Restore (proj);
+				builder.AutomaticNuGetRestore = false;
+				Profile (builder, b => {
+					b.DesignTimeBuild (proj, "CoreCompile", parameters: new string[] { "BuildingInsideVisualStudio=true" });
+				});
+			}
+		}
 	}
 }

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -406,6 +406,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.PackageReferences.Add (KnownPackages.AndroidXAppCompat);
 			proj.MainActivity = proj.DefaultMainActivity;
 			using (var builder = CreateBuilderWithoutLogFile ()) {
+				builder.ThrowOnBuildFailure = false;
 				builder.BuildLogFile = "designtimebuild.log";
 				builder.Verbosity = LoggerVerbosity.Quiet;
 				builder.Clean (proj);

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -11,7 +11,7 @@ using Xamarin.ProjectTools;
 namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
-	[Category ("Performance")]
+	//[Category ("Performance")]
 	public class PerformanceTest : DeviceTest
 	{
 		const int Retry = 2;

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -412,7 +412,7 @@ namespace Xamarin.Android.Build.Tests
 				builder.Restore (proj);
 				builder.AutomaticNuGetRestore = false;
 				Profile (builder, b => {
-					b.DesignTimeBuild (proj, "CoreCompile", parameters: new string[] { "BuildingInsideVisualStudio=true" });
+					b.DesignTimeBuild (proj, "CoreCompile", parameters: new string[] { "BuildingInsideVisualStudio=true", "SkipCompilerExecution=true" });
 				});
 			}
 		}

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -14,4 +14,4 @@ Install_CSharp_Change,4000
 Install_XAML_Change,3750
 Install_CSharp_FromClean,3000
 Install_CSharp_FromClean,20000
-DesignTimeBuild_CSharp_From_Clean,1000
+DesignTimeBuild_CSharp_From_Clean,2000

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -14,4 +14,4 @@ Install_CSharp_Change,4000
 Install_XAML_Change,3750
 Install_CSharp_FromClean,3000
 Install_CSharp_FromClean,20000
-DesignTimeBuild_CSharp_From_Clean,4000
+DesignTimeBuild_CSharp_From_Clean,1000

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -14,3 +14,4 @@ Install_CSharp_Change,4000
 Install_XAML_Change,3750
 Install_CSharp_FromClean,3000
 Install_CSharp_FromClean,20000
+DesignTimeBuild_CSharp_From_Clean,4000


### PR DESCRIPTION
Context https://github.com/dotnet/maui/issues/25207
Also

1. Only import targets we actually need for a DTB
2. re-order the targets to they run in the right places
3. don't run targets we don't need to. 
4. move all design time files (as much as possible) to the `designtime` folder.