### PR TITLE
[Mono.Android] `JavaList.Add` should allow duplicates.

### DIFF
--- a/src/Mono.Android/Android.Runtime/JavaList.cs
+++ b/src/Mono.Android/Android.Runtime/JavaList.cs
@@ -551,8 +551,6 @@ namespace Android.Runtime {
 
 		public virtual bool Add (int index, Java.Lang.Object? item)
 		{
-			if (Contains (item))
-				return false;
 			Add ((object?) item);
 			return true;
 		}

--- a/src/Mono.Android/Android.Runtime/JavaList.cs
+++ b/src/Mono.Android/Android.Runtime/JavaList.cs
@@ -551,7 +551,7 @@ namespace Android.Runtime {
 
 		public virtual bool Add (int index, Java.Lang.Object? item)
 		{
-			Add ((object?) item);
+			Insert (index, (object?) item);
 			return true;
 		}
 

--- a/src/Mono.Android/Android.Runtime/JavaList.cs
+++ b/src/Mono.Android/Android.Runtime/JavaList.cs
@@ -546,7 +546,8 @@ namespace Android.Runtime {
 		//	
 		public virtual bool Add (Java.Lang.Object? item)
 		{
-			return Add (0, item);
+			Add ((object?) item);
+			return true;
 		}
 
 		public virtual bool Add (int index, Java.Lang.Object? item)

--- a/tests/Mono.Android-Tests/Java.Interop/JavaListTest.cs
+++ b/tests/Mono.Android-Tests/Java.Interop/JavaListTest.cs
@@ -28,6 +28,26 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		public void AddWithIndex ()
+		{
+			list.Add ("Apple");
+			list.Add ("Banana");
+			list.Add ("Cherry");
+
+			// Ensure index is respected.
+			list.Add (3, "Grape");
+			list.Add (2, "Blueberry");
+			list.Add (4, "Fig");
+
+			Assert.AreEqual ("Apple", list [0]);
+			Assert.AreEqual ("Banana", list [1]);
+			Assert.AreEqual ("Blueberry", list [2]);
+			Assert.AreEqual ("Cherry", list [3]);
+			Assert.AreEqual ("Fig", list [4]);
+			Assert.AreEqual ("Grape", list [5]);
+		}
+
+		[Test]
 		public void Count ()
 		{
 			list.Add ("foo");

--- a/tests/Mono.Android-Tests/Java.Interop/JavaListTest.cs
+++ b/tests/Mono.Android-Tests/Java.Interop/JavaListTest.cs
@@ -16,6 +16,18 @@ namespace Java.InteropTests
 		public void Setup () => list = new T ();
 
 		[Test]
+		public void Add ()
+		{
+			list.Add ("foo");
+			Assert.AreEqual ("foo", list [0]);
+
+			// Ensure duplicates are allowed.
+			list.Add ("foo");
+			Assert.AreEqual (2, list.Count);
+			Assert.AreEqual ("foo", list [1]);
+		}
+
+		[Test]
 		public void Count ()
 		{
 			list.Add ("foo");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9675

Remove the check for duplicates in `JavaList.Add` to allow duplicates.