### PR TITLE
[Build.Tasks] Better handle gradle project custom output paths

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Microsoft.Android.Sdk.Bindings.Gradle.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Microsoft.Android.Sdk.Bindings.Gradle.targets
@@ -12,8 +12,9 @@ This file contains MSBuild targets that support building and operating on Androi
   <UsingTask TaskName="Xamarin.Android.Tasks.Gradle"              AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
   <PropertyGroup>
-    <_AndroidGradleDefaultOutputPathRoot>$(MSBuildProjectDirectory)/$(IntermediateOutputPath)gradle/</_AndroidGradleDefaultOutputPathRoot>
-    <_AndroidGradleBuildDirInitScriptPath>$(_AndroidGradleDefaultOutputPathRoot)net.android.init.gradle.kts</_AndroidGradleBuildDirInitScriptPath>
+    <_AGPOutDirAbs>$(IntermediateOutputPath)gradle/</_AGPOutDirAbs>
+    <_AGPOutDirAbs Condition=" !$([System.IO.Path]::IsPathRooted('$(_AGPOutDirAbs)')) ">$(MSBuildProjectDirectory)/$(_AGPOutDirAbs)</_AGPOutDirAbs>
+    <_AGPInitScriptPath>$(_AGPOutDirAbs)net.android.init.gradle.kts</_AGPInitScriptPath>
     <_BuildAndroidGradleProjectsStamp>$(_AndroidStampDirectory)_BuildAndroidGradleProjects.stamp</_BuildAndroidGradleProjectsStamp>
   </PropertyGroup>
 
@@ -56,7 +57,10 @@ This file contains MSBuild targets that support building and operating on Androi
     </Hash>
     <ItemGroup>
       <AndroidGradleProject Condition=" '%(AndroidGradleProject.OutputPath)' == '' " >
-        <OutputPath>$(_AndroidGradleDefaultOutputPathRoot)%(ModuleName)%(Configuration)-$([System.String]::Copy($(_AndroidGradleProjectHash)).Substring(0, 5))/</OutputPath>
+        <OutputPath>$(_AGPOutDirAbs)%(ModuleName)%(Configuration)-$([System.String]::Copy($(_AndroidGradleProjectHash)).Substring(0, 5))</OutputPath>
+      </AndroidGradleProject>
+      <AndroidGradleProject>
+        <OutputPath>$([MSBuild]::EnsureTrailingSlash('%(OutputPath)'))</OutputPath>
       </AndroidGradleProject>
     </ItemGroup>
   </Target>
@@ -72,12 +76,12 @@ This file contains MSBuild targets that support building and operating on Androi
     <!-- Create the net.android.init.gradle.kts script used to override the Gradle project output directory -->
     <CopyResource
         ResourceName="net.android.init.gradle.kts"
-        OutputPath="$(_AndroidGradleBuildDirInitScriptPath)"
+        OutputPath="$(_AGPInitScriptPath)"
     />
 
     <!-- Run assemble task for project outputs, android app and library project outputs are currently supported -->
     <Gradle ToolPath="%(AndroidGradleProject.RootDir)%(AndroidGradleProject.Directory)"
-        BuildDirInitScriptPath="$(_AndroidGradleBuildDirInitScriptPath)"
+        BuildDirInitScriptPath="$(_AGPInitScriptPath)"
         Command="assemble%(AndroidGradleProject.Configuration)"
         ModuleName="%(AndroidGradleProject.ModuleName)"
         OutputPath="%(AndroidGradleProject.OutputPath)"
@@ -89,9 +93,9 @@ This file contains MSBuild targets that support building and operating on Androi
       <_AndroidGradleProjectAppOutputs      Include="%(AndroidGradleProject.OutputPath)outputs/**/*.apk" />
       <_AndroidGradleProjectLibraryOutputs  Include="%(AndroidGradleProject.OutputPath)outputs/**/*.aar"
           Condition=" '%(CreateAndroidLibrary)' == 'true' "
