### PR TITLE
[Xamarin.Android.Build.Tasks] implement `dotnet run` with an MSBuild target

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -15,8 +15,6 @@ This file contains targets specific for Android application projects.
     <UseAppHost>false</UseAppHost>
     <!-- see: https://github.com/xamarin/xamarin-macios/blob/a6eb528197854c074d9dd5847328c096890337be/dotnet/targets/Xamarin.Shared.Sdk.props#L38-L52 -->
     <_RuntimeIdentifierUsesAppHost>false</_RuntimeIdentifierUsesAppHost>
-    <RunCommand>dotnet</RunCommand>
-    <RunArguments>build &quot;$(MSBuildProjectFullPath)&quot; -target:Run --configuration &quot;$(Configuration)&quot;</RunArguments>
 
     <!-- If Xamarin.Android.Common.Debugging.targets exists, we can rely on _Run for debugging. -->
     <_RunDependsOn Condition=" '$(_XASupportsFastDev)' == 'true' ">
@@ -27,7 +25,28 @@ This file contains targets specific for Android application projects.
       Install;
       StartAndroidActivity;
     </_RunDependsOn>
+    <_AndroidComputeRunArgumentsDependsOn>
+      Install;
+    </_AndroidComputeRunArgumentsDependsOn>
   </PropertyGroup>
+
+  <Target Name="_AndroidComputeRunArguments"
+      BeforeTargets="ComputeRunArguments"
+      DependsOnTargets="$(_AndroidComputeRunArgumentsDependsOn)">
+    <GetAndroidActivityName
+        Condition=" '$(AndroidLaunchActivity)' == '' "
+        ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml">
+      <Output TaskParameter="ActivityName" PropertyName="AndroidLaunchActivity" />
+    </GetAndroidActivityName>
+    <PropertyGroup>
+      <RunCommand>$(AdbToolExe)</RunCommand>
+      <RunCommand Condition=" $(RunCommand) == '' and $([MSBuild]::IsOSPlatform('windows')) ">adb.exe</RunCommand>
+      <RunCommand Condition=" $(RunCommand) == '' and !$([MSBuild]::IsOSPlatform('windows')) ">adb</RunCommand>
+      <RunCommand>$([System.IO.Path]::Combine ('$(AdbToolPath)', '$(RunCommand)'))</RunCommand>
+      <RunArguments>$(AdbTarget) shell am start -S -n &quot;$(_AndroidPackage)/$(AndroidLaunchActivity)&quot;</RunArguments>
+      <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
+    </PropertyGroup>
+  </Target>
 
   <Target Name="Run" DependsOnTargets="$(_RunDependsOn)" />
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -29,6 +29,24 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void DotNetRun ([Values (true, false)] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease
+			};
+			using var builder = CreateApkBuilder ();
+			builder.Save (proj);
+
+			var dotnet = new DotNetCLI (Path.Combine (Root, builder.ProjectDirectory, proj.ProjectFilePath));
+			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
+			Assert.IsTrue (dotnet.Run (), "`dotnet run --no-build` should succeed");
+
+			bool didLaunch = WaitForActivityToStart (proj.PackageName, "MainActivity",
+				Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), 30);
+			Assert.IsTrue (didLaunch, "Activity should have started.");
+		}
+
+		[Test]
 		public void NativeAssemblyCacheWithSatelliteAssemblies ([Values (true, false)] bool enableMarshalMethods)
 		{
 			var path = Path.Combine ("temp", TestName);


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/42155
Context: https://github.com/dotnet/sdk/pull/42240
Fixes: https://github.com/dotnet/sdk/issues/31253

The .NET SDK has introduced a new `ComputeRunArguments` MSBuild target that allows you to set `$(RunCommand)` and `$(RunArguments)` in a more dynamic way.

So, on Android:

* `ComputeRunArguments` depends on `Install`, so the app is deployed, the `<FastDeploy/>` MSBuild target runs, etc.

* `$(RunCommand)` is a path to `adb`

* `$(RunArguments)` is an `shell am start` command to launch the main activity.

The new implementation also allows us to use the `-p` parameter with `dotnet run`, such as:

    dotnet run -bl -p:AdbTarget=-d

This will pass `-d` to `adb`, which allows you to select an attached device if an emulator is running.

Previously, we had no way to pass `-p` arguments to `dotnet run`.