### PR TITLE
[tests] track dotnet/maui/release/9.0.1xx

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -33,7 +33,7 @@ resources:
   - repository: maui
     type: github
     name: dotnet/maui
-    ref: refs/heads/net9.0
+    ref: refs/heads/release/9.0.1xx
     endpoint: xamarin
 
 parameters:


### PR DESCRIPTION
This should fix the `MAUI Integration` test lane.