### PR TITLE
[Mono.Android] Remove usages of `JNINativeWrapper.CreateDelegate`.

### DIFF
--- a/src/Mono.Android/Android.Animation/AnimatorSet.cs
+++ b/src/Mono.Android/Android.Animation/AnimatorSet.cs
@@ -1,49 +1,48 @@
-#if ANDROID_11
-
 using System;
+using Java.Interop;
 using Android.Runtime;
 
 namespace Android.Animation
 {
 	public partial class AnimatorSet
 	{
-		private static IntPtr id_setDuration_J;
+		static Delegate cb_setDuration_SetDuration_J_Landroid_animation_Animator_;
+
 		[Register ("setDuration", "(J)Landroid/animation/Animator;", "GetSetDuration_JHandler")]
-		public override Animator SetDuration (long duration)
+		public override unsafe Android.Animation.Animator SetDuration (long duration)
 		{
-			if (id_setDuration_J == IntPtr.Zero)
-				id_setDuration_J = JNIEnv.GetMethodID (class_ref, "setDuration", "(J)Landroid/animation/Animator;");
-			
-			if (base.GetType () == this.ThresholdType) {
-				return Java.Lang.Object.GetObject<AnimatorSet> (
-						JNIEnv.CallObjectMethod (base.Handle, id_setDuration_J, new JValue (duration)),
-						JniHandleOwnership.TransferLocalRef)!;
-			} else {
-				return Java.Lang.Object.GetObject<AnimatorSet> (
-						JNIEnv.CallNonvirtualObjectMethod (
-							base.Handle,
-							this.ThresholdClass,
-							JNIEnv.GetMethodID (ThresholdClass, "setDuration", "(J)Landroid/animation/Animator;"),
-							new JValue (duration)),
-						JniHandleOwnership.TransferLocalRef)!;
+			const string __id = "setDuration.(J)Landroid/animation/Animator;";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (duration);
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
+				return global::Java.Lang.Object.GetObject<Android.Animation.Animator> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
 			}
 		}
 		
-		private static Delegate? cb_setDuration_J;
-		
-		private static Delegate GetSetDuration_JHandler ()
+#pragma warning disable 0169
+		static Delegate GetSetDuration_JHandler ()
 		{
-			if (cb_setDuration_J == null)
-				cb_setDuration_J = JNINativeWrapper.CreateDelegate (new Func<IntPtr, IntPtr, long, IntPtr> (n_SetDuration_J));
-			return cb_setDuration_J;
+			return cb_setDuration_SetDuration_J_Landroid_animation_Animator_ ??= new _JniMarshal_PPJ_L (n_SetDuration_J);
 		}
-		
-		private static IntPtr n_SetDuration_J (IntPtr jnienv, IntPtr native__this, long duration)
+
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
+		static IntPtr n_SetDuration_J (IntPtr jnienv, IntPtr native__this, long duration)
 		{
-			AnimatorSet @object = Java.Lang.Object.GetObject<AnimatorSet> (native__this, JniHandleOwnership.DoNotTransfer)!;
-			return JNIEnv.ToJniHandle (@object.SetDuration (duration));
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
+				return default;
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<Android.Animation.AnimatorSet> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.SetDuration (duration));
+			} catch (global::System.Exception __e) {
+				__r.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
+			}
 		}
+#pragma warning restore 0169
 	}
 }
-
-#endif

--- a/src/Mono.Android/Android.Animation/ValueAnimator.cs
+++ b/src/Mono.Android/Android.Animation/ValueAnimator.cs
@@ -1,50 +1,48 @@
-#if ANDROID_11
-
 using System;
