### PR TITLE
[ci] Use new DevDiv/android-platform-support repo

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@62976287a5392ccc17ffff10bcafdc3cecedc89b
+DevDiv/android-platform-support:main@cdef164e7eef35128f74fa1f3ecbd7a878953a43

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@cdef164e7eef35128f74fa1f3ecbd7a878953a43
+DevDiv/android-platform-support:release/9.0.1xx@c22e86517918f75cdf147b12252361d90c6577bd

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ apk-sizes-*.txt
 *.binlog
 *.ProjectImports.zip
 *~
+external/android-platform-support/
 external/monodroid/
 external/mono/
 tests/api-compatibility/reference/*/*.dll

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -16,10 +16,10 @@ resources:
     name: xamarin/yaml-templates
     ref: refs/heads/main
     endpoint: xamarin
-  - repository: monodroid
-    type: github
-    name: xamarin/monodroid
-    endpoint: xamarin
+  - repository: android-platform-support
+    type: git
+    name: DevDiv/android-platform-support
+    ref: refs/heads/main
   - repository: maui
     type: github
     name: dotnet/maui

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -160,7 +160,7 @@ extends:
             testName: Mono.Android.NET_Tests-Debug
             project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
             testResultsFiles: TestResult-Mono.Android.NET_Tests-Debug.xml
-            artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.apk
+            artifactSource: bin/TestDebug/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.apk
             artifactFolder: $(DotNetTargetFramework)-Debug
 
         - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -25,11 +25,10 @@ resources:
     name: xamarin/sdk-insertions
     ref: refs/heads/main
     endpoint: xamarin
-  - repository: monodroid
-    type: github
-    name: xamarin/monodroid
+  - repository: android-platform-support
+    type: git
+    name: DevDiv/android-platform-support
     ref: refs/heads/main
-    endpoint: xamarin
   - repository: maui
     type: github
     name: dotnet/maui
@@ -90,7 +89,7 @@ extends:
       sourceRepositoriesToScan:
         include:
         - ${{ if ne(variables['System.PullRequest.IsFork'], 'True') }}:
-          - repository: monodroid
+          - repository: android-platform-support
         exclude:
         - repository: yaml-templates
         - repository: maui

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -53,15 +53,11 @@ stages:
     - checkout: maui
 
     - ${{ if ne(variables['System.PullRequest.IsFork'], 'True') }}:
-      - checkout: monodroid
+      - checkout: android-platform-support
         clean: true
         submodules: recursive
-        path: s/xamarin-android/external/monodroid
+        path: s/xamarin-android/external/android-platform-support
         persistCredentials: true
-
-      - script: rm -rf external/monodroid/external/xamarin-android
-        workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-        displayName: delete external xamarin-android submodule
 
       - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
         workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -25,25 +25,10 @@ steps:
 - checkout: maui
 
 - ${{ if ne(variables['System.PullRequest.IsFork'], 'True') }}:
-  # Clone 'monodroid' without submodules
-  - checkout: monodroid
-    clean: true
-    path: s/xamarin-android/external/monodroid
-
-  # Tell git to ignore the 'xamarin-android' submodule, which is large and unneeded
-  - script: git config submodule."external/xamarin-android".update none
-    workingDirectory: xamarin-android/external/monodroid
-    displayName: Ignore XA submodule
-
-  # Clone 'monodroid' with the rest of the submodules
-  - checkout: monodroid
+  - checkout: android-platform-support
     submodules: recursive
-    path: s/xamarin-android/external/monodroid
+    path: s/xamarin-android/external/android-platform-support
     persistCredentials: true
-
-  - script: rm -rf external/monodroid/external/xamarin-android
-    workingDirectory: ${{ parameters.xaSourcePath }}
-    displayName: delete legacy xamarin-android submodule
 
   - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
     workingDirectory: ${{ parameters.xaSourcePath }}

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -19,7 +19,7 @@
     <LibExtension Condition=" '$(HostOS)' == 'Windows' ">dll</LibExtension>
     <UseCommercialInstallerName Condition="'$(UseCommercialInstallerName)' == ''">False</UseCommercialInstallerName>
     <_HasCommercialFiles Condition="Exists('$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Common.Debugging.targets')">True</_HasCommercialFiles>
-    <_MonoDroidPath Condition=" '$(_MonoDroidPath)' == '' ">..\..\external\monodroid</_MonoDroidPath>
+    <_MonoDroidPath Condition=" '$(_MonoDroidPath)' == '' ">..\..\external\android-platform-support</_MonoDroidPath>
   </PropertyGroup>
   <Target Name="_FindFrameworkDirs">
     <ItemGroup>

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -6,9 +6,8 @@ ifeq ($(PREPARE_CI_PR)$(PREPARE_CI),00)
 else
 	$(MAKE) prepare
 endif
-ifneq ("$(wildcard $(topdir)/external/monodroid/Makefile)","")
-	cd $(topdir)/external/monodroid && ./configure --with-xamarin-android='$(topdir)'
-	$(call DOTNET_BINLOG,build-commercial) $(SOLUTION) -t:BuildExternal
+ifneq ("$(wildcard $(topdir)/external/android-platform-support/src/Xamarin.Android.Build.Debugging.Tasks/Xamarin.Android.Build.Debugging.Tasks.csproj)","")
+	$(call SYSTEM_DOTNET_BINLOG,build-commercial,msbuild) $(SOLUTION) -t:BuildExternal
 endif
 	$(MAKE) leeroy
 

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -10,8 +10,8 @@
 
   <Target Name="BuildExternal">
     <Exec
-        Command="&quot;$(DotNetPreviewTool)&quot; build monodroid.proj -c $(Configuration) -p:XamarinAndroidSourcePath=$(_Root) -p:DebuggingToolsOutputDirectory=$(MicrosoftAndroidSdkOutDir) -p:CompatTargetsOutputDirectory=$(XAInstallPrefix)xbuild/Novell -bl:$(_BinlogPathPrefix)-build-monodroid.binlog"
-        WorkingDirectory="$(_Root)external\monodroid"
+        Command="&quot;$(DotNetPreviewTool)&quot; build monodroid.proj -c $(Configuration) -p:XamarinAndroidSourcePath=$(_Root) -p:XAIntegrationBuild=true -bl:$(_BinlogPathPrefix)-build-monodroid.binlog"
+        WorkingDirectory="$(_Root)external\android-platform-support\build-tools"
     />
   </Target>
 

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -52,7 +52,7 @@ endef
 
 # $(call DOTNET_BINLOG,name,build=$(DOTNET_VERB),dotnet=$(DOTNET_TOOL))
 define DOTNET_BINLOG
-	$(if $(3),,PATH="$(DOTNET_ROOT):$(PATH)") $(if $(3),$(3),$(DOTNET_TOOL)) $(if $(2),$(2),$(DOTNET_VERB)) -c $(CONFIGURATION) -v:n $(MSBUILD_ARGS) \
+	$(if $(3),,PATH="$(DOTNET_ROOT):$(PATH)") $(if $(3),$(3),$(DOTNET_TOOL)) $(if $(2),$(2),$(DOTNET_VERB)) -p:Configuration=$(CONFIGURATION) -v:n $(MSBUILD_ARGS) \
 		-bl:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/Build$(CONFIGURATION)/msbuild-`date +%Y%m%dT%H%M%S`-$(1).binlog"
 endef
 


### PR DESCRIPTION
Bumps external components to https://devdiv.visualstudio.com/DevDiv/_git/android-platform-support/commit/cdef164e7eef35128f74fa1f3ecbd7a878953a43

A new android-platform-support Azure Repo has been created in the DevDiv
project containing library code from the xamarin/androidtools,
xamarin/monodroid, and xamarin/android-sdk-installer repos.

The build has been updated to build and package all required closed
source components from the new Azure Repo.