### PR TITLE
Fix Analyser to work with global types

### DIFF
--- a/src/Microsoft.Android.Sdk.Analysis/Analyzers/CustomApplicationAnalyzer.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Analyzers/CustomApplicationAnalyzer.cs
@@ -52,10 +52,15 @@ public class CustomApplicationAnalyzer : DiagnosticAnalyzer
 			var parameters = constructor.ParameterList.Parameters;
 			if (parameters.Count != 2)
 				continue;
-			if (parameters [0].Type.ToString () != "IntPtr")
+			var type = parameters [0].Type switch {
+				IdentifierNameSyntax identifierNameSyntax => identifierNameSyntax.Identifier.Text,
+				QualifiedNameSyntax qualifiedNameSyntax => qualifiedNameSyntax.Right.Identifier.Text,
+				_ => parameters [0].Type.ToString ()
+			};
+			if (type != "IntPtr" && type != "nint")
 				continue;
 			var ns = Utilities.GetNamespaceForParameterType (parameters [1], context.SemanticModel);
-			var type = parameters [1].Type switch {
+			type = parameters [1].Type switch {
 				IdentifierNameSyntax identifierNameSyntax => identifierNameSyntax.Identifier.Text,
 				QualifiedNameSyntax qualifiedNameSyntax => qualifiedNameSyntax.Right.Identifier.Text,
 				_ => parameters [1].Type.ToString ()

--- a/src/Microsoft.Android.Sdk.Analysis/Analyzers/CustomApplicationAnalyzer.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Analyzers/CustomApplicationAnalyzer.cs
@@ -55,8 +55,12 @@ public class CustomApplicationAnalyzer : DiagnosticAnalyzer
 			if (parameters [0].Type.ToString () != "IntPtr")
 				continue;
 			var ns = Utilities.GetNamespaceForParameterType (parameters [1], context.SemanticModel);
-            var type = parameters [1].Type.ToString();
-			var isJniHandle = (ns == "Android.Runtime") && (type == "JniHandleOwnership") || (type == "Android.Runtime.JniHandleOwnership");
+			var type = parameters [1].Type switch {
+				IdentifierNameSyntax identifierNameSyntax => identifierNameSyntax.Identifier.Text,
+				QualifiedNameSyntax qualifiedNameSyntax => qualifiedNameSyntax.Right.Identifier.Text,
+				_ => parameters [1].Type.ToString ()
+			};
+			var isJniHandle = (ns == "Android.Runtime") && (type == "JniHandleOwnership");
 			if (!isJniHandle)
 				continue;
 			foundActivationConstructor = true;

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/DNAA0001Tests.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/DNAA0001Tests.cs
@@ -18,12 +18,14 @@ public class DNAA0001Tests
 	[TestCase ("JniHandleOwnership")]
 	[TestCase ("Android.Runtime.JniHandleOwnership")]
 	[TestCase ("global::Android.Runtime.JniHandleOwnership")]
+	[TestCase ("AR.JniHandleOwnership")]
 	public async Task DNAA0001DoesNotShowForExistingCode (string type)
 	{
 		var test = $@"
 using System;
 using Android.App;
 using Android.Runtime;
+using AR = Android.Runtime;
 namespace ConsoleApplication1
 {{
 	public class Foo : Application

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/DNAA0001Tests.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/DNAA0001Tests.cs
@@ -15,11 +15,11 @@ public class DNAA0001Tests
 	}
 
 	[Test]
-	[TestCase ("JniHandleOwnership")]
-	[TestCase ("Android.Runtime.JniHandleOwnership")]
-	[TestCase ("global::Android.Runtime.JniHandleOwnership")]
-	[TestCase ("AR.JniHandleOwnership")]
-	public async Task DNAA0001DoesNotShowForExistingCode (string type)
+	[TestCase ("IntPtr", "JniHandleOwnership")]
+	[TestCase ("nint", "Android.Runtime.JniHandleOwnership")]
+	[TestCase ("global::System.IntPtr", "global::Android.Runtime.JniHandleOwnership")]
+	[TestCase ("System.IntPtr", "AR.JniHandleOwnership")]
+	public async Task DNAA0001DoesNotShowForExistingCode (string handle, string type)
 	{
 		var test = $@"
 using System;
@@ -30,7 +30,7 @@ namespace ConsoleApplication1
 {{
 	public class Foo : Application
 	{{
-		public Foo(IntPtr javaReference, {type} transfer) : base(javaReference, transfer)
+		public Foo({handle} javaReference, {type} transfer) : base(javaReference, transfer)
 		{{
 		}}
 	}}

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/DNAA0001Tests.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/DNAA0001Tests.cs
@@ -17,6 +17,7 @@ public class DNAA0001Tests
 	[Test]
 	[TestCase ("JniHandleOwnership")]
 	[TestCase ("Android.Runtime.JniHandleOwnership")]
+	[TestCase ("global::Android.Runtime.JniHandleOwnership")]
 	public async Task DNAA0001DoesNotShowForExistingCode (string type)
 	{
 		var test = $@"

--- a/src/Microsoft.Android.Sdk.Analysis/Utilities/Utilities.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Utilities/Utilities.cs
@@ -45,7 +45,7 @@ public static class Utilities
 		}
 
 		// Get the symbol for the type of the parameter
-		var typeSymbol = semanticModel.GetSymbolInfo (parameterSyntax.Type).Symbol as ITypeSymbol;
+		var typeSymbol = semanticModel.GetTypeInfo (parameterSyntax.Type).Type;
 
 		if (typeSymbol == null) {
 			return null; // Unable to resolve the symbol


### PR DESCRIPTION
We are seeing the following error in maui apps.

```
error DNAA0001: Application class 'MainApplication' does not have an Activation Constructor 'MainApplication(IntPtr handle, JniHandleOwnership transfer)'. 
```

this is because they are using `global::Android.Runtime.JniHandleOwnership` rather than `Android.Runtime.JniHandleOwnership`. This causes our string comparisons to fail to we report a false error message.

Rather than using `.ToString()` we should switch over to using `QualifiedNameSyntax` and `IdentifierNameSyntax` to get the name of the class. This allows us to remove some string comparisons as we can now get the name of the class without the full namespace if it has a `global::` prefix. 