### PR TITLE
Bump com.android.tools.build:manifest-merger from 30.3.1 to 31.7.2

### DIFF
--- a/src/manifestmerger/build.gradle
+++ b/src/manifestmerger/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
     // https://mvnrepository.com/artifact/com.android.tools.build/manifest-merger
-    implementation 'com.android.tools.build:manifest-merger:30.3.1'
+    implementation 'com.android.tools.build:manifest-merger:31.7.2'
 }
 
 sourceSets {

--- a/src/manifestmerger/manifestmerger.targets
+++ b/src/manifestmerger/manifestmerger.targets
@@ -13,7 +13,7 @@
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <Exec
-        Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs)"
+        Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />


### PR DESCRIPTION
Bumps com.android.tools.build:manifest-merger from 30.3.1 to 31.7.2.

This is a new version of #9500 with a shorter branch name.