### PR TITLE
[XABT] Fix ApplicationAttribute.ManageSpaceActivity manual mapping (#9708)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
@@ -19,6 +19,7 @@ namespace Android.App {
 	partial class ApplicationAttribute {
 
 		string _BackupAgent;
+		string _ManageSpaceActivity;
 		ICustomAttributeProvider provider;
 
 		ICollection<string> specified;
@@ -43,8 +44,8 @@ namespace Android.App {
 			mapping.Add (
 				member: "ManageSpaceActivity",
 				attributeName: "manageSpaceActivity",
-				getter: self => self.ManageSpaceActivity,
-				setter: (self, value) => self.ManageSpaceActivity = (Type?) value,
+				getter: self => self._ManageSpaceActivity,
+				setter: (self, value) => self._ManageSpaceActivity = (string) value,
 				typeof (Type)
 			);
 			mapping.Add (


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9705

Context: 3ab74db2c669fc234c6d60ed9884aecec8dfe61a

When converting `AndroidManifest.xml` attribute mappings in 3ab74db2, `ApplicationAttribute.ManageSpaceActivity` was not correctly mapped in the manual mapping.

The result is that if the property is used:

	[assembly: Application(ManageSpaceActivity=typeof(MyManageSpaceActivity))]

the build will fail:

	error XAGJS7007: System.InvalidCastException: Unable to cast object of type 'System.String' to type 'System.Type'.
	error XAGJS7007:    at Android.App.ApplicationAttribute.<>c.<AddManualMapping>b__189_3(ApplicationAttribute self, Object value) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs:line 47
	error XAGJS7007:    at Xamarin.Android.Manifest.ManifestDocumentElement`1.Load(T value, CustomAttribute attribute, TypeDefinitionCache cache) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs:line 127
	error XAGJS7007:    at Android.App.ApplicationAttribute.FromCustomAttributeProvider(ICustomAttributeProvider provider, TypeDefinitionCache cache) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs:line 67
	error XAGJS7007:    at Xamarin.Android.Tasks.ManifestDocument.CreateApplicationElement(XElement manifest, String applicationClass, List`1 subclasses, TypeDefinitionCache cache) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs:line 581
	error XAGJS7007:    at Xamarin.Android.Tasks.ManifestDocument.Merge(TaskLoggingHelper log, TypeDefinitionCache cache, List`1 subclasses, String applicationClass, Boolean embed, String bundledWearApplicationName, IEnumerable`1 mergedManifestDocuments) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs:line 290
	error XAGJS7007:    at Xamarin.Android.Tasks.GenerateJavaStubs.MergeManifest(NativeCodeGenState codeGenState, Dictionary`2 userAssemblies) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs:line 363
	error XAGJS7007:    at Xamarin.Android.Tasks.GenerateJavaStubs.Run(Boolean useMarshalMethods) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs:line 270
	error XAGJS7007:    at Xamarin.Android.Tasks.GenerateJavaStubs.RunTask() in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs:line 102
	error XAGJS7007:    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 25

`ApplicationAttribute.ManageSpaceActivity` needs to follow the pattern other attributes of type `Type` follow, like `ActivityAttribute.ParentActivity`:

	mapping.Add (
		member: "ParentActivity",
		attributeName: "parentActivityName",
		getter: self => self._ParentActivity,
		setter: (self, value) => self._ParentActivity = (string) value,
		typeof (Type)
	);

With this change, the reported case in #9705 generates the proper `AndroidManifest` value:

	<application android:manageSpaceActivity="crc64fe9411caa440e724.MyManageSpaceActivity" … >