### PR TITLE
[XABT] Add deprecation warning for `$(AndroidCreatePackagePerAbi)`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -400,7 +400,10 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				var bin = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
 				Assert.IsTrue (b.Build (proj), "First build failed");
-				b.AssertHasNoWarnings ();
+
+				// AndroidCreatePackagePerAbi has a deprecation warning
+				if (!perAbiApk)
+					b.AssertHasNoWarnings ();
 
 				//Make sure the APKs are signed
 				foreach (var apk in Directory.GetFiles (bin, "*-Signed.apk")) {
@@ -424,7 +427,10 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 				item.TextContent = () => proj.StringsXml.Replace ("${PROJECT_NAME}", "Foo");
 				item.Timestamp = null;
 				Assert.IsTrue (b.Build (proj), "Second build failed");
-				b.AssertHasNoWarnings ();
+
+				// AndroidCreatePackagePerAbi has a deprecation warning
+				if (!perAbiApk)
+					b.AssertHasNoWarnings ();
 
 				//Make sure the APKs are signed
 				foreach (var apk in Directory.GetFiles (bin, "*-Signed.apk")) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -545,6 +545,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       FormatArguments="AndroidFastDeploymentType;9"
       Condition=" '$(AndroidFastDeploymentType)' != '' "
   />
+  <AndroidWarning Code="XA1037"
+      ResourceName="XA1037"
+      FormatArguments="AndroidCreatePackagePerAbi;10"
+      Condition=" '$(AndroidCreatePackagePerAbi)' == 'true' "
+  />
 </Target>
 
 <Target Name="_CheckNonIdealConfigurations"


### PR DESCRIPTION
***Note this PR is against the `release/9.0.1xx` branch.***

The MSBuild property `$(AndroidCreatePackagePerAbi)` is likely not used much anymore due to Google Play and Amazon stores both moving to the `.aab` format.  Removing it in .NET 10 will allow us to simplify our `BuildApk` MSBuild code.

Add a deprecation warning to .NET 9 for `$(AndroidCreatePackagePerAbi)` to inform users that it will be removed in .NET 10.

The workaround is to use the `-r` specifier when calling `dotnet build` if you still need to create individual `.apk` files per ABI:

```
dotnet build -c Release -r android-arm64
dotnet build -c Release -r android-x64
```