### PR TITLE
[release/9.0.1xx] Bump android-platform-support, android-tools

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:release/9.0.1xx@457de82bb5f8b7a8ee072177fde885e2e391b3bb
+DevDiv/android-platform-support:release/9.0.1xx@8541a696df9896555fb09fd98e7fe123d5b811f2

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:release/9.0.1xx@8541a696df9896555fb09fd98e7fe123d5b811f2
+DevDiv/android-platform-support:release/9.0.1xx@df3620a12d632d018211985921374a88303ce4cd

--- a/.gitmodules
+++ b/.gitmodules
@@ -29,7 +29,7 @@
 [submodule "external/xamarin-android-tools"]
     path = external/xamarin-android-tools
     url = https://github.com/dotnet/android-tools
-    branch = main
+    branch = release/9.0.1xx
 [submodule "external/xxHash"]
     path = external/xxHash
     url = https://github.com/Cyan4973/xxHash.git


### PR DESCRIPTION
Changes: https://devdiv.visualstudio.com/DevDiv/_git/android-platform-support/branchCompare?baseVersion=GC457de82bb5f8b7a8ee072177fde885e2e391b3bb&targetVersion=GCdf3620a12d632d018211985921374a88303ce4cd

 * Merged PR 596023: [release/9.0.1xx] Bump to dotnet/android-tools@f742b155
 * Merged PR 595816: Merged PR 595751: [build] Use flexible cmake path
 * Merged PR 595817: Merged PR 594914: [InstallAndroidDependencies] Correctly init CommonUtilities.Helpers

Changes: https://github.com/dotnet/android-tools/compare/60fae1924e2d71f31dc1ed05f7346fd7874d6636...f742b1555fc78b6a7c105e38dd3efe3bea6ab138

  * dotnet/android-tools@f742b15: Add support to discovering activity-alias activity elements