### PR TITLE
[monodroid] remove `_monodroid_get_identity_hash_code`

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -39,7 +39,7 @@ namespace Android.Runtime {
 
 		internal static IntPtr IdentityHash (IntPtr v)
 		{
-			return RuntimeNativeMethods._monodroid_get_identity_hash_code (Handle, v);
+			return JniEnvironment.References.GetIdentityHashCode (new JniObjectReference (v));
 		}
 
 		public static void CheckHandle (IntPtr jnienv)

--- a/src/Mono.Android/Android.Runtime/RuntimeNativeMethods.cs
+++ b/src/Mono.Android/Android.Runtime/RuntimeNativeMethods.cs
@@ -36,9 +36,6 @@ namespace Android.Runtime
 		internal extern static void monodroid_free (IntPtr ptr);
 
 		[DllImport (RuntimeConstants.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
-		internal extern static IntPtr _monodroid_get_identity_hash_code (IntPtr env, IntPtr value);
-
-		[DllImport (RuntimeConstants.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern int _monodroid_gref_get ();
 
 		[DllImport (RuntimeConstants.InternalDllName, CallingConvention = CallingConvention.Cdecl)]

--- a/src/native/monodroid/internal-pinvokes.cc
+++ b/src/native/monodroid/internal-pinvokes.cc
@@ -139,13 +139,6 @@ monodroid_clear_gdb_wait ()
 }
 
 void*
-_monodroid_get_identity_hash_code (JNIEnv *env, void *v)
-{
-    intptr_t rv = env->CallStaticIntMethod (MonodroidRuntime::get_java_class_System (), MonodroidRuntime::get_java_class_method_System_identityHashCode (), v);
-    return (void*) rv;
-}
-
-void*
 _monodroid_timezone_get_default_id ()
 {
 	JNIEnv *env          = osBridge.ensure_jnienv ();

--- a/src/native/pinvoke-override/generate-pinvoke-tables.cc
+++ b/src/native/pinvoke-override/generate-pinvoke-tables.cc
@@ -47,7 +47,6 @@ const std::vector<std::string> internal_pinvoke_names = {
 	"_monodroid_gc_wait_for_bridge_processing",
 	"_monodroid_get_dns_servers",
 	"monodroid_get_dylib",
-	"_monodroid_get_identity_hash_code",
 	"_monodroid_getifaddrs",
 	"monodroid_get_log_categories",
 	"monodroid_get_namespaced_system_property",

--- a/src/native/pinvoke-override/pinvoke-tables.include
+++ b/src/native/pinvoke-override/pinvoke-tables.include
@@ -11,12 +11,11 @@
 namespace {
 #if INTPTR_MAX == INT64_MAX
 	//64-bit internal p/invoke table
-	std::array<PinvokeEntry, 47> internal_pinvokes {{
+	std::array<PinvokeEntry, 46> internal_pinvokes {{
 		{0x452e23128e42f0a, "monodroid_get_log_categories", reinterpret_cast<void*>(&monodroid_get_log_categories)},
 		{0xa50ce5de13bf8b5, "_monodroid_timezone_get_default_id", reinterpret_cast<void*>(&_monodroid_timezone_get_default_id)},
 		{0x19055d65edfd668e, "_monodroid_get_network_interface_up_state", reinterpret_cast<void*>(&_monodroid_get_network_interface_up_state)},
 		{0x2b3b0ca1d14076da, "monodroid_get_dylib", reinterpret_cast<void*>(&monodroid_get_dylib)},
-		{0x2fbe68718cf2510d, "_monodroid_get_identity_hash_code", reinterpret_cast<void*>(&_monodroid_get_identity_hash_code)},
 		{0x3ade4348ac8ce0fa, "_monodroid_freeifaddrs", reinterpret_cast<void*>(&_monodroid_freeifaddrs)},
 		{0x3b2467e7eadd4a6a, "_monodroid_lref_log_new", reinterpret_cast<void*>(&_monodroid_lref_log_new)},
 		{0x3b8097af56b5361f, "monodroid_log_traces", reinterpret_cast<void*>(&monodroid_log_traces)},
@@ -551,10 +550,9 @@ constexpr hash_t system_security_cryptography_native_android_library_hash = 0x18
 constexpr hash_t system_globalization_native_library_hash = 0x28b5c8fca080abd5;
 #else
 	//32-bit internal p/invoke table
-	std::array<PinvokeEntry, 47> internal_pinvokes {{
+	std::array<PinvokeEntry, 46> internal_pinvokes {{
 		{0xb7a486a, "monodroid_TypeManager_get_java_class_name", reinterpret_cast<void*>(&monodroid_TypeManager_get_java_class_name)},
 		{0xf562bd9, "monodroid_embedded_assemblies_set_assemblies_prefix", reinterpret_cast<void*>(&monodroid_embedded_assemblies_set_assemblies_prefix)},
-		{0x1a8eab17, "_monodroid_get_identity_hash_code", reinterpret_cast<void*>(&_monodroid_get_identity_hash_code)},
 		{0x227a2636, "monodroid_get_namespaced_system_property", reinterpret_cast<void*>(&monodroid_get_namespaced_system_property)},
 		{0x2aea7c33, "_monodroid_max_gref_get", reinterpret_cast<void*>(&_monodroid_max_gref_get)},
 		{0x30b9487b, "_monodroid_get_dns_servers", reinterpret_cast<void*>(&_monodroid_get_dns_servers)},

--- a/src/native/pinvoke-override/pinvoke-tables.include
+++ b/src/native/pinvoke-override/pinvoke-tables.include
@@ -1089,6 +1089,6 @@ constexpr hash_t system_security_cryptography_native_android_library_hash = 0x93
 constexpr hash_t system_globalization_native_library_hash = 0xa66f1e5a;
 #endif
 
-constexpr size_t internal_pinvokes_count = 47;
+constexpr size_t internal_pinvokes_count = 46;
 constexpr size_t dotnet_pinvokes_count = 477;
 } // end of anonymous namespace

--- a/src/native/runtime-base/internal-pinvokes.hh
+++ b/src/native/runtime-base/internal-pinvokes.hh
@@ -36,7 +36,6 @@ void _monodroid_lref_log_new (int lrefc, jobject handle, char type, const char *
 void _monodroid_lref_log_delete (int lrefc, jobject handle, char type, const char *threadName, int threadId, const char  *from, int from_writable);
 void _monodroid_gc_wait_for_bridge_processing ();
 void monodroid_clear_gdb_wait ();
-void* _monodroid_get_identity_hash_code (JNIEnv *env, void *v);
 void* _monodroid_timezone_get_default_id ();
 void _monodroid_counters_dump ([[maybe_unused]] const char *format, [[maybe_unused]] va_list args);
 xamarin::android::managed_timing_sequence* monodroid_timing_start (const char *message);


### PR DESCRIPTION
In a NativeAOT context, we don't have `libmonodroid.so` *at all*. This makes methods like `JNIEnv.GetIdentityHashCode()` non-functional, as it p/invokes into `_monodroid_get_identity_hash_code`.

Remove `_monodroid_get_identity_hash_code`, in favor of:

    return JniEnvironment.References.GetIdentityHashCode (new JniObjectReference (v));

Which should have negligible performance impact and works without `libmonodroid.so`.