### PR TITLE
Add activity-alias support

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@3b4e16f197ff3e102ffb59af0b0f056046cc7658
+DevDiv/android-platform-support:dev/dellis1972/activity-alias@af169a48c5a80b7348540a351442f959b7b008b5

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:dev/dellis1972/activity-alias@af169a48c5a80b7348540a351442f959b7b008b5
+DevDiv/android-platform-support:main@cc26de2b33292462ab2daa70c593c78ef2a241e7

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/MainActivity.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/MainActivity.cs
@@ -11,6 +11,7 @@ using Android.OS;
 namespace ${ROOT_NAMESPACE}
 {
 	[Register ("${JAVA_PACKAGENAME}.MainActivity"), Activity (Label = "${PROJECT_NAME}", MainLauncher = true, Icon = "@drawable/icon")]
+	//${ATTRIBUTES}
 	public class MainActivity : Activity
 	{
 		//${FIELDS}


### PR DESCRIPTION
Context 
https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2305723
https://github.com/mattleibow/MauiAppWithMultipleIcons

Apparently launching an activity-alias was not supported at all. That probably means very few people use it, however we really should be able to launch them.

The changes to `android-platform-support` include the ability for `GetAndroidActivityName` to find `activity-alias` elements which have the correct metadata. This allows us to launch them via the typical `Run` command to launch them. 

Added a unit test.