### PR TITLE
[xa-prep-tasks] fix build errors for long `darc-` branch names

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			if (!string.IsNullOrEmpty (build_sourcebranchname) && build_sourcebranchname.IndexOf ("merge", StringComparison.OrdinalIgnoreCase) == -1) {
 				Branch = build_sourcebranchname.Replace ("refs/heads/", string.Empty);
 				Log.LogMessage ($"Using BUILD_SOURCEBRANCH value: {Branch}");
-				return true;
+				goto done;
 			}
 
 			string gitHeadFile = Path.Combine (WorkingDirectory.ItemSpec, ".git", "HEAD");
@@ -48,15 +48,27 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 				base.Execute ();
 			}
 
+done:
+			CheckBranchLength ();
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (Branch)}: {Branch}");
+			return !Log.HasLoggedErrors;
+		}
+
+		void CheckBranchLength ()
+		{
 			// Trim generated dependabot branch names that are too long to produce useful package names
+			const int maxBranchLength = 32;
 			var lastSlashIndex = Branch.LastIndexOf ('/');
-			if (Branch.StartsWith ("dependabot") && lastSlashIndex != -1 && Branch.Length > 60) {
+			if (Branch.StartsWith ("dependabot") && lastSlashIndex != -1 && Branch.Length > maxBranchLength) {
+				Log.LogMessage ($"Trimming characters from the branch name at index {lastSlashIndex}: {Branch}");
 				Branch = Branch.Substring (lastSlashIndex + 1);
 			}
 
-			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (Branch)}: {Branch}");
-
-			return !Log.HasLoggedErrors;
+			// Trim darc/Maestro branch names that are too long
+			if (Branch.StartsWith ("darc-") && Branch.Length > maxBranchLength) {
+				Log.LogMessage ($"Trimming to {maxBranchLength} characters from the branch name: {Branch}");
+				Branch = Branch.Substring (0, maxBranchLength);
+			}
 		}
 
 		protected override string GenerateCommandLineCommands ()


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9732

PR #9732 failed with:

    NuGet.Build.Tasks.Pack.targets(221,5): error NU5123: Warning As Error: The file 'package/services/metadata/core-properties/027a96e260344b159133798c830dab61.psmdcp' path, name, or both are too long.
    Your package might not work without long file path support. Please shorten the file path or file name.

The branch name is 68 characters long:

    darc-release/10.0.1xx-preview1-94740166-a85b-4349-9dd7-c8274168049c

Update the `<GitBranch/>` MSBuild task to substring long `darc-` branch names to avoid this problem. I found even 50 characters was causing the issue, so I chose 32.