### PR TITLE
[ci] Add template for setting *JAVA_HOME vars

### DIFF
--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -102,7 +102,7 @@ extends:
 
         - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml@self
           parameters:
-            useXAPrepareJdkPath: true
+            useAgentJdkPath: false
 
         # Set MSBuild property overrides if parameters are set
         - ${{ if ne(parameters.apiLevel, 'default') }}:

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -100,10 +100,9 @@ extends:
         - checkout: self
           submodules: recursive
 
-        - script: |
-            echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
-            echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/android-toolchain/jdk-17"
-          displayName: set JI_JAVA_HOME
+        - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml@self
+          parameters:
+            useXAPrepareJdkPath: true
 
         # Set MSBuild property overrides if parameters are set
         - ${{ if ne(parameters.apiLevel, 'default') }}:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -138,7 +138,7 @@ stages:
         avdApiLevel: $(avdApiLevel)
         avdAbi: $(avdAbi)
         avdType: $(avdType)
-        emulatorMSBuildArgs: -p:JavaSdkDirectory=-$(JI_JAVA_HOME_DEFAULT)
+        emulatorMSBuildArgs: -p:JavaSdkDirectory=$(JI_JAVA_HOME_DEFAULT)
 
     - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -123,7 +123,7 @@ stages:
     - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         xaprepareScenario: EmulatorTestDependencies
-        jdkTestFolder: $(JAVA_HOME_11_X64)
+        jdkMajorVersion: 11
 
     - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
       parameters:
@@ -162,7 +162,6 @@ stages:
       emulatorMSBuildArgs: -p:TestAvdExtraBootArgs=-writable-system
       jobName: SystemApplicationTests
       jobTimeout: 120
-      jdkTestFolder: $HOME/android-toolchain/jdk-17
       use1ESTemplate: false
       testSteps:
       - template: run-nunit-tests.yaml
@@ -195,15 +194,11 @@ stages:
     steps:
     - template: agent-cleanser/v1.yml@yaml-templates
 
-    - script: |
-        echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/android-toolchain/jdk-17"
-      displayName: set JAVA_HOME to $HOME/android-toolchain/jdk-17
-
     - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         installTestSlicer: true
         xaprepareScenario: EmulatorTestDependencies
-        jdkTestFolder: $HOME/android-toolchain/jdk-17
+        useXAPrepareJdkPath: true
 
     - task: DownloadPipelineArtifact@2
       inputs:
@@ -251,15 +246,11 @@ stages:
     steps:
     - template: agent-cleanser/v1.yml@yaml-templates
 
-    - script: |
-        echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/android-toolchain/jdk-17"
-      displayName: set JAVA_HOME to $HOME/android-toolchain/jdk-17
-
     - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         installTestSlicer: true
         xaprepareScenario: EmulatorTestDependencies
-        jdkTestFolder: $HOME/android-toolchain/jdk-17
+        useXAPrepareJdkPath: true
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -138,6 +138,7 @@ stages:
         avdApiLevel: $(avdApiLevel)
         avdAbi: $(avdAbi)
         avdType: $(avdType)
+        emulatorMSBuildArgs: -p:JavaSdkDirectory=-$(JI_JAVA_HOME_DEFAULT)
 
     - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -198,7 +198,7 @@ stages:
       parameters:
         installTestSlicer: true
         xaprepareScenario: EmulatorTestDependencies
-        useXAPrepareJdkPath: true
+        useAgentJdkPath: false
 
     - task: DownloadPipelineArtifact@2
       inputs:
@@ -250,7 +250,7 @@ stages:
       parameters:
         installTestSlicer: true
         xaprepareScenario: EmulatorTestDependencies
-        useXAPrepareJdkPath: true
+        useAgentJdkPath: false
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -152,11 +152,6 @@ extends:
           inputs:
             forceReinstallCredentialProvider: true
 
-        - script: |
-            echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_17_X64%
-            echo ##vso[task.setvariable variable=JAVA_HOME]%JAVA_HOME_17_X64%
-          displayName: set JI_JAVA_HOME, JAVA_HOME to $(JAVA_HOME_17_X64)
-
         - script: echo "##vso[task.prependpath]C:\Windows\System32\WindowsPowerShell\v1.0\"
           displayName: add powershell to path
 

--- a/build-tools/automation/yaml-templates/build-windows.yaml
+++ b/build-tools/automation/yaml-templates/build-windows.yaml
@@ -39,9 +39,7 @@ stages:
 
     - template: /build-tools/automation/yaml-templates/clean.yaml
 
