### PR TITLE
[Mono.Android] Add target to build additional API levels

### DIFF
--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -30,17 +30,6 @@
   </Target>
 
   <Target Name="PackDotNet">
-    <!-- Build extra versions of Mono.Android.dll if necessary -->
-    <MSBuild
-         Condition=" '$(AndroidDefaultTargetDotnetApiLevel)' != '$(AndroidLatestStableApiLevel)' "
-         Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
-         Properties="TargetFramework=$(DotNetTargetFramework);AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel);AndroidPlatformId=$(AndroidDefaultTargetDotnetApiLevel);DisableApiCompatibilityCheck=true"
-    />
-    <MSBuild
-         Condition=" '$(AndroidLatestUnstableApiLevel)' != '$(AndroidLatestStableApiLevel)' "
-         Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
-         Properties="TargetFramework=$(DotNetTargetFramework);AndroidApiLevel=$(AndroidLatestUnstableApiLevel);AndroidPlatformId=$(AndroidLatestUnstablePlatformId);DisableApiCompatibilityCheck=true"
-    />
     <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="CreateAllPacks" />
     <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ExtractWorkloadPacks" />
     <!-- Clean up old, previously restored packages -->

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -400,6 +400,7 @@
   <PropertyGroup Condition=" '$(AndroidApiLevel)' &gt;= '$(AndroidDefaultTargetDotnetApiLevel)' ">
     <BuildDependsOn>
       $(BuildDependsOn);
+      _BuildAdditionalApiLevels;
       _ExportMsxDoc;
       _CopyToPackDirs;
     </BuildDependsOn>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -235,6 +235,19 @@
     </ItemGroup>
   </Target>
 
+  <!-- Build Mono.Android.dll for additional API levels if necessary -->
+  <Target Name="_BuildAdditionalApiLevels">
+    <MSBuild
+         Condition=" '$(AndroidDefaultTargetDotnetApiLevel)' != '$(AndroidLatestStableApiLevel)' "
+         Projects="$(XamarinAndroidSourcePath)src\Mono.Android\Mono.Android.csproj"
+         Properties="AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel);AndroidPlatformId=$(AndroidDefaultTargetDotnetApiLevel)"
+    />
+    <MSBuild
+         Condition=" '$(AndroidLatestUnstableApiLevel)' != '$(AndroidLatestStableApiLevel)' "
+         Projects="$(XamarinAndroidSourcePath)src\Mono.Android\Mono.Android.csproj"
+         Properties="AndroidApiLevel=$(AndroidLatestUnstableApiLevel);AndroidPlatformId=$(AndroidLatestUnstablePlatformId)"
+    />
+  </Target>
 
   <PropertyGroup>
     <!-- Override these properties to generate docs against a specific API level -->


### PR DESCRIPTION
Commit https://github.com/dotnet/android/commit/e4a75a816af0847b8db7ecd516b2721ce4a119b9 removed some make magic that ensured Mono.Android.dll
would be built multiple times for additional supported API levels.

A couple of MSBuild tasks used to build multiple versions of
Mono.Android.dll have been moved out of the `PackDotNet` target used by
the Windows build and into the Mono.Android build to fix this.