### PR TITLE
[Xamarin.Android.Build.Tasks] fix incremental builds for `_GenerateAndroidRemapNativeCode`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1647,13 +1647,14 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GenerateEmptyAndroidRemapNativeCode"
         DependsOnTargets="_PrepareAndroidRemapNativeAssemblySources"
         Condition=" '@(_AndroidRemapMembers->Count())' == '0' "
-        Inputs="$(MSBuildProjectFullPath)"
+        Inputs="$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
         Outputs="@(_AndroidRemapAssemblySource)">
   <GenerateJniRemappingNativeCode
       OutputDirectory="$(_NativeAssemblySourceDir)"
       GenerateEmptyCode="True"
       SupportedAbis="@(_BuildTargetAbis)"
    />
+   <Touch Files="@(_AndroidRemapAssemblySource)" />
 </Target>
 
 <PropertyGroup>
@@ -1667,13 +1668,14 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GenerateAndroidRemapNativeCode"
         DependsOnTargets="$(_GenerateAndroidRemapNativeCodeDependsOn)"
         Condition=" '@(_AndroidRemapMembers->Count())' != '0' "
-        Inputs="$(_XARemapMembersFilePath)"
+        Inputs="$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects);$(_XARemapMembersFilePath)"
         Outputs="@(_AndroidRemapAssemblySource)">
   <GenerateJniRemappingNativeCode
       OutputDirectory="$(_NativeAssemblySourceDir)"
       RemappingXmlFilePath="$(_XARemapMembersFilePath)"
       SupportedAbis="@(_BuildTargetAbis)"
       />
+  <Touch Files="@(_AndroidRemapAssemblySource)" />
 </Target>
 
 <Target Name="_RunAotForAllRIDs"


### PR DESCRIPTION
I've noticed we are randomly seeing a test failure like:

    Build_AndroidResource_Change
    Exceeded expected time of 2250ms, actual 2992.086ms

Sometimes, it passes and sometimes not.

Reviewing the `.binlog` I noticed under the top 10 expensive tasks:

    GenerateJniRemappingNativeCode = 97 ms, 1 calls.

Which I found by the target:

    _GenerateEmptyAndroidRemapNativeCode
    Building target "_GenerateEmptyAndroidRemapNativeCode" completely.
    Input file "/Users/runner/work/1/a/TestRelease/11-21_21.07.33/temp/BuildAndroidResourceChange/UnnamedProject.csproj" is newer than output file "obj/Debug/android/jni_remap.x86_64.ll".

Which has the `Inputs/Outputs`:

    Inputs="$(MSBuildProjectFullPath)"
    Outputs="@(_AndroidRemapAssemblySource)"

Reviewing the target, it feels like we should fix the `Inputs` and `Outputs`, such as:

* `Inputs` should include all MSBuild files `@(_AndroidMSBuildAllProjects)`, as settings could be in `Directory.Build.props`, etc.

* `Inputs` should include `build.props` if that file changes to force a rerun.

* We should `<Touch/>` the `Outputs` files to prevent the target from running when it doesn't need to.

After these changes, I'm hoping `Build_AndroidResource_Change` passes more reliably, we will see.