### PR TITLE
Add NugetPackageId Metadata to TaskItems

### DIFF
--- a/Documentation/docs-mobile/messages/xa0141.md
+++ b/Documentation/docs-mobile/messages/xa0141.md
@@ -1,14 +1,28 @@
 ---
 title: .NET for Android warning XA0141
 description: XA0141 warning code
-ms.date: 07/22/2024
+ms.date: 01/08/2025
 ---
 # .NET for Android warning XA0141
 
 ## Issue
 
-Shared library '{3}' must use 16 KB page sizes. Please inform the authors of the NuGet package '{0}' version '{1}' which contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.
+Future versions of Android on arm64 will require that native libraries use 16 KB page sizes.
+This requires that the mentioned native libraries be recompiled, and all apps using those
+native libraries be rebuilt to contain the fixed versions of the native libraries.
+
+See the Android SDK [Support 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes)
+documentation for more information.
 
 ## Solution
 
-The indicated native shared library must be recompiled and relinked with the 16k alignment, as per URL indicated in the message.
+The indicated native shared library must be recompiled and relinked with the 16k alignment, as per
+the Android SDK [Support 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes)
+documentation.
+
+## Example messages
+
+> warning XA0141: Android 16 will require 16 KB page sizes, Shared library 'libface_detector_v2_jni.so' does not have a 16 KB page size.
+> Please inform the authors of the NuGet package 'Xamarin.GooglePlayServices.Vision.Face.Contour.Internal' version '116.1.0.19'
+> which contains 'lib/net8.0-android34.0/play-services-vision-face-contour-internal.aar'.
+> See https://developer.android.com/guide/practices/page-sizes for more details.

--- a/Documentation/docs-mobile/messages/xa0141.md
+++ b/Documentation/docs-mobile/messages/xa0141.md
@@ -7,7 +7,7 @@ ms.date: 07/22/2024
 
 ## Issue
 
-NuGet package '{0}' version '{1}' contains a shared library '{2}' which is not correctly aligned. See https://developer.android.com/guide/practices/page-sizes for more details
+Shared library '{3}' is not correctly aligned. You may wish to inform the creators of the NuGet/Library about this issue. The shared library is from NuGet package '{0}' version '{1}' and contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.
 
 ## Solution
 

--- a/Documentation/docs-mobile/messages/xa0141.md
+++ b/Documentation/docs-mobile/messages/xa0141.md
@@ -7,7 +7,7 @@ ms.date: 07/22/2024
 
 ## Issue
 
-Shared library '{3}' is not correctly aligned. You may wish to inform the creators of the NuGet/Library about this issue. The shared library is from NuGet package '{0}' version '{1}' and contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.
+Shared library '{3}' must use 16 KB page sizes. Please inform the authors of the NuGet package '{0}' version '{1}' which contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.
 
 ## Solution
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -23,7 +23,7 @@ projects.
       <_AarSearchDirectory   Include="@(_ReferencePath->'%(RootDir)%(Directory)')" />
       <_AarSearchDirectory   Include="@(_ReferenceDependencyPaths->'%(RootDir)%(Directory)')" />
       <_AarDistinctDirectory Include="@(_AarSearchDirectory->Distinct())" />
-      <_AarFromLibraries     Include="%(_AarDistinctDirectory.Identity)*.aar" />
+      <_AarFromLibraries     Include="%(_AarDistinctDirectory.Identity)*.aar" NuGetPackageId="%(_AarDistinctDirectory.NuGetPackageId)" NuGetPackageVersion="%(_AarDistinctDirectory.NuGetPackageVersion)"/>
     </ItemGroup>
     <ItemGroup Condition=" '@(_AarFromLibraries->Count())' != '0' ">
       <!--

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1063,7 +1063,7 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - NuGet package version</comment>
   </data>
   <data name="XA0141" xml:space="preserve">
-    <value>Shared library '{3}' must use 16 KB page sizes. Please inform the authors of the NuGet package '{0}' version '{1}' which contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.</value>
+    <value>Android 16 will require 16 KB page sizes, Shared library '{3}' does not have a 16 KB page size. Please inform the authors of the NuGet package '{0}' version '{1}' which contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.</value>
     <comment>The following is a literal name and should not be translated: NuGet
 {0} - NuGet package id
 {1} - NuGet package version

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1063,7 +1063,7 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - NuGet package version</comment>
   </data>
   <data name="XA0141" xml:space="preserve">
-    <value>Android 16 will require 16 KB page sizes, Shared library '{3}' does not have a 16 KB page size. Please inform the authors of the NuGet package '{0}' version '{1}' which contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.</value>
+    <value>Android 16 will require 16 KB page sizes, shared library '{3}' does not have a 16 KB page size. Please inform the authors of the NuGet package '{0}' version '{1}' which contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.</value>
     <comment>The following is a literal name and should not be translated: NuGet
 {0} - NuGet package id
 {1} - NuGet package version

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1063,7 +1063,7 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - NuGet package version</comment>
   </data>
   <data name="XA0141" xml:space="preserve">
-    <value>'{2}' from NuGet package '{0}' version '{1}' contains a shared library '{3}' which is not correctly aligned. You may wish to inform the creators of the Library about this issue. See https://developer.android.com/guide/practices/page-sizes for more details.</value>
+    <value>Shared library '{3}' is not correctly aligned. You may wish to inform the creators of the NuGet/Library about this issue. The shared library is from NuGet package '{0}' version '{1}' and contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.</value>
     <comment>The following is a literal name and should not be translated: NuGet
 {0} - NuGet package id
 {1} - NuGet package version

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1063,7 +1063,7 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - NuGet package version</comment>
   </data>
   <data name="XA0141" xml:space="preserve">
-    <value>Shared library '{3}' is not correctly aligned. You may wish to inform the creators of the NuGet/Library about this issue. The shared library is from NuGet package '{0}' version '{1}' and contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.</value>
+    <value>Shared library '{3}' must use 16 KB page sizes. Please inform the authors of the NuGet package '{0}' version '{1}' which contains '{2}'. See https://developer.android.com/guide/practices/page-sizes for more details.</value>
     <comment>The following is a literal name and should not be translated: NuGet
 {0} - NuGet package id
 {1} - NuGet package version

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1063,11 +1063,12 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - NuGet package version</comment>
   </data>
   <data name="XA0141" xml:space="preserve">
