### PR TITLE
[tests] restore ignored tests from .NET 10 issues

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -651,8 +651,7 @@ public class Test
 		[NonParallelizable]
 		public void BuildApplicationWithSpacesInPath ([Values (true, false)] bool enableMultiDex, [Values ("", "r8")] string linkTool)
 		{
-			// FIXME: https://github.com/dotnet/msbuild/issues/11237, removed `(` and `)` characters
-			var folderName = $"BuildReleaseApp AndÜmläüts{enableMultiDex}{linkTool}";
+			var folderName = $"BuildReleaseApp AndÜmläüts({enableMultiDex}{linkTool})";
 			var lib = new XamarinAndroidLibraryProject {
 				IsRelease = true,
 				ProjectName = "Library1"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1133,8 +1133,7 @@ namespace UnamedProject
 			if (!string.IsNullOrEmpty (rid)) {
 				proj.SetProperty ("RuntimeIdentifier", rid);
 			}
-			// FIXME: https://github.com/dotnet/msbuild/issues/11237, removed `(` and `)` characters
-			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildProguard Enabled1{rid}"))) {
+			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildProguard Enabled(1){rid}"))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				// warning XA4304: ProGuard configuration file 'XYZ' was not found.
 				StringAssertEx.DoesNotContain ("XA4304", b.LastBuildOutput, "Output should *not* contain XA4304 warnings");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -1068,7 +1068,6 @@ class TestActivity : Activity { }"
 
 			var minSdkVersionInt = MonoAndroidHelper.ConvertSupportedOSPlatformVersionToApiLevel (minSdkVersion);
 			if (minSdkVersionInt < 22) {
-				Assert.Ignore ("https://github.com/dotnet/roslyn-analyzers/issues/7525");
 				StringAssertEx.Contains ("warning CA1416", builder.LastBuildOutput, "Should get warning about Android 22 API");
 			} else {
 				builder.AssertHasNoWarnings ();


### PR DESCRIPTION
Context: https://github.com/dotnet/roslyn-analyzers/issues/7525
Context: https://github.com/dotnet/msbuild/issues/11237

The two above issues are fixed, so we can restore the impacted tests by partially reverting 37014d10.