### PR TITLE
Deprecate `AndroidResgenFile` and `AndroidUseIntermediateDesignerFile`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -550,6 +550,16 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       FormatArguments="AndroidCreatePackagePerAbi;10"
       Condition=" '$(AndroidCreatePackagePerAbi)' == 'true' "
   />
+  <AndroidWarning Code="XA1037"
+      ResourceName="XA1037"
+      FormatArguments="AndroidUseIntermediateDesignerFile;10"
+      Condition=" '$(AndroidUseIntermediateDesignerFile)' == 'true'"
+  />
+  <AndroidWarning Code="XA1037"
+      ResourceName="XA1037"
+      FormatArguments="AndroidResgenFile;10"
+      Condition=" '$(AndroidResgenFile)' != ''"
+  />
 </Target>
 
 <Target Name="_CheckNonIdealConfigurations"

--- a/tests/CodeBehind/BuildTests/CodeBehindBuildTests.NET.csproj
+++ b/tests/CodeBehind/BuildTests/CodeBehindBuildTests.NET.csproj
@@ -7,7 +7,6 @@
     <_ApkDebugKeyStore>debug.keystore</_ApkDebugKeyStore>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <AppendTargetFrameworkToIntermediateOutputPath>false</AppendTargetFrameworkToIntermediateOutputPath>


### PR DESCRIPTION
Eventually we want user to migrate to the Resource Designer Assembly. So we should deprecate these properties.