-    <value>NuGet package '{0}' version '{1}' contains a shared library '{2}' which is not correctly aligned. See https://developer.android.com/guide/practices/page-sizes for more details</value>
+    <value>'{2}' from NuGet package '{0}' version '{1}' contains a shared library '{3}' which is not correctly aligned. You may wish to inform the creators of the Library about this issue. See https://developer.android.com/guide/practices/page-sizes for more details.</value>
     <comment>The following is a literal name and should not be translated: NuGet
 {0} - NuGet package id
 {1} - NuGet package version
-{2} - shared library file name
+{2} - Source location path
+{3} - shared library file name
     </comment>
   </data>
   <data name="XA4249" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Tasks
 		};
 
 		[Required]
-		public string TargetDirectory { get; set; }
+		public ITaskItem[] ExtractedDirectories { get; set; }
 
 		public string CacheFile { get; set;} 
 
@@ -35,22 +35,37 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			if (!Directory.Exists (TargetDirectory)) {
-				Log.LogDebugMessage ("Target directory was not found");
-				return true;
-			}
-
 			var manifestDocuments = new List<ITaskItem> ();
 			var nativeLibraries   = new List<ITaskItem> ();
 			var jarFiles          = new List<ITaskItem> ();
-			foreach (var file in Directory.EnumerateFiles (TargetDirectory, "*", SearchOption.AllDirectories)) {
-				if (file.EndsWith (".so", StringComparison.OrdinalIgnoreCase)) {
-					if (AndroidRidAbiHelper.GetNativeLibraryAbi (file) != null)
-						nativeLibraries.Add (new TaskItem (file));
-				} else if (file.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
-					jarFiles.Add (new TaskItem (file));
-				} else if (file.EndsWith (".xml", StringComparison.OrdinalIgnoreCase)) {
-					if (Path.GetFileName (file) == "AndroidManifest.xml") {
+			foreach (var extractedDirectory in ExtractedDirectories) {
+				if (!Directory.Exists (extractedDirectory.ItemSpec)) {
+					continue;
+				}
+				string originalFile = extractedDirectory.GetMetadata (ResolveLibraryProjectImports.OriginalFile);
+				string nuGetPackageId = extractedDirectory.GetMetadata (ResolveLibraryProjectImports.NuGetPackageId);
+				string nuGetPackageVersion = extractedDirectory.GetMetadata (ResolveLibraryProjectImports.NuGetPackageVersion);
+				foreach (var file in Directory.EnumerateFiles (extractedDirectory.ItemSpec, "*", SearchOption.AllDirectories)) {
+					if (file.EndsWith (".so", StringComparison.OrdinalIgnoreCase)) {
+						if (AndroidRidAbiHelper.GetNativeLibraryAbi (file) != null)
+							nativeLibraries.Add (new TaskItem (file, new Dictionary<string, string> {
+								{ ResolveLibraryProjectImports.OriginalFile, originalFile },
+								{ ResolveLibraryProjectImports.NuGetPackageId, nuGetPackageId },
+								{ ResolveLibraryProjectImports.NuGetPackageVersion, nuGetPackageVersion }
+							}));
+						continue;
+					}
+					if (file.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
+						jarFiles.Add (new TaskItem (file, new Dictionary<string, string> {
+								{ ResolveLibraryProjectImports.OriginalFile, originalFile },
+								{ ResolveLibraryProjectImports.NuGetPackageId, nuGetPackageId },
+								{ ResolveLibraryProjectImports.NuGetPackageVersion, nuGetPackageVersion }
+							}));
+						continue;
+					}
+					if (file.EndsWith (".xml", StringComparison.OrdinalIgnoreCase)) {
+						if (Path.GetFileName (file) != "AndroidManifest.xml")
+							continue;
 						// there could be ./AndroidManifest.xml and bin/AndroidManifest.xml, which will be the same. So, ignore "bin" ones.
 						var directory = Path.GetFileName (Path.GetDirectoryName (file));
 						if (IgnoredManifestDirectories.Contains (directory))
@@ -60,7 +75,11 @@ namespace Xamarin.Android.Tasks
 							Log.LogCodedWarning ("XA4315", file, 0, Properties.Resources.XA4315, file);
 							continue;
 						}
-						manifestDocuments.Add (new TaskItem (file));
+						manifestDocuments.Add (new TaskItem (file, new Dictionary<string, string> {
+							{ ResolveLibraryProjectImports.OriginalFile, originalFile },
+							{ ResolveLibraryProjectImports.NuGetPackageId, nuGetPackageId },
+							{ ResolveLibraryProjectImports.NuGetPackageVersion, nuGetPackageVersion }
+						}));
 					}
 				}
 			}
@@ -73,9 +92,9 @@ namespace Xamarin.Android.Tasks
 				var document = new XDocument (
 							new XDeclaration ("1.0", "UTF-8", null),
 							new XElement ("Paths",
-									new XElement ("ManifestDocuments", ManifestDocuments.Select(e => new XElement ("ManifestDocument", e.ItemSpec))),
-									new XElement ("NativeLibraries", NativeLibraries.Select(e => new XElement ("NativeLibrary", e.ItemSpec))),
-									new XElement ("Jars", Jars.Select(e => new XElement ("Jar", e.ItemSpec)))
+									new XElement ("ManifestDocuments", ManifestDocuments.ToXElements ("ManifestDocument", ResolveLibraryProjectImports.KnownMetadata)),
+									new XElement ("NativeLibraries", NativeLibraries.ToXElements ("NativeLibrary", ResolveLibraryProjectImports.KnownMetadata)),
+									new XElement ("Jars", Jars.ToXElements ("Jar", ResolveLibraryProjectImports.KnownMetadata))
 						));
 				document.SaveIfChanged (CacheFile);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -49,17 +49,17 @@ namespace Xamarin.Android.Tasks
 					if (file.EndsWith (".so", StringComparison.OrdinalIgnoreCase)) {
 						if (AndroidRidAbiHelper.GetNativeLibraryAbi (file) != null)
 							nativeLibraries.Add (new TaskItem (file, new Dictionary<string, string> {
-								{ ResolveLibraryProjectImports.OriginalFile, originalFile },
-								{ ResolveLibraryProjectImports.NuGetPackageId, nuGetPackageId },
-								{ ResolveLibraryProjectImports.NuGetPackageVersion, nuGetPackageVersion }
+								[ResolveLibraryProjectImports.OriginalFile] = originalFile,
+								[ResolveLibraryProjectImports.NuGetPackageId] = nuGetPackageId,
+								[ResolveLibraryProjectImports.NuGetPackageVersion] = nuGetPackageVersion,
 							}));
 						continue;
 					}
 					if (file.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
 						jarFiles.Add (new TaskItem (file, new Dictionary<string, string> {
-								{ ResolveLibraryProjectImports.OriginalFile, originalFile },
-								{ ResolveLibraryProjectImports.NuGetPackageId, nuGetPackageId },
-								{ ResolveLibraryProjectImports.NuGetPackageVersion, nuGetPackageVersion }
+								[ResolveLibraryProjectImports.OriginalFile] = originalFile,
+								[ResolveLibraryProjectImports.NuGetPackageId] = nuGetPackageId,
+								[ResolveLibraryProjectImports.NuGetPackageVersion] = nuGetPackageVersion,
 							}));
 						continue;
 					}
@@ -76,9 +76,9 @@ namespace Xamarin.Android.Tasks
 							continue;
 						}
 						manifestDocuments.Add (new TaskItem (file, new Dictionary<string, string> {
-							{ ResolveLibraryProjectImports.OriginalFile, originalFile },
-							{ ResolveLibraryProjectImports.NuGetPackageId, nuGetPackageId },
-							{ ResolveLibraryProjectImports.NuGetPackageVersion, nuGetPackageVersion }
+							[ResolveLibraryProjectImports.OriginalFile] = originalFile,
+							[ResolveLibraryProjectImports.NuGetPackageId] = nuGetPackageId,
+							[ResolveLibraryProjectImports.NuGetPackageVersion] = nuGetPackageVersion,
 						}));
 					}
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadLibraryProjectImportsCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadLibraryProjectImportsCache.cs
@@ -58,6 +58,9 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] ProguardConfigFiles { get; set; }
 
