### PR TITLE
Don't Open .aar files with ReadWrite FileAccess

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Android.Tasks
 					Log.LogDebugMessage ($"Skipping non-existent aar: {aar}");
 					continue;
 				}
-				using (var file = File.Open (aar, FileMode.Open, FileAccess.ReadWrite, FileShare.Read)) {
+				using (var file = File.OpenRead (aar)) {
 					using var zip = new ZipArchive (file);
 					foreach (var entry in zip.Entries) {
 						if (entry.IsDirectory ())


### PR DESCRIPTION
Fixes #9735 

Building a Maui app we end up with the following error

```
System.IO.IOException: The process cannot access the file 'C:\Users\rumar\AppData\Local\Temp\Microsoft.Maui.Cache\NuGet\packages\xamarin.androidx.core\1.15.0.2\aar\androidx.core.core.aar' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   at Xamarin.Android.Tasks.FileResourceParser.Parse(String resourceDirectory, IEnumerable`1 additionalResourceDirectories, IEnumerable`1 aarLibraries, Dictionary`2 resourceMap) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Utilities/FileResourceParser.cs:line 82
   at Xamarin.Android.Tasks.GenerateRtxt.RunTask() in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/GenerateRtxt.cs:line 35
   at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 25
```

This is because we were using `FileShare.ReadWrite` in the `FileResourceParser`. Switch this out to use `File.OpenRead` 
which uses `FileShare.Read` under the hood to open the file.