-    - script: |
-        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_17_X64%
-      displayName: set JI_JAVA_HOME to $(JAVA_HOME_17_X64)
+    - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml
 
     - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -8,8 +8,9 @@ parameters:
   use1ESTemplate: true
 
 steps:
-- script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
-  displayName: set JI_JAVA_HOME
+- template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml
+  parameters:
+    useXAPrepareJdkPath: true
 
 - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -10,7 +10,7 @@ parameters:
 steps:
 - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml
   parameters:
-    useXAPrepareJdkPath: true
+    useAgentJdkPath: false
 
 - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/run-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-emulator-tests.yaml
@@ -5,7 +5,7 @@ parameters:
   jobName: CheckTimeZoneInfoIsCorrectNode1
   jobTimeout: 360
   jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
-  useXAPrepareJdkPath: true
+  useAgentJdkPath: false
   testSteps: []
   use1ESTemplate: true
 
@@ -27,7 +27,7 @@ jobs:
       parameters:
         xaprepareScenario: EmulatorTestDependencies
         jdkMajorVersion: ${{ parameters.jdkMajorVersion }}
-        useXAPrepareJdkPath: ${{ parameters.useXAPrepareJdkPath }}
+        useAgentJdkPath: ${{ parameters.useAgentJdkPath }}
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/run-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-emulator-tests.yaml
@@ -4,7 +4,8 @@ parameters:
   emulatorMSBuildArgs: ''
   jobName: CheckTimeZoneInfoIsCorrectNode1
   jobTimeout: 360
-  jdkTestFolder: $(JAVA_HOME_17_X64)
+  jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
+  useXAPrepareJdkPath: true
   testSteps: []
   use1ESTemplate: true
 
@@ -22,14 +23,11 @@ jobs:
     steps:
     - template: agent-cleanser/v1.yml@yaml-templates
 
-    - script: |
-        echo "##vso[task.setvariable variable=JAVA_HOME]${{ parameters.jdkTestFolder }}"
-      displayName: set JAVA_HOME to ${{ parameters.jdkTestFolder }}
-
     - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         xaprepareScenario: EmulatorTestDependencies
-        jdkTestFolder: ${{ parameters.jdkTestFolder }}
+        jdkMajorVersion: ${{ parameters.jdkMajorVersion }}
+        useXAPrepareJdkPath: ${{ parameters.useXAPrepareJdkPath }}
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
+++ b/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
@@ -1,21 +1,21 @@
 parameters:
   jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
-  useXAPrepareJdkPath: false
+  useAgentJdkPath: true
 
 steps:
 - pwsh: |
     $jdkMajorVersion="${{ parameters.jdkMajorVersion }}"
     $agentArch="$(Agent.OSArchitecture)"
-    $jdkHomeVarName="JAVA_HOME_${jdkMajorVersion}_${agentArch}"
-    $jdkHomePath = (Get-Item -Path "env:$jdkHomeVarName").Value
     $xaPrepareJdkPath="$env:HOME/android-toolchain/jdk-$jdkMajorVersion"
     if ("$AgentOS" -eq "Windows_NT") {
       $xaPrepareJdkPath="$env:USERPROFILE\android-toolchain\jdk-$jdkMajorVersion"
     }
