### PR TITLE
[release/8.0.4xx ][ci] Move PR build to shared pool

### DIFF
--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -50,8 +50,10 @@ stages:
   - job: mac_build_update_docs
     displayName: Update API Docs
     pool:
-      name: VSEng-Xamarin-RedmondMac-Android-Untrusted
-      demands: macOS.Name -equals Monterey
+      name: VSEng-VSMac-Xamarin-Shared
+      demands:
+      - macOS.Name -equals Ventura
+      - macOS.Architecture -equals x64
     timeoutInMinutes: 120
     workspace:
       clean: all

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -37,8 +37,10 @@ stages:
   - job: mac_build_create_installers
     displayName: macOS > Create Installers
     pool:
-      name: VSEng-Xamarin-RedmondMac-Android-Untrusted
-      demands: macOS.Name -equals Monterey
+      name: VSEng-VSMac-Xamarin-Shared
+      demands:
+      - macOS.Name -equals Ventura
+      - macOS.Architecture -equals x64
     timeoutInMinutes: 420
     workspace:
       clean: all

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -29,8 +29,10 @@ stages:
     displayName: ${{ parameters.jobDisplayName }}
     pool:
       ${{ if or(eq(variables['Build.DefinitionName'], 'Xamarin.Android-PR'), eq(variables['Build.DefinitionName'], 'Xamarin.Android Nightly')) }}:
-        name: VSEng-Xamarin-RedmondMac-Android-Untrusted
-        demands: macOS.Name -equals Monterey
+        name: VSEng-VSMac-Xamarin-Shared
+        demands:
+        - macOS.Name -equals Ventura
+        - macOS.Architecture -equals x64
       ${{ else }}:
         name: Azure Pipelines
         vmImage: $(HostedMacImage)


### PR DESCRIPTION
Removes our dependency on the Android specific build pool, which should
reduce overall pool maintenance effort and cost.

The `VSEng-VSMac-Xamarin-Shared` pool is used by a handful of teams and
also consists of physical macOS machines that should be more performant
than the hosted options.