### PR TITLE
Bump .NET 8 SDK to a8cd27e4 34.0.147

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
-    <add key="darc-pub-dotnet-android-df9aaf2-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-df9aaf29-1/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-android-a8cd27e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-a8cd27e4/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!-- ensure only the sources defined below are used -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,9 +21,9 @@
       <Sha>9c9443396f8deacceb8edb169890e52aac25f311</Sha>
     </Dependency>
     <!-- Previous .NET Android version -->
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.145">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.147">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>df9aaf29a52042a4fbf800daf2f3a38964b9e958</Sha>
+      <Sha>a8cd27e430e55df3e3c1e3a43d35c11d9512a2db</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.24480.1</MicrosoftDotNetCecilPackageVersion>
     <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
     <!-- Previous .NET Android version -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.145</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.147</MicrosoftAndroidSdkWindowsPackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftAndroidSdkWindowsPackageVersion)</AndroidNetPreviousVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Changes: https://github.com/dotnet/android/compare/df9aaf29a52042a4fbf800daf2f3a38964b9e958...a8cd27e430e55df3e3c1e3a43d35c11d9512a2db