### PR TITLE
[ci] Fail build if any git tracked files were modified.

### DIFF
--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -104,4 +104,8 @@ stages:
         includeBuildResults: true
         use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
+    - template: /build-tools/automation/yaml-templates/fail-on-dirty-tree.yaml
+      parameters:
+        xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
+
     - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -86,3 +86,7 @@ stages:
         artifactName: ${{ parameters.buildResultArtifactName }}
         includeBuildResults: true
         use1ESTemplate: ${{ parameters.use1ESTemplate }}
+
+    - template: /build-tools/automation/yaml-templates/fail-on-dirty-tree.yaml
+      parameters:
+        xaSourcePath: ${{ parameters.xaSourcePath }}

--- a/build-tools/automation/yaml-templates/build-windows.yaml
+++ b/build-tools/automation/yaml-templates/build-windows.yaml
@@ -117,4 +117,6 @@ stages:
         artifactName: ${{ parameters.buildResultArtifactName }}
         includeBuildResults: true
 
+    - template: /build-tools/automation/yaml-templates/fail-on-dirty-tree.yaml
+
     - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/fail-on-dirty-tree.yaml
+++ b/build-tools/automation/yaml-templates/fail-on-dirty-tree.yaml
@@ -1,0 +1,22 @@
+# Ensure the build did not produce any modified checked in files
+
+parameters:
+  condition: succeeded()
+  xaSourcePath: 
+
+steps:
+- powershell: |
+    # Run this to log the output for the user
+    git status
+
+    # Run this to error the build if untracked files
+    $process= git status --porcelain --untracked-files=no
+
+    if ($process)
+    {
+        Write-Host "##vso[task.logissue type=error]git tree has modified tracked files."
+        Write-Host "##vso[task.complete result=Failed;]"
+    }
+  displayName: Ensure no modified committed files
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  condition: ${{ parameters.condition }}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_ThirdPartyNotices.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_ThirdPartyNotices.cs
@@ -151,7 +151,7 @@ implication, estoppel or otherwise."			}
 			if (!File.Exists (path))
 				throw new InvalidOperationException ($"License file {path} does not exist");
 
-			return File.ReadAllText (path);
+			return File.ReadAllText (path).ReplaceLineEndings ();
 		}
 
 		void EnsureValidTPNType (Type type)


### PR DESCRIPTION
When running `xaprepare` on Windows, your local `git` tree ends up dirty due to line ending changes in `THIRD-PARTY-NOTICES.txt`.

Update `xaprepare` to always normalize line endings to `Environment.NewLine` in `THIRD-PARTY-NOTICES.txt` to prevent this issue.

Additionally, these scenarios where the build unintentionally modifies git tracked files on some platforms are frustrating, so let's prevent them from happening in the first place.

Add a CI check to fail a build if any git tracked files were modified.

Example:

![image](https://github.com/user-attachments/assets/ec8869f5-75a5-4234-b7f4-20c2cabd743e)

Clicking the error will show the modified file(s):

![image](https://github.com/user-attachments/assets/395ee30e-8a37-450c-94ec-106221c40db3)

Source: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10799472&view=results