### PR TITLE
[build] use `javac -source 17 -target 17`

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -135,8 +135,8 @@
     <TestsFlavor>$(_TestsProfiledAotName)$(_TestsAotName)</TestsFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <JavacSourceVersion>1.8</JavacSourceVersion>
-    <JavacTargetVersion>1.8</JavacTargetVersion>
+    <JavacSourceVersion>17</JavacSourceVersion>
+    <JavacTargetVersion>17</JavacTargetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <AndroidNdkFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidNdkDirectory)'))</AndroidNdkFullPath>

--- a/build-tools/scripts/Jar.targets
+++ b/build-tools/scripts/Jar.targets
@@ -33,7 +33,7 @@
       <_Jar>"$(JarPath)"</_Jar>
       <_Targets>-source $(JavacSourceVersion) -target $(JavacTargetVersion)</_Targets>
       <_DestDir>$(IntermediateOutputPath)__CreateTestJarFile-bin</_DestDir>
-      <_AndroidJar>-bootclasspath "$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar"</_AndroidJar>
+      <_AndroidJar>-classpath "$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar"</_AndroidJar>
       <_CP>-cp "$(_JavaInteropJarPath)"</_CP>
       <_JavacFilesResponse>$(IntermediateOutputPath)__javac_response.txt</_JavacFilesResponse>
     </PropertyGroup>

--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -37,7 +37,7 @@
       <_MonoAndroidRuntimeJar>$(MicrosoftAndroidSdkOutDir)java_runtime.jar</_MonoAndroidRuntimeJar>
     </PropertyGroup>
     <Exec
-        Command="&quot;$(JavaCPath)&quot; $(_Target) $(_D) -bootclasspath $(_AndroidJar)$(PathSeparator)&quot;$(_MonoAndroidJar)&quot;$(PathSeparator)&quot;$(_MonoAndroidRuntimeJar)&quot; @$(IntermediateOutputPath)jcw/classes.txt"
+        Command="&quot;$(JavaCPath)&quot; $(_Target) $(_D) -classpath $(_AndroidJar)$(PathSeparator)&quot;$(_MonoAndroidJar)&quot;$(PathSeparator)&quot;$(_MonoAndroidRuntimeJar)&quot; @$(IntermediateOutputPath)jcw/classes.txt"
     />
     <Exec
         Condition="Exists('$(_MonoAndroidJar)')"

--- a/src/java-runtime/java-runtime.targets
+++ b/src/java-runtime/java-runtime.targets
@@ -54,7 +54,7 @@
     <_AndroidJar>"$(AndroidSdkDirectory)\platforms\android-$(AndroidJavaRuntimeApiLevel)\android.jar"</_AndroidJar>
   </PropertyGroup>
   <Exec
-      Command="&quot;$(JavaCPath)&quot; $(_Target) -d %(_RuntimeOutput.IntermediateRuntimeOutputPath) -h %(_RuntimeOutput.IntermediateRuntimeOutputPath) -bootclasspath $(_AndroidJar)$(PathSeparator)&quot;%(_RuntimeOutput.OutputJar)&quot; @%(_RuntimeOutput.IntermediateRuntimeClassesTxt)"
+      Command="&quot;$(JavaCPath)&quot; $(_Target) -d %(_RuntimeOutput.IntermediateRuntimeOutputPath) -h %(_RuntimeOutput.IntermediateRuntimeOutputPath) -classpath $(_AndroidJar)$(PathSeparator)&quot;%(_RuntimeOutput.OutputJar)&quot; @%(_RuntimeOutput.IntermediateRuntimeClassesTxt)"
   />
   <Copy
       SourceFiles="$(IntermediateOutputPath)release/mono_android_Runtime.h"


### PR DESCRIPTION
Context: https://stackoverflow.com/a/76043133

Running `javac` with a newer `-source` and `-target` can run additional optimizations that results in *slightly* smaller Java bytecode and runtime performance.

We should do this for all Java code we build as part of the product, as it might improve install size & build times for tools like `manifestmerger.jar` and `r8.jar`.

After this change, I got the error:

    error: option -bootclasspath not allowed with target 17

Which is fixed by using `-classpath` instead.