### PR TITLE
Bump to dotnet/java-interop/main@2c06b3c2

### DIFF
--- a/src/Mono.Android/Android.Graphics/Color.cs
+++ b/src/Mono.Android/Android.Graphics/Color.cs
@@ -395,7 +395,7 @@ namespace Android.Graphics
 
 	public class ColorValueMarshaler : JniValueMarshaler<Color>
 	{
-		const DynamicallyAccessedMemberTypes ConstructorsAndInterfaces = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.Interfaces;
+		const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 		const string ExpressionRequiresUnreferencedCode = "System.Linq.Expression usage may trim away required code.";
 
 		public override Type MarshalType {
@@ -405,7 +405,7 @@ namespace Android.Graphics
 		public override Color CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type targetType)
 		{
 			throw new NotImplementedException ();

--- a/src/Mono.Android/Android.Runtime/IJavaObjectValueMarshaler.cs
+++ b/src/Mono.Android/Android.Runtime/IJavaObjectValueMarshaler.cs
@@ -10,7 +10,7 @@ namespace Android.Runtime
 {
 	sealed class IJavaObjectValueMarshaler : JniValueMarshaler<IJavaObject> {
 
-		const DynamicallyAccessedMemberTypes ConstructorsAndInterfaces = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.Interfaces;
+		const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 		const string ExpressionRequiresUnreferencedCode = "System.Linq.Expression usage may trim away required code.";
 
 		internal    static  IJavaObjectValueMarshaler              Instance    = new IJavaObjectValueMarshaler ();
@@ -18,7 +18,7 @@ namespace Android.Runtime
 		public override IJavaObject CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			throw new NotImplementedException ();

--- a/tests/api-compatibility/acceptable-breakages-vReference-net9.0.txt
+++ b/tests/api-compatibility/acceptable-breakages-vReference-net9.0.txt
@@ -1,1 +1,2 @@
 Compat issues with assembly Mono.Android:
+CannotChangeAttribute : Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute' on parameter 'targetType' on member 'Android.Graphics.ColorValueMarshaler.CreateGenericValue(Java.Interop.JniObjectReference, Java.Interop.JniObjectReferenceOptions, System.Type)' changed from '[DynamicallyAccessedMembersAttribute(8199)]' in the contract to '[DynamicallyAccessedMembersAttribute(7)]' in the implementation.


### PR DESCRIPTION
Changes: https://github.com/dotnet/java-interop/compare/f800ea52dce62f126926d4b96121681508d506a1...2c06b3c2a11833aea0e9b51aac2a72195bd64539

  * dotnet/java-interop@2c06b3c2: [Java.Interop] remove `DynamicallyAccessedMemberTypes.Interfaces` (dotnet/java-interop#1285)