### PR TITLE
[docs] Sync docs with dotnet/docs-mobile@9ccd7291

### DIFF
--- a/Documentation/docs-mobile/TOC.yml
+++ b/Documentation/docs-mobile/TOC.yml
@@ -60,7 +60,7 @@
         href: binding-libs/advanced-concepts/resolving-java-dependencies.md
       - name: Distribute bindings libraries
         href: binding-libs/advanced-concepts/distributing.md
-      - name: Native Library Interop
+      - name: Native library interop
         href: binding-libs/advanced-concepts/native-library-interop.md
     - name: Troubleshoot bindings
       href: binding-libs/customizing-bindings/troubleshooting-bindings.md

--- a/Documentation/docs-mobile/binding-libs/advanced-concepts/native-library-interop.md
+++ b/Documentation/docs-mobile/binding-libs/advanced-concepts/native-library-interop.md
@@ -1,12 +1,11 @@
 ---
-title: AndroidMavenLibrary Build Action .NET for Android
-description: AndroidMavenLibrary Build Action .NET for Android
+title: Native Library Interop
+description: Learn how to perform native library interop to access native SDKs in .NET for Android and .NET MAUI projects,
 ms.date: 10/21/2024
 ---
-# NativeLibraryInterop
+# Native library interop
 
-## Overview
-Native Library Interop (formerly referred to as the "Slim Binding" approach), refers to a
+Native library interop (formerly referred to as the "Slim Binding" approach), refers to a
 pattern for accessing native SDKs in .NET for Android and .NET MAUI projects.
 
 Starting in .NET 9, the .NET for Android SDK supports building Gradle projects
@@ -23,10 +22,11 @@ When an `@(AndroidGradleProject)` item is added to a .NET for Android project, t
 will attempt to create an AAR or APK file from the specified Gradle project. Any AAR output files
 will be added to the .NET project as an `@(AndroidLibrary)` to be bound.
 
-Please see the [build-items](../../building-apps/build-items.md) docs for more information about
+## See also
+
+* The [.NET MAUI Community Toolkit - Native Library Interop](/dotnet/communitytoolkit/maui/native-library-interop)
+guide for more detailed docs.
+* The [build-items](../../building-apps/build-items.md) docs for more information about
 the `@(AndroidGradleProject)` build action.
