### PR TITLE
[templates] Default `$(SupportedOSPlatformVersion)` to `24.

### DIFF
--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
@@ -21,7 +21,7 @@
       "description": "Overrides $(SupportedOSPlatformVersion) in the project",
       "datatype": "string",
       "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
-      "defaultValue": "21"
+      "defaultValue": "24"
     }
   },
   "defaultName": "AndroidBinding1"

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/template.json
@@ -34,7 +34,7 @@
       "description": "Overrides $(SupportedOSPlatformVersion) in the project",
       "datatype": "string",
       "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
-      "defaultValue": "23"
+      "defaultValue": "24"
     }
   },
   "defaultName": "AndroidApp1"

--- a/src/Microsoft.Android.Templates/android/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/template.json
@@ -34,7 +34,7 @@
       "description": "Overrides $(SupportedOSPlatformVersion) in the project",
       "datatype": "string",
       "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
-      "defaultValue": "21"
+      "defaultValue": "24"
     }
   },
   "defaultName": "AndroidApp1"

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
@@ -21,7 +21,7 @@
       "description": "Overrides $(SupportedOSPlatformVersion) in the project",
       "datatype": "string",
       "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
-      "defaultValue": "21"
+      "defaultValue": "24"
     }
   },
   "defaultName": "AndroidLib1"


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9517
Context: https://github.com/dotnet/android-libraries/issues/767
Context: https://github.com/dotnet/android-libraries/issues/767#issuecomment-2448729455

For .NET 10, update the [`dotnet new android` template](https://github.com/dotnet/android/blob/main/src/Microsoft.Android.Templates/android/AndroidApp1.csproj) so that `$(SupportedOSPlatformVersion)` is 24, bumping from the current default of 21.

The reason for this is that "desugaring" "moves" Java methods to locations that we don't expect, which can result in `AbstractMethodError`s at runtime.  Setting the minimum SDK version to >= 24 avoids this desugaring step, preventing the Java methods from being moved in a manner we don't expect, and thus avoiding the `AbstractMethodError`.

Note that 21 will still be the supported minimum for those that need it, however this will keep most users who do not need to support devices that old from having desugaring issues.