### PR TITLE
[CI] Set "WearOS Tests" parallelization to 2 agents.

### DIFF
--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -81,7 +81,7 @@ stages:
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 2
     strategy:
-      parallel: 1
+      parallel: 2
     variables:
       avdApiLevel: 30
       avdAbi: x86


### PR DESCRIPTION
The "WearOS Test" job regularly takes over an hour to complete.  Split the tests it runs into 2 parallel jobs to reduce the time taken to complete the stage.