+using Java.Interop;
 using Android.Runtime;
 
 namespace Android.Animation
 {
 	public partial class ValueAnimator
 	{
-		private static IntPtr id_setDuration_J;
+		static Delegate cb_setDuration_SetDuration_J_Landroid_animation_Animator_;
 		
 		[Register ("setDuration", "(J)Landroid/animation/Animator;", "GetSetDuration_JHandler")]
-		public override Animator SetDuration (long duration)
+		public override unsafe Android.Animation.Animator SetDuration (long duration)
 		{
-			if (id_setDuration_J == IntPtr.Zero)
-				id_setDuration_J = JNIEnv.GetMethodID (class_ref, "setDuration", "(J)Landroid/animation/Animator;");
-			
-			if (base.GetType () == this.ThresholdType) {
-				return Java.Lang.Object.GetObject<ValueAnimator> (
-						JNIEnv.CallObjectMethod (base.Handle, id_setDuration_J, new JValue (duration)),
-						JniHandleOwnership.TransferLocalRef)!;
-			} else {
-				return Java.Lang.Object.GetObject<ValueAnimator> (
-						JNIEnv.CallNonvirtualObjectMethod (
-							base.Handle,
-							this.ThresholdClass,
-							JNIEnv.GetMethodID (ThresholdClass, "setDuration", "(J)Landroid/animation/Animator;"),
-							new JValue (duration)),
-						JniHandleOwnership.TransferLocalRef)!;
+			const string __id = "setDuration.(J)Landroid/animation/Animator;";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (duration);
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
+				return global::Java.Lang.Object.GetObject<Android.Animation.Animator> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
 			}
 		}
 		
-		private static Delegate? cb_setDuration_J;
-		
-		private static Delegate GetSetDuration_JHandler ()
+#pragma warning disable 0169
+		static Delegate GetSetDuration_JHandler ()
 		{
-			if (cb_setDuration_J == null)
-				cb_setDuration_J = JNINativeWrapper.CreateDelegate (new Func<IntPtr, IntPtr, long, IntPtr> (n_SetDuration_J));
-			return cb_setDuration_J;
+			return cb_setDuration_SetDuration_J_Landroid_animation_Animator_ ??= new _JniMarshal_PPJ_L (n_SetDuration_J);
 		}
-		
-		private static IntPtr n_SetDuration_J (IntPtr jnienv, IntPtr native__this, long duration)
+
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
+		static IntPtr n_SetDuration_J (IntPtr jnienv, IntPtr native__this, long duration)
 		{
-			ValueAnimator @object = Java.Lang.Object.GetObject<ValueAnimator> (native__this, JniHandleOwnership.DoNotTransfer)!;
-			return JNIEnv.ToJniHandle (@object.SetDuration (duration));
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
+				return default;
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<Android.Animation.ValueAnimator> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.SetDuration (duration));
+			} catch (global::System.Exception __e) {
+				__r.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
+			}
 		}
+#pragma warning restore 0169
 	}
 }
-
-#endif

--- a/src/Mono.Android/Android.Bluetooth/BluetoothGattServerCallback.cs
+++ b/src/Mono.Android/Android.Bluetooth/BluetoothGattServerCallback.cs
@@ -24,17 +24,26 @@ namespace Android.Bluetooth
 #pragma warning disable 0169
 		static Delegate GetOnServiceAdded_ILandroid_bluetooth_BluetoothGattService_Handler_ext ()
 		{
-			if (cb_onServiceAdded_ILandroid_bluetooth_BluetoothGattService_ext == null)
-				cb_onServiceAdded_ILandroid_bluetooth_BluetoothGattService_ext = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, int, IntPtr>) n_OnServiceAdded_ILandroid_bluetooth_BluetoothGattService_ext);
-			return cb_onServiceAdded_ILandroid_bluetooth_BluetoothGattService_ext;
+			return cb_onServiceAdded_ILandroid_bluetooth_BluetoothGattService_ext ??= new _JniMarshal_PPIL_V (n_OnServiceAdded_ILandroid_bluetooth_BluetoothGattService_ext);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_OnServiceAdded_ILandroid_bluetooth_BluetoothGattService_ext (IntPtr jnienv, IntPtr native__this, int native_status, IntPtr native_service)
 		{
-			Android.Bluetooth.BluetoothGattServerCallback __this = global::Java.Lang.Object.GetObject<Android.Bluetooth.BluetoothGattServerCallback> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-			Android.Bluetooth.ProfileState status = (Android.Bluetooth.ProfileState) native_status;
-			var service = global::Java.Lang.Object.GetObject<Android.Bluetooth.BluetoothGattService> (native_service, JniHandleOwnership.DoNotTransfer);
-			__this.ActualOnServiceAdded (status, service);
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
+				return;
+
+			try {
+				Android.Bluetooth.BluetoothGattServerCallback __this = global::Java.Lang.Object.GetObject<Android.Bluetooth.BluetoothGattServerCallback> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+				Android.Bluetooth.ProfileState status = (Android.Bluetooth.ProfileState) native_status;
+				var service = global::Java.Lang.Object.GetObject<Android.Bluetooth.BluetoothGattService> (native_service, JniHandleOwnership.DoNotTransfer);
+				__this.ActualOnServiceAdded (status, service);
+			} catch (global::System.Exception __e) {
+				__r.OnUserUnhandledException (ref __envp, __e);
+				return;
+			} finally {
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
+			}
 		}
 #pragma warning restore 0169
 	}

