### PR TITLE
[ci] Run Mac MSBuild tests on `macos-14-arm64`

### DIFF
--- a/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
+++ b/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
@@ -1,11 +1,11 @@
 parameters:
-  jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
-  useAgentJdkPath: true
+  jdkMajorVersion: $(DefaultJavaSdkMajorVersion)   # Generally 11|17|21
+  useAgentJdkPath: true                            # true to use preinstalled agent JDK, false to use 'android-toolchain/jdk-NN'
 
 steps:
 - pwsh: |
     $agentOS="$(Agent.OS)"
-    $agentArch="$(Agent.OSArchitecture)"
+    $agentArch="$(Agent.OSArchitecture)" -eq "ARM64" ? "arm64" : "$(Agent.OSArchitecture)"
     $jdkMajorVersion="${{ parameters.jdkMajorVersion }}"
     $xaPrepareJdkPath="$env:HOME/android-toolchain/jdk-$jdkMajorVersion"
     if ("$agentOS" -eq "Windows_NT") {

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -27,6 +27,21 @@ steps:
     jdkMajorVersion: ${{ parameters.jdkMajorVersion }}
     useAgentJdkPath: ${{ parameters.useAgentJdkPath }}
 
+# If an explicit Java SDK path wasn't provided, choose JDK-17 for the appropriate architecture
+- pwsh: |
+    Write-Host "##vso[task.setvariable variable=JI_JAVA_HOME]$env:JAVA_HOME_17_X64"
+  displayName: set JI_JAVA_HOME to JAVA_HOME_17_X64
+  condition: and(succeeded(), eq('${{ parameters.jdkTestFolder }}', ''), eq(variables['agent.osarchitecture'], 'X64'))
+
+- pwsh: |
+    Write-Host "##vso[task.setvariable variable=JI_JAVA_HOME]$env:JAVA_HOME_17_arm64"
+  displayName: set JI_JAVA_HOME to JAVA_HOME_17_arm64
+  condition: and(succeeded(), eq('${{ parameters.jdkTestFolder }}', ''), eq(variables['agent.osarchitecture'], 'ARM64'))
+
+- script: |
+    echo $(JI_JAVA_HOME)
+  displayName: print JI_JAVA_HOME
+
 # Install latest .NET
 - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -27,21 +27,6 @@ steps:
     jdkMajorVersion: ${{ parameters.jdkMajorVersion }}
     useAgentJdkPath: ${{ parameters.useAgentJdkPath }}
 
-# If an explicit Java SDK path wasn't provided, choose JDK-17 for the appropriate architecture
-- pwsh: |
-    Write-Host "##vso[task.setvariable variable=JI_JAVA_HOME]$env:JAVA_HOME_17_X64"
-  displayName: set JI_JAVA_HOME to JAVA_HOME_17_X64
-  condition: and(succeeded(), eq('${{ parameters.jdkTestFolder }}', ''), eq(variables['agent.osarchitecture'], 'X64'))
-
-- pwsh: |
-    Write-Host "##vso[task.setvariable variable=JI_JAVA_HOME]$env:JAVA_HOME_17_arm64"
-  displayName: set JI_JAVA_HOME to JAVA_HOME_17_arm64
-  condition: and(succeeded(), eq('${{ parameters.jdkTestFolder }}', ''), eq(variables['agent.osarchitecture'], 'ARM64'))
-
-- script: |
-    echo $(JI_JAVA_HOME)
-  displayName: print JI_JAVA_HOME
-
 # Install latest .NET
 - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -27,7 +27,7 @@ stages:
     displayName: "macOS > Tests > MSBuild+Emulator"
     pool:
       name: Azure Pipelines
-      vmImage: $(HostedMacImage)
+      vmImage: $(HostedMacImageWithEmulator)
       os: macOS
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
@@ -89,7 +89,7 @@ stages:
       deviceName: wear_square
     pool:
       name: Azure Pipelines
-      vmImage: $(HostedMacImage)
+      vmImage: $(HostedMacImageWithEmulator)
       os: macOS
     workspace:
       clean: all

--- a/build-tools/automation/yaml-templates/stage-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-tests.yaml
@@ -22,7 +22,7 @@ stages:
       testOS: macOS
       jobName: mac_msbuild_tests
       jobDisplayName: macOS > Tests > MSBuild
-      agentCount: 14
+      agentCount: 10
       xaSourcePath: ${{ parameters.xaSourcePath }}
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
@@ -34,7 +34,7 @@ stages:
       testOS: Windows
       jobName: win_msbuild_tests
       jobDisplayName: Windows > Tests > MSBuild
-      agentCount: 6
+      agentCount: 8
       xaSourcePath: ${{ parameters.xaSourcePath }}
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}

--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -13,7 +13,7 @@ stages:
     displayName: macOS > Tests > APKs 1
     pool:
       name: Azure Pipelines
-      vmImage: $(HostedMacImage)
+      vmImage: $(HostedMacImageWithEmulator)
       os: macOS
     timeoutInMinutes: 180
     workspace:
@@ -120,7 +120,7 @@ stages:
     displayName: macOS > Tests > APKs 2
     pool:
       name: Azure Pipelines
-      vmImage: $(HostedMacImage)
+      vmImage: $(HostedMacImageWithEmulator)
       os: macOS
     timeoutInMinutes: 180
     workspace:

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -14,7 +14,7 @@ variables:
 - name: WindowsToolchainPdbArtifactName
   value: windows-toolchain-pdb
 - name: ApkDiffToolVersion
-  value: 0.0.15
+  value: 0.0.17
 - name: TestSlicerToolVersion
   value: 0.1.0-alpha7
 - name: BootsToolVersion

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -31,6 +31,8 @@ variables:
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage
   value: macOS-14-arm64
+- name: HostedMacImageWithEmulator
+  value: macOS-14
 - name: SharedMacPool
   value: VSEng-VSMac-Xamarin-Shared
 - name: SharedMacName

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -30,7 +30,7 @@ variables:
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage
-  value: macOS-14
+  value: macOS-14-arm64
 - name: SharedMacPool
   value: VSEng-VSMac-Xamarin-Shared
 - name: SharedMacName


### PR DESCRIPTION
Azure Pipelines now provides the `macos-14-arm64` image.  We can use this image to run our MSBuild tests on.  This is a benefit because it's nearly twice as fast and nowadays our Mac users are probably more likely to be running arm64.

Unfortunately it [does not support nested virtualization](https://github.com/actions/runner-images/issues/9460), so we can't run our emulator tests on this image.  Supposedly Apple added nested virtualization in MacOS 15, but Azure does not have `macos-15-arm64` images yet.  Hopefully we will be able to use those for emulator tests in the future.

Additionally:
- Update `apkdiff` to a [newer version with Apple Silicon support](https://github.com/radekdoulik/apkdiff/pull/8).
- Tweak agent count since we now need fewer Mac agents, but could use a couple more Windows agents.
- Bugfix to make sure we're using the right JDK path for ARM64.