### PR TITLE
[Mono.Android] introduce `#if NATIVEAOT` for `monodroid_get_log_categories()`

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -40,6 +40,7 @@
     <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' ">$(AndroidLatestStableFrameworkVersion)</AndroidFrameworkVersion>
     <AndroidUseLatestPlatformSdk Condition=" '$(AndroidFrameworkVersion)' == '' ">True</AndroidUseLatestPlatformSdk>
     <AndroidJavaRuntimeApiLevel Condition="'$(AndroidJavaRuntimeApiLevel)' == ''">$(AndroidLatestStableApiLevel)</AndroidJavaRuntimeApiLevel>
+    <AndroidRuntime Condition=" '$(AndroidRuntime)' == '' ">Mono</AndroidRuntime>
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
@@ -60,7 +61,7 @@
     <AutoProvisionUsesSudo Condition=" '$(AutoProvisionUsesSudo)' == '' ">False</AutoProvisionUsesSudo>
     <_XABinRelativeInstallPrefix>lib\xamarin.android</_XABinRelativeInstallPrefix>
     <XAInstallPrefix Condition=" '$(XAInstallPrefix)' == '' ">$(MSBuildThisFileDirectory)bin\$(Configuration)\$(_XABinRelativeInstallPrefix)\</XAInstallPrefix>
-    <_MonoAndroidNETOutputRoot>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\</_MonoAndroidNETOutputRoot>
+    <_MonoAndroidNETOutputRoot>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android.$(AndroidRuntime)\</_MonoAndroidNETOutputRoot>
     <_MonoAndroidNETDefaultOutDir>$(_MonoAndroidNETOutputRoot)$(AndroidApiLevel)\</_MonoAndroidNETDefaultOutDir>
     <MicrosoftAndroidRefPackDir>$(BuildOutputDirectory)lib\packs\Microsoft.Android.Ref.$(AndroidApiLevel)\$(AndroidPackVersion)\ref\$(DotNetTargetFramework)\</MicrosoftAndroidRefPackDir>
     <MicrosoftAndroidSdkPackDir>$(BuildOutputDirectory)lib\packs\$(MicrosoftAndroidSdkPackName)\$(AndroidPackVersion)\</MicrosoftAndroidSdkPackDir>
@@ -214,7 +215,8 @@
 
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\Ndk.targets" />
   <ItemGroup>
-    <AndroidAbiAndRuntimeFlavor Include="@(AndroidSupportedTargetJitAbi)" AndroidRuntime="Mono" />
-    <AndroidAbiAndRuntimeFlavor Include="@(AndroidSupportedTargetJitAbi)" AndroidRuntime="NativeAOT" />
+    <AndroidRuntimes Include="Mono" />
+    <AndroidRuntimes Include="NativeAOT" />
+    <AndroidAbiAndRuntimeFlavor Include="@(AndroidSupportedTargetJitAbi)" AndroidRuntime="%(AndroidRuntimes.Identity)" />
   </ItemGroup>
 </Project>

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -11,7 +11,6 @@ projects that use the Microsoft.Android framework in .NET 6+.
 
   <PropertyGroup>
     <AndroidRID Condition=" '$(AndroidRID)' == '' ">android-arm64</AndroidRID>
-    <AndroidRuntime Condition=" '$(AndroidRuntime)' == '' ">Mono</AndroidRuntime>
     <PackageId>Microsoft.Android.Runtime.$(AndroidRuntime).$(AndroidApiLevel).$(AndroidRID)</PackageId>
     <Description>Microsoft.Android runtime components for API $(AndroidApiLevel). Please do not reference directly.</Description>
     <_AndroidRuntimePackAssemblyPath>runtimes\$(AndroidRID)\lib\$(DotNetTargetFramework)</_AndroidRuntimePackAssemblyPath>

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -29,22 +29,30 @@
     <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ConfigureLocalWorkload" />
   </Target>
 
+  <Target Name="BuildOtherRuntimes">
+    <MSBuild
+        Condition=" '%(AndroidRuntimes.Identity)' != 'Mono' "
+        Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
+        Properties="AndroidRuntime=%(AndroidRuntimes.Identity)"
+    />
+  </Target>
+
   <!-- Build Mono.Android.dll for additional API levels if necessary -->
   <Target Name="BuildExtraApiLevels">
     <MSBuild
          Condition=" '$(AndroidDefaultTargetDotnetApiLevel)' != '$(AndroidLatestStableApiLevel)' "
          Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
-         Properties="AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel);AndroidPlatformId=$(AndroidDefaultTargetDotnetApiLevel)"
+         Properties="AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel);AndroidPlatformId=$(AndroidDefaultTargetDotnetApiLevel);AndroidRuntime=%(AndroidRuntimes.Identity)"
     />
     <MSBuild
          Condition=" '$(AndroidLatestUnstableApiLevel)' != '$(AndroidLatestStableApiLevel)' "
          Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
