### PR TITLE
[Mono.Android-Tests] Ignore "BadGateway" test failures.

### DIFF
--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -258,8 +258,8 @@ namespace Xamarin.Android.NetTests {
 				RunIgnoringNetworkIssues (() => tr.Wait (), out connectionFailed);
 				if (connectionFailed)
 					return;
-
-				tr.Result.EnsureSuccessStatusCode ();
+				
+				EnsureSuccessStatusCode (tr.Result);
 				Assert.AreEqual (redirectedURI, tr.Result.RequestMessage.RequestUri, "Invalid redirected URI");
 			}
 		}
@@ -281,9 +281,20 @@ namespace Xamarin.Android.NetTests {
 				if (connectionFailed)
 					return;
 
-				response.EnsureSuccessStatusCode ();
+				EnsureSuccessStatusCode (response);
 				Assert.AreEqual (redirectedURI, response.RequestMessage.RequestUri, "Invalid redirected URI");
 			}
+		}
+
+		void EnsureSuccessStatusCode (HttpResponseMessage response)
+		{
+			// If we hit a 502 (which is quite common on CI) just ignore the test
+			if (response.StatusCode == HttpStatusCode.BadGateway) {
+				Assert.Ignore ($"Ignoring network failure: {response.StatusCode}");
+				return;
+			}
+
+			response.EnsureSuccessStatusCode ();
 		}
 	}
 


### PR DESCRIPTION
Building on https://github.com/dotnet/android/pull/2279, the network tests in our "Packaging Tests" very frequently fail with `BadGateway`, indicating a server side problem.  

Our "fix" has been to rerun the tests until they pass.  This wastes a considerable amount of developer and CI resources.

Instead, let's detect this case and ignore the test so that it isn't reported as "failed".