### PR TITLE
[CI] Break "Linux Tests" into 2 parallel jobs.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -108,66 +108,7 @@ extends:
       parameters:
         macTestAgentsUseCleanImages: ${{ parameters.macTestAgentsUseCleanImages }}
 
-    - stage: linux_tests
-      displayName: Linux Tests
-      dependsOn:
-      - mac_build
-      - linux_build
-      jobs:
-      # Check - "Xamarin.Android (Linux Tests Linux > Tests > MSBuild)"
-      - job: linux_tests_smoke
-        displayName: Linux > Tests > MSBuild
-        pool:
-          name: MAUI-1ESPT
-          image: $(LinuxPoolImage1ESPT)
-          os: linux
-        timeoutInMinutes: 180
-        workspace:
-          clean: all
-        steps:
-        - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
-
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            artifactName: $(TestAssembliesArtifactName)
-            downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
-
-        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
-          parameters:
-            testRunTitle: Xamarin.Android.Build.Tests - Linux BuildTest
-            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
-            dotNetTestExtraArgs: --filter "Name = BuildTest"
-
-        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
-          parameters:
-            testRunTitle: Xamarin.Android.Build.Tests - Linux PackagingTest
-            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
-            dotNetTestExtraArgs: --filter "Name = PackagingTest"
-
-        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
-          parameters:
-            testRunTitle: Xamarin.Android.Build.Tests - Linux XASdkTests
-            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
-            dotNetTestExtraArgs: --filter "Name = XASdkTests & Name != XamarinLegacySdk"
-
-        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
-          parameters:
-            testRunTitle: Xamarin.Android.Build.Tests - Linux AndroidDependenciesTests
-            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
-            dotNetTestExtraArgs: --filter "Name = AndroidDependenciesTests"
-
-        - task: ShellScript@2
-          displayName: Test dotnet-local.sh
-          inputs:
-            scriptPath: dotnet-local.sh
-            args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
-
-        - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
-          parameters:
-            configuration: $(XA.Build.Configuration)
-            artifactName: Test Results - MSBuild - Linux
-
-        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+    - template: /build-tools/automation/yaml-templates/stage-linux-tests.yaml@self
 
     - template: /build-tools/automation/yaml-templates/stage-msbuild-tests.yaml@self
 

--- a/build-tools/automation/yaml-templates/stage-linux-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-linux-tests.yaml
@@ -1,0 +1,87 @@
+# Runs smoke tests on Linux packages.
+
+stages:
+- stage: linux_tests
+  displayName: Linux Tests
+  dependsOn:
+  - mac_build
+  - linux_build
+  jobs:
+  # Check - "Xamarin.Android (Linux Tests Linux > Tests > MSBuild)"
+  - job: linux_tests_smoke_1
+    displayName: Linux > Tests > MSBuild 1
+    pool:
+      name: MAUI-1ESPT
+      image: $(LinuxPoolImage1ESPT)
+      os: linux
+    timeoutInMinutes: 180
+    workspace:
+      clean: all
+    steps:
+    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
+
+    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+      parameters:
+        testRunTitle: Xamarin.Android.Build.Tests - Linux BuildTest
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
+        dotNetTestExtraArgs: --filter "Name = BuildTest"
+
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+      parameters:
+        configuration: $(XA.Build.Configuration)
+        artifactName: Test Results - MSBuild - Linux 1
+
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+
+  - job: linux_tests_smoke_2
+    displayName: Linux > Tests > MSBuild 2
+    pool:
+      name: MAUI-1ESPT
+      image: $(LinuxPoolImage1ESPT)
+      os: linux
+    timeoutInMinutes: 180
+    workspace:
+      clean: all
+    steps:
+    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
+
+    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+      parameters:
+        testRunTitle: Xamarin.Android.Build.Tests - Linux PackagingTest
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
+        dotNetTestExtraArgs: --filter "Name = PackagingTest"
+
+    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+      parameters:
+        testRunTitle: Xamarin.Android.Build.Tests - Linux XASdkTests
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
+        dotNetTestExtraArgs: --filter "Name = XASdkTests & Name != XamarinLegacySdk"
+
+    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+      parameters:
+        testRunTitle: Xamarin.Android.Build.Tests - Linux AndroidDependenciesTests
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
+        dotNetTestExtraArgs: --filter "Name = AndroidDependenciesTests"
+
+    - task: ShellScript@2
+      displayName: Test dotnet-local.sh
+      inputs:
+        scriptPath: dotnet-local.sh
+        args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
+
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+      parameters:
+        configuration: $(XA.Build.Configuration)
+        artifactName: Test Results - MSBuild - Linux 2
+
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self

--- a/build-tools/automation/yaml-templates/stage-linux-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-linux-tests.yaml
@@ -18,25 +18,25 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
+    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
       parameters:
         testRunTitle: Xamarin.Android.Build.Tests - Linux BuildTest
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
         dotNetTestExtraArgs: --filter "Name = BuildTest"
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
         artifactName: Test Results - MSBuild - Linux 1
 
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
 
   - job: linux_tests_smoke_2
     displayName: Linux > Tests > MSBuild 2
@@ -48,26 +48,26 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
+    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
       parameters:
         testRunTitle: Xamarin.Android.Build.Tests - Linux PackagingTest
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
         dotNetTestExtraArgs: --filter "Name = PackagingTest"
 
