### PR TITLE
$(AndroidPackVersionSuffix)=preview.1; main is 35.99.x

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,8 +35,8 @@
          * Major/Minor match Android stable API level, such as 30.0 for API 30.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>35.0.1</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rtm</AndroidPackVersionSuffix>
+    <AndroidPackVersion>35.99.0</AndroidPackVersion>
+    <AndroidPackVersionSuffix>preview.1</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
We branched for .NET 9 GA from b90c5590 into `release/9.0.1xx`; the main branch is now .NET 10 Preview 1.

Using 35.99.x for now, until we know that API 36 is a stable API.