### PR TITLE
Set `$(TreatWarningsAsErrors)` = `true` for CI builds.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,5 +56,27 @@
     <HumanizerVersion>2.14.1</HumanizerVersion>
     <MdocPackageVersion Condition=" '$(MdocPackageVersion)' == '' ">5.9.3</MdocPackageVersion>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- 
+      Use $(TreatWarningsAsErrors) for 'Release' builds. We have grandfathered some projects that have existing warnings,
+      but we would like to go ahead and prevent any other projects from getting new warnings.
+    -->
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'assembly-store-reader.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'decompress-assemblies.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'jnienv-gen.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Microsoft.Android.Sdk.ILLink.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Microsoft.Android.Templates.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Mono.Android.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Mono.Android.NET-Tests.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'MSBuildDeviceIntegration.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'TestRunner.Core.NET.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.Build.Tasks.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.Build.Tests.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.JcwGen-Tests.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.NUnitLite.NET.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.ProjectTools.csproj' ">true</_AllowProjectWarnings>
+    <TreatWarningsAsErrors Condition=" '$(Configuration)' == 'Release' AND $(_AllowProjectWarnings) != 'true' ">true</TreatWarningsAsErrors>
+  </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -72,6 +72,7 @@
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Mono.Android.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Mono.Android.NET-Tests.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'MSBuildDeviceIntegration.csproj' ">true</_AllowProjectWarnings>
+    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'NativeAOT.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'TestRunner.Core.NET.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.Build.Tasks.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.Build.Tests.csproj' ">true</_AllowProjectWarnings>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,8 +59,10 @@
   
   <PropertyGroup>
     <!-- 
-      Use $(TreatWarningsAsErrors) for 'Release' builds. We have grandfathered some projects that have existing warnings,
+      Use $(TreatWarningsAsErrors) for CI builds. We have grandfathered some projects that have existing warnings,
       but we would like to go ahead and prevent any other projects from getting new warnings.
+      
+      This can be opted into locally with $(_AndroidTreatWarningsAsErrors) = true.
     -->
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'assembly-store-reader.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'decompress-assemblies.csproj' ">true</_AllowProjectWarnings>
@@ -76,7 +78,7 @@
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.JcwGen-Tests.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.NUnitLite.NET.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.ProjectTools.csproj' ">true</_AllowProjectWarnings>
-    <TreatWarningsAsErrors Condition=" '$(Configuration)' == 'Release' AND $(_AllowProjectWarnings) != 'true' ">true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition=" ('$(RunningOnCI)' == 'true' OR '$(_AndroidTreatWarningsAsErrors)' == 'true') AND '$(_AllowProjectWarnings)' != 'true' ">true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/samples/HelloWorld/HelloLibrary/LibraryActivity.cs
+++ b/samples/HelloWorld/HelloLibrary/LibraryActivity.cs
@@ -44,7 +44,6 @@ namespace HelloLibrary
 
 #if __ANDROID_8__
     public class MyBackupAgent : BackupAgent {
-      [Preserve]
       public MyBackupAgent ()
       {
       }


### PR DESCRIPTION
Modern best practices for software development recommend treating warnings as errors. Although the majority of warnings are benign, warnings for any potential actual issues will be lost in the sea of benign warnings and will not be caught.

However, having to fix warnings during the development process can be annoying as code is often in a temporary state.  As a balance, we only error on warnings when building on CI.  This way local development isn't hindered, but CI will protect us from committing new warnings.

Developers can opt-in to the errors locally by setting `$(_AndroidTreatWarningsAsErrors)` to `true`.

There are several projects that have warnings today.  For now, we will simply grandfather those projects in, allowing us to move forward with protecting the rest of the projects from new warnings.  With time, we should endeavor to fix these projects' warnings and remove them from this list.  (Our build currently has ~170 warnings spread across these projects.)