--- a/src/Mono.Android/Android.Telephony/CellInfo.cs
+++ b/src/Mono.Android/Android.Telephony/CellInfo.cs
@@ -14,16 +14,25 @@ namespace Android.Telephony {
 		[global::System.Runtime.Versioning.SupportedOSPlatform ("android28.0")]
 		static Delegate GetGetCellIdentityHandler ()
 		{
-			if (cb_getCellIdentity == null)
-				cb_getCellIdentity = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetCellIdentity);
-			return cb_getCellIdentity;
+			return cb_getCellIdentity ??= new _JniMarshal_PP_L (n_GetCellIdentity);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		[global::System.Runtime.Versioning.SupportedOSPlatform ("android28.0")]
 		static IntPtr n_GetCellIdentity (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<Android.Telephony.CellInfo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-			return JNIEnv.ToLocalJniHandle (__this.CellIdentity);
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
+				return default;
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<Android.Telephony.CellInfo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+				return JNIEnv.ToLocalJniHandle (__this.CellIdentity);
+			} catch (global::System.Exception __e) {
+				__r.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
+			}
 		}
 #pragma warning restore 0169
 
@@ -47,15 +56,24 @@ namespace Android.Telephony {
 #pragma warning disable 0169
 		static Delegate GetGetCellSignalStrengthHandler ()
 		{
-			if (cb_getCellSignalStrength == null)
-				cb_getCellSignalStrength = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetCellSignalStrength);
-			return cb_getCellSignalStrength;
+			return cb_getCellSignalStrength ??= new _JniMarshal_PP_L (n_GetCellSignalStrength);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetCellSignalStrength (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<Android.Telephony.CellInfo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-			return JNIEnv.ToLocalJniHandle (__this.CellSignalStrength);
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
+				return default;
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<Android.Telephony.CellInfo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+				return JNIEnv.ToLocalJniHandle (__this.CellSignalStrength);
+			} catch (global::System.Exception __e) {
+				__r.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
+			}
 		}
 #pragma warning restore 0169
 

