### PR TITLE
[java-runtime] simplify `mono.MonoPackageManager.LoadApplication()`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Bundled.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Bundled.java
@@ -18,19 +18,7 @@ public class MonoRuntimeProvider
 	@Override
 	public void attachInfo (android.content.Context context, android.content.pm.ProviderInfo info)
 	{
-		// Mono Runtime Initialization {{{
-		android.content.pm.ApplicationInfo applicationInfo = context.getApplicationInfo ();
-		String[] apks = null;
-		String[] splitApks = applicationInfo.splitSourceDirs;
-		if (splitApks != null && splitApks.length > 0) {
-			apks = new String[splitApks.length + 1];
-			apks [0] = applicationInfo.sourceDir;
-			System.arraycopy (splitApks, 0, apks, 1, splitApks.length);
-		} else {
-			apks = new String[] { applicationInfo.sourceDir };
-		}
-		mono.MonoPackageManager.LoadApplication (context, applicationInfo, apks);
-		// }}}
+		mono.MonoPackageManager.LoadApplication (context);
 		super.attachInfo (context, info);
 	}
 

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -26,9 +26,20 @@ public class MonoPackageManager {
 
 	static android.content.Context Context;
 
-	public static void LoadApplication (Context context, ApplicationInfo runtimePackage, String[] apks)
+	public static void LoadApplication (Context context)
 	{
 		synchronized (lock) {
+			android.content.pm.ApplicationInfo runtimePackage = context.getApplicationInfo ();
+			String[] apks = null;
+			String[] splitApks = runtimePackage.splitSourceDirs;
+			if (splitApks != null && splitApks.length > 0) {
+				apks = new String[splitApks.length + 1];
+				apks [0] = runtimePackage.sourceDir;
+				System.arraycopy (splitApks, 0, apks, 1, splitApks.length);
+			} else {
+				apks = new String[] { runtimePackage.sourceDir };
+			}
+
 			if (context instanceof android.app.Application) {
 				Context = context;
 			}


### PR DESCRIPTION
We currently have code that loads `MonoRuntimeProvider.Bundled.java` and parses Java code comments between:

    // Mono Runtime Initialization {{{
    android.content.pm.ApplicationInfo applicationInfo = context.getApplicationInfo ();
    String[] apks = null;
    String[] splitApks = applicationInfo.splitSourceDirs;
    if (splitApks != null && splitApks.length > 0) {
        apks = new String[splitApks.length + 1];
        apks [0] = applicationInfo.sourceDir;
        System.arraycopy (splitApks, 0, apks, 1, splitApks.length);
    } else {
        apks = new String[] { applicationInfo.sourceDir };
    }
    mono.MonoPackageManager.LoadApplication (context, applicationInfo, apks);
    // }}}

These lines are used for any `Instrumentation` type, such as:

https://github.com/dotnet/java-interop/blob/2c06b3c2a11833aea0e9b51aac2a72195bd64539/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.CallableWrapperMembers/CallableWrapperType.cs#L238-L241

To refactor and cleanup, we can:

* Make `mono.MonoPackageManager.LoadApplication()` only take in a single `Context context` parameter.

* Move the Java code that looks at `applicationInfo.splitSourceDirs` inside `mono.MonoPackageManager.LoadApplication()`.

* Reduce the code in the `// Mono Runtime Initialization {{{` block to a single line.

* Now we no longer need to load the `MonoRuntimeProvider.Bundled.java` file during a build, we can simply declare the one line of Java code as a C# string.

This will make refactoring `<GenerateJavaStubs/>` easier in future PRs.