### PR TITLE
[ci] Remove test environment PATH additions

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -152,9 +152,6 @@ extends:
           inputs:
             forceReinstallCredentialProvider: true
 
-        - script: echo "##vso[task.prependpath]C:\Windows\System32\WindowsPowerShell\v1.0\"
-          displayName: add powershell to path
-
         - task: DownloadPipelineArtifact@2
           inputs:
             artifactName: $(NuGetArtifactName)

--- a/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
+++ b/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
@@ -23,5 +23,3 @@ steps:
       --version ${{ parameters.version }}
       --add-source "https://api.nuget.org/v3/index.json"
 
-- script: echo "##vso[task.prependpath]$(Agent.ToolsDirectory)"
-  displayName: add $(Agent.ToolsDirectory) to path


### PR DESCRIPTION
A couple of scripts that added various tools to $PATH have been removed.
These were added when we were onboarding to the 1ES pipeline template
and testing new machine pool/image requirements. The Windows images
we're using have received many updates since then, and these workarounds
that updated $PATH are no longer necessary.