### PR TITLE
[Mono.Android] Generate API docs for API level 35

### DIFF
--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -181,3 +181,4 @@ extends:
                 exit 1
             }
           displayName: Report issues in docs generation
+          continueOnError: true

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -8,6 +8,13 @@
 trigger: none
 pr: none
 
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
 parameters:
 - name: apiLevel
   displayName: AndroidApiLevel property value
@@ -50,113 +57,123 @@ variables:
   value: ''
 
 
-stages:
-- stage: mac_build
-  displayName: Build
-  dependsOn: []
-  jobs:
-  - job: mac_build_update_docs
-    displayName: Update API Docs
-    pool:
-      name: $(SharedMacPool)
-      demands:
-      - macOS.Name -equals $(SharedMacName)
-      - Agent.OSArchitecture -equals $(SharedMacArch)
-    timeoutInMinutes: 120
-    workspace:
-      clean: all
-    steps:
-    - checkout: self
-      submodules: recursive
+extends:
+  ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  ${{ else }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  parameters:
+    sourceAnalysisPool:
+      name: AzurePipelines-EO
+      image: $(WindowsPoolImage1ESPT)
+      os: windows
+    suppression:
+      suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
+    stages:
+    - stage: mac_build
+      displayName: Build
+      dependsOn: []
+      jobs:
+      - job: mac_build_update_docs
+        displayName: Update API Docs
+        pool:
+          name: $(SharedMacPool)
+          demands:
+          - macOS.Name -equals $(SharedMacName)
+          - Agent.OSArchitecture -equals $(SharedMacArch)
+        timeoutInMinutes: 120
+        workspace:
+          clean: all
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: upload docs binaries
+            artifactName: Binaries
+            targetPath: $(Build.SourcesDirectory)/src/Mono.Android/obj/docs-gen-temp
+          - output: pipelineArtifact
+            displayName: upload docs diff
+            artifactName: Api Docs Diff
+            targetPath: $(Build.StagingDirectory)/api-doc-diff
+        steps:
+        - checkout: self
+          submodules: recursive
 
-    - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
-      displayName: set JI_JAVA_HOME
+        - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
+          displayName: set JI_JAVA_HOME
 
-    # Set MSBuild property overrides if parameters are set
-    - ${{ if ne(parameters.apiLevel, 'default') }}:
-      - script: echo "##vso[task.setvariable variable=DocsApiLevelArg]-p:DocsApiLevel=${{ parameters.apiLevel }}"
-        displayName: set DocsApiLevelArg
+        # Set MSBuild property overrides if parameters are set
+        - ${{ if ne(parameters.apiLevel, 'default') }}:
+          - script: echo "##vso[task.setvariable variable=DocsApiLevelArg]-p:DocsApiLevel=${{ parameters.apiLevel }}"
+            displayName: set DocsApiLevelArg
 
-    - ${{ if ne(parameters.platformId, 'default') }}:
-      - script: echo "##vso[task.setvariable variable=DocsPlatformIdArg]-p:DocsPlatformId=${{ parameters.platformId }}"
-        displayName: set DocsPlatformIdArg
+        - ${{ if ne(parameters.platformId, 'default') }}:
+          - script: echo "##vso[task.setvariable variable=DocsPlatformIdArg]-p:DocsPlatformId=${{ parameters.platformId }}"
+            displayName: set DocsPlatformIdArg
 
-    - ${{ if ne(parameters.frameworkVersion, 'default') }}:
-      - script: echo "##vso[task.setvariable variable=DocsFxVersionArg]-p:DocsFxVersion=${{ parameters.frameworkVersion }}"
-        displayName: set DocsFxVersionArg
+        - ${{ if ne(parameters.frameworkVersion, 'default') }}:
+          - script: echo "##vso[task.setvariable variable=DocsFxVersionArg]-p:DocsFxVersion=${{ parameters.frameworkVersion }}"
+            displayName: set DocsFxVersionArg
 
-    - ${{ if ne(parameters.mdocVersion, 'default') }}:
-      - script: echo "##vso[task.setvariable variable=MdocPackageVersionArg]-p:MdocPackageVersion=${{ parameters.mdocVersion }}"
-        displayName: set MdocPackageVersionArg
+        - ${{ if ne(parameters.mdocVersion, 'default') }}:
+          - script: echo "##vso[task.setvariable variable=MdocPackageVersionArg]-p:MdocPackageVersion=${{ parameters.mdocVersion }}"
+            displayName: set MdocPackageVersionArg
 
-    - ${{ if ne(parameters.javadocVerbosity, 'default') }}:
-      - script: echo "##vso[task.setvariable variable=AndroidJavadocVerbosity]-p:AndroidJavadocVerbosity=${{ parameters.javadocVerbosity }}"
-        displayName: set AndroidJavadocVerbosity
+        - ${{ if ne(parameters.javadocVerbosity, 'default') }}:
+          - script: echo "##vso[task.setvariable variable=AndroidJavadocVerbosity]-p:AndroidJavadocVerbosity=${{ parameters.javadocVerbosity }}"
+            displayName: set AndroidJavadocVerbosity
 
-    - template: yaml-templates/use-dot-net.yaml
+        - template: yaml-templates/use-dot-net.yaml
 
-    - task: NuGetAuthenticate@1
-      displayName: authenticate with azure artifacts
-      inputs:
-        forceReinstallCredentialProvider: true
+        - task: NuGetAuthenticate@1
+          displayName: authenticate with azure artifacts
+          inputs:
+            forceReinstallCredentialProvider: true
 
-    - script: dotnet tool update -v:n boots --version 1.1.0.36 --add-source "https://api.nuget.org/v3/index.json" --global
-      displayName: Install boots
+        - script: dotnet tool update -v:n boots --version 1.1.0.36 --add-source "https://api.nuget.org/v3/index.json" --global
+          displayName: Install boots
 
-    - script: boots https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-6.12.0.188.macos10.xamarin.universal.pkg
-      displayName: Install Mono
+        - script: boots https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-6.12.0.188.macos10.xamarin.universal.pkg
+          displayName: Install Mono
 
-    - script: make prepare CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
-      workingDirectory: $(Build.SourcesDirectory)
-      displayName: make prepare
+        - script: make prepare CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+          workingDirectory: $(Build.SourcesDirectory)
+          displayName: make prepare
 
-    - script: >-
-        make update-api-docs CONFIGURATION=$(XA.Build.Configuration)
-        MSBUILD_ARGS='$(DocsApiLevelArg) $(DocsPlatformIdArg) $(DocsFxVersionArg) $(MdocPackageVersionArg) $(AndroidJavadocVerbosity)'
-      workingDirectory: $(Build.SourcesDirectory)
-      displayName: make update-api-docs
+        - script: >-
+            make update-api-docs CONFIGURATION=$(XA.Build.Configuration)
+            MSBUILD_ARGS='$(DocsApiLevelArg) $(DocsPlatformIdArg) $(DocsFxVersionArg) $(MdocPackageVersionArg) $(AndroidJavadocVerbosity)'
+          workingDirectory: $(Build.SourcesDirectory)
+          displayName: make update-api-docs
 
-    - task: PublishPipelineArtifact@1
-      displayName: upload docs files
-      inputs:
-        artifactName: Binaries
-        targetPath: $(Build.SourcesDirectory)/src/Mono.Android/obj/docs-gen-temp
+        - script: >
+            mkdir -p $(Build.StagingDirectory)/api-doc-diff &&
+            ln $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/UpdateApiDocs*.diff $(Build.StagingDirectory)/api-doc-diff/
+          displayName: copy api docs diff
 
-    - script: >
-        mkdir -p $(Build.StagingDirectory)/api-doc-diff &&
-        ln $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/UpdateApiDocs*.diff $(Build.StagingDirectory)/api-doc-diff/
-      displayName: copy api docs diff
+        - template: yaml-templates/upload-results.yaml
+          parameters:
+            artifactName: Build Results - API Docs Update
+            includeBuildResults: true
+            condition: always()
 
-    - task: PublishPipelineArtifact@1
-      displayName: upload api docs diff
-      inputs:
-        artifactName: Api Docs Diff
-        targetPath: $(Build.StagingDirectory)/api-doc-diff
+        - powershell: |
+            $docsUpdateBinlog = Get-ChildItem -Path "$(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)" -Filter *UpdateApiDocs-*.binlog | Select-Object -First 1
+            $buildLog = "$(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/temp-build.log"
+            & "$(Build.SourcesDirectory)/bin/$(XA.Build.Configuration)/dotnet/dotnet" build $docsUpdateBinlog > $buildLog
 
-    - template: yaml-templates/upload-results.yaml
-      parameters:
-        artifactName: Build Results - API Docs Update
-        includeBuildResults: true
-        condition: always()
-
-    - powershell: |
-        $docsUpdateBinlog = Get-ChildItem -Path "$(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)" -Filter *UpdateApiDocs-*.binlog | Select-Object -First 1
-        $buildLog = "$(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/temp-build.log"
-        & "$(Build.SourcesDirectory)/bin/$(XA.Build.Configuration)/dotnet/dotnet" build $docsUpdateBinlog > $buildLog
-
-        $issueContent = & {
-            Get-Content -Path $buildLog | Select-String "## Exception translating remarks"
-            Get-Content -Path $buildLog | Select-String "## Unable to translate remarks"
-            Get-Content -Path $buildLog | Select-String "JavadocImport-"
-        }
-
-        if ($issueContent) {
-            Write-Host "The following issues were found, review the build log for more details:"
-            Write-Host ""
-            foreach ($line in $issueContent) {
-                Write-Host $line
-                Write-Host ""
+            $issueContent = & {
+                Get-Content -Path $buildLog | Select-String "## Exception translating remarks"
+                Get-Content -Path $buildLog | Select-String "## Unable to translate remarks"
+                Get-Content -Path $buildLog | Select-String "JavadocImport-"
             }
-            exit 1
-        }
-      displayName: Report issues in docs generation
+
+            if ($issueContent) {
+                Write-Host "The following issues were found, review the build log for more details:"
+                Write-Host ""
+                foreach ($line in $issueContent) {
+                    Write-Host $line
+                    Write-Host ""
+                }
+                exit 1
+            }
+          displayName: Report issues in docs generation

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -100,10 +100,11 @@ stages:
       inputs:
         forceReinstallCredentialProvider: true
 
-    - template: yaml-templates/run-xaprepare.yaml
-      parameters:
-        displayName: update mono
-        arguments: --s=UpdateMono
+    - script: dotnet tool update -v:n boots --version 1.1.0.36 --add-source "https://api.nuget.org/v3/index.json" --global
+      displayName: Install boots
+
+    - script: boots https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-6.12.0.188.macos10.xamarin.universal.pkg
+      displayName: Install Mono
 
     - script: make prepare CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
       workingDirectory: $(Build.SourcesDirectory)
@@ -115,17 +116,11 @@ stages:
       workingDirectory: $(Build.SourcesDirectory)
       displayName: make update-api-docs
 
-    - script: >
-        mkdir -p $(Build.StagingDirectory)/docs-binaries &&
-        ln $(Build.SourcesDirectory)/bin/$(XA.Build.Configuration)/lib/xamarin.android/xbuild-frameworks/Microsoft.Android/34/*.dll $(Build.StagingDirectory)/docs-binaries/ &&
-        ln $(Build.SourcesDirectory)/bin/$(XA.Build.Configuration)/lib/xamarin.android/xbuild-frameworks/Microsoft.Android/34/*.xml $(Build.StagingDirectory)/docs-binaries/
-      displayName: copy docs files
-
     - task: PublishPipelineArtifact@1
       displayName: upload docs files
       inputs:
         artifactName: Binaries
-        targetPath: $(Build.StagingDirectory)/docs-binaries
+        targetPath: $(Build.SourcesDirectory)/src/Mono.Android/obj/docs-gen-temp
 
     - script: >
         mkdir -p $(Build.StagingDirectory)/api-doc-diff &&

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -100,8 +100,12 @@ extends:
         - checkout: self
           submodules: recursive
 
-        - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
-          displayName: set JI_JAVA_HOME
+        - task: JavaToolInstaller@0
+          displayName: Install JDK
+          inputs:
+            versionSpec: 17
+            jdkArchitectureOption: x64
+            jdkSourceOption: PreInstalled
 
         # Set MSBuild property overrides if parameters are set
         - ${{ if ne(parameters.apiLevel, 'default') }}:
@@ -140,6 +144,9 @@ extends:
         - script: make prepare CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
           workingDirectory: $(Build.SourcesDirectory)
           displayName: make prepare
+
+        - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
+          displayName: set JI_JAVA_HOME
 
         - script: >-
             make update-api-docs CONFIGURATION=$(XA.Build.Configuration)

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -151,7 +151,8 @@ extends:
 
         - script: >
             mkdir -p $(Build.StagingDirectory)/api-doc-diff &&
-            ln $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/UpdateApiDocs*.diff $(Build.StagingDirectory)/api-doc-diff/
+            ln $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/UpdateApiDocs*.diff $(Build.StagingDirectory)/api-doc-diff/ &&
+            ln $(Build.SourcesDirectory)/external/android-api-docs/docs/xml/index.xml $(Build.StagingDirectory)/api-doc-diff/
           displayName: copy api docs diff
 
         - template: /build-tools/automation/yaml-templates/upload-results.yaml@self

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -123,7 +123,7 @@ extends:
           - script: echo "##vso[task.setvariable variable=AndroidJavadocVerbosity]-p:AndroidJavadocVerbosity=${{ parameters.javadocVerbosity }}"
             displayName: set AndroidJavadocVerbosity
 
-        - template: yaml-templates/use-dot-net.yaml
+        - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
 
         - task: NuGetAuthenticate@1
           displayName: authenticate with azure artifacts
@@ -151,7 +151,7 @@ extends:
             ln $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/UpdateApiDocs*.diff $(Build.StagingDirectory)/api-doc-diff/
           displayName: copy api docs diff
 
-        - template: yaml-templates/upload-results.yaml
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml
           parameters:
             artifactName: Build Results - API Docs Update
             includeBuildResults: true

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -123,7 +123,7 @@ extends:
           - script: echo "##vso[task.setvariable variable=AndroidJavadocVerbosity]-p:AndroidJavadocVerbosity=${{ parameters.javadocVerbosity }}"
             displayName: set AndroidJavadocVerbosity
 
-        - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
+        - template: /build-tools/automation/yaml-templates/use-dot-net.yaml@self
 
         - task: NuGetAuthenticate@1
           displayName: authenticate with azure artifacts
@@ -151,7 +151,7 @@ extends:
             ln $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/UpdateApiDocs*.diff $(Build.StagingDirectory)/api-doc-diff/
           displayName: copy api docs diff
 
-        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
           parameters:
             artifactName: Build Results - API Docs Update
             includeBuildResults: true

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -162,13 +162,13 @@ extends:
 
         - powershell: |
             $docsUpdateBinlog = Get-ChildItem -Path "$(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)" -Filter *UpdateApiDocs-*.binlog | Select-Object -First 1
-            $buildLog = "$(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/temp-build.log"
+            $buildLog = "$(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/temp-UpdateApiDocs-build.log"
             & "$(Build.SourcesDirectory)/bin/$(XA.Build.Configuration)/dotnet/dotnet" build $docsUpdateBinlog > $buildLog
 
             $issueContent = & {
-                Get-Content -Path $buildLog | Select-String "## Exception translating remarks"
-                Get-Content -Path $buildLog | Select-String "## Unable to translate remarks"
-                Get-Content -Path $buildLog | Select-String "JavadocImport-"
+                Get-Content -Path $buildLog | Select-String "## Exception translating remarks" -Context 0, 3
+                Get-Content -Path $buildLog | Select-String "## Unable to translate remarks" -Context 0, 3
+                Get-Content -Path $buildLog | Select-String "JavadocImport-" -Context 0, 3
             }
 
             if ($issueContent) {
@@ -180,5 +180,6 @@ extends:
                 }
                 exit 1
             }
+            Write-Host "No issues found."
           displayName: Report issues in docs generation
           continueOnError: true

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -100,6 +100,11 @@ extends:
         - checkout: self
           submodules: recursive
 
+        - script: |
+            echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
+            echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/android-toolchain/jdk-17"
+          displayName: set JI_JAVA_HOME
+
         # Set MSBuild property overrides if parameters are set
         - ${{ if ne(parameters.apiLevel, 'default') }}:
           - script: echo "##vso[task.setvariable variable=DocsApiLevelArg]-p:DocsApiLevel=${{ parameters.apiLevel }}"
@@ -137,11 +142,6 @@ extends:
         - script: make prepare CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
           workingDirectory: $(Build.SourcesDirectory)
           displayName: make prepare
-
-        - script: |
-            echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
-            echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/android-toolchain/jdk-17"
-          displayName: set JI_JAVA_HOME
 
         - script: >-
             make update-api-docs CONFIGURATION=$(XA.Build.Configuration)

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -100,13 +100,6 @@ extends:
         - checkout: self
           submodules: recursive
 
-        - task: JavaToolInstaller@0
-          displayName: Install JDK
-          inputs:
-            versionSpec: 17
-            jdkArchitectureOption: x64
-            jdkSourceOption: PreInstalled
-
         # Set MSBuild property overrides if parameters are set
         - ${{ if ne(parameters.apiLevel, 'default') }}:
           - script: echo "##vso[task.setvariable variable=DocsApiLevelArg]-p:DocsApiLevel=${{ parameters.apiLevel }}"
@@ -145,7 +138,9 @@ extends:
           workingDirectory: $(Build.SourcesDirectory)
           displayName: make prepare
 
-        - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
+        - script: |
+            echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
+            echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/android-toolchain/jdk-17"
           displayName: set JI_JAVA_HOME
 
         - script: >-

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -82,6 +82,7 @@ extends:
           demands:
           - macOS.Name -equals $(SharedMacName)
           - Agent.OSArchitecture -equals $(SharedMacArch)
+          os: macOS
         timeoutInMinutes: 120
         workspace:
           clean: all

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -63,12 +63,13 @@ extends:
   ${{ else }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
-    sourceAnalysisPool:
-      name: AzurePipelines-EO
-      image: $(WindowsPoolImage1ESPT)
-      os: windows
-    suppression:
-      suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
+    sdl:
+      sourceAnalysisPool:
+        name: AzurePipelines-EO
+        image: $(WindowsPoolImage1ESPT)
+        os: windows
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
     stages:
     - stage: mac_build
       displayName: Build

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -75,11 +75,11 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-35_r01",   apiLevel: "35", pkgRevision: "1", isLatestStable: true),
 				new AndroidPlatformComponent ("platform-Baklava_r01",   apiLevel: "Baklava", pkgRevision: "1", isLatestStable: true),
 
-				new AndroidToolchainComponent ("sources-34_r01",
-					destDir: Path.Combine ("sources", "android-34"),
+				new AndroidToolchainComponent ("source-35_r01",
+					destDir: Path.Combine ("sources", "android-35"),
 					pkgRevision: "1",
 					dependencyType: AndroidToolchainComponentType.BuildDependency,
-					buildToolVersion: "34.1"
+					buildToolVersion: "35.1"
 				),
 				new AndroidToolchainComponent ("docs-24_r01",
 					destDir: "docs",

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -244,6 +244,7 @@
     <DocsExportOutput Condition=" '$(DocsExportOutput)' == '' ">$(_MonoAndroidNETDefaultOutDir)Mono.Android.xml</DocsExportOutput>
     <_ExternalDocsRoot>$(XamarinAndroidSourcePath)external/android-api-docs/docs/xml</_ExternalDocsRoot>
     <_LogPrefix>$(MSBuildThisFileDirectory)../../bin/Build$(Configuration)/UpdateApiDocs-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))</_LogPrefix>
+    <_ManagedRuntime Condition=" !$([MSBuild]::IsOSPlatform('windows')) ">mono</_ManagedRuntime>
     <_MdocExe Condition=" '$(Pkgmdoc)' != '' ">"$(Pkgmdoc)/tools/net471/mdoc.exe"</_MdocExe>
     <_MdocExe Condition=" '$(Pkgmdoc)' == '' ">"$(XAPackagesDir)/mdoc/$(MdocPackageVersion)/tools/net471/mdoc.exe"</_MdocExe>
     <_Mdoc Condition=" '$(Pkgmdoc)' != '' ">"$(Pkgmdoc)/tools/net6.0/mdoc.dll"</_Mdoc>
@@ -280,7 +281,6 @@
   </Target>
   <Target Name="_RunMdoc">
     <PropertyGroup>
-      <_ManagedRuntime Condition=" !$([MSBuild]::IsOSPlatform('windows')) ">mono</_ManagedRuntime>
       <_Libdir>-L "$(DotNetPreviewPath)packs/Microsoft.NETCore.App.Ref"</_Libdir>
       <_Output>-o "$(_ExternalDocsRoot)"</_Output>
       <_DocTypeArgs Condition=" '$(DocTypeName)' != '' ">--type=$(DocTypeName)</_DocTypeArgs>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -272,7 +272,7 @@
     />
   </Target>
 
-  <!-- `mdoc fx-bootstrap` and `mdoc update` still require the mono version of mdoc, but these targets are only ran locally an in azure-pipelines-apidocs.yaml -->
+  <!-- `mdoc fx-bootstrap` and `mdoc update` still require the mono version of mdoc, but these targets are only ran ad-hoc and in azure-pipelines-apidocs.yaml -->
   <Target Name="RunMdoc">
     <MSBuild Projects="$(MSBuildThisFileDirectory)Mono.Android.csproj"
         Targets="_RunMdoc"

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -272,7 +272,7 @@
     />
   </Target>
 
-  <!-- `mdoc fx-bootstrap` and `mdoc update` still require the mono version of mdoc, but these targets are only ran ad-hoc and in azure-pipelines-apidocs.yaml -->
+  <!-- `mdoc fx-bootstrap` and `mdoc update` require the .NET framework version of mdoc, a mono install will be needed to run the RunMdoc target on macOS/Linux -->
   <Target Name="RunMdoc">
     <MSBuild Projects="$(MSBuildThisFileDirectory)Mono.Android.csproj"
         Targets="_RunMdoc"
@@ -280,6 +280,7 @@
   </Target>
   <Target Name="_RunMdoc">
     <PropertyGroup>
+      <_ManagedRuntime Condition=" !$([MSBuild]::IsOSPlatform('windows')) ">mono</_ManagedRuntime>
       <_Libdir>-L "$(DotNetPreviewPath)packs/Microsoft.NETCore.App.Ref"</_Libdir>
       <_Output>-o "$(_ExternalDocsRoot)"</_Output>
       <_DocTypeArgs Condition=" '$(DocTypeName)' != '' ">--type=$(DocTypeName)</_DocTypeArgs>
@@ -309,11 +310,11 @@
         DestinationFolder="$(_RootFxDir)$(DocsFxMoniker)"
     />
     <Exec
-        Command="mono $(_MdocExe) fx-bootstrap -fx $(_RootFxDir) -importContent true"
+        Command="$(_ManagedRuntime) $(_MdocExe) fx-bootstrap -fx $(_RootFxDir) -importContent true"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <Exec
-        Command="mono $(_MdocExe) update $(_Libdir) $(_Output) $(_DocTypeArgs) $(_FxConfig) $(_ExtraMdocArgs)"
+        Command="$(_ManagedRuntime) $(_MdocExe) update $(_Libdir) $(_Output) $(_DocTypeArgs) $(_FxConfig) $(_ExtraMdocArgs)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -238,12 +238,14 @@
 
   <PropertyGroup>
     <!-- Override these properties to generate docs against a specific API level -->
-    <DocsApiLevel Condition=" '$(DocsApiLevel)' == '' ">34</DocsApiLevel>
+    <DocsApiLevel Condition=" '$(DocsApiLevel)' == '' ">35</DocsApiLevel>
     <DocsPlatformId Condition=" '$(DocsPlatformId)' == '' ">$(DocsApiLevel)</DocsPlatformId>
     <DocsFxMoniker Condition=" '$(DocsFxMoniker)' == '' ">net-android-$(DocsApiLevel).0</DocsFxMoniker>
     <DocsExportOutput Condition=" '$(DocsExportOutput)' == '' ">$(_MonoAndroidNETDefaultOutDir)Mono.Android.xml</DocsExportOutput>
     <_ExternalDocsRoot>$(XamarinAndroidSourcePath)external/android-api-docs/docs/xml</_ExternalDocsRoot>
     <_LogPrefix>$(MSBuildThisFileDirectory)../../bin/Build$(Configuration)/UpdateApiDocs-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))</_LogPrefix>
+    <_MdocExe Condition=" '$(Pkgmdoc)' != '' ">"$(Pkgmdoc)/tools/net471/mdoc.exe"</_MdocExe>
+    <_MdocExe Condition=" '$(Pkgmdoc)' == '' ">"$(XAPackagesDir)/mdoc/$(MdocPackageVersion)/tools/net471/mdoc.exe"</_MdocExe>
     <_Mdoc Condition=" '$(Pkgmdoc)' != '' ">"$(Pkgmdoc)/tools/net6.0/mdoc.dll"</_Mdoc>
     <_Mdoc Condition=" '$(Pkgmdoc)' == '' ">"$(XAPackagesDir)/mdoc/$(MdocPackageVersion)/tools/net6.0/mdoc.dll"</_Mdoc>
   </PropertyGroup>
@@ -270,6 +272,7 @@
     />
   </Target>
 
+  <!-- `mdoc fx-bootstrap` and `mdoc update` still require the mono version of mdoc, but these targets are only ran locally an in azure-pipelines-apidocs.yaml -->
   <Target Name="RunMdoc">
     <MSBuild Projects="$(MSBuildThisFileDirectory)Mono.Android.csproj"
         Targets="_RunMdoc"
@@ -305,16 +308,12 @@
         SourceFiles="@(_FxAssembly);@(_FxAssemblyXml)"
         DestinationFolder="$(_RootFxDir)$(DocsFxMoniker)"
     />
-    <WriteLinesToFile
-        File="$(_RootFxDir)frameworks.xml"
-        Lines="$(FrameworksXmlContent)"
-    />
     <Exec
-        Command="dotnet $(_Mdoc) fx-bootstrap -fx $(_RootFxDir) -importContent true"
+        Command="mono $(_MdocExe) fx-bootstrap -fx $(_RootFxDir) -importContent true"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <Exec
-        Command="dotnet $(_Mdoc) update $(_Libdir) $(_Output) $(_DocTypeArgs) $(_FxConfig) $(_ExtraMdocArgs)"
+        Command="mono $(_MdocExe) update $(_Libdir) $(_Output) $(_DocTypeArgs) $(_FxConfig) $(_ExtraMdocArgs)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>


### PR DESCRIPTION
Updates xaprepare and Mono.Android to generate API Docs against API level 35 sources.

The azure-pipelines-apidocs.yaml pipeline has been updated to use the 1ES pipeline template to improve compatibility with existing yaml templates.

The semi-automated API docs build and update workflow uses the .NET framework version of Mdoc and the <RunMdoc/> target has been updated to continue to mirror that workflow. 

Bumps to dotnet/java-interop@fe00cef5:
https://github.com/dotnet/java-interop/compare/2c06b3c2a11833aea0e9b51aac2a72195bd64539...fe00cef5290a7e75b8e73e3044966a14e6c312c9
