### PR TITLE
[Xamarin.Android.Build.Tasks] Add PerformanceTimer for measuring task steps time.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/PerformanceTimer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/PerformanceTimer.cs
@@ -1,0 +1,83 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tasks.Utilities;
+
+// A class that faciliates performance timing of a task.
+// Example usage:
+//   var timer = PerformanceTimer.Create ("MyTask");
+//   timer.StartSubTask ("Step 1");
+//   <do stuff>
+//   timer.StartSubTask ("Step 2");
+//   <do stuff>
+//   timer.Stop ();
+//   timer.Log (Log);
+// Also supports Disposable syntax:
+//   using (timer.StartSubTask ("Step 1")) {
+//     <do stuff>
+//   }
+class PerformanceTimer : IDisposable
+{
+	readonly Stopwatch sw;
+	readonly List<PerformanceTimer> subtasks = [];
+
+	PerformanceTimer? active_subtask;
+
+	public string Name { get; }
+
+	PerformanceTimer (string name)
+	{
+		Name = name;
+		sw = Stopwatch.StartNew ();
+	}
+
+	public static PerformanceTimer Create (string name)
+	{
+		return new PerformanceTimer (name);
+	}
+
+	public void Dispose ()
+	{
+		Stop ();
+	}
+
+	public PerformanceTimer StartSubTask (string name)
+	{
+		active_subtask?.Stop ();
+
+		active_subtask = new PerformanceTimer (name);
+		subtasks.Add (active_subtask);
+		return active_subtask;
+	}
+
+	public void Stop ()
+	{
+		active_subtask?.Stop ();
+		sw.Stop ();
+	}
+
+	public void WriteLog (TaskLoggingHelper log)
+	{
+		var sb = new StringBuilder ();
+
+		WriteLog (sb, 0);
+
+		log.LogDebugMessage (sb.ToString ());
+	}
+
+	void WriteLog (StringBuilder sb, int level)
+	{
+		sb.AppendLine ($"{new string (' ', level * 2)}- {Name} - {sw.ElapsedMilliseconds}ms");
+
+		level++;
+
+		foreach (var timer in subtasks)
+			timer.WriteLog (sb, level);
+	}
+}


### PR DESCRIPTION
Running an MSBuild task in a profiler is extremely hard, so for now I've been resorting to "printf" profiling.  This adds a utility class that makes it easier to add performance information to the steps in a task.  The output ends up in a `.binlog`.
 
Example output (MAUI template release build):

```
- BuildApk.RunTask - 13597ms
  - Setup - 0ms
  - Compression - 0ms
  - DSOWrapperGenerator - 0ms
  - ExecuteWithAbi 'arm64-v8a, x86_64' - 13591ms
    - Setup - 24ms
    - Add DalvikClasses - 1933ms
    - Embed Assemblies - 5120ms
      - Add 156 user assemblies - 2420ms
      - Add 80 framework assemblies - 1739ms
      - Generate assembly store - 42ms
      - Add assembly store - 918ms
    - AddRuntimeConfigBlob - 197ms
    - AddRuntimeLibraries - 21ms
    - Flush - 169ms
    - AddNativeLibraries - 829ms
    - AddAdditionalNativeLibraries - 0ms
    - Add files - 42ms
    - Add Jars - 515ms
    - Clean up Removed files - 0ms
    - Flush - 4640ms
    - FixupArchive - 93ms
  - Cleanup - 2ms
```

This is roughly what I used to profile the `GenerateJavaStubs` task (https://github.com/dotnet/android/pull/9208, https://github.com/dotnet/android/pull/9215) and I am now starting to look and see if there are any performance wins in `BuildApk`.  I use this locally, the team can decide if we want to commit this to the repo or not.