### PR TITLE
Bump com.android.tools.build:manifest-merger in /src/manifestmerger

### DIFF
--- a/src/manifestmerger/build.gradle
+++ b/src/manifestmerger/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
     // https://mvnrepository.com/artifact/com.android.tools.build/manifest-merger
-    implementation 'com.android.tools.build:manifest-merger:31.7.2'
+    implementation 'com.android.tools.build:manifest-merger:31.7.3'
 }
 
 sourceSets {


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9581

Bumps com.android.tools.build:manifest-merger from 31.7.2 to 31.7.3.

---
updated-dependencies:
- dependency-name: com.android.tools.build:manifest-merger dependency-type: direct:production update-type: version-update:semver-patch ...