### PR TITLE
[release/9.0.1xx] Use stable 35.0.x branding

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,10 @@
          * Major/Minor match Android stable API level, such as 30.0 for API 30.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>35.0.1</AndroidPackVersion>
+    <AndroidPackVersion>35.0.2</AndroidPackVersion>
+    <AndroidPackVersionPatchIndex>$(AndroidPackVersion.LastIndexOf("."))</AndroidPackVersionPatchIndex>
+    <AndroidPackVersionMajorMinor>$(AndroidPackVersion.Substring(0,$(AndroidPackVersionPatchIndex)))</AndroidPackVersionMajorMinor>
+    <AndroidPackVersionPatch>$(AndroidPackVersion.Substring($([MSBuild]::Add($(AndroidPackVersionPatchIndex), 1))))</AndroidPackVersionPatch>
     <AndroidPackVersionSuffix>rtm</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -83,7 +83,7 @@
     <ReplaceFileContents
         SourceFile="vs-workload.in.props"
         DestinationFile="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\vs-workload.props"
-        Replacements="@PACK_VERSION_LONG@=$(AndroidPackVersionLong);@PACK_VERSION_SHORT@=$(AndroidMSIVersion);@WORKLOAD_VERSION@=$(AndroidMSIVersion);@VSMAN_VERSION@=$(DotNetTargetFramework)"
+        Replacements="@PACK_VERSION_LONG@=$(AndroidPackVersionLong);@PACK_VERSION_SHORT@=$(AndroidPackVersionLong);@WORKLOAD_VERSION@=$(AndroidMSIVersion);@VSMAN_VERSION@=$(DotNetTargetFramework)"
     />
   </Target>
 

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -81,9 +81,10 @@
       <_AndroidPackBranch>$([System.Text.RegularExpressions.Regex]::Replace('$(XAVersionBranch)', '[^a-zA-Z0-9-]', '-'))</_AndroidPackBranch>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' and $(XAVersionBranch.StartsWith('release/'))">$(AndroidPackVersionSuffix).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(_AndroidPackBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
-      <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)</AndroidPackVersionLong>
-      <AndroidMSIVersion>$(AndroidPackVersion).$(PackVersionCommitCount)</AndroidMSIVersion>
+      <AndroidPackVersionLong>$(AndroidPackVersionMajorMinor).$([MSBuild]::Add($(AndroidPackVersionPatch), $(PackVersionCommitCount)))</AndroidPackVersionLong>
+      <AndroidMSIVersion>$(AndroidPackVersionLong).0</AndroidMSIVersion>
       <IsStableBuild Condition=" '$(AndroidPackVersionSuffix)' == 'rtm' and $(XAVersionBranch.StartsWith('release/')) ">true</IsStableBuild>
     </PropertyGroup>
+    <Message Text="XAVersionInfo: $(XAVersionBranch)/$(XAVersionHash) - PackVersion: $(AndroidPackVersionLong) MSIVersion: $(AndroidMSIVersion) IsStable: $(IsStableBuild)" />
   </Target>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/0f2a3231c564b47acbbd4857c17ed9efe4bafcdc
Context: https://github.com/dotnet/android/commit/4ea5dbb921ccebb93f2a03d33169d2ebb6248936

Brings in stable versioning changes from previous .NET 8 and .NET 7
release branches.  We've historically added a few new version properties
to represent the stable version and calculate the patch delta.

`$(AndroidPackVersion)` has been updated to "reset" the commit distance.