### PR TITLE
[native, Mono.Android] GC bridge logging improvements

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -846,7 +846,13 @@ namespace Android.Runtime {
 				throw new ArgumentNullException (nameof (value));
 
 			if (Logger.LogGlobalRef) {
-				RuntimeNativeMethods._monodroid_gref_log ($"Finalizing handle {value.PeerReference}\n");
+				RuntimeNativeMethods._monodroid_gref_log (
+						string.Format (CultureInfo.InvariantCulture,
+							"Finalizing Instance.Type={0} PeerReference={1} IdentityHashCode=0x{2:x} Instance=0x{3:x}",
+							value.GetType ().ToString (),
+							value.PeerReference.ToString (),
+							value.JniIdentityHashCode,
+							RuntimeHelpers.GetHashCode (value)));
 			}
 
 			// FIXME: need hash cleanup mechanism.

--- a/src/native/monodroid/monodroid-glue.cc
+++ b/src/native/monodroid/monodroid-glue.cc
@@ -779,15 +779,19 @@ MonodroidRuntime::lookup_bridge_info (MonoClass *klass, const OSBridge::MonoJava
 	info->handle            = mono_class_get_field_from_name (info->klass, const_cast<char*> ("handle"));
 	info->handle_type       = mono_class_get_field_from_name (info->klass, const_cast<char*> ("handle_type"));
 	info->refs_added        = mono_class_get_field_from_name (info->klass, const_cast<char*> ("refs_added"));
+	info->key_handle        = mono_class_get_field_from_name (info->klass, const_cast<char*> ("key_handle"));
+
+	// key_handle is optional, as Java.Interop.JavaObject doesn't currently have it
 	if (info->klass == nullptr || info->handle == nullptr || info->handle_type == nullptr || info->refs_added == nullptr) {
 		Helpers::abort_application (
 			Util::monodroid_strdup_printf (
-				"The type `%s.%s` is missing required instance fields! handle=%p handle_type=%p refs_added=%p",
+				"The type `%s.%s` is missing required instance fields! handle=%p handle_type=%p refs_added=%p key_handle=%p",
 				type->_namespace,
 				type->_typename,
 				info->handle,
 				info->handle_type,
-				info->refs_added
+				info->refs_added,
+				info->key_handle
 			)
 		);
 	}

--- a/src/native/monodroid/monodroid-glue.cc
+++ b/src/native/monodroid/monodroid-glue.cc
@@ -965,7 +965,6 @@ MonodroidRuntime::propagate_uncaught_exception (JNIEnv *env, jobject javaThread,
 	mono_runtime_invoke (method, nullptr, args, nullptr);
 }
 
-#if DEBUG
 static void
 setup_gc_logging (void)
 {
@@ -974,7 +973,6 @@ setup_gc_logging (void)
 		log_categories |= LOG_GC;
 	}
 }
-#endif
 
 inline void
 MonodroidRuntime::set_environment_variable_for_directory (const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode)
@@ -1431,8 +1429,9 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 
 	Logger::init_reference_logging (AndroidSystem::get_primary_override_dir ());
 
-#if DEBUG
 	setup_gc_logging ();
+
+#if DEBUG
 	set_debug_env_vars ();
 #endif
 

--- a/src/native/monodroid/osbridge.hh
+++ b/src/native/monodroid/osbridge.hh
@@ -40,6 +40,7 @@ namespace xamarin::android::internal
 			MonoClassField  *handle;
 			MonoClassField  *handle_type;
 			MonoClassField  *refs_added;
+			MonoClassField  *key_handle;
 		};
 
 		// add_reference can work with objects which are either MonoObjects with java peers, or raw jobjects

--- a/src/native/runtime-base/logger.cc
+++ b/src/native/runtime-base/logger.cc
@@ -240,5 +240,5 @@ Logger::init_logging_categories (char*& mono_log_mask, char*& mono_log_level) no
 	}
 
 	if ((log_categories & LOG_GC) != 0)
-		_gc_spew_enabled = 1;
+		_gc_spew_enabled = true;
 }

--- a/src/native/runtime-base/logger.cc
+++ b/src/native/runtime-base/logger.cc
@@ -239,8 +239,6 @@ Logger::init_logging_categories (char*& mono_log_mask, char*& mono_log_level) no
 #endif
 	}
 
-#if DEBUG
 	if ((log_categories & LOG_GC) != 0)
 		_gc_spew_enabled = 1;
-#endif  /* DEBUG */
 }

--- a/src/native/runtime-base/logger.hh
+++ b/src/native/runtime-base/logger.hh
@@ -32,12 +32,12 @@ namespace xamarin::android {
 		}
 #endif // def DEBUG
 
-		static void set_gc_spew_enabled (int yesno) noexcept
+		static void set_gc_spew_enabled (bool yesno) noexcept
 		{
 			_gc_spew_enabled = yesno;
 		}
 
-		static int gc_spew_enabled () noexcept
+		static bool gc_spew_enabled () noexcept
 		{
 			return _gc_spew_enabled;
 		}

