### PR TITLE
[build] fix `MAUI Integration` lane

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -32,7 +32,7 @@ resources:
   - repository: maui
     type: github
     name: dotnet/maui
-    ref: refs/heads/net9.0
+    ref: refs/heads/net10.0
     endpoint: xamarin
 
 parameters:


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/tree/net10.0
Context: https://github.com/dotnet/maui/pull/27040

dotnet/maui is using the `net10.0` branch for .NET 10.