-    if ("${{ parameters.useXAPrepareJdkPath }}" -eq "true") {
-      $jdkHomePath=$xaPrepareJdkPath
+    $jdkHomePath=$xaPrepareJdkPath
+    if ("${{ parameters.useAgentJdkPath }}" -eq "true") {
+      $jdkHomeVarName="JAVA_HOME_${jdkMajorVersion}_${agentArch}"
+      $jdkHomePath=(Get-Item -Path "env:$jdkHomeVarName").Value
     }
-    Write-Host "Setting variable 'JI_JAVA_HOME' to '$jdkHomePath'"
+    Write-Host "Setting variable 'JAVA_HOME' and 'JI_JAVA_HOME' to '$jdkHomePath'"
     Write-Host "##vso[task.setvariable variable=JAVA_HOME]$jdkHomePath"
     Write-Host "##vso[task.setvariable variable=JI_JAVA_HOME]$jdkHomePath"
   displayName: set JAVA_HOME and JI_JAVA_HOME

--- a/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
+++ b/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
@@ -4,10 +4,11 @@ parameters:
 
 steps:
 - pwsh: |
-    $jdkMajorVersion="${{ parameters.jdkMajorVersion }}"
+    $agentOS="$(Agent.OS)"
     $agentArch="$(Agent.OSArchitecture)"
+    $jdkMajorVersion="${{ parameters.jdkMajorVersion }}"
     $xaPrepareJdkPath="$env:HOME/android-toolchain/jdk-$jdkMajorVersion"
-    if ("$AgentOS" -eq "Windows_NT") {
+    if ("$agentOS" -eq "Windows_NT") {
       $xaPrepareJdkPath="$env:USERPROFILE\android-toolchain\jdk-$jdkMajorVersion"
     }
     $jdkHomePath=$xaPrepareJdkPath

--- a/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
+++ b/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
@@ -1,0 +1,21 @@
+parameters:
+  jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
+  useXAPrepareJdkPath: false
+
+steps:
+- pwsh: |
+    $jdkMajorVersion="${{ parameters.jdkMajorVersion }}"
+    $agentArch="$(Agent.OSArchitecture)"
+    $jdkHomeVarName="JAVA_HOME_${jdkMajorVersion}_${agentArch}"
+    $jdkHomePath = (Get-Item -Path "env:$jdkHomeVarName").Value
+    $xaPrepareJdkPath="$env:HOME/android-toolchain/jdk-$jdkMajorVersion"
+    if ("$AgentOS" -eq "Windows_NT") {
+      $xaPrepareJdkPath="$env:USERPROFILE\android-toolchain\jdk-$jdkMajorVersion"
+    }
+    if ("${{ parameters.useXAPrepareJdkPath }}" -eq "true") {
+      $jdkHomePath=$xaPrepareJdkPath
+    }
+    Write-Host "Setting variable 'JI_JAVA_HOME' to '$jdkHomePath'"
+    Write-Host "##vso[task.setvariable variable=JAVA_HOME]$jdkHomePath"
+    Write-Host "##vso[task.setvariable variable=JI_JAVA_HOME]$jdkHomePath"
+  displayName: set JAVA_HOME and JI_JAVA_HOME

--- a/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
+++ b/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
@@ -13,9 +13,13 @@ steps:
     }
     $jdkHomePath=$xaPrepareJdkPath
     if ("${{ parameters.useAgentJdkPath }}" -eq "true") {
+      $defaultJdkHomeVarName="JAVA_HOME_$(DefaultJavaSdkMajorVersion)_${agentArch}"
+      $defaultJdkHomePath=(Get-Item -Path "env:$defaultJdkHomeVarName").Value
       $jdkHomeVarName="JAVA_HOME_${jdkMajorVersion}_${agentArch}"
       $jdkHomePath=(Get-Item -Path "env:$jdkHomeVarName").Value
     }
+    Write-Host "Setting variable 'JI_JAVA_HOME_DEFAULT' to '$defaultJdkHomePath'"
+    Write-Host "##vso[task.setvariable variable=JI_JAVA_HOME_DEFAULT]$defaultJdkHomePath"
     Write-Host "Setting variable 'JAVA_HOME' and 'JI_JAVA_HOME' to '$jdkHomePath'"
     Write-Host "##vso[task.setvariable variable=JAVA_HOME]$jdkHomePath"
     Write-Host "##vso[task.setvariable variable=JI_JAVA_HOME]$jdkHomePath"

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -1,7 +1,8 @@
 parameters:
   configuration: $(XA.Build.Configuration)
   xaSourcePath: $(System.DefaultWorkingDirectory)
-  jdkTestFolder: $(JAVA_HOME_17_X64)
+  jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
+  useXAPrepareJdkPath: false
   remove_dotnet: false
   dotnetVersion: $(DotNetSdkVersion)
   dotnetQuality: $(DotNetSdkQuality)
@@ -21,17 +22,10 @@ steps:
     clean: true
     submodules: recursive
 
-- script: |
-    echo "##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkTestFolder }}"
-    echo "##vso[task.setvariable variable=DOTNET_TOOL_PATH]${{ parameters.xaSourcePath }}/bin/${{ parameters.configuration }}/dotnet/dotnet"
-  displayName: set JI_JAVA_HOME to ${{ parameters.jdkTestFolder }}
-  condition: and(succeeded(), ne(variables['agent.os'], 'Windows_NT'))
-
-- script: |
-    echo ##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkTestFolder }}
-    echo ##vso[task.setvariable variable=DOTNET_TOOL_PATH]${{ parameters.xaSourcePath }}\bin\${{ parameters.configuration }}\dotnet\dotnet.exe
-  displayName: set JI_JAVA_HOME to ${{ parameters.jdkTestFolder }}
-  condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+- template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml
+  parameters:
+    jdkMajorVersion: ${{ parameters.jdkMajorVersion }}
+    useXAPrepareJdkPath: ${{ parameters.useXAPrepareJdkPath }}
 
 # Install latest .NET
 - template: /build-tools/automation/yaml-templates/use-dot-net.yaml

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -2,7 +2,7 @@ parameters:
   configuration: $(XA.Build.Configuration)
   xaSourcePath: $(System.DefaultWorkingDirectory)
   jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
-  useXAPrepareJdkPath: false
+  useAgentJdkPath: true
   remove_dotnet: false
   dotnetVersion: $(DotNetSdkVersion)
   dotnetQuality: $(DotNetSdkQuality)
@@ -25,7 +25,7 @@ steps:
 - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml
   parameters:
     jdkMajorVersion: ${{ parameters.jdkMajorVersion }}
-    useXAPrepareJdkPath: ${{ parameters.useXAPrepareJdkPath }}
+    useAgentJdkPath: ${{ parameters.useAgentJdkPath }}
 
 # Install latest .NET
 - template: /build-tools/automation/yaml-templates/use-dot-net.yaml

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -58,6 +58,8 @@ variables:
   value: $[or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'))]
 - name: DefaultTestSdkPlatforms  # Comma-separated SDK Platform(s) to install on test agents (no spaces)
   value: 35,Baklava
+- name: DefaultJavaSdkMajorVersion
+  value: 17
 - name: ExcludedNightlyNUnitCategories
   value: 'cat != SystemApplication & cat != TimeZoneInfo & cat != Localization'
 - name: RunMAUITestJob

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -380,6 +380,7 @@
     <!-- SDK component installation can be frail, try a few times. -->
     <Exec
         Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
         ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />
     </Exec>
@@ -389,6 +390,7 @@
     />
     <Exec
         Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
         ContinueOnError="true"
         Condition=" '$(_SdkManagerExitCode)' != '0' ">
       <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />
@@ -399,6 +401,7 @@
     />
     <Exec
         Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
         ContinueOnError="true"
         Condition=" '$(_SdkManagerExitCode)' != '0' ">
       <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallAdoptOpenJDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallAdoptOpenJDK.cs
@@ -59,19 +59,11 @@ namespace Xamarin.Android.Prepare
 				return true;
 			}
 
-			// Check for a JDK installed on CI with a matching major version to use for test jobs
+			// Check for a JDK installed on CI to use for test jobs
 			var jiJavaHomeVarValue = Environment.GetEnvironmentVariable ("JI_JAVA_HOME");
-			if (AllowJIJavaHomeMatch && Directory.Exists (jiJavaHomeVarValue)) {
-				jdkInstallDir = jiJavaHomeVarValue;
-				OpenJDKExistsAndIsValid (jdkInstallDir, out installedVersion);
-				if (Version.TryParse (installedVersion, out Version? cversion) && cversion != null) {
-					if (cversion.Major == JdkVersion.Major) {
-						Log.Status ($"{ProductName} with version ");
-						Log.Status (installedVersion ?? "Unknown", ConsoleColor.Yellow);
-						Log.StatusLine (" already installed in: ", jdkInstallDir, tailColor: ConsoleColor.Cyan);
-						return true;
-					}
-				}
+			if (AllowJIJavaHomeMatch && Directory.Exists (jiJavaHomeVarValue) && JdkFilesExist (jiJavaHomeVarValue)) {
+				Log.StatusLine ("Skipping JDK install for test job, JDK exists at: ", jdkInstallDir, tailColor: ConsoleColor.Cyan);
+				return true;
 			}
 
 			Log.StatusLine ($"{ProductName} {JdkVersion} r{JdkRelease} will be installed to {jdkInstallDir}");
@@ -254,6 +246,11 @@ namespace Xamarin.Android.Prepare
 				return false;
 			}
 
+			return JdkFilesExist (installDir);
+		}
+
+		bool JdkFilesExist (string installDir)
+		{
 			foreach (string f in jdkFiles) {
 				string file = Path.Combine (installDir, f);
 				if (!File.Exists (file)) {


### PR DESCRIPTION
Adds a `setup-jdk-variables.yaml` template to set the `JAVA_HOME` and 
`JI_JAVA_HOME` variables from a single script location.

A new `JI_JAVA_HOME_DEFAULT` variable will also be set to point to a
current JDK that can be used to run various Android SDK tools as needed.

Consolidating this logic should make it easier to update the default
JDK version we install and/or test against in the future.

Build jobs and some test jobs that run on custom agents will use the
default android-toolchain path that xaprepare installs into.

Most other test jobs will attempt to use the value of a preinstalled JDK
found at `$JAVA_HOME_$(JAVA_VERSION)_$(OS_ARCH)` if it is defined.