+		[Output]
+		public ITaskItem [] ExtractedDirectories { get; set; }
+
 		public override bool RunTask ()
 		{
 			Log.LogDebugMessage ("Task ReadLibraryProjectImportsCache");
@@ -74,6 +77,7 @@ namespace Xamarin.Android.Tasks
 			ResolvedResourceDirectoryStamps = doc.GetPathsAsTaskItems ("ResolvedResourceDirectoryStamps"
 				, "ResolvedResourceDirectoryStamp");
 			ProguardConfigFiles = doc.GetPathsAsTaskItems ("ProguardConfigFiles", "ProguardConfigFile");
+			ExtractedDirectories = doc.GetPathsAsTaskItems ("ExtractedDirectories", "ExtractedDirectory");
 
 			Log.LogDebugTaskItems ("  Jars: ", Jars);
 			Log.LogDebugTaskItems ("  ResolvedAssetDirectories: ", ResolvedAssetDirectories);
@@ -81,6 +85,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugTaskItems ("  ResolvedEnvironmentFiles: ", ResolvedEnvironmentFiles);
 			Log.LogDebugTaskItems ("  ResolvedResourceDirectoryStamps: ", ResolvedResourceDirectoryStamps);
 			Log.LogDebugTaskItems ("  ProguardConfigFiles: ", ProguardConfigFiles);
+			Log.LogDebugTaskItems ("  ExtractedDirectories: ", ExtractedDirectories);
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -393,7 +393,6 @@ namespace Xamarin.Android.Tasks
 				string proguardFile = Path.Combine (importsDir, "proguard.txt");
 				string nuGetPackageId = aarFile.GetMetadata (NuGetPackageId) ?? string.Empty;
 				string nuGetPackageVersion = aarFile.GetMetadata (NuGetPackageVersion) ?? string.Empty;
-				Console.WriteLine ($"{aarFile.ItemSpec}: {nuGetPackageId} {nuGetPackageVersion}");
 				extractedDirectories.Add (new TaskItem (outDirForDll, new Dictionary<string, string> {
 					{ OriginalFile, aarFile.ItemSpec },
 					{ NuGetPackageId, nuGetPackageId },

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -270,9 +270,9 @@ namespace Xamarin.Android.Tasks
 								updated |= Files.CopyIfStreamChanged (stream, outFile);
 							}
 							resolvedEnvironments.Add (new TaskItem (Path.GetFullPath (outFile), new Dictionary<string, string> {
-								{ OriginalFile, assemblyPath },
-								{ NuGetPackageId, nuGetPackageId },
-								{ NuGetPackageVersion, nuGetPackageVersion },
+								[OriginalFile] = assemblyPath,
+								[NuGetPackageId] = nuGetPackageId,
+								[NuGetPackageVersion] = nuGetPackageVersion,
 							}));
 						}
 						// embedded jars (EmbeddedJar, EmbeddedReferenceJar)
@@ -338,10 +338,10 @@ namespace Xamarin.Android.Tasks
 							if (Directory.Exists (resDir)) {
 								CreateResourceArchive (resDir, resDirArchive);
 								var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
-									{ OriginalFile, assemblyPath },
-									{ ResourceDirectoryArchive, Path.GetFullPath (resDirArchive)},
-									{ NuGetPackageId, nuGetPackageId },
-									{ NuGetPackageVersion, nuGetPackageVersion },
+									[OriginalFile] = assemblyPath,
+									[ResourceDirectoryArchive] = Path.GetFullPath (resDirArchive),
+									[NuGetPackageId] = nuGetPackageId,
+									[NuGetPackageVersion] = nuGetPackageVersion,
 								});
 								if (bool.TryParse (assemblyItem.GetMetadata (AndroidSkipResourceProcessing), out skip) && skip)
 									taskItem.SetMetadata (AndroidSkipResourceProcessing, "True");
@@ -349,9 +349,9 @@ namespace Xamarin.Android.Tasks
 							}
 							if (Directory.Exists (assetsDir)) {
 								resolvedAssetDirectories.Add (new TaskItem (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
-									{ OriginalFile, assemblyPath },
-									{ NuGetPackageId, nuGetPackageId },
-									{ NuGetPackageVersion, nuGetPackageVersion },
+									[OriginalFile] = assemblyPath,
+									[NuGetPackageId] = nuGetPackageId,
+									[NuGetPackageVersion] = nuGetPackageVersion,
 								}));
 							}
 						}
@@ -394,9 +394,9 @@ namespace Xamarin.Android.Tasks
 				string nuGetPackageId = aarFile.GetMetadata (NuGetPackageId) ?? string.Empty;
 				string nuGetPackageVersion = aarFile.GetMetadata (NuGetPackageVersion) ?? string.Empty;
 				extractedDirectories.Add (new TaskItem (outDirForDll, new Dictionary<string, string> {
-					{ OriginalFile, aarFile.ItemSpec },
-					{ NuGetPackageId, nuGetPackageId },
-					{ NuGetPackageVersion, nuGetPackageVersion }
+					[OriginalFile] = aarFile.ItemSpec,
+					[NuGetPackageId] = nuGetPackageId,
+					[NuGetPackageVersion] = nuGetPackageVersion,
 				}));
 
 				bool updated = false;
