### PR TITLE
AndroidPackagingOptionsInclude is ignored

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2222,6 +2222,7 @@ because xbuild doesn't support framework reference assemblies.
 			ZipFlushFilesLimit="$(_ZipFlushFilesLimit)"
 			ZipFlushSizeLimit="$(_ZipFlushSizeLimit)"
 			ExcludeFiles="@(AndroidPackagingOptionsExclude)"
+			IncludeFiles="@(AndroidPackagingOptionsInclude)"
 			AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
 			IntermediateOutputPath="$(IntermediateOutputPath)">
 		<Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
@@ -2261,6 +2262,7 @@ because xbuild doesn't support framework reference assemblies.
 			ZipFlushFilesLimit="$(_ZipFlushFilesLimit)"
 			ZipFlushSizeLimit="$(_ZipFlushSizeLimit)"
 			ExcludeFiles="@(AndroidPackagingOptionsExclude)"
+			IncludeFiles="@(AndroidPackagingOptionsInclude)"
 			AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
 			IntermediateOutputPath="$(IntermediateOutputPath)">
 		<Output TaskParameter="OutputFiles" ItemName="BaseZipFile" />


### PR DESCRIPTION
Fixes #9520

PR #8459 added support for the `AndroidPackagingOptionsInclude`. Unfortunately we forgot to add that property to the `BuildApk` and `BuildBaseAppBundle` calls in the closed source part of the product.

Since then we have move that code into this repo. So lets update all the `BuildApk` and `BuildBaseAppBundle` calls to use the new property.