### PR TITLE
[Xamarin.Android.Build.Tasks] add `AndroidAotMode=FullInterp`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Android.Tasks
 		Hybrid    = 0x0002,
 		Full      = 0x0003,
 		Interp    = 0x0004,
+		FullInterp = 0x0005,
 	}
 
 	public enum SequencePointsMode {
@@ -180,6 +181,10 @@ namespace Xamarin.Android.Tasks
 
 						case AotMode.Hybrid:
 							aotOptions.Add ("hybrid");
+							break;
+
+						case AotMode.FullInterp:
+							aotOptions.Add ("fullinterp");
 							break;
 					}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -98,6 +98,9 @@ namespace Xamarin.Android.Tasks
 			case "full":
 				aotMode = AotMode.Full;
 				return true;
+			case "fullinterp":
+				aotMode = AotMode.FullInterp;
+				return true;
 			case "interpreter":
 				// We don't do anything here for this mode, this is just to set the flag for the XA
 				// runtime to initialize Mono in the interpreter "AOT" mode.

--- a/src/native/runtime-base/android-system.cc
+++ b/src/native/runtime-base/android-system.cc
@@ -589,7 +589,11 @@ AndroidSystem::setup_environment () noexcept
 				break;
 
 			case 'f':
-				aotMode = MonoAotMode::MONO_AOT_MODE_FULL;
+				if (strcmp (mono_aot_mode_name, "fullinterp") == 0) {
+					aotMode = MonoAotMode::MONO_AOT_MODE_INTERP;
+				} else {
+					aotMode = MonoAotMode::MONO_AOT_MODE_FULL;
+				}
 				break;
 
 			case 'i':


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/9469#issuecomment-2457930832

I don't think this actually works, as the AOT compiler fails with:

    > dotnet build -c Release -p:AndroidAotMode=FullInterp -p:AndroidEnableProfiledAot=false -bl -t:Install -r android-x64
    helloandroid failed with 1 error(s) (8.9s)
        D:\src\xamarin-android\bin\Debug\lib\packs\Microsoft.Android.Sdk.Windows\35.99.0\targets\Microsoft.Android.Sdk.Aot.targets(110,5): error :
        Precompiling failed for D:\src\helloandroid\obj\Release\net9.0-android\android-x64\linked\System.Private.CoreLib.dll with exit code -1073740791.
        Mono Ahead of Time compiler - compiling assembly D:\src\helloandroid\obj\Release\net9.0-android\android-x64\linked\System.Private.CoreLib.dll
        AOTID 7FACD039-CD91-2136-1ACD-BC2EDF417C8D
        * Assertion: should not be reached at D:\a\_work\1\s\src\mono\mono\mini\tramp-amd64.c:1216
    helloandroid failed (0.7s) → bin\Release\net9.0-android\android-x64\helloandroid.dll

Which is the assertion here:

https://github.com/dotnet/runtime/blob/7dab903b20269d78c6bc08d5269947db7d35c22b/src/mono/mono/mini/tramp-amd64.c#L1216