@@ -417,18 +417,18 @@ namespace Xamarin.Android.Tasks
 							skipProcessing = "True";
 						}
 						resolvedResourceDirectories.Add (new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
-							{ OriginalFile, Path.GetFullPath (aarFile.ItemSpec) },
-							{ AndroidSkipResourceProcessing, skipProcessing },
-							{ ResourceDirectoryArchive, Path.GetFullPath (resDirArchive)},
-							{ NuGetPackageId, nuGetPackageId },
-							{ NuGetPackageVersion, nuGetPackageVersion },
+							[OriginalFile] = Path.GetFullPath (aarFile.ItemSpec),
+							[AndroidSkipResourceProcessing] = skipProcessing,
+							[ResourceDirectoryArchive] = Path.GetFullPath (resDirArchive),
+							[NuGetPackageId] = nuGetPackageId,
+							[NuGetPackageVersion] = nuGetPackageVersion,
 						}));
 					}
 					if (Directory.Exists (assetsDir))
 						resolvedAssetDirectories.Add (new TaskItem  (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
-							{ OriginalFile, aarFullPath },
-							{ NuGetPackageId, nuGetPackageId },
-							{ NuGetPackageVersion, nuGetPackageVersion },
+							[OriginalFile] = aarFullPath,
+							[NuGetPackageId] = nuGetPackageId,
+							[NuGetPackageVersion] = nuGetPackageVersion,
 						}));
 					continue;
 				}
@@ -455,9 +455,9 @@ namespace Xamarin.Android.Tasks
 									entryFullName.StartsWith (".net\\env\\", StringComparison.OrdinalIgnoreCase)) {
 								var fullPath = Path.GetFullPath (Path.Combine (importsDir, entryFullName));
 								resolvedEnvironments.Add (new TaskItem (fullPath, new Dictionary<string, string> {
-									{ OriginalFile, aarFile.ItemSpec },
-									{ NuGetPackageId, nuGetPackageId },
-									{ NuGetPackageVersion, nuGetPackageVersion },
+									[OriginalFile] = aarFile.ItemSpec,
+									[NuGetPackageId] = nuGetPackageId,
+									[NuGetPackageVersion] = nuGetPackageVersion,
 								}));
 							}
 							return entryFullName;
@@ -482,24 +482,24 @@ namespace Xamarin.Android.Tasks
 						skipProcessing = "True";
 					}
 					resolvedResourceDirectories.Add (new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
-						{ OriginalFile, aarFullPath },
-						{ AndroidSkipResourceProcessing, skipProcessing },
-						{ ResourceDirectoryArchive, Path.GetFullPath (resDirArchive)},
-						{ NuGetPackageId, nuGetPackageId },
-						{ NuGetPackageVersion, nuGetPackageVersion },
+						[OriginalFile] = aarFullPath,
+						[AndroidSkipResourceProcessing] = skipProcessing,
+						[ResourceDirectoryArchive] = Path.GetFullPath (resDirArchive),
+						[NuGetPackageId] = nuGetPackageId,
+						[NuGetPackageVersion] = nuGetPackageVersion,
 					}));
 				}
 				if (Directory.Exists (assetsDir))
 					resolvedAssetDirectories.Add (new TaskItem (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
-						{ OriginalFile, aarFullPath },
-						{ NuGetPackageId, nuGetPackageId },
-						{ NuGetPackageVersion, nuGetPackageVersion },
+						[OriginalFile] = aarFullPath,
+						[NuGetPackageId] = nuGetPackageId,
+						[NuGetPackageVersion] = nuGetPackageVersion,
 					}));
 				if (AndroidApplication && File.Exists (proguardFile)) {
 					proguardConfigFiles.Add (new TaskItem (Path.GetFullPath (proguardFile), new Dictionary<string, string> {
-						{ OriginalFile, aarFullPath },
-						{ NuGetPackageId, nuGetPackageId },
-						{ NuGetPackageVersion, nuGetPackageVersion },
+						[OriginalFile] = aarFullPath,
+						[NuGetPackageId] = nuGetPackageId,
+						[NuGetPackageVersion] = nuGetPackageVersion,
 					}));
 				}
 			}
@@ -525,9 +525,9 @@ namespace Xamarin.Android.Tasks
 		{
 			if (!jars.ContainsKey (fullPath)) {
 				jars.Add (fullPath, new TaskItem (fullPath, new Dictionary<string, string> {
-					{ OriginalFile, originalFile },
-					{ NuGetPackageId, nuGetPackageId },
-					{ NuGetPackageVersion, nuGetPackageVersion },
+					[OriginalFile] = originalFile,
+					[NuGetPackageId] = nuGetPackageId,
+					[NuGetPackageVersion] = nuGetPackageVersion,
 				}));
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -211,9 +211,9 @@ namespace Xamarin.Android.Tasks
 				string nuGetPackageId = assemblyItem.GetMetadata (NuGetPackageId) ?? string.Empty;
 				string nuGetPackageVersion = assemblyItem.GetMetadata (NuGetPackageVersion) ?? string.Empty;
 				extractedDirectories.Add (new TaskItem (outDirForDll, new Dictionary<string, string> {
-					{ OriginalFile, assemblyPath },
-					{ NuGetPackageId, nuGetPackageId },
-					{ NuGetPackageVersion, nuGetPackageVersion }
+					[OriginalFile] = assemblyPath,
+					[NuGetPackageId] = nuGetPackageId,
+					[NuGetPackageVersion] = nuGetPackageVersion
 				}));
 
 				// Skip already-extracted resources.
@@ -230,10 +230,10 @@ namespace Xamarin.Android.Tasks
 					}
 					if (Directory.Exists (resDir)) {
 						var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
-							{ OriginalFile, assemblyPath },
-							{ ResourceDirectoryArchive, Path.GetFullPath (resDirArchive)},
-							{ NuGetPackageId, nuGetPackageId },
-							{ NuGetPackageVersion, nuGetPackageVersion },
+							[OriginalFile] = assemblyPath,
+							[ResourceDirectoryArchive] = Path.GetFullPath (resDirArchive),
+							[NuGetPackageId] = nuGetPackageId,
+							[NuGetPackageVersion] = nuGetPackageVersion,
 						});
 						if (bool.TryParse (assemblyItem.GetMetadata (AndroidSkipResourceProcessing), out skip) && skip)
 							taskItem.SetMetadata (AndroidSkipResourceProcessing, "True");
