### PR TITLE
[Xamarin.Android.Build.Tasks] close `XAAssemblyResolvers`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -222,7 +222,7 @@ namespace Xamarin.Android.Tasks
 			}
 			JCWGenerator.EnsureAllArchitecturesAreIdentical (Log, nativeCodeGenStates);
 
-			NativeCodeGenState.Template = templateCodeGenState;
+			NativeCodeGenState.TemplateJniAddNativeMethodRegistrationAttributePresent = templateCodeGenState.JniAddNativeMethodRegistrationAttributePresent;
 			BuildEngine4.RegisterTaskObjectAssemblyLocal (ProjectSpecificTaskObjectKey (NativeCodeGenStateRegisterTaskKey), nativeCodeGenStates, RegisteredTaskObjectLifetime.Build);
 
 			if (useMarshalMethods) {
@@ -269,6 +269,11 @@ namespace Xamarin.Android.Tasks
 
 			IList<string> additionalProviders = MergeManifest (templateCodeGenState, MaybeGetArchAssemblies (userAssembliesPerArch, templateCodeGenState.TargetArch));
 			GenerateAdditionalProviderSources (templateCodeGenState, additionalProviders);
+
+			// Dispose all XAAssemblyResolvers
+			foreach (var state in nativeCodeGenStates.Values) {
+				state.Resolver.Dispose ();
+			}
 
 			Dictionary<string, ITaskItem> MaybeGetArchAssemblies (Dictionary<AndroidTargetArch, Dictionary<string, ITaskItem>> dict, AndroidTargetArch arch)
 			{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -331,7 +331,7 @@ namespace Xamarin.Android.Tasks
 				BrokenExceptionTransitions = environmentParser.BrokenExceptionTransitions,
 				PackageNamingPolicy = pnp,
 				BoundExceptionType = boundExceptionType,
-				JniAddNativeMethodRegistrationAttributePresent = NativeCodeGenState.Template != null ? NativeCodeGenState.Template.JniAddNativeMethodRegistrationAttributePresent : false,
+				JniAddNativeMethodRegistrationAttributePresent = NativeCodeGenState.TemplateJniAddNativeMethodRegistrationAttributePresent,
 				HaveRuntimeConfigBlob = haveRuntimeConfigBlob,
 				NumberOfAssembliesInApk = assemblyCount,
 				BundledAssemblyNameWidth = assemblyNameWidth,

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeCodeGenState.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeCodeGenState.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Tasks;
 /// </summary>
 class NativeCodeGenState
 {
-	public static NativeCodeGenState? Template                 { get; set; }
+	public static bool TemplateJniAddNativeMethodRegistrationAttributePresent { get; set; }
 
 	/// <summary>
 	/// Target architecture for which this instance was created.


### PR DESCRIPTION
Context: https://discord.com/channels/732297728826277939/732297916680765551/1308554103206580244
Fixes: https://github.com/dotnet/android/issues/9133
Context: 86260ed3

Various customers have been reporting `UnauthorizedAccessExceptions` in incremental builds, which seems to be a new problem in .NET 9. We were not able to reproduce the issue locally, but with the number of reports it seems to be a real issue.

One customer shared a `MSBuild.dmp` file (while the file was locked), where I could observe the objects in memory:

    MemoryMappedViewStream	132
        Mono.Cecil.PE.Image	100
            Mono.Cecil.ModuleDefinition	100
                Mono.Cecil.TypeDefinition	100
                    Mono.Cecil.TypeDefinition[]	100
                        List<Mono.Cecil.TypeDefinition>	1
                            Xamarin.Android.Tasks.NativeCodeGenState [Static variable Xamarin.Android.Tasks.NativeCodeGenState.<Template>k__BackingField]	1

Then realized the problem was:

* We opened some `.dll` files with `Mono.Cecil`.

* They were never closed.

* Future incremental build attempts would fail on various operations of the same `.dll` files.

We were also storing some static state (`NativeCodeGenState`) to be shared across multiple MSBuild tasks:

    public static NativeCodeGenState? Template { get; set; }

`NativeCodeGenState` also holds a `XAAssemblyResolver` in a `Resolver` property. This means this `XAAssemblyResolver` instance would *also* be kept alive.

It appears we only use the static `Template` property for a `bool` flag, so I changed the property to a `bool` instead.

After this change, we can safely dispose `Resolver` instances. I looped over the `NativeCodeGenState` instances disposing of each `Resolver` at the end of the `<GenerateJavaStubs/>` MSBuild task.