### PR TITLE
[XABT] Make assembly compression incremental.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectAssemblyFilesForArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectAssemblyFilesForArchive.cs
@@ -1,0 +1,130 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks;
+
+/// <summary>
+/// This task figures out the compression/assembly store/wrapping operations that need to
+/// be performed on the assemblies before they are added to the APK. This is done "ahead of time"
+/// so that the actual work can be done in an incremental way.
+/// </summary>
+public class CollectAssemblyFilesToCompress : AndroidTask
+{
+	public override string TaskPrefix => "CAF";
+
+	[Required]
+	public string AssemblyCompressionDirectory { get; set; } = "";
+
+	public bool EmbedAssemblies { get; set; }
+
+	[Required]
+	public bool EnableCompression { get; set; }
+
+	public bool IncludeDebugSymbols { get; set; }
+
+	[Required]
+	public string ProjectFullPath { get; set; } = "";
+
+	[Required]
+	public ITaskItem [] ResolvedFrameworkAssemblies { get; set; } = [];
+
+	[Required]
+	public ITaskItem [] ResolvedUserAssemblies { get; set; } = [];
+
+	[Required]
+	public string [] SupportedAbis { get; set; } = [];
+
+	[Output]
+	public ITaskItem [] AssembliesToCompressOutput { get; set; } = [];
+
+	[Output]
+	public ITaskItem [] ResolvedFrameworkAssembliesOutput { get; set; } = [];
+
+	[Output]
+	public ITaskItem [] ResolvedUserAssembliesOutput { get; set; } = [];
+
+	public override bool RunTask ()
+	{
+		ResolvedFrameworkAssembliesOutput = ResolvedFrameworkAssemblies;
+		ResolvedUserAssembliesOutput = ResolvedUserAssemblies;
+
+		// We aren't going to compress any assemblies
+		if (IncludeDebugSymbols || !EnableCompression || !EmbedAssemblies)
+			return true;
+
+		var assemblies_to_compress = new List<ITaskItem> ();
+		var compressed_assemblies_info = GetCompressedAssemblyInfo ();
+
+		// Get all the user and framework assemblies we may need to compresss
+		var assemblies = ResolvedFrameworkAssemblies.Concat (ResolvedUserAssemblies).Where (asm => !(ShouldSkipAssembly (asm))).ToArray ();
+		var per_arch_assemblies = MonoAndroidHelper.GetPerArchAssemblies (assemblies, SupportedAbis, true);
+
+		foreach (var kvp in per_arch_assemblies) {
+			Log.LogDebugMessage ($"Preparing assemblies for architecture '{kvp.Key}'");
+
+			foreach (var asm in kvp.Value.Values) {
+
+				if (bool.TryParse (asm.GetMetadata ("AndroidSkipCompression"), out bool value) && value) {
+					Log.LogDebugMessage ($"Skipping compression of {asm.ItemSpec} due to 'AndroidSkipCompression' == 'true' ");
+					continue;
+				}
+
+				if (!AssemblyCompression.TryGetDescriptorIndex (Log, asm, compressed_assemblies_info, out var descriptor_index)) {
+					Log.LogDebugMessage ($"Skipping compression of {asm.ItemSpec} due to missing descriptor index.");
+					continue;
+				}
+
+				var compressed_assembly = AssemblyCompression.GetCompressedAssemblyOutputPath (asm, AssemblyCompressionDirectory);
+
+				assemblies_to_compress.Add (CreateAssemblyToCompress (asm.ItemSpec, compressed_assembly, descriptor_index));
+
+				// Mark this assembly as "compressed", if the compression process fails we will remove this metadata later
+				asm.SetMetadata ("CompressedAssembly", compressed_assembly);
+			}
+		}
+
+		AssembliesToCompressOutput = assemblies_to_compress.ToArray ();
+
+		return !Log.HasLoggedErrors;
+	}
+
+	TaskItem CreateAssemblyToCompress (string sourceAssembly, string destinationAssembly, uint descriptorIndex)
+	{
+		var item = new TaskItem (sourceAssembly);
+		item.SetMetadata ("DestinationPath", destinationAssembly);
+		item.SetMetadata ("DescriptorIndex", descriptorIndex.ToString ());
+
+		return item;
+	}
+
+	IDictionary<AndroidTargetArch, Dictionary<string, CompressedAssemblyInfo>> GetCompressedAssemblyInfo ()
+	{
+		var key = CompressedAssemblyInfo.GetKey (ProjectFullPath);
+		Log.LogDebugMessage ($"Retrieving assembly compression info with key '{key}'");
+
+		var compressedAssembliesInfo = BuildEngine4.UnregisterTaskObjectAssemblyLocal<IDictionary<AndroidTargetArch, Dictionary<string, CompressedAssemblyInfo>>> (key, RegisteredTaskObjectLifetime.Build);
+
+		if (compressedAssembliesInfo is null)
+			throw new InvalidOperationException ($"Assembly compression info not found for key '{key}'. Compression will not be performed.");
+		BuildEngine4.RegisterTaskObjectAssemblyLocal (key, compressedAssembliesInfo, RegisteredTaskObjectLifetime.Build);
+
+		return compressedAssembliesInfo;
+	}
+
+	bool ShouldSkipAssembly (ITaskItem asm)
+	{
+		var should_skip = asm.GetMetadataOrDefault ("AndroidSkipAddToPackage", false);
+
+		if (should_skip)
+			Log.LogDebugMessage ($"Skipping {asm.ItemSpec} due to 'AndroidSkipAddToPackage' == 'true' ");
+
+		return should_skip;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompressAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompressAssemblies.cs
@@ -2,11 +2,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Framework;
-using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks;
 
@@ -20,107 +17,39 @@ public class CompressAssemblies : AndroidTask
 	public override string TaskPrefix => "CAS";
 
 	[Required]
-	public string ApkOutputPath { get; set; } = "";
-
-	public bool EmbedAssemblies { get; set; }
-
-	[Required]
-	public bool EnableCompression { get; set; }
-
-	public bool IncludeDebugSymbols { get; set; }
-
-	[Required]
-	public string ProjectFullPath { get; set; } = "";
-
-	[Required]
-	public ITaskItem [] ResolvedFrameworkAssemblies { get; set; } = [];
-
-	[Required]
-	public ITaskItem [] ResolvedUserAssemblies { get; set; } = [];
-
-	[Required]
-	public string [] SupportedAbis { get; set; } = [];
+	public ITaskItem [] AssembliesToCompress { get; set; } = [];
 
 	[Output]
-	public ITaskItem [] ResolvedFrameworkAssembliesOutput { get; set; } = [];
-
-	[Output]
-	public ITaskItem [] ResolvedUserAssembliesOutput { get; set; } = [];
+	public ITaskItem [] FailedToCompressAssembliesOutput { get; set; } = [];
 
 	public override bool RunTask ()
 	{
-		if (IncludeDebugSymbols || !EnableCompression || !EmbedAssemblies) {
-			ResolvedFrameworkAssembliesOutput = ResolvedFrameworkAssemblies;
-			ResolvedUserAssembliesOutput = ResolvedUserAssemblies;
-			return true;
-		}
+		var failed_assemblies = new List<ITaskItem> ();
 
-		var compressed_assemblies_info = GetCompressedAssemblyInfo ();
+		foreach (var assembly in AssembliesToCompress) {
+			MonoAndroidHelper.LogIfReferenceAssembly (assembly, Log);
 
-		// Get all the user and framework assemblies we may need to compresss
-		var assemblies = ResolvedFrameworkAssemblies.Concat (ResolvedUserAssemblies).Where (asm => !(ShouldSkipAssembly (asm))).ToArray ();
-		var per_arch_assemblies = MonoAndroidHelper.GetPerArchAssemblies (assemblies, SupportedAbis, true);
-		var compressed_output_dir = Path.GetFullPath (Path.Combine (Path.GetDirectoryName (ApkOutputPath), "..", "lz4"));
+			if (!assembly.TryGetRequiredMetadata ("AssembliesToCompress", "DestinationPath", Log, out var destination_path))
+				break;
 
-		foreach (var kvp in per_arch_assemblies) {
-			Log.LogDebugMessage ($"Compressing assemblies for architecture '{kvp.Key}'");
+			if (!assembly.TryGetRequiredMetadata ("AssembliesToCompress", "DescriptorIndex", Log, out var descriptor_index_string))
+				break;
 
-			foreach (var asm in kvp.Value.Values) {
-				if (bool.TryParse (asm.GetMetadata ("AndroidSkipCompression"), out bool value) && value) {
-					Log.LogDebugMessage ($"Skipping compression of {asm.ItemSpec} due to 'AndroidSkipCompression' == 'true' ");
-					continue;
-				}
-
-				if (!AssemblyCompression.TryGetDescriptorIndex (Log, asm, compressed_assemblies_info, out var descriptor_index)) {
-					Log.LogDebugMessage ($"Skipping compression of {asm.ItemSpec} due to missing descriptor index.");
-					continue;
-				}
-
-				var compressed_assembly = AssemblyCompression.GetCompressedAssemblyOutputPath (asm, compressed_output_dir);
-
-				if (!MonoAndroidHelper.IsFileOutOfDate (asm.ItemSpec, compressed_assembly)) {
-					asm.SetMetadata ("CompressedAssembly", compressed_assembly);
-					Log.LogDebugMessage ($"Skipping compression of {asm.ItemSpec} because the compressed assembly is up to date.");
-					continue;
-				}
-
-				MonoAndroidHelper.LogIfReferenceAssembly (asm, Log);
-
-				if (!AssemblyCompression.TryCompress (Log, asm.ItemSpec, compressed_assembly, descriptor_index)) {
-					continue;
-				}
-
-				Log.LogDebugMessage ($"Compressed '{asm.ItemSpec}' to '{compressed_assembly}'.");
-				asm.SetMetadata ("CompressedAssembly", compressed_assembly);
+			if (!uint.TryParse (descriptor_index_string, out var descriptor_index)) {
+				Log.LogError ($"Failed to parse 'DescriptorIndex' metadata value '{descriptor_index_string}' for assembly '{assembly.ItemSpec}'");
+				break;
 			}
+			
+			if (!AssemblyCompression.TryCompress (Log, assembly.ItemSpec, destination_path, descriptor_index)) {
+				failed_assemblies.Add (assembly);
+				continue;
+			}
+
+			Log.LogDebugMessage ($"Compressed '{assembly.ItemSpec}' to '{destination_path}'.");
 		}
 
-		ResolvedFrameworkAssembliesOutput = ResolvedFrameworkAssemblies;
-		ResolvedUserAssembliesOutput = ResolvedUserAssemblies;
+		FailedToCompressAssembliesOutput = failed_assemblies.ToArray ();
 
 		return !Log.HasLoggedErrors;
-	}
-
-	IDictionary<AndroidTargetArch, Dictionary<string, CompressedAssemblyInfo>> GetCompressedAssemblyInfo ()
-	{
-		var key = CompressedAssemblyInfo.GetKey (ProjectFullPath);
-		Log.LogDebugMessage ($"Retrieving assembly compression info with key '{key}'");
-
-		var compressedAssembliesInfo = BuildEngine4.UnregisterTaskObjectAssemblyLocal<IDictionary<AndroidTargetArch, Dictionary<string, CompressedAssemblyInfo>>> (key, RegisteredTaskObjectLifetime.Build);
-
-		if (compressedAssembliesInfo is null)
-			throw new InvalidOperationException ($"Assembly compression info not found for key '{key}'. Compression will not be performed.");
-
-		return compressedAssembliesInfo;
-	}
-
-	bool ShouldSkipAssembly (ITaskItem asm)
-	{
-		var should_skip = asm.GetMetadataOrDefault ("AndroidSkipAddToPackage", false);
-
-		if (should_skip)
-			Log.LogDebugMessage ($"Skipping {asm.ItemSpec} due to 'AndroidSkipAddToPackage' == 'true' ");
-
-		return should_skip;
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblyCompressionFailures.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblyCompressionFailures.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.Tasks;
+
+/// <summary>
+/// Remove "CompressedAssembly" metadata from assemblies that failed to compress.
+/// </summary>
+public class ProcessAssemblyCompressionFailures : AndroidTask
+{
+	public override string TaskPrefix => "PAC";
+
+	[Required]
+	public ITaskItem [] FailedToCompressAssembliesOutput { get; set; } = [];
+
+	[Required]
+	public ITaskItem [] ResolvedFrameworkAssemblies { get; set; } = [];
+
+	[Required]
+	public ITaskItem [] ResolvedUserAssemblies { get; set; } = [];
+
+	[Output]
+	public ITaskItem [] ResolvedFrameworkAssembliesOutput { get; set; } = [];
+
+	[Output]
+	public ITaskItem [] ResolvedUserAssembliesOutput { get; set; } = [];
+
+	public override bool RunTask ()
+	{
+		// We always need to set the output properties so that future tasks can use them
+		ResolvedFrameworkAssembliesOutput = ResolvedFrameworkAssemblies;
+		ResolvedUserAssembliesOutput = ResolvedUserAssemblies;
+
+		foreach (var failure in FailedToCompressAssembliesOutput) {
+			var assembly = ResolvedFrameworkAssemblies.Concat (ResolvedUserAssemblies).Single (a => a.ItemSpec == failure.ItemSpec);
+			assembly.RemoveMetadata ("CompressedAssembly");
+
+			Log.LogDebugMessage ($"Removed 'CompressedAssembly' metadata from '{assembly.ItemSpec}'.");
+		}
+
+		return !Log.HasLoggedErrors;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -67,6 +67,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "third build failed");
 				b.Output.AssertTargetIsNotSkipped ("CoreCompile");
 				b.Output.AssertTargetIsNotSkipped ("_Sign");
+				b.Output.AssertTargetIsPartiallyBuilt ("_CompressAssemblies");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyCompression.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyCompression.cs
@@ -55,10 +55,12 @@ namespace Xamarin.Android.Tasks
 
 		static readonly ArrayPool<byte> bytePool = ArrayPool<byte>.Shared;
 
-		static CompressionResult Compress (AssemblyData data, string outputDirectory)
+		static CompressionResult Compress (AssemblyData data, string outputFilePath)
 		{
 			if (data == null)
 				throw new ArgumentNullException (nameof (data));
+
+			var outputDirectory = Path.GetDirectoryName (outputFilePath);
 
 			if (String.IsNullOrEmpty (outputDirectory))
 				throw new ArgumentException ("must not be null or empty", nameof (outputDirectory));
@@ -72,7 +74,8 @@ namespace Xamarin.Android.Tasks
 			// 	return CompressionResult.InputTooBig;
 			// }
 
-			data.DestinationPath = Path.Combine (outputDirectory, $"{Path.GetFileName (data.SourcePath)}.lz4");
+			data.DestinationPath = outputFilePath;
+				//Path.Combine (outputDirectory, $"{Path.GetFileName (data.SourcePath)}.lz4");
 			data.SourceSize = checked((uint)fi.Length);
 
 			int bytesRead;
@@ -111,56 +114,72 @@ namespace Xamarin.Android.Tasks
 			return CompressionResult.Success;
 		}
 
-		public static string Compress (
-			TaskLoggingHelper log,
-			ITaskItem assembly,
-			IDictionary<AndroidTargetArch, Dictionary<string, CompressedAssemblyInfo>> compressedAssembliesInfo,
-			string compressedOutputDir)
+		public static bool TryCompress (TaskLoggingHelper log, string sourceAssembly, string destinationAssembly, uint descriptorIndex)
 		{
-			if (bool.TryParse (assembly.GetMetadata ("AndroidSkipCompression"), out bool value) && value) {
-				log.LogDebugMessage ($"Skipping compression of {assembly.ItemSpec} due to 'AndroidSkipCompression' == 'true' ");
-				return assembly.ItemSpec;
+			AssemblyData compressedAssembly = new AssemblyData (sourceAssembly, descriptorIndex);
+			CompressionResult result = Compress (compressedAssembly, destinationAssembly);
+
+			if (result != CompressionResult.Success) {
+				switch (result) {
+					case CompressionResult.EncodingFailed:
+						log.LogMessage ($"Failed to compress {sourceAssembly}");
+						break;
+					case CompressionResult.InputTooBig:
+						log.LogMessage ($"Input assembly {sourceAssembly} exceeds maximum input size");
+						break;
+					default:
+						log.LogMessage ($"Unknown error compressing {sourceAssembly}");
+						break;
+				}
+
+				return false;
 			}
 
-			string key = CompressedAssemblyInfo.GetDictionaryKey (assembly);
-			AndroidTargetArch arch = MonoAndroidHelper.GetTargetArch (assembly);
+			return true;
+		}
+
+		// Gets the descriptor index for the specified assembly from the compressed assembly info
+		public static bool TryGetDescriptorIndex (TaskLoggingHelper log, ITaskItem assembly, IDictionary<AndroidTargetArch, Dictionary<string, CompressedAssemblyInfo>> compressedAssembliesInfo, out uint descriptorIndex)
+		{
+			descriptorIndex = 0;
+
+			var key = CompressedAssemblyInfo.GetDictionaryKey (assembly);
+			var arch = MonoAndroidHelper.GetTargetArch (assembly);
+
 			if (!compressedAssembliesInfo.TryGetValue (arch, out Dictionary<string, CompressedAssemblyInfo> assembliesInfo)) {
 				throw new InvalidOperationException ($"Internal error: compression assembly info for architecture {arch} not available");
 			}
 
 			if (!assembliesInfo.TryGetValue (key, out CompressedAssemblyInfo info) || info == null) {
 				log.LogDebugMessage ($"Assembly missing from {nameof (CompressedAssemblyInfo)}: {key}");
-				return assembly.ItemSpec;
+				return false;
 			}
 
-			AssemblyData compressedAssembly = new AssemblyData (assembly.ItemSpec, info.DescriptorIndex);
+			descriptorIndex = info.DescriptorIndex;
+
+			return true;
+		}
+
+		// Gets the output path for the compressed assembly
+		public static string GetCompressedAssemblyOutputPath (ITaskItem assembly, string compressedOutputDir)
+		{
+			var assemblyOutputDir = GetCompressedAssemblyOutputDirectory (assembly, compressedOutputDir);
+			return Path.Combine (assemblyOutputDir, $"{Path.GetFileName (assembly.ItemSpec)}.lz4");
+		}
+
+		static string GetCompressedAssemblyOutputDirectory (ITaskItem assembly, string compressedOutputDir)
+		{
 			string assemblyOutputDir;
 			string subDirectory = assembly.GetMetadata ("DestinationSubDirectory");
 			string abi = MonoAndroidHelper.GetAssemblyAbi (assembly);
-			if (!String.IsNullOrEmpty (subDirectory) && !(subDirectory.EndsWith ($"{abi}/", StringComparison.Ordinal) || subDirectory.EndsWith ($"{abi}\\", StringComparison.Ordinal))) {
+
+			if (!string.IsNullOrEmpty (subDirectory) && !(subDirectory.EndsWith ($"{abi}/", StringComparison.Ordinal) || subDirectory.EndsWith ($"{abi}\\", StringComparison.Ordinal))) {
 				assemblyOutputDir = Path.Combine (compressedOutputDir, abi, subDirectory);
 			} else {
 				assemblyOutputDir = Path.Combine (compressedOutputDir, abi);
 			}
 
-			CompressionResult result = AssemblyCompression.Compress (compressedAssembly, assemblyOutputDir);
-			if (result != CompressionResult.Success) {
-				switch (result) {
-					case AssemblyCompression.CompressionResult.EncodingFailed:
-						log.LogMessage ($"Failed to compress {assembly.ItemSpec}");
-						break;
-
-					case AssemblyCompression.CompressionResult.InputTooBig:
-						log.LogMessage ($"Input assembly {assembly.ItemSpec} exceeds maximum input size");
-						break;
-
-					default:
-						log.LogMessage ($"Unknown error compressing {assembly.ItemSpec}");
-						break;
-				}
-				return assembly.ItemSpec;
-			}
-			return compressedAssembly.DestinationPath;
+			return assemblyOutputDir;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyCompression.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyCompression.cs
@@ -75,7 +75,6 @@ namespace Xamarin.Android.Tasks
 			// }
 
 			data.DestinationPath = outputFilePath;
-				//Path.Combine (outputDirectory, $"{Path.GetFileName (data.SourcePath)}.lz4");
 			data.SourceSize = checked((uint)fi.Length);
 
 			int bytesRead;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ITaskItemExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ITaskItemExtensions.cs
@@ -47,6 +47,18 @@ namespace Xamarin.Android.Tasks
 			return value;
 		}
 
+		public static bool TryGetRequiredMetadata (this ITaskItem item, string itemName, string name, TaskLoggingHelper log, out string value)
+		{
+			value = item.GetMetadata (name);
+
+			if (string.IsNullOrWhiteSpace (value)) {
+				log.LogCodedError ("XA4234", Properties.Resources.XA4234, itemName, item.ToString (), name);
+				return false;
+			}
+
+			return true;
+		}
+
 		public static bool HasMetadata (this ITaskItem item, string name)
 			=> item.MetadataNames.OfType<string> ().Contains (name, StringComparer.OrdinalIgnoreCase);
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -830,5 +830,22 @@ namespace Xamarin.Android.Tasks
 			// Default runtime is MonoVM
 			return AndroidRuntime.MonoVM;
 		}
+
+		/// <summary>
+		/// Returns true if the input file is newer than the output file.
+		/// </summary>
+		public static bool IsFileOutOfDate (string input, string output)
+		{
+			if (!File.Exists (output))
+				return true;
+
+			var inputInfo = new FileInfo (input);
+			var outputInfo = new FileInfo (output);
+
+			if (inputInfo.LastWriteTimeUtc > outputInfo.LastWriteTimeUtc)
+				return true;
+
+			return false;
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -830,22 +830,5 @@ namespace Xamarin.Android.Tasks
 			// Default runtime is MonoVM
 			return AndroidRuntime.MonoVM;
 		}
-
-		/// <summary>
-		/// Returns true if the input file is newer than the output file.
-		/// </summary>
-		public static bool IsFileOutOfDate (string input, string output)
-		{
-			if (!File.Exists (output))
-				return true;
-
-			var inputInfo = new FileInfo (input);
-			var outputInfo = new FileInfo (output);
-
-			if (inputInfo.LastWriteTimeUtc > outputInfo.LastWriteTimeUtc)
-				return true;
-
-			return false;
-		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2110,7 +2110,7 @@ because xbuild doesn't support framework reference assemblies.
 -->
 <Target Name="_CompressAssemblies"
     DependsOnTargets="_CollectAssembliesToCompress"
-    Inputs="@(_AssembliesToCompress);@(_AndroidMSBuildAllProjects)"
+    Inputs="@(_AssembliesToCompress);@(_AndroidMSBuildAllProjects);$(_AndroidBuildPropertiesCache)"
     Outputs="@(_AssembliesToCompress->'%(DestinationPath)')"
     Condition="'$(EmbedAssembliesIntoApk)' == 'True'">
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2286,20 +2286,6 @@ because xbuild doesn't support framework reference assemblies.
     <_DalvikClasses Include="@(_DexFile)" />
   </ItemGroup>
 
-  <!-- Put the assemblies and native libraries in the apk -->
-  <CompressAssemblies
-      ApkOutputPath="$(_ApkOutputPath)"
-      EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-      EnableCompression="$(AndroidEnableAssemblyCompression)"
-      IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
-      ProjectFullPath="$(MSBuildProjectFullPath)"
-      ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
-      ResolvedUserAssemblies="@(_ShrunkUserAssemblies);@(_AndroidResolvedSatellitePaths)"
-      SupportedAbis="@(_BuildTargetAbis)">
-    <Output TaskParameter="ResolvedFrameworkAssembliesOutput" ItemName="_BuildApkResolvedFrameworkAssemblies" />
-    <Output TaskParameter="ResolvedUserAssembliesOutput" ItemName="_BuildApkResolvedUserAssemblies" />
-  </CompressAssemblies>
-
 	<CollectDalvikFilesForArchive
       AndroidPackageFormat="$(AndroidPackageFormat)"
       DalvikClasses="@(_DalvikClasses)">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -40,6 +40,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckForRemovedItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckForInvalidResourceFileNames" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckClientHandlerType" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.CollectAssemblyFilesToCompress" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CollectDalvikFilesForArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CollectJarContentFilesForArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CollectNativeFilesForArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -83,6 +84,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.MamJsonToXml" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ManifestMerger" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.MonoSymbolicate" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.ProcessAssemblyCompressionFailures" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.RemoveDirFixed" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.RemoveRegisterAttribute" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ReadAndroidManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -2079,8 +2081,61 @@ because xbuild doesn't support framework reference assemblies.
 	</_BuildApkEmbedInputs>
 </PropertyGroup>
 
-<Target Name="_BuildApkEmbed"
+<!--
+  Find all assemblies that need to be compressed and set up the @(_AssembliesToCompress) item
+  group so that we can run an MSBuild incremental target to compress them.
+-->
+<Target Name="_CollectAssembliesToCompress"
   DependsOnTargets="_PrepareBuildApk"
+  Condition="'$(EmbedAssembliesIntoApk)' == 'True'">
+
+  <CollectAssemblyFilesToCompress
+      AssemblyCompressionDirectory="$(IntermediateOutputPath)android\lz4\"
+      EmbedAssemblies="$(EmbedAssembliesIntoApk)"
+      EnableCompression="$(AndroidEnableAssemblyCompression)"
+      IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
+      ProjectFullPath="$(MSBuildProjectFullPath)"
+      ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
+      ResolvedUserAssemblies="@(_ShrunkUserAssemblies);@(_AndroidResolvedSatellitePaths)"
+      SupportedAbis="@(_BuildTargetAbis)">
+    <Output TaskParameter="AssembliesToCompressOutput" ItemName="_AssembliesToCompress" />
+    <Output TaskParameter="ResolvedFrameworkAssembliesOutput" ItemName="_CompressedResolvedFrameworkAssemblies" />
+    <Output TaskParameter="ResolvedUserAssembliesOutput" ItemName="_CompressedBuildApkResolvedUserAssemblies" />
+  </CollectAssemblyFilesToCompress>
+</Target>
+
+<!--
+  LZ4 Compress all compressable assemblies. Note this is an incremental MSBuild target.
+  @(AssembliesToCmpress) will only contain assemblies that have changed since the last build.
+-->
+<Target Name="_CompressAssemblies"
+    DependsOnTargets="_CollectAssembliesToCompress"
+    Inputs="@(_AssembliesToCompress);@(_AndroidMSBuildAllProjects)"
+    Outputs="@(_AssembliesToCompress->'%(DestinationPath)')"
+    Condition="'$(EmbedAssembliesIntoApk)' == 'True'">
+
+    <CompressAssemblies
+        AssembliesToCompress="@(_AssembliesToCompress)">
+      <Output TaskParameter="FailedToCompressAssembliesOutput" ItemName="_FailedToCompressAssemblies" />
+    </CompressAssemblies>
+</Target>
+
+<!-- Remove "CompressedAssembly" metadata from any assemblies that failed to compress. -->
+<Target Name="_ProcessAssemblyCompressionFailures"
+    DependsOnTargets="_CompressAssemblies"
+    Condition="'$(EmbedAssembliesIntoApk)' == 'True'">
+
+    <ProcessAssemblyCompressionFailures
+        FailedToCompressAssembliesOutput="@(_FailedToCompressAssemblies)"
+        ResolvedFrameworkAssemblies="@(_CompressedResolvedFrameworkAssemblies)"
+        ResolvedUserAssemblies="@(_CompressedBuildApkResolvedUserAssemblies)">
+      <Output TaskParameter="ResolvedFrameworkAssembliesOutput" ItemName="_BuildApkResolvedFrameworkAssemblies" />
+      <Output TaskParameter="ResolvedUserAssembliesOutput" ItemName="_BuildApkResolvedUserAssemblies" />
+    </ProcessAssemblyCompressionFailures>
+</Target>
+
+<Target Name="_BuildApkEmbed"
+  DependsOnTargets="_ProcessAssemblyCompressionFailures"
   Inputs="$(_BuildApkEmbedInputs)"
   Outputs="$(_BuildApkEmbedOutputs)"
   Condition="'$(EmbedAssembliesIntoApk)' == 'True'">
@@ -2099,19 +2154,6 @@ because xbuild doesn't support framework reference assemblies.
     also need to have the args added to Xamarin.Android.Common.Debugging.targets
     in monodroid.
   -->
-  <CompressAssemblies
-      ApkOutputPath="$(_ApkOutputPath)"
-      EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-      EnableCompression="$(AndroidEnableAssemblyCompression)"
-      IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
-      ProjectFullPath="$(MSBuildProjectFullPath)"
-      ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
-      ResolvedUserAssemblies="@(_ShrunkUserAssemblies);@(_AndroidResolvedSatellitePaths)"
-      SupportedAbis="@(_BuildTargetAbis)">
-    <Output TaskParameter="ResolvedFrameworkAssembliesOutput" ItemName="_BuildApkResolvedFrameworkAssemblies" />
-    <Output TaskParameter="ResolvedUserAssembliesOutput" ItemName="_BuildApkResolvedUserAssemblies" />
-  </CompressAssemblies>
-
   <CreateAssemblyStore
       AppSharedLibrariesDir="$(_AndroidApplicationSharedLibraryPath)"
       IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2105,7 +2105,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <!--
-  LZ4 Compress all compressable assemblies. Note this is an incremental MSBuild target.
+  LZ4 compress all compressable assemblies. Note this is an incremental MSBuild target.
   @(AssembliesToCmpress) will only contain assemblies that have changed since the last build.
 -->
 <Target Name="_CompressAssemblies"


### PR DESCRIPTION
If using `$(AndroidEnableAssemblyCompression)` today, we do not compress assemblies incrementally.  That is, we always compress every assembly even if they haven't changed since the previous build.

Update the `CompressAssemblies` task to check if the input is newer than the output, and skip recompressing if the input has not changed.

This is most visible with the following test case:

```
dotnet new android
dotnet build -p:EmbedAssembliesIntoApk=true -p:AndroidIncludeDebugSymbols=false
```

| Scenario (`CompressAssemblies` tasks)        | main     | This PR  |
| --------------- | -------- | -------- |
| Full            | 44.26 s | 44.2 s  |
| NoChanges       | not run | 34 ms   |
| ChangeResource  | 27.8 s  | 9 ms    |
| AddResource     | 25.81 s | 25 ms   |
| ChangeCSharp    | 25.87 s | 30 ms   |
| ChangeCSharpJLO | 27.04 s | 23.36 s |

`ChangeCSharpJLO` should be similarly reduced, however something earlier in the build process is causing `Mono.Android.dll` to get touched so it is getting recompressed.  We'll leave that as an investigation for another day.