### PR TITLE
Fix printf format for the library name hash

### DIFF
--- a/src/native/monodroid/embedded-assemblies-zip.cc
+++ b/src/native/monodroid/embedded-assemblies-zip.cc
@@ -293,7 +293,7 @@ EmbeddedAssemblies::zip_load_assembly_store_entries (std::vector<uint8_t> const&
 			apk_entry->offset = state.data_offset;
 			apk_entry->fd = state.file_fd;
 
-			log_debug (LOG_ASSEMBLY, "Found a shared library entry %s (index: %u; name: %s; hash: 0x%zx; apk offset: %u)", entry_name.get (), number_of_zip_dso_entries, name, apk_entry->name_hash, apk_entry->offset);
+			log_debug (LOG_ASSEMBLY, "Found a shared library entry %s (index: %u; name: %s; hash: 0x%llx; apk offset: %u)", entry_name.get (), number_of_zip_dso_entries, name, apk_entry->name_hash, apk_entry->offset);
 			number_of_zip_dso_entries++;
 		}
 	}


### PR DESCRIPTION
Hash is always 64-bit, even on 32-bit platforms, use the correct
format (`%llx`) to fix incorrect value conversion on 32-bit targets.