### PR TITLE
[monodroid] remove `monodroid_get_log_categories()`

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -515,7 +515,7 @@ namespace Android.Runtime {
 			}
 
 			if (ret == IntPtr.Zero) {
-				if (JNIEnvInit.LogAssemblyCategory) {
+				if (Logger.LogAssembly) {
 					RuntimeNativeMethods.monodroid_log (LogLevel.Warn, LogCategories.Default, $"typemap: failed to map managed type to Java type: {type.AssemblyQualifiedName} (Module ID: {type.Module.ModuleVersionId}; Type token: {type.MetadataToken})");
 					LogTypemapTrace (new StackTrace (true));
 				}

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -38,7 +38,6 @@ namespace Android.Runtime
 		internal static AndroidValueManager? AndroidValueManager;
 		internal static bool IsRunningOnDesktop;
 		internal static bool jniRemappingInUse;
-		internal static bool LogAssemblyCategory;
 		internal static bool MarshalMethodsEnabled;
 		internal static bool PropagateExceptions;
 		internal static BoundExceptionType BoundExceptionType;
@@ -83,7 +82,7 @@ namespace Android.Runtime
 			IntPtr total_timing_sequence = IntPtr.Zero;
 			IntPtr partial_timing_sequence = IntPtr.Zero;
 
-			LogAssemblyCategory = (args->logCategories & (uint)LogCategories.Assembly) != 0;
+			Logger.SetLogCategories ((LogCategories)args->logCategories);
 
 			gref_gc_threshold = args->grefGcThreshold;
 

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
@@ -40,7 +40,7 @@ namespace Android.Runtime {
 			if (result != null)
 				return result;
 
-			if (JNIEnvInit.LogAssemblyCategory) {
+			if (Logger.LogAssembly) {
 				RuntimeNativeMethods.monodroid_log (LogLevel.Debug, LogCategories.Assembly, $"Falling back to System.Reflection.Emit for delegate type '{delegateType}': {dlg.Method}");
 			}
 

--- a/src/Mono.Android/Android.Runtime/Logger.cs
+++ b/src/Mono.Android/Android.Runtime/Logger.cs
@@ -58,12 +58,7 @@ namespace Android.Runtime {
 			}
 		}
 
-		[DllImport (RuntimeConstants.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
-		extern static uint monodroid_get_log_categories ();
-
-		static Logger ()
-		{
-			Categories = (LogCategories) monodroid_get_log_categories ();
-		}
+		internal static void SetLogCategories (LogCategories categories) =>
+			Categories = categories;
 	}
 }

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -224,7 +224,7 @@ namespace Java.Interop {
 
 			if (!JNIEnvInit.IsRunningOnDesktop) {
 				// Miss message is logged in the native runtime
-				if (JNIEnvInit.LogAssemblyCategory)
+				if (Logger.LogAssembly)
 					JNIEnv.LogTypemapTrace (new System.Diagnostics.StackTrace (true));
 				return null;
 			}

--- a/src/native/monodroid/internal-pinvokes.cc
+++ b/src/native/monodroid/internal-pinvokes.cc
@@ -6,12 +6,6 @@
 using namespace xamarin::android;
 using namespace xamarin::android::internal;
 
-unsigned int
-monodroid_get_log_categories ()
-{
-	return log_categories;
-}
-
 int
 monodroid_get_system_property (const char *name, char **value)
 {

--- a/src/native/pinvoke-override/generate-pinvoke-tables.cc
+++ b/src/native/pinvoke-override/generate-pinvoke-tables.cc
@@ -48,7 +48,6 @@ const std::vector<std::string> internal_pinvoke_names = {
 	"_monodroid_get_dns_servers",
 	"monodroid_get_dylib",
 	"_monodroid_getifaddrs",
-	"monodroid_get_log_categories",
 	"monodroid_get_namespaced_system_property",
 	"_monodroid_get_network_interface_supports_multicast",
 	"_monodroid_get_network_interface_up_state",

--- a/src/native/pinvoke-override/pinvoke-tables.include
+++ b/src/native/pinvoke-override/pinvoke-tables.include
@@ -11,8 +11,7 @@
 namespace {
 #if INTPTR_MAX == INT64_MAX
 	//64-bit internal p/invoke table
-	std::array<PinvokeEntry, 46> internal_pinvokes {{
-		{0x452e23128e42f0a, "monodroid_get_log_categories", reinterpret_cast<void*>(&monodroid_get_log_categories)},
+	std::array<PinvokeEntry, 45> internal_pinvokes {{
 		{0xa50ce5de13bf8b5, "_monodroid_timezone_get_default_id", reinterpret_cast<void*>(&_monodroid_timezone_get_default_id)},
 		{0x19055d65edfd668e, "_monodroid_get_network_interface_up_state", reinterpret_cast<void*>(&_monodroid_get_network_interface_up_state)},
 		{0x2b3b0ca1d14076da, "monodroid_get_dylib", reinterpret_cast<void*>(&monodroid_get_dylib)},
@@ -550,7 +549,7 @@ constexpr hash_t system_security_cryptography_native_android_library_hash = 0x18
 constexpr hash_t system_globalization_native_library_hash = 0x28b5c8fca080abd5;
 #else
 	//32-bit internal p/invoke table
-	std::array<PinvokeEntry, 46> internal_pinvokes {{
+	std::array<PinvokeEntry, 45> internal_pinvokes {{
 		{0xb7a486a, "monodroid_TypeManager_get_java_class_name", reinterpret_cast<void*>(&monodroid_TypeManager_get_java_class_name)},
 		{0xf562bd9, "monodroid_embedded_assemblies_set_assemblies_prefix", reinterpret_cast<void*>(&monodroid_embedded_assemblies_set_assemblies_prefix)},
 		{0x227a2636, "monodroid_get_namespaced_system_property", reinterpret_cast<void*>(&monodroid_get_namespaced_system_property)},
@@ -584,7 +583,6 @@ constexpr hash_t system_globalization_native_library_hash = 0x28b5c8fca080abd5;
 		{0xc5146c54, "_monodroid_gref_log_delete", reinterpret_cast<void*>(&_monodroid_gref_log_delete)},
 		{0xc58eafa5, "java_interop_free", reinterpret_cast<void*>(&java_interop_free)},
 		{0xd3b5d2c1, "_monodroid_freeifaddrs", reinterpret_cast<void*>(&_monodroid_freeifaddrs)},
-		{0xd78c749d, "monodroid_get_log_categories", reinterpret_cast<void*>(&monodroid_get_log_categories)},
 		{0xd91f3619, "create_public_directory", reinterpret_cast<void*>(&create_public_directory)},
 		{0xe215a17c, "_monodroid_weak_gref_delete", reinterpret_cast<void*>(&_monodroid_weak_gref_delete)},
 		{0xe4c3ee19, "monodroid_log_traces", reinterpret_cast<void*>(&monodroid_log_traces)},
@@ -1089,6 +1087,6 @@ constexpr hash_t system_security_cryptography_native_android_library_hash = 0x93
 constexpr hash_t system_globalization_native_library_hash = 0xa66f1e5a;
 #endif
 
-constexpr size_t internal_pinvokes_count = 46;
+constexpr size_t internal_pinvokes_count = 45;
 constexpr size_t dotnet_pinvokes_count = 477;
 } // end of anonymous namespace

--- a/src/native/runtime-base/internal-pinvokes.hh
+++ b/src/native/runtime-base/internal-pinvokes.hh
@@ -19,7 +19,6 @@ mono_bool _monodroid_get_network_interface_up_state (const char *ifname, mono_bo
 mono_bool _monodroid_get_network_interface_supports_multicast (const char *ifname, mono_bool *supports_multicast);
 int _monodroid_get_dns_servers (void **dns_servers_array);
 
-unsigned int monodroid_get_log_categories ();
 int monodroid_get_system_property (const char *name, char **value);
 int monodroid_embedded_assemblies_set_assemblies_prefix (const char *prefix);
 void monodroid_log (xamarin::android::LogLevel level, LogCategories category, const char *message);


### PR DESCRIPTION
In a NativeAOT context, we don't have `libmonodroid.so` *at all*.
Let's remove the `monodroid_get_log_categories()` function, as we
already pass in `args->logCategories` at startup. We can use a new
`Logger.SetLogCategories()` method to pass the value in.

I also removed `JNIEnvInit.LogAssemblyCategory`, as we can just use
the `Logger` class instead.

The startup sequence in C++ seems OK, so doesn't seem like this
changes any behavior:

* `Java_mono_android_Runtime_initInternal()` sets up logging
  categories very early in startup.

* `create_and_initialize_domain()` calls...

* `init_android_runtime()` calls...

* Calls managed code, `JNIEnvInit.Initialize()` using the correct
  logging categories.