--- a/src/native/runtime-base/logger.hh
+++ b/src/native/runtime-base/logger.hh
@@ -30,6 +30,7 @@ namespace xamarin::android {
 		{
 			return _debugger_log_level;
 		}
+#endif // def DEBUG
 
 		static void set_gc_spew_enabled (int yesno) noexcept
 		{
@@ -40,7 +41,6 @@ namespace xamarin::android {
 		{
 			return _gc_spew_enabled;
 		}
-#endif // def DEBUG
 
 	private:
 		static bool set_category (std::string_view const& name, internal::string_segment& arg, unsigned int entry, bool arg_starts_with_name = false) noexcept;
@@ -50,8 +50,8 @@ namespace xamarin::android {
 #if defined(DEBUG)
 		static inline bool _got_debugger_log_level = false;
 		static inline int _debugger_log_level = 0;
-		static inline int _gc_spew_enabled = 0;
 #endif // def DEBUG
+		static inline bool _gc_spew_enabled = false;
 	};
 }
 #endif


### PR DESCRIPTION
[native, Mono.Android] GC bridge logging improvements

Context: https://github.com/dotnet/android/issues/9039

While trying to further diagnose #9039, @jonpryor started fearing
that a GC bridge issue might be at play, but the current GC bridge
logging could use some improvements.

Update `OSBridge::take_weak_global_ref_jni()` to do two things:

 1. Set the `handle` and `handle_type` fields *before* deleting the
    original GREF.  This is for a hypothetical thread-safety issue
    wherein the `handle` field and the `Handle` property could return
    a *deleted* GREF before being updated to the "new" Weak GREF.

    We have not seen this as being an issue in practice, but it's
    something we noticed.  If it did happen, the app would crash and
    a JNI error message would be present in `adb logcat`, a'la:

        JNI DETECTED ERROR IN APPLICATION: use of deleted global reference 0x3d86

 2. Update the `from` parameter text to `_monodroid_weak_gref_new()`
    to look more like a stack trace.

    Previously, the GREF log would contain entries such as:

        monodroid-gref: -g- grefc 441 gwrefc 1 handle 0x4fda/G from thread 'finalizer'(17269)
        monodroid-gref: take_weak_global_ref_jni

    making me wonder "why is `take_weak_global_ref_jni` there?!"

    It's there because of the "from" parameter, to provide context.
    Update it to instead read:

        monodroid-gref: -g- grefc 441 gwrefc 1 handle 0x4fda/G from thread 'finalizer'(17269)
        monodroid-gref:    at [[gc:take_weak_global_ref_jni]]

    which makes it clearer what's intended.

Update `OSBridge::take_global_ref_jni()` in a similar manner.

Update other `_monodroid*_gref_*()` call sites to update *their*
`from` parameters accordingly.

Update `AndroidRuntime.FinalizePeer()` so that the messages it logs
are actually useful.  Currently they are:

	Finalizing handle 0x0/G

which leaves a lot to be desired.  Update it to instead read:

	Finalizing Instance.Type=Example.Whatever PeerReference=0x0/G IdentityHashCode=0x123456 Instance=0xdeadbeef

Note that the `Instance` value is `RuntimeHelpers.GetHashCode()`,
which may not be immediately useful.

"Promote" `LOG_GC` to work in Release builds as well.  This allows:

	adb shell setprop debug.mono.gc 1

to work with `libmono-android.release.so`, i.e. Release builds
of apps.

Update `OSBridge::gc_cross_references()` log the `handle` field of
bridged instances when `debug.mono.gc` is set.

When the `debug.mono.log` system property contains `gref`, you can
then correlate the handle values; for example:

	I monodroid-gc: cross references callback invoked with 1 sccs and 0 xrefs.
	I monodroid-gc: group 0 with 1 objects
	I monodroid-gc:  obj 0x6f4f3d4fd0 [android_net8_hw::MainActivity] handle 0x39c6
	I monodroid-gref: +w+ grefc 18 gwrefc 1 obj-handle 0x39c6/G -> new-handle 0x8cf/W from thread 'finalizer'(18712)
	I monodroid-gref:    at [[gc:take_weak_global_ref_jni]]
	I monodroid-gref: -g- grefc 17 gwrefc 1 handle 0x39c6/G from thread 'finalizer'(18712)
	I monodroid-gref:    at [[gc:take_weak_global_ref_jni]]
	I monodroid-gref: +g+ grefc 18 gwrefc 1 obj-handle 0x8cf/W -> new-handle 0x39ce/G from thread 'finalizer'(18712)
	I monodroid-gref:    at [[gc:take_global_ref_jni]]
	I monodroid-gref: -w- grefc 18 gwrefc 0 handle 0x8cf/W from thread 'finalizer'(18712)
	I monodroid-gref:    at [[gc:take_global_ref_jni]]
	I monodroid-gc: GC cleanup summary: 1 objects tested - resurrecting 1.

shows that the `MainActivity` instance with handle `0x39c6` was
provided to the GC bridge, and it survived the Java-side GC and was
kept alive ("resurrected").
