### PR TITLE
Bump NDK to r28

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "27c";
-		public const string AndroidNdkPkgRevision = "27.2.12479018";
+		public const string AndroidNdkVersion = "28-beta2";
+		public const string AndroidNdkPkgRevision = "28.0.12674087-rc1";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 21;
 

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "28-beta2";
-		public const string AndroidNdkPkgRevision = "28.0.12674087-rc1";
+		public const string AndroidNdkVersion = "28-beta3";
+		public const string AndroidNdkPkgRevision = "28.0.12916984-rc2";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 21;
 

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "28-beta3";
-		public const string AndroidNdkPkgRevision = "28.0.12916984-rc2";
+		public const string AndroidNdkVersion = "28";
+		public const string AndroidNdkPkgRevision = "28.0.13004108";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 21;
 


### PR DESCRIPTION
Changes: https://github.com/android/ndk/wiki/Changelog-r28

Important changes:

   * Toolchain switches to LLVM 19.0.0
   * 16k page alignment is enabled by default