### PR TITLE
[Xamarin.Android.Build.Tasks] add missing `Condition` in `AutoImport.props`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -62,7 +62,7 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
     <ProguardConfiguration Include="**\proguard-rules.pro" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '9.0')) ">
     <AndroidPackagingOptionsExclude Include="DebugProbesKt.bin" />
     <AndroidPackagingOptionsExclude Include="$([MSBuild]::Escape('*.kotlin*'))" />
     <AndroidPackagingOptionsInclude Include="$([MSBuild]::Escape('*.kotlin_builtins'))" />


### PR DESCRIPTION
One of the "gotchas" with `AutoImport.props`, is the file is imported by literally *all* .NET projects. Even .NET 8 and .NET 9 Android projects import their files on top of each other...

This means every `<ItemGroup>` needs a `Condition` that checks:

* is this Android?

* is this the expected .NET framework version?

`<ItemGroup>`s in `AutoImport.props` should have, something like:

    <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '9.0')) ">

`$(EnableDefaultAndroidItems)` checks also work for some cases, but .NET MAUI turns this off in favor of their own wildcards:

https://github.com/dotnet/maui/blob/f269ef3de701043910c941bbbfcbdb7422cc245c/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.SingleProject.Before.targets#L10