### PR TITLE
[XABT] Fix `ApplicationAttribute.ManageSpaceActivity` manual mapping

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
@@ -19,6 +19,7 @@ namespace Android.App {
 	partial class ApplicationAttribute {
 
 		string? _BackupAgent;
+		string? _ManageSpaceActivity;
 		ICustomAttributeProvider? provider;
 
 		ICollection<string>? specified;
@@ -43,8 +44,8 @@ namespace Android.App {
 			mapping.Add (
 				member: "ManageSpaceActivity",
 				attributeName: "manageSpaceActivity",
-				getter: self => self.ManageSpaceActivity,
-				setter: (self, value) => self.ManageSpaceActivity = (Type?) value,
+				getter: self => self._ManageSpaceActivity,
+				setter: (self, value) => self._ManageSpaceActivity = (string) value,
 				typeof (Type)
 			);
 			mapping.Add (


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9705

When [converting the AndroidManifest attribute mappings system in .NET 9](https://github.com/dotnet/android/pull/8781), `ApplicationAttribute.ManageSpaceActivity` was not correctly mapped in the manual mapping.  It needs to follow the pattern other attributes of type `Type` follow, like `ActivityAttribute.ParentActivity`:

https://github.com/dotnet/android/blob/7454deb40ce06501831973e5186e2f71d0ecf804/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs#L31-L37

With this change, the reported case in #9705 generates the proper AndroidManifest value:

```xml
<application ... android:manageSpaceActivity="crc64fe9411caa440e724.ManageSpaceActivity" ... >
```