-
-Additional documentation and references can be found below:
-
-* https://learn.microsoft.com/en-us/dotnet/communitytoolkit/maui/native-library-interop
-* https://github.com/CommunityToolkit/Maui.NativeLibraryInterop
+* The [Maui.NativeLibraryInterop](https://github.com/CommunityToolkit/Maui.NativeLibraryInterop)
+git repository for code samples.

--- a/Documentation/docs-mobile/building-apps/build-items.md
+++ b/Documentation/docs-mobile/building-apps/build-items.md
@@ -4,7 +4,7 @@ description: .NET for Android Build Items
 ms.date: 09/09/2024
 ---
 
-# Build Items
+# Build items
 
 Build items control how a .NET for Android application
 or library project is built.
@@ -18,9 +18,8 @@ an [MSBuild ItemGroup](/visualstudio/msbuild/itemgroup-element-msbuild).
 ## AndroidAdditionalJavaManifest
 
 `<AndroidAdditionalJavaManifest>` is used in conjunction with
-[Java Dependency Resolution](../features/maven/java-dependency-verification.md).
-
-It is used to specify additional POM files that will be needed to verify dependencies.
+[Java Dependency Resolution](../features/maven/java-dependency-verification.md)
+to specify additional POM files that will be needed to verify dependencies.
 These are often parent or imported POM files referenced by a Java library's POM file.
 
 ```xml
@@ -237,7 +236,7 @@ This simplification means you can use **AndroidLibrary** everywhere.
 ## AndroidLintConfig
 
 The Build action 'AndroidLintConfig' should be used in conjunction with the
-[`$(AndroidLintEnabled)`](/xamarin/android/deploy-test/building-apps/build-properties.md#androidlintenabled)
+[`$(AndroidLintEnabled)`](/xamarin/android/deploy-test/building-apps/build-properties#androidlintenabled)
 property. Files with this build action will be merged together and passed to the
 android `lint` tooling. They should be XML files containing information on
 tests to enable and disable.
@@ -325,7 +324,7 @@ used to specify the ABI that the library targets. Thus, if you add
 `lib/armeabi-v7a/libfoo.so` to the build, then the ABI will be "sniffed" as
 `armeabi-v7a`.
 
-### Item Attribute Name
+### Item attribute name
 
 **Abi** &ndash; Specifies the ABI of the native library.
 
@@ -354,7 +353,7 @@ However these Items MUST be URL encoded or use
 [`$([MSBuild]::Escape(''))`](/visualstudio/msbuild/how-to-escape-special-characters-in-msbuild).
 This is so MSBuild does not try to interpret them as actual file wildcards.
 
-For example 
+For example
 
 ```xml
 <ItemGroup>
@@ -366,7 +365,7 @@ For example
 NOTE: `*`, `?` and `.` will be replaced in the `BuildApk` task with the
 appropriate file globs.
 
-If the default file glob is too restrictive you can remove it by adding the 
+If the default file glob is too restrictive you can remove it by adding the
 following to your csproj
 
 ```xml
@@ -391,7 +390,7 @@ included from the final package. The default values are as follows
 Items can use file blob characters for wildcards such as `*` and `?`.
 However these Items MUST use URL encoding or '$([MSBuild]::Escape(''))'.
 This is so MSBuild does not try to interpret them as actual file wildcards.
-For example 
+For example
 
 ```xml
 <ItemGroup>
@@ -566,5 +565,5 @@ this build action, see
 [ProGuard](/xamarin/android/deploy-test/release-prep/proguard).
 
 These files are ignored unless the
-[`$(EnableProguard)`](/xamarin/android/deploy-test/building-apps/build-properties.md#enableproguard)
+[`$(EnableProguard)`](/xamarin/android/deploy-test/building-apps/build-properties#enableproguard)
 MSBuild property is `True`.

--- a/Documentation/docs-mobile/building-apps/build-process.md
+++ b/Documentation/docs-mobile/building-apps/build-process.md
@@ -4,7 +4,7 @@ description: .NET for Android Build Process
 ms.date: 04/11/2024
 ---
 
-# Build Process
+# Build process
 
 The .NET for Android build process is responsible for gluing everything
 together:
@@ -17,7 +17,7 @@ generating
 [Android-callable wrappers](/xamarin/android/platform/java-integration/android-callable-wrappers),
 and generating a `.apk` for execution on Android devices.
 
-## Application Packages
+## Application packages
 
 In broad terms, there are two types of Android application packages
 (`.apk` files) which the .NET for Android build system can generate:
@@ -33,7 +33,7 @@ produces the package.
 
 <a name="Fast_Deployment"></a>
 
-## Fast Deployment
+## Fast deployment
 
 *Fast deployment* works by further shrinking Android application
 package size. This is done by excluding the app's assemblies from the
@@ -59,7 +59,7 @@ This will deploy both assemblies, native libraries, typemaps and dexes to the `f
 directory. But you should only really need to enable this if you are changing
 native libraries, bindings or Java code.
 
-## MSBuild Projects
+## MSBuild projects
 
 The .NET for Android build process is based on MSBuild, which is also
 the project file format used by Visual Studio for Mac and Visual Studio.
@@ -75,7 +75,7 @@ MSBuild items, properties and targets.
 
 <a name="Build_Targets"></a>
 
-## Binding Projects
+## Binding projects
 
 The following MSBuild properties are used with
 [Binding projects](/xamarin/android/platform/binding-java-library):
@@ -97,7 +97,7 @@ The Following MSBuild properties are used to control generation of the
 - [`$(AndroidUseAapt2)`](build-properties.md#androiduseaapt2)
 - [`$(MonoAndroidResourcePrefix)`](build-properties.md#monoandroidresourceprefix)
 
-## Signing Properties
+## Signing properties
 
 Signing properties control how the Application package is signed so
 that it may be installed onto an Android device. To allow
@@ -154,7 +154,7 @@ To use the keystore generated above, use the property group:
 </PropertyGroup>
 ```
 
-## Build Extension Points
+## Build extension points
 
 The .NET for Android build system exposes a few public extension points
 for users wanting to hook into our build process. To use one of these
@@ -173,6 +173,7 @@ appropriate MSBuild property in a `PropertyGroup`. For example:
 Extension points include:
 
 - [`$(AfterGenerateAndroidManifest)](build-properties.md#aftergenerateandroidmanifest)
+- [`$(AndroidPrepareForBuildDependsOn)](build-properties.md#androidprepareforbuilddependson)
 - [`$(BeforeGenerateAndroidManifest)](build-properties.md#beforegenerateandroidmanifest)
 - [`$(BeforeBuildAndroidAssetPacks)`](build-properties.md#beforebuildandroidassetpacks)
 
@@ -182,7 +183,7 @@ performance, especially if they run on every build. It is
 highly recommended that you read the MSBuild [documentation](/visualstudio/msbuild/msbuild)
 before implementing such extensions.
 
-## Target Definitions
+## Target definitions
 
 The .NET for Android-specific parts of the build process are defined in
 `$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets`,

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -4,7 +4,7 @@ description: .NET for Android Build Properties
 ms.date: 09/09/2024
 ---
 
-# Build Properties
+# Build properties
 
 MSBuild properties control the behavior of the
 [targets](build-targets.md).

--- a/Documentation/docs-mobile/building-apps/build-targets.md
+++ b/Documentation/docs-mobile/building-apps/build-targets.md
@@ -4,7 +4,7 @@ description: "This document will list all supported targets in the .NET for Andr
 ms.date: 04/11/2024
 ---
 
-# Build Targets
+# Build targets
 
 The following build targets are defined in .NET for Android projects.
 

--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -1,4 +1,4 @@
---
+---
 title: .NET for Android errors and warnings reference
 description: Build and deployment error and warning codes in .NET for Android, their meanings, and guidance on how to address them.
 ms.date: 04/11/2024

--- a/Documentation/docs-mobile/messages/xa0141.md
+++ b/Documentation/docs-mobile/messages/xa0141.md
@@ -1,7 +1,7 @@
 ---
 title: .NET for Android warning XA0141
 description: XA0141 warning code
-ms.date: 22/07/2024
+ms.date: 07/22/2024
 ---
 # .NET for Android warning XA0141
 

--- a/build-tools/scripts/sync-mobile-docs.ps1
+++ b/build-tools/scripts/sync-mobile-docs.ps1
@@ -1,0 +1,20 @@
+param (
+    [string]$DocsMobilePath,
+    [switch]$SyncToAndroid
+)
+
+$androidDocsPath = Join-Path -Path $PSScriptRoot -ChildPath "../../Documentation/docs-mobile"
+$docsMobilePath = Join-Path -Path $DocsMobilePath -ChildPath "docs/android"
+$sourcePath = $androidDocsPath 
+$destinationPath = $docsMobilePath 
+if ($SyncToAndroid) {
+    $sourcePath = $docsMobilePath
+    $destinationPath = $androidDocsPath
+}
+Write-Host "Syncing content from '$sourcePath' to Folder '$destinationPath'..."
+try {
+    Copy-Item -Path $sourcePath\* -Destination $destinationPath -Recurse -Force
+    Write-Output "Files copied from '$sourcePath' to '$destinationPath' successfully."
+} catch {
+    Write-Error "Error copying files: $_"
+}


### PR DESCRIPTION
The `docs-mobile` content has been synced with https://github.com/dotnet/docs-mobile/commit/9ccd7291ce358a14b3c027a54be8726956372501.

A `build-tools/scripts/sync-mobile-docs.ps1` script has been added to improve this workflow in the future. The default sync direction is from dotnet/android to dotnet/docs-mobile as content is typically authored in this repo first.

To sync, run the following:

    pwsh build-tools/scripts/sync-mobile-docs.ps1 -DocsMobilePath ~/source/docs-mobile

To sync content back from docs-mobile to android, run the following:

    pwsh build-tools/scripts/sync-mobile-docs.ps1 -DocsMobilePath ~/source/docs-mobile -SyncToAndroid