### PR TITLE
Add `$(Nullable)` = `annotations` to projects using NRT annotations without NRT enabled.

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -5,6 +5,7 @@
     <DefineConstants>ILLINK</DefineConstants>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(MicrosoftAndroidSdkOutDir)</OutputPath>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.ILLink" Version="$(MicrosoftNETILLinkTasksPackageVersion)" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -9,6 +9,7 @@
     <DebugSymbols>True</DebugSymbols>
     <DebugType>portable</DebugType>
     <NoWarn>$(NoWarn);CA1305</NoWarn>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\Configuration.props" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -8,6 +8,7 @@
     <AssemblyOriginatorKeyFile>..\..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);CA1305</NoWarn>
     <_IncludeMicrosoftBuildPackage>true</_IncludeMicrosoftBuildPackage>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
   <Import Project="..\..\..\..\Configuration.props" />
   <Import Project="..\..\..\..\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\MSBuildReferences.projitems" />

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -9,6 +9,7 @@
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <DebugSymbols>True</DebugSymbols>
     <DebugType>portable</DebugType>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />


### PR DESCRIPTION
Several of our projects that have not been NRT enabled import `.cs` files from other projects that do have NRT annotations.

This results in warning CS8632:

```
warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
```

We can allow NRT annotations without enabling NRT by adding `<Nullable>annotations</Nullable>` to these projects, fixing ~100 build warnings.