-    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
       parameters:
         testRunTitle: Xamarin.Android.Build.Tests - Linux XASdkTests
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
         dotNetTestExtraArgs: --filter "Name = XASdkTests & Name != XamarinLegacySdk"
 
-    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
       parameters:
         testRunTitle: Xamarin.Android.Build.Tests - Linux AndroidDependenciesTests
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
@@ -79,9 +79,9 @@ stages:
         scriptPath: dotnet-local.sh
         args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
         artifactName: Test Results - MSBuild - Linux 2
 
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -19,7 +19,7 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
+    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         xaprepareScenario: EmulatorTestDependencies
 
@@ -35,7 +35,7 @@ stages:
         projects: $(System.DefaultWorkingDirectory)/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
         arguments: -c Debug -bl:$(System.DefaultWorkingDirectory)/bin/TestDebug/BootstrapTasks.binlog
 
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
       parameters:
         project: Xamarin.Android.sln
         arguments: >-
@@ -44,14 +44,14 @@ stages:
         displayName: prepare java.interop Debug
         continueOnError: false
 
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
       parameters:
         project: Xamarin.Android.sln
         arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) --no-restore
         displayName: prepare java.interop $(XA.Build.Configuration)
         continueOnError: false
 
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
       parameters:
         command: test
         project: src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj 
@@ -59,9 +59,9 @@ stages:
         displayName: Test Microsoft.Android.Sdk.Analysis $(XA.Build.Configuration)
         continueOnError: false
 
-    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml@self
+    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
 
-    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
+    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         buildConfiguration: $(XA.Build.Configuration)
         configuration: Debug
@@ -71,7 +71,7 @@ stages:
         artifactSource: bin/TestDebug/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: $(DotNetTargetFramework)-Debug
 
-    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
+    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
         testName: Mono.Android.NET_Tests-$(XA.Build.Configuration)
@@ -80,7 +80,7 @@ stages:
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: $(DotNetTargetFramework)-$(XA.Build.Configuration)
 
-    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
+    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
         testName: Mono.Android.NET_Tests-NoAab
@@ -90,7 +90,7 @@ stages:
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: $(DotNetTargetFramework)-NoAab
 
-    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
+    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
         testName: Mono.Android.NET_Tests-Interpreter
@@ -101,20 +101,20 @@ stages:
         artifactFolder: $(DotNetTargetFramework)-Interpreter
 
     - ${{ if ne(parameters.macTestAgentsUseCleanImages, true) }}:
-      - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml@self
+      - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
         parameters:
           command: stop
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         artifactName: Test Results - APKs .NET $(XA.Build.Configuration) - macOS 1
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         artifactName: Test Results - APKs .NET Debug - macOS 1
         configuration: Debug
 
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
 
   - job: mac_apk_tests_net_2
     displayName: macOS > Tests > APKs 2
@@ -126,7 +126,7 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
+    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         xaprepareScenario: EmulatorTestDependencies
 
@@ -142,7 +142,7 @@ stages:
         projects: $(System.DefaultWorkingDirectory)/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
         arguments: -c Debug -bl:$(System.DefaultWorkingDirectory)/bin/TestDebug/BootstrapTasks.binlog
 
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
       parameters:
         project: Xamarin.Android.sln
         arguments: >-
@@ -151,14 +151,14 @@ stages:
         displayName: prepare java.interop Debug
         continueOnError: false
 
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
       parameters:
         project: Xamarin.Android.sln
         arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) --no-restore
         displayName: prepare java.interop $(XA.Build.Configuration)
         continueOnError: false
 
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
       parameters:
         command: test
         project: src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj 
@@ -166,9 +166,9 @@ stages:
         displayName: Test Microsoft.Android.Sdk.Analysis $(XA.Build.Configuration)
         continueOnError: false
 
-    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml@self
+    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
 
-    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
+    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
         testName: Mono.Android.NET_Tests-NoAot
@@ -178,7 +178,7 @@ stages:
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: $(DotNetTargetFramework)-NoAot
 
-    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
+    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
         testName: Mono.Android.NET_Tests-TrimModePartial
@@ -188,7 +188,7 @@ stages:
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: $(DotNetTargetFramework)-TrimModePartial
 
-    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
+    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
         testName: Mono.Android.NET_Tests-AotLlvm
@@ -198,7 +198,7 @@ stages:
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: $(DotNetTargetFramework)-AotLlvm
 
-    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
+    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
         testName: Xamarin.Android.JcwGen_Tests
@@ -207,7 +207,7 @@ stages:
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Xamarin.Android.JcwGen_Tests-Signed.apk
         artifactFolder: $(DotNetTargetFramework)-Default
 
-    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
       parameters:
         testRunTitle: Xamarin.Android.Tools.Aidl-Tests - macOS
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Tools.Aidl-Tests.dll
@@ -219,17 +219,17 @@ stages:
         args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
 
     - ${{ if ne(parameters.macTestAgentsUseCleanImages, true) }}:
-      - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml@self
+      - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
         parameters:
           command: stop
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         artifactName: Test Results - APKs .NET $(XA.Build.Configuration) - macOS 2
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         artifactName: Test Results - APKs .NET Debug - macOS 2
         configuration: Debug
 
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml


### PR DESCRIPTION
The "Linux Tests" stage/job regularly approaches an hour runtime, after a ~17 minute Linux build.  This puts it beyond our "ideal" 1 hour PR CI build.

Manually split the job up into 2 jobs that each run in parallel to reduce the overall runtime.