### PR TITLE
Remove call to CollectAssemblyFilesForArchive for Fast Deployment.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectAssemblyFilesForArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectAssemblyFilesForArchive.cs
@@ -29,8 +29,6 @@ public class CollectAssemblyFilesForArchive : AndroidTask
 	[Required]
 	public string AppSharedLibrariesDir { get; set; } = "";
 
-	public bool EmbedAssemblies { get; set; }
-
 	[Required]
 	public bool EnableCompression { get; set; }
 
@@ -58,10 +56,6 @@ public class CollectAssemblyFilesForArchive : AndroidTask
 
 	public override bool RunTask ()
 	{
-		// If we aren't embedding assemblies, we don't need to do anything
-		if (!EmbedAssemblies)
-			return !Log.HasLoggedErrors;
-
 		var files = new PackageFileListBuilder ();
 
 		DSOWrapperGenerator.Config dsoWrapperConfig = DSOWrapperGenerator.GetConfig (Log, AndroidBinUtilsDirectory, IntermediateOutputPath);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2117,7 +2117,6 @@ because xbuild doesn't support framework reference assemblies.
       AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
       ApkOutputPath="$(_ApkOutputPath)"
       AppSharedLibrariesDir="$(_AndroidApplicationSharedLibraryPath)"
-      EmbedAssemblies="$(EmbedAssembliesIntoApk)"
       EnableCompression="$(AndroidEnableAssemblyCompression)"
       IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
       IntermediateOutputPath="$(IntermediateOutputPath)"
@@ -2247,21 +2246,6 @@ because xbuild doesn't support framework reference assemblies.
       LibraryProjectJars="@(ExtractedJarImports)">
     <Output TaskParameter="FilesToAddToArchive" ItemName="FilesToAddToArchive" />
   </CollectJarContentFilesForArchive>
-    
-  <CollectAssemblyFilesForArchive
-      AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
-      ApkOutputPath="$(_ApkOutputPath)"
-      AppSharedLibrariesDir="$(_AndroidApplicationSharedLibraryPath)"
-      EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-      EnableCompression="$(AndroidEnableAssemblyCompression)"
-      IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
-      IntermediateOutputPath="$(IntermediateOutputPath)"
-      ProjectFullPath="$(MSBuildProjectFullPath)"
-      ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
-      ResolvedUserAssemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
-      SupportedAbis="@(_BuildTargetAbis)">
-    <Output TaskParameter="FilesToAddToArchive" ItemName="FilesToAddToArchive" />
-  </CollectAssemblyFilesForArchive>
 
   <CollectRuntimeConfigFilesForArchive
       AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"


### PR DESCRIPTION
Commit 6b91b042 split up the BuildApk task into their own Tasks to improve build performance. In that change the call to `CollectAssemblyFilesForArchive` was a no-op if `EmbedAssembliesIntoApk` was set to `False`. However it was still being called in the `_BuildApkFastDev` target, even though it had a condition which would skip the target entirely if `EmbedAssembliesIntoApk` was `False`.

So lets remove the call to `CollectAssemblyFilesForArchive` from `_BuildApkFastDev` completely. We can also remove the `EmbedAssemblies` property from the `CollectAssemblyFilesForArchive` task as it is no longer needed.