### PR TITLE
[Mono.Android] remove `Xamarin.Android.VSAndroidDesigner.IsSupported` feature switch

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -395,11 +395,6 @@ namespace Android.Runtime {
 			return handlerType;
 		}
 
-		internal static bool VSAndroidDesignerIsEnabled { get; } = InitializeVSAndroidDesignerIsEnabled ();
-
-		static bool InitializeVSAndroidDesignerIsEnabled () =>
-		    !AppContext.TryGetSwitch ("Xamarin.Android.VSAndroidDesigner.IsSupported", out bool isEnabled) || isEnabled;
-
 		class _Proxy : IWebProxy {
 			readonly ProxySelector selector = ProxySelector.Default!;
 

--- a/src/Mono.Android/Android.Runtime/Logger.cs
+++ b/src/Mono.Android/Android.Runtime/Logger.cs
@@ -55,8 +55,6 @@ namespace Android.Runtime {
 						hasNoLibLog = true;
 					}
 				}
-				if (AndroidEnvironment.VSAndroidDesignerIsEnabled && hasNoLibLog)
-					System.Console.WriteLine ("[{0}] {1}: {2}", level, appname, line);
 			}
 		}
 

--- a/src/Mono.Android/ILLink/ILLink.Substitutions.xml
+++ b/src/Mono.Android/ILLink/ILLink.Substitutions.xml
@@ -1,13 +1,5 @@
 <linker>
   <assembly fullname="Mono.Android">
-    <type fullname="Android.Runtime.AndroidEnvironment" feature="Android.Runtime.AndroidEnvironment.VSAndroidDesignerIsEnabled" featurevalue="false">
-      <method signature="System.Boolean get_VSAndroidDesignerIsEnabled()" body="stub" value="false" />
-    </type>
-    <type fullname="Java.Interop.TypeManager" feature="Android.Runtime.AndroidEnvironment.VSAndroidDesignerIsEnabled" featurevalue="false">
-      <method signature="System.Type TypeRegistrationFallback(System.String)" body="stub" />
-      <method signature="System.Void RegisterPackage(System.String,System.Converter`2&lt;System.String,System.Type&gt;)" body="stub" />
-      <method signature="System.Void RegisterPackages(System.String[],System.Converter`2&lt;System.String,System.Type&gt;[])" body="stub" />
-    </type>
     <type fullname="Xamarin.Android.Net.AndroidMessageHandler">
       <method signature="System.Boolean get_NegotiateAuthenticationIsEnabled()" body="stub" feature="Xamarin.Android.Net.UseNegotiateAuthentication" featurevalue="false" value="false" />
       <method signature="System.Boolean get_NegotiateAuthenticationIsEnabled()" body="stub" feature="Xamarin.Android.Net.UseNegotiateAuthentication" featurevalue="true" value="true" />

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -229,34 +229,6 @@ namespace Java.Interop {
 				return null;
 			}
 
-			if (AndroidEnvironment.VSAndroidDesignerIsEnabled)
-				return TypeRegistrationFallback (class_name);
-
-			return null;
-		}
-
-		internal static Type? TypeRegistrationFallback (string class_name)
-		{
-			[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Type should be preserved by the MarkJavaObjects trimmer step.")]
-			static Type? TypeGetType (string name) =>
-				Type.GetType (name, throwOnError: false);
-
-			__TypeRegistrations.RegisterPackages ();
-
-			Type? type = null;
-			int ls = class_name.LastIndexOf ('/');
-			var package = ls >= 0 ? class_name.Substring (0, ls) : "";
-			if (packageLookup!.TryGetValue (package, out var mappers)) {
-				foreach (Converter<string, Type?> c in mappers) {
-					type = c (class_name);
-					if (type == null)
-						continue;
-					return type;
-				}
-			}
-			if ((type = TypeGetType (JavaNativeTypeManager.ToCliType (class_name))) != null) {
-				return type;
-			}
 			return null;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -124,7 +124,6 @@
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' and '$(TrimMode)' == 'full'">true</EnableTrimAnalyzer>
 
     <!-- XA feature switches defaults -->
-    <VSAndroidDesigner Condition="'$(VSAndroidDesigner)' == ''">false</VSAndroidDesigner>
     <AndroidUseNegotiateAuthentication Condition="'$(AndroidUseNegotiateAuthentication)' == ''">false</AndroidUseNegotiateAuthentication>
 
     <!-- profiler won't work without internet permission, we must thus force it -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -26,11 +26,6 @@ This file contains the .NET 5-specific targets to customize ILLink
       <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">$(IntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>
     </PropertyGroup>
     <ItemGroup>
-      <RuntimeHostConfigurationOption Include="Android.Runtime.AndroidEnvironment.VSAndroidDesignerIsEnabled"
-          Condition="'$(VSAndroidDesigner)' != ''"
-          Value="$(VSAndroidDesigner)"
-          Trim="true" />
-
       <!--
         Used for the <ILLink CustomData="@(_TrimmerCustomData)" /> value:
         https://github.com/dotnet/sdk/blob/a5393731b5b7b225692fff121f747fbbc9e8b140/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets#L147

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -513,26 +513,6 @@ namespace UnnamedProject {
 		}
 
 		[Test]
-		public void TypeRegistrationsFallback ([Values (true, false)] bool enabled)
-		{
-			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
-			if (enabled)
-				proj.SetProperty (proj.ActiveConfigurationProperties, "VSAndroidDesigner", "true");
-
-			using (var b = CreateApkBuilder ()) {
-				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				var assemblyFile = "Mono.Android.dll";
-				var assemblyPath = BuildTest.GetLinkedPath (b, true, assemblyFile);
-				using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
-					Assert.IsTrue (assembly != null);
-
-					var td = assembly.MainModule.GetType ("Java.Interop.__TypeRegistrations");
-					Assert.IsTrue ((td != null) == enabled);
-				}
-			}
-		}
-
-		[Test]
 		public void AndroidUseNegotiateAuthentication ([Values (true, false, null)] bool? useNegotiateAuthentication)
 		{
 			var proj = new XamarinAndroidApplicationProject { IsRelease = true };


### PR DESCRIPTION
Context: https://developercommunity.visualstudio.com/t/XamarinAndroid-Designer---Replacement/10728132
Context: 363935b4

As the Android designer is no longer supported in Visual Studio, we are removing the `Xamarin.Android.VSAndroidDesigner.IsSupported` feature switch and `$(VSAndroidDesigner)` MSBuild property.

This removes the codepath for Java types at runtime (on desktop) via `TypeManager.TypeRegistrationFallback()`. This also removes a `Console.WriteLine()` call when `liblog` and `__android_log_print` cannot be found.