### PR TITLE
[Xamarin.Android.Build.Tasks] redistribute `proguard-android.txt` from Android gradle plugin

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -11,7 +11,7 @@ bring it to our attention. Post an issue or email us:
 
 The attached notices are provided for information only.
 
-1. android/platform/tools/base (https://android.googlesource.com/platform/tools/base/+/d41d662dbf89f9b60ca6256415a059c0107749b8/sdk-common/NOTICE)
+1. android/platform/tools/base (https://android.googlesource.com/platform/tools/base/+/refs/heads/main/sdk-common/NOTICE)
 2. bazelbuild/bazel (https://github.com/bazelbuild/bazel/)
 3. chys87/constexpr-xxh3 (https://github.com/chys87/constexpr-xxh3/)
 4. Cyan4973/xxHash (https://github.com/Cyan4973/xxHash/)

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -125,6 +125,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FFCF518F-2A4
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Android.Sdk.Analysis", "src\Microsoft.Android.Sdk.Analysis\Microsoft.Android.Sdk.Analysis.csproj", "{5E806C9F-1B67-4B6B-A6AB-258834250DBB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "proguard-android", "src\proguard-android\proguard-android.csproj", "{5FD0133B-69E5-4474-9B67-9FD1D0150C70}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
@@ -343,6 +345,10 @@ Global
 		{5E806C9F-1B67-4B6B-A6AB-258834250DBB}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{5E806C9F-1B67-4B6B-A6AB-258834250DBB}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{5E806C9F-1B67-4B6B-A6AB-258834250DBB}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{5FD0133B-69E5-4474-9B67-9FD1D0150C70}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{5FD0133B-69E5-4474-9B67-9FD1D0150C70}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{5FD0133B-69E5-4474-9B67-9FD1D0150C70}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{5FD0133B-69E5-4474-9B67-9FD1D0150C70}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -402,6 +408,7 @@ Global
 		{BA4D889D-066B-4C2C-A973-09E319CBC396} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{A39B6D7C-6616-40D6-8AE4-C6CEE93D2708} = {CAB438D8-B0F5-4AF0-BEBD-9E2ADBD7B483}
 		{5E806C9F-1B67-4B6B-A6AB-258834250DBB} = {FFCF518F-2A4A-40A2-9174-2EE13B76C723}
+		{5FD0133B-69E5-4474-9B67-9FD1D0150C70} = {FFCF518F-2A4A-40A2-9174-2EE13B76C723}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {53A1F287-EFB2-4D97-A4BB-4A5E145613F6}

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -138,6 +138,7 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_net6.dex" ExcludeFromLegacy="true" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_fastdev_net6.dex" ExcludeFromLegacy="true" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)manifestmerger.jar" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)proguard-android.txt" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)protobuf-net.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)System.CodeDom.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)System.Collections.Immutable.dll" />

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Build.Tasks.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Build.Tasks.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.Prepare
 	[TPN]
 	class XamarinAndroidBuildTasks_AOSP : ThirdPartyNotice
 	{
-		static readonly Uri    url         = new Uri ("https://android.googlesource.com/platform/tools/base/+/d41d662dbf89f9b60ca6256415a059c0107749b8/sdk-common/NOTICE");
+		static readonly Uri    url         = new Uri ("https://android.googlesource.com/platform/tools/base/+/refs/heads/main/sdk-common/NOTICE");
 
 		public override string LicenseText => String.Empty;
 		public override string LicenseFile => CommonLicenses.Apache20Path;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1899,7 +1899,7 @@ because xbuild doesn't support framework reference assemblies.
     <_ProguardConfiguration Include="$(ProguardConfigFiles)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(ProguardConfigFiles)' == '' ">
-    <_ProguardConfiguration Include="$(_AndroidSdkDirectory)tools\proguard\proguard-android.txt"     Condition=" Exists ('$(_AndroidSdkDirectory)tools\proguard\proguard-android.txt') " />
+    <_ProguardConfiguration Include="$(MSBuildThisFileDirectory)proguard-android.txt" />
     <_ProguardConfiguration Include="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"         Condition=" '$(AndroidLinkTool)' != '' " />
     <_ProguardConfiguration Include="$(_ProguardProjectConfiguration)"                               Condition=" '$(AndroidLinkTool)' != '' " />
     <_ProguardConfiguration Include="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg" Condition=" '$(AndroidLinkTool)' != '' " />

--- a/src/proguard-android/.gitignore
+++ b/src/proguard-android/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+build/
+out/
+.classpath
+.project
+.settings/

--- a/src/proguard-android/build.gradle
+++ b/src/proguard-android/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'com.android.application' version '8.7.0'
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+android {
+    namespace 'com.microsoft.proguard.android'
+    // Setting the minimum we support at the moment, might not matter
+    compileSdk 21
+}

--- a/src/proguard-android/proguard-android.csproj
+++ b/src/proguard-android/proguard-android.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath Condition="'$(OutputPath)'==''">bin\$(Configuration)</OutputPath>
+  </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="proguard-android.targets" />
+</Project>

--- a/src/proguard-android/proguard-android.targets
+++ b/src/proguard-android/proguard-android.targets
@@ -1,0 +1,34 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_Destination>$(MicrosoftAndroidSdkOutDir)proguard-android.txt</_Destination>
+  </PropertyGroup>
+
+  <Target Name="_GenerateProGuardRules"
+      BeforeTargets="Build"
+      Inputs="$(MSBuildThisFile);build.gradle;settings.gradle"
+      Outputs="$(_Destination)">
+    <Exec
+        Command="&quot;$(GradleWPath)&quot; extractProguardFiles $(GradleArgs)"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        WorkingDirectory="$(MSBuildThisFileDirectory)"
+    />
+    <ItemGroup>
+      <_ProguardRules Include="$(MSBuildThisFileDirectory)build\intermediates\default_proguard_files\global\proguard-android.txt-*" />
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(_ProguardRules)"
+        DestinationFiles="$(_Destination)"
+    />
+    <Touch Files="$(_Destination)" />
+  </Target>
+
+  <Target Name="_CleanProguardRules" BeforeTargets="Clean">
+    <Delete Files="$(_Destination)" />
+    <Exec
+        Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        WorkingDirectory="$(MSBuildThisFileDirectory)"
+    />
+  </Target>
+
+</Project>

--- a/src/proguard-android/settings.gradle
+++ b/src/proguard-android/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = 'proguard-android'


### PR DESCRIPTION
Context: https://discord.com/channels/732297728826277939/732297837953679412/1303383272918618163

A customer found their app grew in size when building on Windows
versus macOS.

The difference being a file that was passed to the `<R8/>` task on
Windows, but not on macOS:

    C:\Users\[username]\AppData\Local\Android\Sdk\tools\proguard\proguard-android.txt

`tools` is *ancient*, as any Android SDK should be using
`cmdline-tools` now.

Let's stop using this file as a default set of proguard rules.

But we need to use the *right* set of proguard rules, reading
the text of the old one:

> This file is no longer maintained and is not used by new (2.2+)
> versions of the # Android plugin for Gradle. Instead, the Android
> plugin for Gradle generates the # default rules at build time and
> stores them in the build directory.

I found the source code for the gradle task that generates the new
files at:

* https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/ProguardFiles.java;l=116

In order to get this file, we can setup an empty gradle project
using the Android gradle plugin:

    plugins {
        id 'com.android.application' version '8.7.0'
    }

Which, hopefully, dependabot is able to update this version.

Then we can run the task:

    .\gradlew extractProguardFiles

This outputs files such as:

    src\proguard-android\build\intermediates\default_proguard_files\global\proguard-android-optimize.txt-8.7.0
    src\proguard-android\build\intermediates\default_proguard_files\global\proguard-android.txt-8.7.0
    src\proguard-android\build\intermediates\default_proguard_files\global\proguard-defaults.txt-8.7.0

For now, I simply redistributed the `proguard-android.txt` file, but
we could consider making `proguard-android-optimize.txt` useable in
the future. I believe the only difference is the
`-allowaccessmodification` flag, which users could put in their own
proguard rules.