### PR TITLE
Enable `DefaultValueAttributeSupport` in partial trim mode.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -206,6 +206,16 @@ extends:
         - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
           parameters:
             configuration: $(XA.Build.Configuration)
+            testName: Mono.Android.NET_Tests-TrimModePartial
+            project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+            testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)TrimModePartial.xml
+            extraBuildArgs: -p:TestsFlavor=TrimModePartial -p:TrimMode=partial
+            artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
+            artifactFolder: $(DotNetTargetFramework)-TrimModePartial
+
+        - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
+          parameters:
+            configuration: $(XA.Build.Configuration)
             testName: Mono.Android.NET_Tests-AotLlvm
             project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
             testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)AotLlvm.xml

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -114,6 +114,8 @@
     <UseNativeHttpHandler Condition="'$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler>
     <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
     <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == '' and '$(TrimMode)' == 'partial'">true</JsonSerializerIsReflectionEnabledByDefault>
+    <!-- Set to disable throwing behavior, see: https://github.com/dotnet/runtime/issues/109724 -->
+    <_DefaultValueAttributeSupport Condition="'$(_DefaultValueAttributeSupport)' == '' and '$(TrimMode)' == 'partial'">true</_DefaultValueAttributeSupport>
     <MetricsSupport Condition="'$(MetricsSupport)' == ''">false</MetricsSupport>
     <AndroidAvoidEmitForPerformance Condition="'$(AndroidAvoidEmitForPerformance)' == ''">$(AvoidEmitForPerformance)</AndroidAvoidEmitForPerformance>
     <AndroidAvoidEmitForPerformance Condition="'$(AndroidAvoidEmitForPerformance)' == ''">true</AndroidAvoidEmitForPerformance>

--- a/tests/Mono.Android-Tests/Mono.Android-Test.Shared.projitems
+++ b/tests/Mono.Android-Tests/Mono.Android-Test.Shared.projitems
@@ -48,6 +48,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System.Text\EncodingTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System.Text.Json\JsonSerializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System.Threading\InterlockedTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System.Xml\XmlSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\JavaObjectExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Android.Net\AndroidClientHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Android.Net\AndroidMessageHandlerTests.cs" />

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -38,7 +38,8 @@
     <AndroidLinkTool Condition=" '$(AndroidLinkTool)' == '' ">r8</AndroidLinkTool>
     <TrimMode Condition=" '$(TrimMode)' == '' ">full</TrimMode>
     <!-- Trimmer switches required for tests -->
-    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    <JsonSerializerIsReflectionEnabledByDefault Condition="'$(TrimMode)' == 'full'">true</JsonSerializerIsReflectionEnabledByDefault>
+    <_DefaultValueAttributeSupport Condition="'$(TrimMode)' == 'full'">true</_DefaultValueAttributeSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Mono.Android-Tests/System.Xml/XmlSerializer.cs
+++ b/tests/Mono.Android-Tests/System.Xml/XmlSerializer.cs
@@ -1,0 +1,23 @@
+using System.Xml.Serialization;
+using System.ComponentModel;
+
+using NUnit.Framework;
+
+namespace System.XmlTests {
+    public class C {
+        [DefaultValue(typeof(C), "c")]
+        public Type? T { get; }
+    }
+    
+    [TestFixture]
+    public class XmlSerializerTest {
+
+        [Test]
+        public void TrimmingDefaultValueAttribute ()
+        {
+            // Context: https://github.com/dotnet/runtime/issues/109724
+            var s = new XmlSerializer(typeof(C));
+            _ = new C().T; // Prevent C.T from being removed by trimming
+        }
+    }
+}


### PR DESCRIPTION
Currently, users can experience runtime crashes related to the use of `DefaultValue` attributes (taking type and string) without any trim warnings (see https://github.com/dotnet/runtime/issues/109724). This is because the trim warnings are disable in partial trim mode and this use-case of `DefaultValue` attributes is not trim compatible.

Workaround around this is to enable `_DefaultValueAttributeSupport` to prevent customer apps from crashing without trim warnings. App will still crash in `TrimMode="full"` but user would get warned during compile time.