@@ -241,15 +241,15 @@ namespace Xamarin.Android.Tasks
 					}
 					if (Directory.Exists (assetsDir))
 						resolvedAssetDirectories.Add (new TaskItem (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
-							{ OriginalFile, assemblyPath },
-							{ NuGetPackageId, nuGetPackageId },
-							{ NuGetPackageVersion, nuGetPackageVersion },
+							[OriginalFile] = assemblyPath,
+							[NuGetPackageId] = nuGetPackageId,
+							[NuGetPackageVersion] = nuGetPackageVersion,
 						}));
 					foreach (var env in Directory.EnumerateFiles (outDirForDll, "__AndroidEnvironment__*", SearchOption.TopDirectoryOnly)) {
 						resolvedEnvironments.Add (new TaskItem (env, new Dictionary<string, string> {
-							{ OriginalFile, assemblyPath },
-							{ NuGetPackageId, nuGetPackageId },
-							{ NuGetPackageVersion, nuGetPackageVersion },
+							[OriginalFile] = assemblyPath,
+							[NuGetPackageId] = nuGetPackageId,
+							[NuGetPackageVersion] = nuGetPackageVersion,
 						}));
 					}
 					continue;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -210,7 +210,6 @@ namespace Xamarin.Android.Tasks
 				string assetsDir = Path.Combine (importsDir, "assets");
 				string nuGetPackageId = assemblyItem.GetMetadata (NuGetPackageId) ?? string.Empty;
 				string nuGetPackageVersion = assemblyItem.GetMetadata (NuGetPackageVersion) ?? string.Empty;
-				Console.WriteLine ($"{assemblyPath}: {nuGetPackageId} {nuGetPackageVersion}");
 				extractedDirectories.Add (new TaskItem (outDirForDll, new Dictionary<string, string> {
 					{ OriginalFile, assemblyPath },
 					{ NuGetPackageId, nuGetPackageId },

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -64,14 +64,24 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] ProguardConfigFiles { get; set; }
 
+		[Output]
+		public ITaskItem [] ExtractedDirectories { get; set; }
+
 		internal const string OriginalFile = "OriginalFile";
 		internal const string AndroidSkipResourceProcessing = "AndroidSkipResourceProcessing";
 
 		internal const string ResourceDirectoryArchive = "ResourceDirectoryArchive";
-		static readonly string [] knownMetadata = new [] {
+
+		internal const string NuGetPackageVersion = "NuGetPackageVersion";
+
+		internal const string NuGetPackageId = "NuGetPackageId";
+
+		internal static readonly string [] KnownMetadata = new [] {
 			OriginalFile,
 			AndroidSkipResourceProcessing,
-			ResourceDirectoryArchive
+			ResourceDirectoryArchive,
+			NuGetPackageId,
+			NuGetPackageVersion,
 		};
 
 		AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap();
@@ -89,10 +99,11 @@ namespace Xamarin.Android.Tasks
 			var resolvedAssetDirectories      = new List<ITaskItem> ();
 			var resolvedEnvironmentFiles      = new List<ITaskItem> ();
 			var proguardConfigFiles           = new List<ITaskItem> ();
+			var extractedDirectories          = new List<ITaskItem> ();
 
 			assemblyMap.Load (AssemblyIdentityMapFile);
 			try {
-				Extract (jars, resolvedResourceDirectories, resolvedAssetDirectories, resolvedEnvironmentFiles, proguardConfigFiles);
+				Extract (jars, resolvedResourceDirectories, resolvedAssetDirectories, resolvedEnvironmentFiles, proguardConfigFiles, extractedDirectories);
 			} catch (ZipIOException ex) {
 				Log.LogCodedError ("XA1004", ex.Message);
 				Log.LogDebugMessage (ex.ToString ());
@@ -103,6 +114,7 @@ namespace Xamarin.Android.Tasks
 			ResolvedAssetDirectories    = resolvedAssetDirectories.ToArray ();
 			ResolvedEnvironmentFiles    = resolvedEnvironmentFiles.ToArray ();
 			ProguardConfigFiles         = proguardConfigFiles.ToArray ();
+			ExtractedDirectories        = extractedDirectories.ToArray ();
 
 			ResolvedResourceDirectoryStamps = ResolvedResourceDirectories
 				.Select (s => new TaskItem (Path.GetFullPath (Path.Combine (s.ItemSpec, "../..")) + ".stamp"))
@@ -123,15 +135,17 @@ namespace Xamarin.Android.Tasks
 						new XElement ("Jars",
 							Jars.Select(e => new XElement ("Jar", e))),
 						new XElement ("ResolvedResourceDirectories",
-							ResolvedResourceDirectories.ToXElements ("ResolvedResourceDirectory", knownMetadata)),
+							ResolvedResourceDirectories.ToXElements ("ResolvedResourceDirectory", KnownMetadata)),
 						new XElement ("ResolvedAssetDirectories",
-							ResolvedAssetDirectories.ToXElements ("ResolvedAssetDirectory", knownMetadata)),
+							ResolvedAssetDirectories.ToXElements ("ResolvedAssetDirectory", KnownMetadata)),
 						new XElement ("ResolvedEnvironmentFiles",
-							ResolvedEnvironmentFiles.ToXElements ("ResolvedEnvironmentFile", knownMetadata)),
+							ResolvedEnvironmentFiles.ToXElements ("ResolvedEnvironmentFile", KnownMetadata)),
 						new XElement ("ResolvedResourceDirectoryStamps",
-							ResolvedResourceDirectoryStamps.ToXElements ("ResolvedResourceDirectoryStamp", knownMetadata)),
+							ResolvedResourceDirectoryStamps.ToXElements ("ResolvedResourceDirectoryStamp", KnownMetadata)),
 						new XElement ("ProguardConfigFiles",
-							ProguardConfigFiles.ToXElements ("ProguardConfigFile", knownMetadata))
+							ProguardConfigFiles.ToXElements ("ProguardConfigFile", KnownMetadata)),
+						new XElement ("ExtractedDirectories",
+							ExtractedDirectories.ToXElements ("ExtractedDirectory", KnownMetadata))
 					));
 				document.SaveIfChanged (CacheFile);
 			}
