### PR TITLE
[build] fix missing `darc-pub-dotnet-android-*` feed for MAUI

### DIFF
--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -58,26 +58,23 @@
       Query="/Project/ItemGroup/PackageDownload[contains(@Include,'Microsoft.NET.Sdk.Android.Manifest-')]/@Include" />
     <XmlPeek
         XmlInputPath="$(_Root)NuGet.config"
-        Query="/configuration/packageSources/add[starts-with(@key,'darc-pub-dotnet-android-')]/@key">
-      <Output TaskParameter="Result" PropertyName="_DotNetAndroidNuGetKey" />
+        Query="/configuration/packageSources/add[starts-with(@key,'darc-pub-dotnet-android-')]">
+      <Output TaskParameter="Result" ItemName="_DotNetAndroidFeeds" />
     </XmlPeek>
     <XmlPeek
-        XmlInputPath="$(_Root)NuGet.config"
-        Query="/configuration/packageSources/add[starts-with(@key,'darc-pub-dotnet-android-')]/@value">
-      <Output TaskParameter="Result" PropertyName="_DotNetAndroidNuGetValue" />
+        Condition=" '@(_DotNetAndroidFeeds->Count())' != '0' "
+        XmlInputPath="$(MauiSourcePath)\NuGet.config"
+        Query="/configuration/packageSources/*">
+      <Output TaskParameter="Result" ItemName="_DotNetMauiFeeds" />
     </XmlPeek>
-    <!-- Updates an element such as <add key="nuget-only" value="NUGET_ONLY_PLACEHOLDER" /> -->
+    <ItemGroup>
+      <_DotNetMauiFeeds Include="@(_DotNetAndroidFeeds)" />
+    </ItemGroup>
     <XmlPoke
-        Condition=" '$(_DotNetAndroidNuGetValue)' != '' "
+        Condition=" '@(_DotNetAndroidFeeds->Count())' != '0' "
         XmlInputPath="$(MauiSourcePath)\NuGet.config"
-        Value="$(_DotNetAndroidNuGetValue)"
-        Query="/configuration/packageSources/add[@key='nuget-only']/@value"
-    />
-    <XmlPoke
-        Condition=" '$(_DotNetAndroidNuGetKey)' != '' "
-        XmlInputPath="$(MauiSourcePath)\NuGet.config"
-        Value="$(_DotNetAndroidNuGetKey)"
-        Query="/configuration/packageSources/add[@key='nuget-only']/@key"
+        Value="@(_DotNetMauiFeeds, ' ')"
+        Query="/configuration/packageSources"
     />
   </Target>
 

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -66,7 +66,13 @@
         Condition=" '$(_DotNetAndroidNuGetSource)' != '' "
         XmlInputPath="$(MauiSourcePath)\NuGet.config"
         Value="$(_DotNetAndroidNuGetSource)"
-        Query="/configuration/packageSources/add[@value='NUGET_ONLY_PLACEHOLDER']/@value"
+        Query="/configuration/packageSources/add[@key='nuget-only']/@value"
+    />
+    <XmlPoke
+        Condition=" '$(_DotNetAndroidNuGetSource)' != '' "
+        XmlInputPath="$(MauiSourcePath)\NuGet.config"
+        Value="false"
+        Query="/configuration/disabledPackageSources/add[@key='nuget-only']/@value"
     />
   </Target>
 

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -56,6 +56,18 @@
       XmlInputPath="$(MauiSourcePath)\src\DotNet\Dependencies\Workloads.csproj"
       Value="Microsoft.NET.Sdk.Android.Manifest-$(DotNetSdkManifestsFolder)"
       Query="/Project/ItemGroup/PackageDownload[contains(@Include,'Microsoft.NET.Sdk.Android.Manifest-')]/@Include" />
+    <XmlPeek
+        XmlInputPath="$(_Root)NuGet.config"
+        Query="/configuration/packageSources/add[starts-with(@key,'darc-pub-dotnet-android-')]/@value">
+      <Output TaskParameter="Result" PropertyName="_DotNetAndroidNuGetSource" />
+    </XmlPeek>
+    <!-- Updates an element such as <add key="nuget-only" value="NUGET_ONLY_PLACEHOLDER" /> -->
+    <XmlPoke
+        Condition=" '$(_DotNetAndroidNuGetSource)' != '' "
+        XmlInputPath="$(MauiSourcePath)\NuGet.config"
+        Value="$(_DotNetAndroidNuGetSource)"
+        Query="/configuration/packageSources/add[@value='NUGET_ONLY_PLACEHOLDER']/@value"
+    />
   </Target>
 
   <Target Name="InstallMaui">

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -58,21 +58,26 @@
       Query="/Project/ItemGroup/PackageDownload[contains(@Include,'Microsoft.NET.Sdk.Android.Manifest-')]/@Include" />
     <XmlPeek
         XmlInputPath="$(_Root)NuGet.config"
+        Query="/configuration/packageSources/add[starts-with(@key,'darc-pub-dotnet-android-')]/@key">
+      <Output TaskParameter="Result" PropertyName="_DotNetAndroidNuGetKey" />
+    </XmlPeek>
+    <XmlPeek
+        XmlInputPath="$(_Root)NuGet.config"
         Query="/configuration/packageSources/add[starts-with(@key,'darc-pub-dotnet-android-')]/@value">
-      <Output TaskParameter="Result" PropertyName="_DotNetAndroidNuGetSource" />
+      <Output TaskParameter="Result" PropertyName="_DotNetAndroidNuGetValue" />
     </XmlPeek>
     <!-- Updates an element such as <add key="nuget-only" value="NUGET_ONLY_PLACEHOLDER" /> -->
     <XmlPoke
-        Condition=" '$(_DotNetAndroidNuGetSource)' != '' "
+        Condition=" '$(_DotNetAndroidNuGetValue)' != '' "
         XmlInputPath="$(MauiSourcePath)\NuGet.config"
-        Value="$(_DotNetAndroidNuGetSource)"
+        Value="$(_DotNetAndroidNuGetValue)"
         Query="/configuration/packageSources/add[@key='nuget-only']/@value"
     />
     <XmlPoke
-        Condition=" '$(_DotNetAndroidNuGetSource)' != '' "
+        Condition=" '$(_DotNetAndroidNuGetKey)' != '' "
         XmlInputPath="$(MauiSourcePath)\NuGet.config"
-        Value="false"
-        Query="/configuration/disabledPackageSources/add[@key='nuget-only']/@value"
+        Value="$(_DotNetAndroidNuGetKey)"
+        Query="/configuration/packageSources/add[@key='nuget-only']/@key"
     />
   </Target>
 


### PR DESCRIPTION
Our MAUI integration lane currently fails with:

    Workload installation failed: Version 34.0.145 of package microsoft.android.sdk.windows is not found in NuGet feeds...

They are missing the `darc-pub-dotnet-android-df9aaf2-1` feed containing our .NET 8 package on the dotnet/maui/net9.0 branch.

To fix this, let's read our `NuGet.config` and add any sources that start with `darc-pub-dotnet-android-*` into their `NuGet.config`.

Going forward, the lane should work without issue.