### PR TITLE
Fix an bug in the Design Time Build

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Android.Tasks
 							entryStream.CopyTo (ms);
 						}
 						ms.Position = 0;
-						using (var reader = new StreamReader (ms, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: -1, leaveOpen: true)) {
+						using (var reader = new StreamReader (ms, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true)) {
 							string line;
 							// Read each line until the end of the file
 							while ((line = reader.ReadLine()) != null) {


### PR DESCRIPTION
We got a bug report that a DTB in VS results in the following error.

```
System.ArgumentOutOfRangeException: Positive number required.
Parameter name: bufferSize
   at System.IO.StreamReader..ctor(Stream stream, Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize, Boolean leaveOpen)
   at Xamarin.Android.Tasks.GenerateResourceCaseMap.RunTask() in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs:line 94
   at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 25
```

We were passing `-1` as the bufferSize. While this is fine under .net 9/10. It seems the full .net framework does not like it.

So lets fix it.