### PR TITLE
Fix AndroidResource Incremental build issue

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -61,6 +61,9 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] ResolvedResourceFiles { get; set; }
 
+		[Output]
+		public string FilesHash { get; set; }
+
 		public override bool RunTask ()
 		{
 			var intermediateFiles = new List<ITaskItem> (ResourceFiles.Length);
@@ -77,6 +80,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			var nameCaseMap = new Dictionary<string, string> (ResourceFiles.Length, StringComparer.Ordinal);
+			var sb = new StringBuilder ();
 
 			for (int i = 0; i < ResourceFiles.Length; i++) {
 				var item = ResourceFiles [i];
@@ -151,10 +155,13 @@ namespace Xamarin.Android.Tasks
 				item.CopyMetadataTo (newItem);
 				intermediateFiles.Add (newItem);
 				resolvedFiles.Add (item);
+				// write both files so we handle changes in destination also
+				sb.AppendLine ($"{item.ItemSpec};{newItem.ItemSpec}");
 			}
 
 			IntermediateFiles = intermediateFiles.ToArray ();
 			ResolvedResourceFiles = resolvedFiles.ToArray ();
+			FilesHash = Files.HashString (sb.ToString ());
 			MonoAndroidHelper.SaveResourceCaseMap (BuildEngine4, nameCaseMap, ProjectSpecificTaskObjectKey);
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -904,6 +904,29 @@ namespace Lib2
 
 		[Test]
 		[NonParallelizable]
+		public void AddNewAndroidResourceOnSecondBuild ()
+		{
+			var xml = new AndroidItem.AndroidResource (@"Resources\values\emptyvalues.xml") {
+				TextContent = () => "<?xml version=\"1.0\" encoding=\"utf-8\" ?><resources></resources>"
+			};
+
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				var projectFile = Path.Combine (Root, b.ProjectDirectory, proj.ProjectFilePath);
+				b.ThrowOnBuildFailure = false;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				b.Output.AssertTargetIsNotSkipped ("_GenerateAndroidResourceDir");
+				proj.OtherBuildItems.Add (xml);
+				b.Save (proj, doNotCleanupOnUpdate: true);
+				var modified = File.GetLastWriteTimeUtc (Path.Combine (Root, b.ProjectDirectory, "Resources","layout","Main.axml"));
+				File.SetLastWriteTimeUtc (Path.Combine (Root, b.ProjectDirectory, "Resources","values", "emptyvalues.xml"), modified);
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				b.Output.AssertTargetIsNotSkipped ("_GenerateAndroidResourceDir");
+			}
+		}
+
+		[Test]
+		[NonParallelizable]
 		public void InvalidAndroidResource ()
 		{
 			var invalidXml = new AndroidItem.AndroidResource (@"Resources\values\ids.xml") {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1057,13 +1057,24 @@ because xbuild doesn't support framework reference assemblies.
 	>
 		<Output ItemName="_AndroidResourceDest" TaskParameter="IntermediateFiles" />
 		<Output ItemName="_AndroidResolvedResources" TaskParameter="ResolvedResourceFiles" />
+		<Output PropertyName="_AndroidResolvedResourcesFilesHash" TaskParameter="FilesHash" />
 	</AndroidComputeResPaths>
+
+	<WriteLinesToFile
+		File="$(IntermediateOutputPath)_AndroidResolvedResourcesFilesHash.txt"
+		Lines="$(_AndroidResolvedResourcesFilesHash)"
+		Overwrite="True"
+		WriteOnlyWhenDifferent="True"
+	/>
+  <ItemGroup>
+    <FileWrites Include="$(IntermediateOutputPath)_AndroidResolvedResourcesFilesHash.txt"/>
+  </ItemGroup>
 
 	<MakeDir Directories="$(MonoAndroidResDirIntermediate)" />
 </Target>
 
 <Target Name="_GenerateAndroidResourceDir"
-	Inputs="$(MSBuildProjectFullPath);@(_AndroidMSBuildAllProjects);@(_AndroidResolvedResources);$(_AndroidBuildPropertiesCache)"
+	Inputs="$(MSBuildProjectFullPath);@(_AndroidMSBuildAllProjects);@(_AndroidResolvedResources);$(_AndroidBuildPropertiesCache);$(IntermediateOutputPath)_AndroidResolvedResourcesFilesHash.txt"
 	Outputs="$(_AndroidResFlagFile)"
 	DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
 	<CheckForInvalidResourceFileNames

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -232,6 +232,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidBuildIdFile>$(IntermediateOutputPath)buildid.txt</_AndroidBuildIdFile>
         <_AndroidApplicationSharedLibraryPath>$(IntermediateOutputPath)app_shared_libraries\</_AndroidApplicationSharedLibraryPath>
 	<_ResolvedUserAssembliesHashFile>$(IntermediateOutputPath)resolvedassemblies.hash</_ResolvedUserAssembliesHashFile>
+  <_AndroidResolvedResourcesHashFile>$(IntermediateOutputPath)_AndroidResolvedResources.hash</_AndroidResolvedResourcesHashFile>
 
 	<AndroidDexTool   Condition=" '$(AndroidDexTool)' != 'dx' ">d8</AndroidDexTool>
 	<_AndroidXA1027 Condition=" '$(EnableProguard)' == 'true' And '$(AndroidEnableProguard)' == '' And '$(AndroidDexTool)' == 'd8' And $(AndroidLinkTool) == '' ">true</_AndroidXA1027>
@@ -1061,20 +1062,20 @@ because xbuild doesn't support framework reference assemblies.
 	</AndroidComputeResPaths>
 
 	<WriteLinesToFile
-		File="$(IntermediateOutputPath)_AndroidResolvedResourcesFilesHash.txt"
+		File="$(_AndroidResolvedResourcesHashFile)"
 		Lines="$(_AndroidResolvedResourcesFilesHash)"
 		Overwrite="True"
 		WriteOnlyWhenDifferent="True"
 	/>
   <ItemGroup>
-    <FileWrites Include="$(IntermediateOutputPath)_AndroidResolvedResourcesFilesHash.txt"/>
+    <FileWrites Include="$(_AndroidResolvedResourcesHashFile)"/>
   </ItemGroup>
 
 	<MakeDir Directories="$(MonoAndroidResDirIntermediate)" />
 </Target>
 
 <Target Name="_GenerateAndroidResourceDir"
-	Inputs="$(MSBuildProjectFullPath);@(_AndroidMSBuildAllProjects);@(_AndroidResolvedResources);$(_AndroidBuildPropertiesCache);$(IntermediateOutputPath)_AndroidResolvedResourcesFilesHash.txt"
+	Inputs="$(MSBuildProjectFullPath);@(_AndroidMSBuildAllProjects);@(_AndroidResolvedResources);$(_AndroidBuildPropertiesCache);$(_AndroidResolvedResourcesHashFile)"
 	Outputs="$(_AndroidResFlagFile)"
 	DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
 	<CheckForInvalidResourceFileNames


### PR DESCRIPTION
Fixes #9588 

Adding a new Android resource to a project causes the incremental build to error with:

```Resources\layout\activity_two.xml error APT2126: file not found.```

This error comes from the Aapt2Compile task. It is looking for \obj\Debug\net9.0-android\res\layout\activity_two.xml but that file doesn't exist. 

What was happening is the new file had the same modified date as the flag/stamp file that was used to generate it. 
The user was using `copy Resources\layout\activity_main.xml Resources\layout\activity_two.xml`. So the modified date was not "new". This caused the `_GenerateAndroidResourceDir` target to get skipped. 

What we should do is copy what we do in other places, and hash all the input files (and their destinations) into one hash. 
We can then use that hash file as an input to the target. This allows us to detect when a new file is added, even if it has an old timestamp. 

A unit test was added as well.