### PR TITLE
[build+macOS] Remove quarantine from OpenJDK installations

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallAdoptOpenJDK.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallAdoptOpenJDK.MacOS.cs
@@ -10,6 +10,12 @@ namespace Xamarin.Android.Prepare
 		{
 			string realSourceDir = Path.Combine (sourceDir, "Contents", "Home");
 			Utilities.MoveDirectoryContentsRecursively (realSourceDir, destinationDir);
+
+			var xattr_d = new ProcessRunner ("xattr", "-d", "-r", "com.apple.quarantine", ".") {
+				EchoStandardError   = true,
+				WorkingDirectory    = destinationDir,
+			};
+			xattr_d.Run ();
 		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9651

Recent versions of macOS, Safari, and **tar**(1) [^0] interact such that if you manually download a tarball and extract it, *all the extracted files* contain the `com.apple.quarantine` extended attribute.  This is a security feature, but it also means that the provisioned JDK *cannot be used*:

	% $HOME/android-toolchain/jdk-21/bin/javac
	zsh: operation not permitted: ./jdk-21/bin/javac

Which in turn means if you do something "reasonable" like download Microsoft OpenJDK and place it into `$HOME/android-archives` -- so that `xaprepare` doesn't need to download it *again* -- then the provisioned JDK will be *unusable*.  Which makes @jonpryor sad.

Update `Step_InstallAdoptOpenJDK.MacOS.cs` to run
`xattr -d -r com.apple.quarantine $HOME/android-toolchain/jdk-21`. This will *delete* the offending extended attribute, allowing e.g. `javac` to run without error.

[^0]: Which versions?  ¯\\_(ツ)_/¯