@@ -144,6 +158,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugTaskItems ("  ResolvedEnvironmentFiles: ", ResolvedEnvironmentFiles);
 			Log.LogDebugTaskItems ("  ResolvedResourceDirectoryStamps: ", ResolvedResourceDirectoryStamps);
 			Log.LogDebugTaskItems ("  ProguardConfigFiles:", ProguardConfigFiles);
+			Log.LogDebugTaskItems ("  ExtractedDirectories:", ExtractedDirectories);
 
 			return !Log.HasLoggedErrors;
 		}
@@ -155,7 +170,8 @@ namespace Xamarin.Android.Tasks
 				ICollection<ITaskItem> resolvedResourceDirectories,
 				ICollection<ITaskItem> resolvedAssetDirectories,
 				ICollection<ITaskItem> resolvedEnvironments,
-				ICollection<ITaskItem> proguardConfigFiles)
+				ICollection<ITaskItem> proguardConfigFiles,
+				ICollection<ITaskItem> extractedDirectories)
 		{
 			// lets "upgrade" the old directory.
 			string oldPath = Path.GetFullPath (Path.Combine (OutputImportDirectory, "..", "__library_projects__"));
@@ -192,6 +208,14 @@ namespace Xamarin.Android.Tasks
 				string resDir = Path.Combine (importsDir, "res");
 				string resDirArchive = Path.Combine (resDir, "..", "res.zip");
 				string assetsDir = Path.Combine (importsDir, "assets");
+				string nuGetPackageId = assemblyItem.GetMetadata (NuGetPackageId) ?? string.Empty;
+				string nuGetPackageVersion = assemblyItem.GetMetadata (NuGetPackageVersion) ?? string.Empty;
+				Console.WriteLine ($"{assemblyPath}: {nuGetPackageId} {nuGetPackageVersion}");
+				extractedDirectories.Add (new TaskItem (outDirForDll, new Dictionary<string, string> {
+					{ OriginalFile, assemblyPath },
+					{ NuGetPackageId, nuGetPackageId },
+					{ NuGetPackageVersion, nuGetPackageVersion }
+				}));
 
 				// Skip already-extracted resources.
 				bool updated = false;
@@ -202,13 +226,15 @@ namespace Xamarin.Android.Tasks
 					Log.LogDebugMessage ("Skipped resource lookup for {0}: extracted files are up to date", assemblyPath);
 					if (Directory.Exists (importsDir)) {
 						foreach (var file in Directory.EnumerateFiles (importsDir, "*.jar", SearchOption.AllDirectories)) {
-							AddJar (jars, Path.GetFullPath (file));
+							AddJar (jars, Path.GetFullPath (file), nuGetPackageId: nuGetPackageId, nuGetPackageVersion: nuGetPackageVersion);
 						}
 					}
 					if (Directory.Exists (resDir)) {
 						var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 							{ OriginalFile, assemblyPath },
 							{ ResourceDirectoryArchive, Path.GetFullPath (resDirArchive)},
+							{ NuGetPackageId, nuGetPackageId },
+							{ NuGetPackageVersion, nuGetPackageVersion },
 						});
 						if (bool.TryParse (assemblyItem.GetMetadata (AndroidSkipResourceProcessing), out skip) && skip)
 							taskItem.SetMetadata (AndroidSkipResourceProcessing, "True");
@@ -216,11 +242,15 @@ namespace Xamarin.Android.Tasks
 					}
 					if (Directory.Exists (assetsDir))
 						resolvedAssetDirectories.Add (new TaskItem (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
-							{ OriginalFile, assemblyPath }
+							{ OriginalFile, assemblyPath },
+							{ NuGetPackageId, nuGetPackageId },
+							{ NuGetPackageVersion, nuGetPackageVersion },
 						}));
 					foreach (var env in Directory.EnumerateFiles (outDirForDll, "__AndroidEnvironment__*", SearchOption.TopDirectoryOnly)) {
 						resolvedEnvironments.Add (new TaskItem (env, new Dictionary<string, string> {
-							{ OriginalFile, assemblyPath }
+							{ OriginalFile, assemblyPath },
+							{ NuGetPackageId, nuGetPackageId },
+							{ NuGetPackageVersion, nuGetPackageVersion },
 						}));
 					}
 					continue;
@@ -241,13 +271,15 @@ namespace Xamarin.Android.Tasks
 								updated |= Files.CopyIfStreamChanged (stream, outFile);
 							}
 							resolvedEnvironments.Add (new TaskItem (Path.GetFullPath (outFile), new Dictionary<string, string> {
-								{ OriginalFile, assemblyPath }
+								{ OriginalFile, assemblyPath },
+								{ NuGetPackageId, nuGetPackageId },
+								{ NuGetPackageVersion, nuGetPackageVersion },
 							}));
 						}
 						// embedded jars (EmbeddedJar, EmbeddedReferenceJar)
 						else if (name.EndsWith (".jar", StringComparison.InvariantCultureIgnoreCase)) {
 							using (var stream = pe.GetEmbeddedResourceStream (resource)) {
-								AddJar (jars, importsDir, name, assemblyPath);
+								AddJar (jars, importsDir, name, assemblyPath, nuGetPackageId: nuGetPackageId, nuGetPackageVersion: nuGetPackageVersion);
 								updated |= Files.CopyIfStreamChanged (stream, Path.Combine (importsDir, name));
 							}
 						}
@@ -286,7 +318,7 @@ namespace Xamarin.Android.Tasks
 											.Replace ("library_project_imports\\", "")
 											.Replace ("library_project_imports/", "");
 										if (path.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
-											AddJar (jars, importsDir, path, assemblyPath);
+											AddJar (jars, importsDir, path, assemblyPath, nuGetPackageId, nuGetPackageVersion);
 										}
 										return path;
 									}, deleteCallback: (fileToDelete) => {
@@ -309,7 +341,8 @@ namespace Xamarin.Android.Tasks
 								var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 									{ OriginalFile, assemblyPath },
 									{ ResourceDirectoryArchive, Path.GetFullPath (resDirArchive)},
-
+									{ NuGetPackageId, nuGetPackageId },
+									{ NuGetPackageVersion, nuGetPackageVersion },
 								});
 								if (bool.TryParse (assemblyItem.GetMetadata (AndroidSkipResourceProcessing), out skip) && skip)
 									taskItem.SetMetadata (AndroidSkipResourceProcessing, "True");
