### PR TITLE
[Xamarin.Android.Build.Tasks] fix Debug mode and $(PublishTrimmed)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -185,7 +185,8 @@ _ResolveAssemblies MSBuild target.
 
   <Target Name="_PrepareAssemblies"
       DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)">
-    <ItemGroup Condition=" '$(PublishTrimmed)' != 'true' ">
+    <!-- Condition should be inverse of <ItemGroup> below -->
+    <ItemGroup Condition=" '$(PublishTrimmed)' != 'true' or '$(AndroidIncludeDebugSymbols)' == 'true' ">
       <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"          Condition=" '%(DestinationSubPath)' != '' " />
       <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"      Condition=" '%(DestinationSubPath)' != '' " />
       <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" Condition=" '%(DestinationSubPath)' != '' " />
@@ -194,7 +195,8 @@ _ResolveAssemblies MSBuild target.
       <_ShrunkUserAssemblies        Include="@(_ResolvedUserAssemblies)" />
       <_ShrunkFrameworkAssemblies   Include="@(_ResolvedFrameworkAssemblies)" />
     </ItemGroup>
-    <ItemGroup Condition=" '$(PublishTrimmed)' == 'true' ">
+    <!-- Condition should match <ProcessAssemblies/> task's logic for ShrunkAssemblies -->
+    <ItemGroup Condition=" '$(PublishTrimmed)' == 'true' and '$(AndroidIncludeDebugSymbols)' != 'true' ">
       <_ResolvedAssemblies          Include="@(ResolvedAssemblies)" />
       <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies)" />
       <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies)" />


### PR DESCRIPTION
There is a problem if you have the combination:

* `Configuration=Debug`

* `PublishTrimmed=true`

We emit an `XA0119` warning with this combination, as there is not a good reason to do it.

But unfortunately, the build will be completely broken as all the .NET assemblies don't make it to the `.apk`! I could reproduce this in a test.

The fix is that the logic in the `<ProcessAssemblies/>` MSBuild task needs to match the logic in the `_PrepareAssemblies` MSBuild target:

    if (PublishTrimmed && !AndroidIncludeDebugSymbols) {
        //...
        ShrunkAssemblies = shrunkAssemblies.ToArray ();
    }

Should match:

    <ItemGroup Condition=" '$(PublishTrimmed)' == 'true' and '$(AndroidIncludeDebugSymbols)' != 'true' ">

With the preceding `<ItemGroup>` having the inverse of this `Condition`.

Going forward, we could probably refactor some of this logic to make things simpler, but this is a reasonable fix for now.