### PR TITLE
[d17-5][ci] Move PR build to shared pool

### DIFF
--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -50,8 +50,10 @@ stages:
   - job: mac_build_update_docs
     displayName: Update API Docs
     pool:
-      name: VSEng-Xamarin-RedmondMac-Android-Untrusted
-      demands: macOS.Name -equals Monterey
+      name: VSEng-VSMac-Xamarin-Shared
+      demands:
+      - macOS.Name -equals Ventura
+      - macOS.Architecture -equals x64
     timeoutInMinutes: 120
     workspace:
       clean: all

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -43,8 +43,10 @@ stages:
   - job: mac_build_create_installers
     displayName: macOS > Create Installers
     pool:
-      name: VSEng-Xamarin-RedmondMac-Android-Untrusted
-      demands: macOS.Name -equals Monterey
+      name: VSEng-VSMac-Xamarin-Shared
+      demands:
+      - macOS.Name -equals Ventura
+      - macOS.Architecture -equals x64
     timeoutInMinutes: 420
     workspace:
       clean: all

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -99,7 +99,7 @@ stages:
     displayName: macOS > Build
     pool:
       name: Azure Pipelines
-      value: macOS-13
+      vmImage: macOS-13
       #name: $(MacBuildPoolName)
       #vmImage: $(MacBuildPoolImage)
       #${{ if eq(variables['MacBuildPoolName'], 'VSEng-VSMac-Xamarin-Shared') }}:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -77,12 +77,12 @@ variables:
   - name: MacBuildPoolName
     value: Azure Pipelines
   - name: MacBuildPoolImage
-    value: internal-macos12
+    value: macOS-13
 - ${{ if or(and(ne(variables['Build.DefinitionName'],'Xamarin.Android'), ne(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), eq(variables['Build.Reason'], 'PullRequest')) }}:
   - name: MicroBuildSignType
     value: Test
   - name: MacBuildPoolName
-    value: VSEng-Xamarin-RedmondMac-Android-Untrusted
+    value: VSEng-VSMac-Xamarin-Shared
   - name: MacBuildPoolImage
     value: ''
   - name: DisablePipelineConfigDetector
@@ -98,10 +98,14 @@ stages:
   - job: mac_build_create_installers
     displayName: macOS > Build
     pool:
-      name: $(MacBuildPoolName)
-      vmImage: $(MacBuildPoolImage)
-      ${{ if eq(variables['MacBuildPoolName'], 'VSEng-Xamarin-RedmondMac-Android-Untrusted') }}:
-        demands: macOS.Name -equals Monterey
+      name: Azure Pipelines
+      value: macOS-13
+      #name: $(MacBuildPoolName)
+      #vmImage: $(MacBuildPoolImage)
+      #${{ if eq(variables['MacBuildPoolName'], 'VSEng-VSMac-Xamarin-Shared') }}:
+      #  demands:
+      #  - macOS.Name -equals Ventura
+      #  - macOS.Architecture -equals x64
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:


### PR DESCRIPTION
Removes our dependency on the Android specific build pool, which should
reduce overall pool maintenance effort and cost.

The `VSEng-VSMac-Xamarin-Shared` pool is used by a handful of teams and
also consists of physical macOS machines that should be more performant
than the hosted options.