-          Bind="%(Bind)"
-          Pack="%(Pack)"
-          Visible="%(Visible)" />
+          Bind="%(AndroidGradleProject.Bind)"
+          Pack="%(AndroidGradleProject.Pack)"
+          Visible="%(AndroidGradleProject.Visible)" />
     </ItemGroup>
 
     <AndroidMessage ResourceName="XAGRDLRefLibraryOutputs"
@@ -113,7 +117,7 @@ This file contains MSBuild targets that support building and operating on Androi
       Condition=" '@(AndroidGradleProject->Count())' != '0' "
       DependsOnTargets="_CalculateAndroidGradleProjectOutputPath" >
     <Gradle ToolPath="%(AndroidGradleProject.RootDir)%(AndroidGradleProject.Directory)"
-        BuildDirInitScriptPath="$(_AndroidGradleBuildDirInitScriptPath)"
+        BuildDirInitScriptPath="%(AndroidGradleProject.OutputPath)$(_AGPInitScriptPath)"
         Command="clean"
         ModuleName="%(AndroidGradleProject.ModuleName)"
         OutputPath="%(AndroidGradleProject.OutputPath)"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidGradleProjectTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidGradleProjectTests.cs
@@ -210,6 +210,33 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void BuildCustomOutputPaths ()
+		{
+			var gradleProject = AndroidGradleProject.CreateDefault (GradleTestProjectDir);
+			var moduleName = gradleProject.Modules.First ().Name;
+
+			using var builder = CreateDllBuilder ();
+			var customOutputPathsRoot = Path.Combine (Root, builder.ProjectDirectory, "customout");
+			var gradleOutputPath = Path.Combine (customOutputPathsRoot, "gradleoutdir");
+
+			var proj = new XamarinAndroidLibraryProject {
+				OtherBuildItems = {
+					new BuildItem (KnownProperties.AndroidGradleProject, gradleProject.BuildFilePath) {
+						Metadata = {
+							{ "ModuleName", moduleName },
+							{ "OutputPath", gradleOutputPath },
+						},
+					},
+				},
+				OutputPath = Path.Combine (customOutputPathsRoot, "outdir"),
+				IntermediateOutputPath = Path.Combine (customOutputPathsRoot, "intermediatedir"),
+			};
+
+			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+			FileAssert.Exists (Path.Combine (proj.OutputPath, $"{moduleName}-release.aar"));
+		}
+
+		[Test]
 		public void BuildMultipleModules ()
 		{
 			var gradleProject = new AndroidGradleProject (GradleTestProjectDir) {


### PR DESCRIPTION
The AndroidGradleProject targets have been updated to fix some issues we
ran into when trying to use this new build action in the MAUI build.

The default output path property will now check to see if it is rooted
before adding a `$(MSBuildProjectDirectory)` prefix to make it an
absolute path. The property name has also been shortened. This fixes
projects/builds that set `$(BaseIntermediateOutputPath)` or
`$(IntermediateOutputPath)` to an absolute path that would hit an error
along the lines of:

    D:\a\_work\1\s\.dotnet\packs\Microsoft.Android.Sdk.Windows\35.0.0-rc.2.152\tools\Microsoft.Android.Sdk.Bindings.Gradle.targets(73,5): error XACPR7024: System.IO.IOException: The filename, directory name, or volume label syntax is incorrect. : 'D:\a\_work\1\s\src\Core\src\D:\a\_work\1\s\artifacts\obj\Core\Release\net9.0-android35.0\gradle'.

Projects which set the `%(AndroidGradleProject.OutputPath)` metadata to
use a custom gradle output path have been fixed to ensure a trailing
slash is always used.

While looking through binlogs I also noticed the following message:

    MSB4120: Item '_AndroidGradleProjectLibraryOutputs' definition within target references itself via (qualified or unqualified) metadatum 'Bind'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref

This has been fixed by qualifying the metadata that is added when
creating `@(_AndroidGradleProjectLibraryOutputs)` items.

A test has also been added for `$(UseArtifactsOutput)`:
https://learn.microsoft.com/dotnet/core/sdk/artifacts-output