### PR TITLE
Bump to DevDiv/android-platform-support@52dd010a

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:dev/pjc/build-tasks-ambig@22a776c0f5c9a583ad03c6f3abf1fcd3072834ad
+DevDiv/android-platform-support:dev/pjc/build-tasks-ambig@114246480666883ad8c62ba52b99ef7751876c8a

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@c22e86517918f75cdf147b12252361d90c6577bd
+DevDiv/android-platform-support:main@d0479f7d6e849bd598f374856e1bc0ff79c33e0a

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@d0479f7d6e849bd598f374856e1bc0ff79c33e0a
+DevDiv/android-platform-support:dev/pjc/build-tasks-ambig@de537b371679e73230f8a1c3f46e424c18fe52f5

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:dev/pjc/build-tasks-ambig@114246480666883ad8c62ba52b99ef7751876c8a
+DevDiv/android-platform-support:main@52dd010acff1fa00d172609c231b7ee7b56b94a3

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:dev/pjc/build-tasks-ambig@de537b371679e73230f8a1c3f46e424c18fe52f5
+DevDiv/android-platform-support:dev/pjc/build-tasks-ambig@22a776c0f5c9a583ad03c6f3abf1fcd3072834ad


### PR DESCRIPTION
Changes: https://devdiv.visualstudio.com/DevDiv/_git/android-platform-support/branchCompare?baseVersion=GCc22e86517918f75cdf147b12252361d90c6577bd&targetVersion=GC52dd010acff1fa00d172609c231b7ee7b56b94a3

* Merged PR 594914: [InstallAndroidDependencies] Correctly init CommonUtilities.Helpers
* Merged PR 595751: [build] Use flexible cmake path
* Merged PR 595711: [oneloc] Fix lcl file paths
* Merged PR 594792: Ensures JavaSDK is installed previous to AndroidSDK
* Merged PR 594160: [OneLoc] Fix LocProject and OneLoc build pipeline