@@ -317,7 +350,9 @@ namespace Xamarin.Android.Tasks
 							}
 							if (Directory.Exists (assetsDir)) {
 								resolvedAssetDirectories.Add (new TaskItem (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
-									{ OriginalFile, assemblyPath }
+									{ OriginalFile, assemblyPath },
+									{ NuGetPackageId, nuGetPackageId },
+									{ NuGetPackageVersion, nuGetPackageVersion },
 								}));
 							}
 						}
@@ -357,6 +392,14 @@ namespace Xamarin.Android.Tasks
 				string rTxt = Path.Combine (importsDir, "R.txt");
 				string assetsDir = Path.Combine (importsDir, "assets");
 				string proguardFile = Path.Combine (importsDir, "proguard.txt");
+				string nuGetPackageId = aarFile.GetMetadata (NuGetPackageId) ?? string.Empty;
+				string nuGetPackageVersion = aarFile.GetMetadata (NuGetPackageVersion) ?? string.Empty;
+				Console.WriteLine ($"{aarFile.ItemSpec}: {nuGetPackageId} {nuGetPackageVersion}");
+				extractedDirectories.Add (new TaskItem (outDirForDll, new Dictionary<string, string> {
+					{ OriginalFile, aarFile.ItemSpec },
+					{ NuGetPackageId, nuGetPackageId },
+					{ NuGetPackageVersion, nuGetPackageVersion }
+				}));
 
 				bool updated = false;
 				string aarHash = Files.HashFile (aarFile.ItemSpec);
@@ -367,7 +410,7 @@ namespace Xamarin.Android.Tasks
 					Log.LogDebugMessage ("Skipped {0}: extracted files are up to date", aarFile.ItemSpec);
 					if (Directory.Exists (importsDir)) {
 						foreach (var file in Directory.EnumerateFiles (importsDir, "*.jar", SearchOption.AllDirectories)) {
-							AddJar (jars, Path.GetFullPath (file));
+							AddJar (jars, Path.GetFullPath (file), nuGetPackageId: nuGetPackageId, nuGetPackageVersion: nuGetPackageVersion);
 						}
 					}
 					if (Directory.Exists (resDir) || File.Exists (rTxt)) {
@@ -379,11 +422,15 @@ namespace Xamarin.Android.Tasks
 							{ OriginalFile, Path.GetFullPath (aarFile.ItemSpec) },
 							{ AndroidSkipResourceProcessing, skipProcessing },
 							{ ResourceDirectoryArchive, Path.GetFullPath (resDirArchive)},
+							{ NuGetPackageId, nuGetPackageId },
+							{ NuGetPackageVersion, nuGetPackageVersion },
 						}));
 					}
 					if (Directory.Exists (assetsDir))
 						resolvedAssetDirectories.Add (new TaskItem  (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
 							{ OriginalFile, aarFullPath },
+							{ NuGetPackageId, nuGetPackageId },
+							{ NuGetPackageVersion, nuGetPackageVersion },
 						}));
 					continue;
 				}
@@ -401,16 +448,18 @@ namespace Xamarin.Android.Tasks
 							if (entryFileName.StartsWith ("internal_impl", StringComparison.InvariantCulture)) {
 								var hash = Files.HashString (entryFileName);
 								var jar = Path.Combine (entryPath, $"internal_impl-{hash}.jar");
-								AddJar (jars, importsDir, jar, aarFullPath);
+								AddJar (jars, importsDir, jar, aarFullPath, nuGetPackageId: nuGetPackageId, nuGetPackageVersion: nuGetPackageVersion);
 								return jar;
 							}
 							if (entryFullName.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
-								AddJar (jars, importsDir, entryFullName, aarFullPath);
+								AddJar (jars, importsDir, entryFullName, aarFullPath, nuGetPackageId: nuGetPackageId, nuGetPackageVersion: nuGetPackageVersion);
 							} else if (entryFullName.StartsWith (".net/env/", StringComparison.OrdinalIgnoreCase) ||
 									entryFullName.StartsWith (".net\\env\\", StringComparison.OrdinalIgnoreCase)) {
 								var fullPath = Path.GetFullPath (Path.Combine (importsDir, entryFullName));
 								resolvedEnvironments.Add (new TaskItem (fullPath, new Dictionary<string, string> {
-									{ OriginalFile, aarFile.ItemSpec }
+									{ OriginalFile, aarFile.ItemSpec },
+									{ NuGetPackageId, nuGetPackageId },
+									{ NuGetPackageVersion, nuGetPackageVersion },
 								}));
 							}
 							return entryFullName;
@@ -438,15 +487,21 @@ namespace Xamarin.Android.Tasks
 						{ OriginalFile, aarFullPath },
 						{ AndroidSkipResourceProcessing, skipProcessing },
 						{ ResourceDirectoryArchive, Path.GetFullPath (resDirArchive)},
+						{ NuGetPackageId, nuGetPackageId },
+						{ NuGetPackageVersion, nuGetPackageVersion },
 					}));
 				}
 				if (Directory.Exists (assetsDir))
 					resolvedAssetDirectories.Add (new TaskItem (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
 						{ OriginalFile, aarFullPath },
+						{ NuGetPackageId, nuGetPackageId },
+						{ NuGetPackageVersion, nuGetPackageVersion },
 					}));
 				if (AndroidApplication && File.Exists (proguardFile)) {
 					proguardConfigFiles.Add (new TaskItem (Path.GetFullPath (proguardFile), new Dictionary<string, string> {
 						{ OriginalFile, aarFullPath },
+						{ NuGetPackageId, nuGetPackageId },
+						{ NuGetPackageVersion, nuGetPackageVersion },
 					}));
 				}
 			}
@@ -462,17 +517,19 @@ namespace Xamarin.Android.Tasks
 			});
 		}
 
-		static void AddJar (IDictionary<string, ITaskItem> jars, string destination, string path, string originalFile = null)
+		static void AddJar (IDictionary<string, ITaskItem> jars, string destination, string path, string originalFile = null, string nuGetPackageId = null, string nuGetPackageVersion = null)
 		{
 			var fullPath = Path.GetFullPath (Path.Combine (destination, path));
-			AddJar (jars, fullPath, originalFile);
+			AddJar (jars, fullPath, originalFile: originalFile, nuGetPackageId: nuGetPackageId, nuGetPackageVersion: nuGetPackageVersion);
 		}
 
