### PR TITLE
[Xamarin.Android.Build.Tasks] fix $DOTNET_MODIFIABLE_ASSEMBLIES when FastDev is off

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -72,7 +72,7 @@ properties that determine build ordering.
       _ConvertCustomView;
       $(_AfterConvertCustomView);
       $(AfterGenerateAndroidManifest);
-      _GenerateEnvironmentFiles;
+      _ReadAndroidManifest;
       _CompileJava;
       _CreateApplicationSharedLibraries;
       _CompileDex;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1796,7 +1796,7 @@ because xbuild doesn't support framework reference assemblies.
 		_ManifestMerger;
 		_ConvertCustomView;
 		$(_AfterConvertCustomView);
-		_GenerateEnvironmentFiles;
+		_ReadAndroidManifest;
 		_GetLibraryImports;
 		_CheckDuplicateJavaLibraries;
 		UpdateAndroidAssets;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1455,7 +1455,7 @@ because xbuild doesn't support framework reference assemblies.
   </_GenerateJavaStubsDependsOnTargets>
 </PropertyGroup>
 
-<Target Name="_GetGenerateJavaStubsInputs">
+<Target Name="_GetGenerateJavaStubsInputs" DependsOnTargets="_GenerateEnvironmentFiles">
   <ItemGroup>
     <_GenerateJavaStubsInputs Include="@(_AndroidMSBuildAllProjects)" />
     <_GenerateJavaStubsInputs Include="$(_ResolvedUserAssembliesHashFile)" />
@@ -1616,7 +1616,7 @@ because xbuild doesn't support framework reference assemblies.
   </PrepareAbiItems>
 </Target>
 
-<Target Name="_GenerateEnvironmentFiles" DependsOnTargets="_ReadAndroidManifest">
+<Target Name="_GenerateEnvironmentFiles">
   <ItemGroup>
     <_GeneratedAndroidEnvironment Include="__XA_PACKAGE_NAMING_POLICY__=$(AndroidPackageNamingPolicy)" />
     <_GeneratedAndroidEnvironment Include="mono.enable_assembly_preload=0" Condition=" '$(AndroidEnablePreloadAssemblies)' != 'True' " />

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -951,12 +951,20 @@ namespace UnnamedProject
 		}
 
 		[Test]
-		public void FastDeployEnvironmentFiles ([Values (false, true)] bool isRelease)
+		[TestCase (false, true)]
+		[TestCase (false, false)]
+		[TestCase (true, false)]
+		public void FastDeployEnvironmentFiles (bool isRelease, bool embedAssembliesIntoApk)
 		{
+			if (embedAssembliesIntoApk) {
+				AssertCommercialBuild ();
+			}
+
 			var proj = new XamarinAndroidApplicationProject {
 				ProjectName = nameof (FastDeployEnvironmentFiles),
 				RootNamespace = nameof (FastDeployEnvironmentFiles),
 				IsRelease = isRelease,
+				EmbedAssembliesIntoApk = embedAssembliesIntoApk,
 				EnableDefaultItems = true,
 				OtherBuildItems = {
 					new BuildItem("AndroidEnvironment", "env.txt") {


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10431207&view=ms.vss-test-web.build-test-results-tab&runId=114098346&resultId=100000&paneView=debug

The `FastDeployEnvironmentFiles(false)` test fails on PRs from forks, because the "Fast Deployment" feature is not included in OSS builds.

The problem appears to be related to target ordering:

* `_GetGenerateJavaStubsInputs` : uses `@(AndroidEnvironment)` to set `@(_EnvironmentFiles)`

* `_GetGenerateJavaStubs` : must have same `Inputs` as `_GeneratePackageManagerJava`

* `_GeneratePackageManagerJava`: actually uses `@(_EnvironmentFiles)`

* `_GenerateEnvironmentFiles` : creates a new `@(AndroidEnvironment)` file, that won't be used!

But when using either a `Release` build or `Debug` build with `FastDev` enabled, everything works fine.

To fix this, we can rework the target ordering:

* `_GetGenerateJavaStubsInputs` depends on `_GenerateEnvironmentFiles`

* Unfortunately, this is now a circular dependency that causes an MSBuild error.

* `_GenerateEnvironmentFiles` no longer depends on `_ReadAndroidManifest` to break the cycle.

I does not appear that `_ReadAndroidManifest` is needed, as no properties created there are used.