### PR TITLE
[build] Support JDK-21 (#9672)

### DIFF
--- a/build-tools/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/build-tools/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
@@ -124,6 +124,7 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
         Jars="@(_BindingJavaLibrariesToCompile);@(_ReferenceJavaLibs)"
         JavacTargetVersion="$(JavacTargetVersion)"
         JavacSourceVersion="$(JavacSourceVersion)"
+        JdkVersion="$(_JdkVersion)"
         IntermediateOutputPath="$(IntermediateOutputPath)"
         AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
     />
@@ -171,6 +172,7 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
         Jars="@(_JavaLibrariesToCompile);@(_InstantRunJavaReference);@(_ReferenceJavaLibs)"
         JavacTargetVersion="$(JavacTargetVersion)"
         JavacSourceVersion="$(JavacSourceVersion)"
+        JdkVersion="$(_JdkVersion)"
         IntermediateOutputPath="$(IntermediateOutputPath)"
         AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
     />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Android.Tasks
 		public string JavacTargetVersion { get; set; }
 		public string JavacSourceVersion { get; set; }
 
+		public string JdkVersion { get; set; }
+
 		public override string DefaultErrorCode => "JAVAC0000";
 
 		public override bool RunTask ()
@@ -61,10 +63,26 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-J-Dfile.encoding=", "UTF8");
 
 			cmd.AppendFileNameIfNotNull (string.Format ("@{0}", TemporarySourceListFile));
-			cmd.AppendSwitchIfNotNull ("-target ", JavacTargetVersion);
-			cmd.AppendSwitchIfNotNull ("-source ", JavacSourceVersion);
+
+			if (int.TryParse (JavacSourceVersion, out int sourceVersion) &&
+					int.TryParse (JavacTargetVersion, out int targetVersion) &&
+					JavacSupportsRelease ()) {
+				cmd.AppendSwitchIfNotNull ("--release ", Math.Max (sourceVersion, targetVersion).ToString ());
+			} else {
+				cmd.AppendSwitchIfNotNull ("-target ", JavacTargetVersion);
+				cmd.AppendSwitchIfNotNull ("-source ", JavacSourceVersion);
+			}
 
 			return cmd.ToString ();
+		}
+
+		bool JavacSupportsRelease ()
+		{
+			if (string.IsNullOrEmpty (JdkVersion)) {
+				return false;
+			}
+			var jdkVersion  = Version.Parse (JdkVersion);
+			return jdkVersion.Major >= 17;
 		}
 
 		protected override void WriteOptionsToResponseFile (StreamWriter sw)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -17,7 +17,7 @@
 		<ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
-		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">17.0.99</LatestSupportedJavaVersion>
+		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">21.0.99</LatestSupportedJavaVersion>
 		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9651

PR #9651 demonstrated that it was fairly straightforward to use JDK-21 on CI.  We don't want to fully bump to JDK-21, because we still support building with JDK-17, so we *at minimum* need to run tests on both JDK-17 and JDK-21.

As a "minimal introductory step", add support for JDK-21:

  * Update to Gradle 8.12, for harmony with dotnet/java-interop.

  * Update the `<Javac/>` task to use `javac --release N` when using JDK-17 and later.  JDK-11 doesn't support `javac --release`. (Why care about JDK-11?  Because .NET 8 still supports it, and this will make future cherry-picking easier.)

  * Set `$(LatestSupportedJavaVersion)`=21.0.99, which removes the XA0030 error which would result from using JDK-21.