-		static void AddJar (IDictionary<string, ITaskItem> jars, string fullPath, string originalFile = null)
+		static void AddJar (IDictionary<string, ITaskItem> jars, string fullPath, string originalFile = null, string nuGetPackageId = null, string nuGetPackageVersion = null)
 		{
 			if (!jars.ContainsKey (fullPath)) {
 				jars.Add (fullPath, new TaskItem (fullPath, new Dictionary<string, string> {
-					{  OriginalFile, originalFile },
+					{ OriginalFile, originalFile },
+					{ NuGetPackageId, nuGetPackageId },
+					{ NuGetPackageVersion, nuGetPackageVersion },
 				}));
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -376,6 +376,25 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void XA0141ErrorIsRaised ([Values (false, true)] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+				PackageReferences = {
+					KnownPackages.SkiaSharp,
+					KnownPackages.AndroidXAppCompat,
+					KnownPackages.AndroidXAppCompatResources,
+				},
+			};
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "XA0141"),
+					"Error XA0141 should have been raised.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, $"NuGet package 'SkiaSharp.NativeAssets.Android' version '{KnownPackages.SkiaSharp.Version}' "), "Warning does not have the correct Nuget package information.");
+			}
+		}
+
+		[Test]
 		[TestCase ("AndroidFastDeploymentType", "Assemblies", true, false)]
 		[TestCase ("AndroidFastDeploymentType", "Assemblies", false, false)]
 		[TestCase ("_AndroidUseJavaLegacyResolver", "true", false, true)]

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ELFHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ELFHelper.cs
@@ -80,7 +80,10 @@ namespace Xamarin.Android.Tasks
 
 				string? metaValue = item.GetMetadata ("OriginalFile");
 				if (String.IsNullOrEmpty (metaValue)) {
-					return (Unknown, Unknown, Unknown);
+					metaValue = item.GetMetadata ("PathInPackage");
+					if (String.IsNullOrEmpty (metaValue)) {
+						metaValue = item.ItemSpec;
+					}
 				}
 				string originalFile = metaValue;
 				metaValue = item.GetMetadata ("NuGetPackageId");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ELFHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ELFHelper.cs
@@ -78,9 +78,9 @@ namespace Xamarin.Android.Tasks
 					return (Unknown, Unknown, Unknown);
 				}
 
-				string? metaValue = item.GetMetadata ("OriginalFile");
+				string? metaValue = item.GetMetadata ("PathInPackage");
 				if (String.IsNullOrEmpty (metaValue)) {
-					metaValue = item.GetMetadata ("PathInPackage");
+					metaValue = item.GetMetadata ("OriginalFile");
 					if (String.IsNullOrEmpty (metaValue)) {
 						metaValue = item.ItemSpec;
 					}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ELFHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ELFHelper.cs
@@ -65,22 +65,27 @@ namespace Xamarin.Android.Tasks
 				}
 				log.LogDebugMessage ($"    expected segment alignment of 0x{pageSize:x}, found 0x{segment64.Alignment:x}");
 
-				(string packageId, string packageVersion) = GetNugetPackageInfo ();
-				log.LogCodedWarning ("XA0141", Properties.Resources.XA0141, packageId, packageVersion, Path.GetFileName (path));
+				(string packageId, string packageVersion, string originalFile) = GetNugetPackageInfo ();
+				log.LogCodedWarning ("XA0141", Properties.Resources.XA0141, packageId, packageVersion, originalFile, Path.GetFileName (path));
 				break;
 			}
 
-			(string packageId, string packageVersion) GetNugetPackageInfo ()
+			(string packageId, string packageVersion, string originalFile) GetNugetPackageInfo ()
 			{
 				const string Unknown = "<unknown>";
 
 				if (item == null) {
-					return (Unknown, Unknown);
+					return (Unknown, Unknown, Unknown);
 				}
 
-				string? metaValue = item.GetMetadata ("NuGetPackageId");
+				string? metaValue = item.GetMetadata ("OriginalFile");
 				if (String.IsNullOrEmpty (metaValue)) {
-					return (Unknown, Unknown);
+					return (Unknown, Unknown, Unknown);
+				}
+				string originalFile = metaValue;
+				metaValue = item.GetMetadata ("NuGetPackageId");
+				if (String.IsNullOrEmpty (metaValue)) {
+					return (Unknown, Unknown, originalFile);
 				}
 
 				string id = metaValue;
@@ -92,7 +97,7 @@ namespace Xamarin.Android.Tasks
 					version = Unknown;
 				}
 
-				return (id, version);
+				return (id, version, originalFile);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -64,6 +64,7 @@ This file is used by all project types, including binding projects.
       <Output TaskParameter="ResolvedEnvironmentFiles" ItemName="LibraryEnvironments" />
       <Output TaskParameter="ResolvedResourceDirectoryStamps" ItemName="_LibraryResourceDirectoryStamps" />
       <Output TaskParameter="ProguardConfigFiles" ItemName="ProguardConfiguration" />
+      <Output TaskParameter="ExtractedDirectories" ItemName="_ExtractedDirectories" />
     </ReadLibraryProjectImportsCache>
     <ItemGroup>
       <FileWrites Include="@(ResolvedResourceDirectories->'%(ResourceDirectoryArchive)')"
@@ -75,7 +76,7 @@ This file is used by all project types, including binding projects.
       Inputs="$(_AndroidLibraryProjectImportsCache)"
       Outputs="$(_AndroidStampDirectory)_BuildLibraryImportsCache.stamp">
     <GetImportedLibraries
-        TargetDirectory="$(_AndroidLibrayProjectIntermediatePath)"
+        ExtractedDirectories="@(_ExtractedDirectories)"
         CacheFile="$(_AndroidLibraryImportsCache)"
     />
     <Touch Files="$(_AndroidStampDirectory)_BuildLibraryImportsCache.stamp" AlwaysCreate="true" />


### PR DESCRIPTION
Figuring out how to fix a `XA0141` error is almost impossible for an end user at this time. The default error message is

```
NuGet package '' version '' contains a shared library 'foo.so' which is not correctly aligned. See https://developer.android.com/guide/practices/page-sizes for more details
```

the assumption was that the NuGet package and Version would be available as metadata items on the 
MSBuild Items. Unfortunately that was not the case, so the data the user gets is empty. 

This commit adds the required Metadata to all NuGet Package references resolved by the project. This will allow us to propagate that data throughout the build Items as they are transformed. This will in the end mean we can provide a decent error message to the user. 

```
Shared library 'foo.so' must use 16 KB page sizes. Please inform the authors of the NuGet package 'Foo.Bar' version '1.2.3.4' which contains 'lib/arm64-v8a/foo.so'. See https://developer.android.com/guide/practices/page-sizes for more details.
```