-         Properties="AndroidApiLevel=$(AndroidLatestUnstableApiLevel);AndroidPlatformId=$(AndroidLatestUnstablePlatformId);AndroidFrameworkVersion=$(AndroidLatestUnstableFrameworkVersion)"
+         Properties="AndroidApiLevel=$(AndroidLatestUnstableApiLevel);AndroidPlatformId=$(AndroidLatestUnstablePlatformId);AndroidFrameworkVersion=$(AndroidLatestUnstableFrameworkVersion);AndroidRuntime=%(AndroidRuntimes.Identity)"
     />
   </Target>
 
   <Target Name="PackDotNet"
-      DependsOnTargets="BuildExtraApiLevels">
+      DependsOnTargets="BuildExtraApiLevels;BuildOtherRuntimes">
     <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="CreateAllPacks" />
     <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ExtractWorkloadPacks" />
     <!-- Clean up old, previously restored packages -->

--- a/src/Mono.Android/Android.Runtime/Logger.cs
+++ b/src/Mono.Android/Android.Runtime/Logger.cs
@@ -58,12 +58,19 @@ namespace Android.Runtime {
 			}
 		}
 
+		#if !NATIVEAOT
 		[DllImport (RuntimeConstants.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		extern static uint monodroid_get_log_categories ();
+		#endif
 
 		static Logger ()
 		{
+			#if NATIVEAOT
+			// TODO: p/invoke into __system_property_get
+			Categories = LogCategories.Default | LogCategories.Assembly;
+			#else // !NATIVEAOT
 			Categories = (LogCategories) monodroid_get_log_categories ();
+			#endif // !NATIVEAOT
 		}
 	}
 }

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -13,7 +13,8 @@
     <NoWarn>0618;0809;0108;0114;0465;8609;8610;8614;8617;8613;8764;8765;8766;8767;RS0041</NoWarn>
     <WarningsAsErrors>$(WarningsAsErrors);CS2002</WarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);JAVA_INTEROP</DefineConstants>
+    <DefineConstants Condition=" '$(AndroidRuntime)' == 'Mono' ">$(DefineConstants);JAVA_INTEROP;MONO</DefineConstants>
+    <DefineConstants Condition=" '$(AndroidRuntime)' == 'NativeAOT' ">$(DefineConstants);JAVA_INTEROP;NATIVEAOT</DefineConstants>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\android-$(AndroidPlatformId)\</IntermediateOutputPath>
     <ImplicitlyExpandDesignTimeFacades>false</ImplicitlyExpandDesignTimeFacades>
     <JavaCallableWrapperAfterTargets>CoreBuild</JavaCallableWrapperAfterTargets>
@@ -410,7 +411,7 @@
       <_RefExtras Include="$(OutputPath)*.*" Exclude="$(OutputPath)*.dll" />
       <_SourceFiles Include="$(OutputPath)Mono.Android.*" />
       <_SourceFiles Include="$(OutputPath)Java.Interop.*" />
-      <_RuntimePackFiles Include="@(_SourceFiles)" AndroidRID="%(AndroidAbiAndRuntimeFlavor.AndroidRID)" AndroidRuntime="%(AndroidAbiAndRuntimeFlavor.AndroidRuntime)" />
+      <_RuntimePackFiles Include="@(_SourceFiles)" AndroidRID="%(AndroidAbiAndRuntimeFlavor.AndroidRID)" />
     </ItemGroup>
     <Copy
         SourceFiles="@(_RefExtras)"
@@ -424,7 +425,7 @@
     />
     <Copy
         SourceFiles="%(_RuntimePackFiles.Identity)"
-        DestinationFolder="$(BuildOutputDirectory)lib\packs\Microsoft.Android.Runtime.%(_RuntimePackFiles.AndroidRuntime).$(AndroidApiLevel).%(_RuntimePackFiles.AndroidRID)\$(AndroidPackVersion)\runtimes\%(_RuntimePackFiles.AndroidRID)\lib\$(DotNetTargetFramework)"
+        DestinationFolder="$(BuildOutputDirectory)lib\packs\Microsoft.Android.Runtime.$(AndroidRuntime).$(AndroidApiLevel).%(_RuntimePackFiles.AndroidRID)\$(AndroidPackVersion)\runtimes\%(_RuntimePackFiles.AndroidRID)\lib\$(DotNetTargetFramework)"
         SkipUnchangedFiles="true"
     />
     <Copy


### PR DESCRIPTION
In a NativeAOT context, we don't have `libmonodroid.so` *at all*.

This change introduces a new `#if NATIVEAOT` block in `Logger.cs` to avoid calling `monodroid_get_log_categories()` and using `Default | Assembly` by default.

I also reworked the build, so that the `$(AndroidRuntime)` property is defined in `Configuration.props`. Other projects can eventually use it as-needed.

In a future PR, we could consider p/invoke into `__system_property_get()` and parse values. But we might want to reconsider the *names* of some of the system properties as they have `debug.mono.*` prefixes.

Hardcoding a default value is at least *better*, so it won't crash.