### PR TITLE
Fix WorkloadDependencies.proj build.

### DIFF
--- a/tools/workload-dependencies/WorkloadDependencies.proj
+++ b/tools/workload-dependencies/WorkloadDependencies.proj
@@ -60,6 +60,7 @@
 
     <ItemGroup>
       <_WorkloadDeps Include="--project &quot;$(_Project)&quot;" />
+      <_WorkloadDeps Include="-p:DotNetStableTargetFramework=$(DotNetStableTargetFramework)" />
       <_WorkloadDeps Include="-p:MonoOptionsVersion=$(MonoOptionsVersion)" />
       <_WorkloadDeps Include="-p:NewtonsoftJsonPackageVersion=$(NewtonsoftJsonPackageVersion)" />
       <_WorkloadDeps Include="--" />


### PR DESCRIPTION
Commit b716173a added the ability to generate the workload.json file. However there was a bug where the `$(DotNetStableTargetFramework)` was not being defined for the workload-dependencies.csproj. This would resolve in the following error

```
bin/Release/dotnet/sdk/9.0.100-rtm.24512.1/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(96,5): error NETSDK1013: The TargetFramework value '' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly.
```

The problem was that the `DotNetStableTargetFramework` property was not being passed on to the `dotnet run` call in WorkloadDependencies.proj. The CI build was working because we define the `DotNetStableTargetFramework` as an environment variable at https://github.com/dotnet/android/blob/6b37563d39d4357069ed59ca046d4c2a154937f4/build-tools/automation/yaml-templates/variables.yaml#L52-L53.

The fix is to pass the `DotNetStableTargetFramework` property to the call to `dotnet run`.