### PR TITLE
[XABT] Avoid non-blittable types in native callback methods

### DIFF
--- a/src/Mono.Android/Android.Runtime/ExtraDelegates.cs
+++ b/src/Mono.Android/Android.Runtime/ExtraDelegates.cs
@@ -1,0 +1,30 @@
+// There are built-in delegates for these, but we no longer generate them in Mono.Android.dll
+// because bool is not a blittable type.  But we still need them for pre-existing bindings.
+using System;
+
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate bool _JniMarshal_PP_Z (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate bool _JniMarshal_PPL_Z (IntPtr jnienv, IntPtr klass, IntPtr p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate bool _JniMarshal_PPJ_Z (IntPtr jnienv, IntPtr klass, long p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate void _JniMarshal_PPLZ_V (IntPtr jnienv, IntPtr klass, IntPtr p0, bool p1);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate bool _JniMarshal_PPLL_Z (IntPtr jnienv, IntPtr klass, IntPtr p0, IntPtr p1);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate bool _JniMarshal_PPIL_Z (IntPtr jnienv, IntPtr klass, int p0, IntPtr p1);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate bool _JniMarshal_PPLII_Z (IntPtr jnienv, IntPtr klass, IntPtr p0, int p1, int p2);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate bool _JniMarshal_PPLLJ_Z (IntPtr jnienv, IntPtr klass, IntPtr p0, IntPtr p1, long p2);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate bool _JniMarshal_PPLIL_Z (IntPtr jnienv, IntPtr klass, IntPtr p0, int p1, IntPtr p2);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate bool _JniMarshal_PPLLL_Z (IntPtr jnienv, IntPtr klass, IntPtr p0, IntPtr p1, IntPtr p2);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate IntPtr _JniMarshal_PPIZI_L (IntPtr jnienv, IntPtr klass, int p0, bool p1, int p2);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate bool _JniMarshal_PPLZZL_Z (IntPtr jnienv, IntPtr klass, IntPtr p0, bool p1, bool p2, IntPtr p3);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
+delegate void _JniMarshal_PPZIIII_V (IntPtr jnienv, IntPtr klass, bool p0, int p1, int p2, int p3, int p4);

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Android.Icu\DateIntervalFormat.cs" />
     <Compile Include="Android.Net.Wifi.P2p\WifiP2pManager.cs" />
     <Compile Include="Android.Runtime\DynamicMethodNameCounter.cs" />
+    <Compile Include="Android.Runtime\ExtraDelegates.cs" />
     <Compile Include="Android.Runtime\IJavaObjectValueMarshaler.cs" />
     <Compile Include="Android.Telecom\InCallService.cs" />
     <Compile Include="Android.Telephony.Mbms\StreamingService.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsClassifier.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsClassifier.cs
@@ -234,10 +234,10 @@ namespace Xamarin.Android.Tasks
 
 			// Because these types are marshaled as different blittable types,
 			// we need to accept them as equivalent
-			static readonly Tuple<string, string>[] equivalent_types = new [] {
-				Tuple.Create ("System.Boolean", "System.SByte"),
-				Tuple.Create ("System.Char", "System.UInt16"),
-			};
+			static readonly (string Source, string Replacement)[] equivalent_types = [
+				(Source: "System.Boolean", Replacement: "System.SByte"),
+				(Source: "System.Char", Replacement: "System.UInt16"),
+			];
 
 			static bool TypeMatches (string type, string methodType)
 			{
@@ -245,10 +245,10 @@ namespace Xamarin.Android.Tasks
 					return true;
 
 				foreach (var eq in equivalent_types) {
-					if (string.Compare (eq.Item1, type, StringComparison.Ordinal) == 0 && string.Compare (eq.Item2, methodType, StringComparison.Ordinal) == 0)
+					if (string.Compare (eq.Source, type, StringComparison.Ordinal) == 0 && string.Compare (eq.Replacement, methodType, StringComparison.Ordinal) == 0)
 						return true;
 
-					if (string.Compare (eq.Item1, methodType, StringComparison.Ordinal) == 0 && string.Compare (eq.Item2, type, StringComparison.Ordinal) == 0)
+					if (string.Compare (eq.Source, methodType, StringComparison.Ordinal) == 0 && string.Compare (eq.Replacement, type, StringComparison.Ordinal) == 0)
 						return true;
 				}
 


### PR DESCRIPTION
Context: https://github.com/dotnet/java-interop/pull/1296
Context: https://github.com/dotnet/java-interop/issues/1027

Changing callback methods to blittable types (`bool` -> `sbyte` and `char` -> `ushort`) causes warnings when the marshal method classifier verifies that the marshal types match the native types:

```
Xamarin.Android.Common.targets(1502,3): Method 'System.SByte Java.Lang.Object::n_Equals_Ljava_lang_Object_(System.IntPtr,System.IntPtr,System.IntPtr)' doesn't match native callback signature (invalid return type: expected 'System.Boolean', found 'System.SByte')
Xamarin.Android.Common.targets(1502,3): Unable to find native callback method 'n_Equals_Ljava_lang_Object_' in type 'Java.Lang.Object', matching the 'System.Boolean Java.Lang.Object::Equals(Java.Lang.Object)' signature (jniName: 'equals') [Arch: X86_64; Assembly: obj/Release/android-x64/linked/Mono.Android.dll]
Xamarin.Android.Common.targets(1502,3): Method 'System.Boolean Java.Lang.Object::Equals(Java.Lang.Object)' will be registered dynamically [Arch: X86_64; Assembly: obj/Release/android-x64/linked/Mono.Android.dll]
Xamarin.Android.Common.targets(1502,3): Method 'System.SByte Java.Lang.Object::n_Equals_Ljava_lang_Object_(System.IntPtr,System.IntPtr,System.IntPtr)' doesn't match native callback signature (invalid return type: expected 'System.Boolean', found 'System.SByte')
Xamarin.Android.Common.targets(1502,3): Unable to find native callback method 'n_Equals_Ljava_lang_Object_' in type 'Java.Lang.Object', matching the 'System.Boolean Java.Lang.Object::Equals(Java.Lang.Object)' signature (jniName: 'equals') [Arch: Arm64; Assembly: obj/Release/android-arm64/linked/Mono.Android.dll]
Xamarin.Android.Common.targets(1502,3): Method 'System.Boolean Java.Lang.Object::Equals(Java.Lang.Object)' will be registered dynamically [Arch: Arm64; Assembly: obj/Release/android-arm64/linked/Mono.Android.dll]
Xamarin.Android.Common.targets(1502,3): Type 'Android.Runtime.JavaObject, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065' will register some of its Java override methods dynamically. This may adversely affect runtime performance. See preceding warnings for names of dynamically registered methods.
Xamarin.Android.Common.targets(1502,3): [Arm64] Number of methods in the project that will be registered dynamically: 1
Xamarin.Android.Common.targets(1502,3): [X86_64] Number of methods in the project that will be registered dynamically: 1
```

Fix this by treating our blittable types as equivalent to their native types in the marshal method classifier.

Additionally, `Mono.Android` has "built-in delegates" that marshal `bool` types (eg: `_JniMarshal_PP_Z`).  Because `generator` no longer creates these delegates (it will now create `_JniMarshal_PP_B` instead), we need to add them manually.