### PR TITLE
[NativeAOT] improve build logic, part 2

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -88,7 +88,7 @@
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' and '$(PublishTrimmed)' == 'true' ">SdkOnly</AndroidLinkMode>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
     <!-- For compat with user code not marked trimmable, only trim opt-in by default. -->
-    <TrimMode Condition=" '$(TrimMode)' == '' and '$(AndroidLinkMode)' == 'Full' ">full</TrimMode>
+    <TrimMode Condition=" '$(TrimMode)' == '' and ('$(AndroidLinkMode)' == 'Full' or '$(_AndroidNativeAot)' == 'true') ">full</TrimMode>
 		<TrimMode Condition="'$(TrimMode)' == ''">partial</TrimMode>
     <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' and ('$(TrimMode)' == 'full' or '$(IsAotCompatible)' == 'true') ">false</SuppressTrimAnalysisWarnings>
     <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -25,7 +25,9 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
     </IlcCompileDependsOn>
   </PropertyGroup>
 
-  <Target Name="_AndroidBeforeIlcCompile" BeforeTargets="SetupProperties">
+  <Target Name="_AndroidBeforeIlcCompile"
+      DependsOnTargets="_PrepareLinking"
+      BeforeTargets="SetupProperties">
     <!-- Example settings from: https://github.com/jonathanpeppers/Android-NativeAOT/blob/ea69d122cdc7de67aa6a5db14b7e560763c63cdd/DotNet/libdotnet.targets -->
     <PropertyGroup>
       <_NdkSysrootAbi>aarch64-linux-android</_NdkSysrootAbi>
@@ -33,7 +35,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('windows')) ">windows-x86_64</_NdkPrebuiltAbi>
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('osx')) ">darwin-x86_64</_NdkPrebuiltAbi>
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('linux')) ">linux-x86_64</_NdkPrebuiltAbi>
-      <_NdkSysrootDir>$(_AndroidNdkDirectory)toolchains/llvm/prebuilt/$(_NdkPrebuiltAbi)/sysroot/usr/lib/$(_NdkSysrootAbi)</_NdkSysrootDir>
+      <_NdkSysrootDir>$(_AndroidNdkDirectory)toolchains/llvm/prebuilt/$(_NdkPrebuiltAbi)/sysroot/usr/lib/$(_NdkSysrootAbi)/</_NdkSysrootDir>
       <_NdkBinDir>$(_AndroidNdkDirectory)toolchains/llvm/prebuilt/$(_NdkPrebuiltAbi)/bin/</_NdkBinDir>
       <CppCompilerAndLinker>$(_NdkBinDir)$(_NdkClangPrefix)clang++</CppCompilerAndLinker>
       <CppLinker>$(CppCompilerAndLinker)</CppLinker>
@@ -56,6 +58,8 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <_targetOS>linux</_targetOS>
       <!-- HACK: prevents libSystem.Net.Security.Native.a from being added -->
       <_linuxLibcFlavor>bionic</_linuxLibcFlavor>
+      <!-- HACK: prevents: java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "__start___modules" -->
+      <LinkerFlavor Condition=" '$(LinkerFlavor)' == '' ">lld</LinkerFlavor>
     </PropertyGroup>
   </Target>
 
@@ -76,6 +80,8 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <IlcReference Include="@(_AndroidILLinkAssemblies)" />
       <!-- Passes linked assemblies to outer MSBuild tasks/targets -->
       <ResolvedFileToPublish Include="@(IlcCompileInput);@(_AndroidILLinkAssemblies)" RuntimeIdentifier="$(_OriginalRuntimeIdentifier)" />
+      <!-- Include libc++ -->
+      <ResolvedFileToPublish Include="$(_NdkSysrootDir)libc++_shared.so" RuntimeIdentifier="$(_OriginalRuntimeIdentifier)" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -387,7 +387,9 @@ namespace Xamarin.Android.Tasks
 			var tdCache = new TypeDefinitionCache ();
 			(List<TypeDefinition> allJavaTypes, List<TypeDefinition> javaTypesForJCW) = ScanForJavaTypes (resolver, tdCache, assemblies, userAssemblies, useMarshalMethods);
 			var jcwContext = new JCWGeneratorContext (arch, resolver, assemblies.Values, javaTypesForJCW, tdCache, useMarshalMethods);
-			var jcwGenerator = new JCWGenerator (Log, jcwContext);
+			var jcwGenerator = new JCWGenerator (Log, jcwContext) {
+				NativeAot = NativeAot,
+			};
 			bool success;
 
 			if (generateJavaCode) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JCWGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JCWGenerator.cs
@@ -44,6 +44,8 @@ class JCWGenerator
 	readonly TaskLoggingHelper log;
 	readonly JCWGeneratorContext context;
 
+	public bool NativeAot { get; set; }
+
 	public MarshalMethodsClassifier? Classifier { get; private set; }
 
 	public JCWGenerator (TaskLoggingHelper log, JCWGeneratorContext context)
@@ -125,7 +127,7 @@ class JCWGenerator
 		bool ok = true;
 		using var writer = MemoryStreamPool.Shared.CreateStreamWriter ();
 		var writer_options = new CallableWrapperWriterOptions {
-			CodeGenerationTarget    = JavaPeerStyle.XAJavaInterop1
+			CodeGenerationTarget    = NativeAot ? JavaPeerStyle.JavaInterop1 : JavaPeerStyle.XAJavaInterop1
 		};
 
 		try {


### PR DESCRIPTION
This is another set of changes to Android apps to *run* under NativeAOT:

* Default to `$(TrimMode)=Full` for NativeAOT, this enables trimmer warnings and should be the default mode for NativeAOT.

* Ensure `_PrepareLinking` MSBuild target runs at the appropriate time. This was causing `Android.App.Activity`'s `GetOnCreate_Landroid_os_Bundle_Handler()` to get trimmed away.

* Default to `$(LinkerFlavor)=lld` to avoid a `java.lang.UnsatisfiedLinkError` at runtime.

* Include `libc++_shared.so` to avoid a `java.lang.UnsatisfiedLinkError` at runtime.

* Emit `JavaPeerStyle.JavaInterop1` java stubs for NativeAOT, as it is easier to get working in place of `JavaPeerStyle.XAJavaInterop1`.

I updated our existing `NativeAOT()` test to assert for these changes where possible.