### PR TITLE
fix: jit-times - Timestamp arithmetic + add warnings for negative times

### DIFF
--- a/tools/jit-times/Program.cs
+++ b/tools/jit-times/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Text.RegularExpressions;
 using static System.Console;
 
@@ -159,7 +160,7 @@ namespace jittimes {
 					var info = GetMethodInfo (method);
 
 					if (info.state != MethodInfo.State.None && Verbose)
-						Warning ($"duplicit begin of `{info.method}`");
+						Warning ($"duplicite begin of `{info.method}`");
 
 					info.state = MethodInfo.State.Begin;
 					info.begin = time;
@@ -183,6 +184,12 @@ namespace jittimes {
 					info.total = info.done - info.begin;
 
 					info.CalcSelfTime ();
+					if (Verbose) {
+						if (info.self.nanoseconds < 0)
+							Warning ($"negative self time for method {method}: {info.self}");
+						if (info.total.nanoseconds < 0)
+							Warning ($"negative total time for method {method}: {info.total}");
+					}
 
 					jitMethods.Pop ();
 
@@ -229,7 +236,7 @@ namespace jittimes {
 				var info = pair.Value;
 				WriteLine ($"{info.total.Milliseconds (),10:F2} | {info.self.Milliseconds (),10:F2} | {info.method}");
 
-				sum += info.self;
+				sum += info.self.Positive();
 			}
 
 			return sum;


### PR DESCRIPTION
1. Plus and minus operators for Timestamp type can produce invalid Timestamps. All of Timestamp parts should be either (0 or positive) or (0 or negative), but statements like `result.milliseconds--` don't take this value into account in the next "if".

2. The reporting there is broken - the tool parses methods.txt in assumption it is produced by a single-threaded app, and it seems that it's not the case in reality. That's why many "self" timings are negative.