### PR TITLE
[.github] Update issue templates to include `net10.0-android`.

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-building-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/01-building-an-application.yml
@@ -16,6 +16,7 @@ body:
       options:
       - net8.0-android
       - net9.0-android
+      - net10.0-android (Preview)
       - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/02-running-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/02-running-an-application.yml
@@ -16,6 +16,7 @@ body:
       options:
       - net8.0-android
       - net9.0-android
+      - net10.0-android (Preview)
       - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
+++ b/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
@@ -21,6 +21,7 @@ body:
       options:
       - net8.0-android
       - net9.0-android
+      - net10.0-android (Preview)
       - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
+++ b/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
@@ -18,6 +18,7 @@ body:
       options:
       - net8.0-android
       - net9.0-android
+      - net10.0-android (Preview)
       - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/05-other.yml
+++ b/.github/ISSUE_TEMPLATE/05-other.yml
@@ -16,6 +16,7 @@ body:
       options:
       - net8.0-android
       - net9.0-android
+      - net10.0-android (Preview)
       - Other
     validations:
       required: true


### PR DESCRIPTION
Users will (hopefully!) be testing the forthcoming .NET 10 for Android preview bits and providing feedback.  Or even providing feedback today on `main` builds!

Update our issue templates to include `net10.0-android (Preview)` as an option.