### PR TITLE
`$(AndroidPackVersionSuffix)`=preview.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>35.99.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.1</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.2</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/10.0.1xx-preview1

We branched for .NET 10 Preview 1 from 3856e621 into `release/10.0.1xx-preview1`; the main branch is now .NET 10 Preview 2.