--- a/src/Mono.Android/Android.Widget/AbsListView.cs
+++ b/src/Mono.Android/Android.Widget/AbsListView.cs
@@ -13,31 +13,49 @@ namespace Android.Widget {
 #pragma warning disable 0169
 		static Delegate GetGetAdapterHandler ()
 		{
-			if (cb_getAdapter == null)
-				cb_getAdapter = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetAdapter);
-			return cb_getAdapter;
+			return cb_getAdapter ??= new _JniMarshal_PP_L (n_GetAdapter);
 		}
 
 		static IntPtr id_getAdapter;
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<Android.Widget.AbsListView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-			return JNIEnv.ToLocalJniHandle (__this.Adapter);
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
+				return default;
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<Android.Widget.AbsListView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+				return JNIEnv.ToLocalJniHandle (__this.Adapter);
+			} catch (global::System.Exception __e) {
+				__r.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
+			}
 		}
 
 		static Delegate? cb_setAdapter_Landroid_widget_Adapter_;
 #pragma warning disable 0169
 		static Delegate GetSetAdapter_Landroid_widget_ListAdapter_Handler ()
 		{
-			if (cb_setAdapter_Landroid_widget_Adapter_ == null)
-				cb_setAdapter_Landroid_widget_Adapter_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_SetAdapter_Landroid_widget_ListAdapter_);
-			return cb_setAdapter_Landroid_widget_Adapter_;
+			return cb_setAdapter_Landroid_widget_Adapter_ ??= new _JniMarshal_PPL_V (n_SetAdapter_Landroid_widget_ListAdapter_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetAdapter_Landroid_widget_ListAdapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			var __this  = Java.Lang.Object.GetObject<Android.Widget.AbsListView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-			__this.Adapter      = Java.Interop.JavaConvert.FromJniHandle<IListAdapter> (native_adapter, JniHandleOwnership.DoNotTransfer);
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
+				return;
+
+			try {
+				var __this  = Java.Lang.Object.GetObject<Android.Widget.AbsListView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+				__this.Adapter      = Java.Interop.JavaConvert.FromJniHandle<IListAdapter> (native_adapter, JniHandleOwnership.DoNotTransfer);
+			} catch (global::System.Exception __e) {
+				__r.OnUserUnhandledException (ref __envp, __e);
+				return;
+			} finally {
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
+			}
 		}
 #pragma warning restore 0169
 

--- a/src/Mono.Android/Java.Util/IList.cs
+++ b/src/Mono.Android/Java.Util/IList.cs
@@ -12,16 +12,25 @@ public partial interface IList
 	[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android35.0")]
 	private static Delegate GetReversedHandler ()
 	{
-		if (cb_reversed == null)
-			cb_reversed = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Reversed));
-		return cb_reversed;
+		return cb_reversed ??= new _JniMarshal_PP_L (n_Reversed);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android35.0")]
 	private static IntPtr n_Reversed (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<Java.Util.IList> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		return JNIEnv.ToLocalJniHandle (__this.Reversed ());
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
+			return default;
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<Java.Util.IList> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			return JNIEnv.ToLocalJniHandle (__this.Reversed ());
+		} catch (global::System.Exception __e) {
+			__r.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
+		}
 	}
 #pragma warning restore 0169
 

--- a/src/Mono.Android/Java.Util/ISortedMap.cs
+++ b/src/Mono.Android/Java.Util/ISortedMap.cs
@@ -12,16 +12,25 @@ public partial interface ISortedMap
 	[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android35.0")]
 	private static Delegate GetReversedHandler ()
 	{
-		if (cb_reversed == null)
-			cb_reversed = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Reversed));
-		return cb_reversed;
+		return cb_reversed ??= new _JniMarshal_PP_L (n_Reversed);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android35.0")]
 	private static IntPtr n_Reversed (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<Java.Util.ISortedMap> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		return JNIEnv.ToLocalJniHandle (__this.Reversed ());
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
+			return default;
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<Java.Util.ISortedMap> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			return JNIEnv.ToLocalJniHandle (__this.Reversed ());
+		} catch (global::System.Exception __e) {
+			__r.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
+		}
 	}
 #pragma warning restore 0169
 


### PR DESCRIPTION
Context: https://github.com/dotnet/java-interop/pull/1275

Throughout the years of binding `Mono.Android` there have been instances where we need to write manual binding code to work around issues in `generator`.  These instances need to be manually updated to mirror the latest `generator` output by removing calls to `JNINativeWrapper.CreateDelegate` that would prevent NativeAOT from functioning.

It is recommended to review this PR with "Hide Whitespace Changes", as adding try/catch blocks affected indentation.