### PR TITLE
[coreclr] projects with `UseMonoRuntime=false` successfully build

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -216,5 +216,6 @@
   <ItemGroup>
     <AndroidAbiAndRuntimeFlavor Include="@(AndroidSupportedTargetJitAbi)" AndroidRuntime="Mono" />
     <AndroidAbiAndRuntimeFlavor Include="@(AndroidSupportedTargetJitAbi)" AndroidRuntime="NativeAOT" />
+    <AndroidAbiAndRuntimeFlavor Include="@(AndroidSupportedTargetJitAbi)" AndroidRuntime="CoreCLR" />
   </ItemGroup>
 </Project>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -56,7 +56,7 @@
 
   <Target Name="_CreateItemGroups">
     <ItemGroup>
-      <_AndroidRuntimeNames Include="Mono;NativeAOT" />
+      <_AndroidRuntimeNames Include="@(AndroidAbiAndRuntimeFlavor->'%(AndroidRuntime)'->Distinct())" />
       <_AndroidRIDs Include="android-arm;android-arm64;android-x86;android-x64" Runtime="%(_AndroidRuntimeNames.Identity)" />
     </ItemGroup>
   </Target>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
@@ -1,0 +1,15 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.CoreCLR.targets
+
+This file contains the CoreCLR-specific MSBuild logic for .NET for Android.
+***********************************************************************************************
+-->
+<Project>
+
+  <!-- Default property values for CoreCLR -->
+  <PropertyGroup>
+    <_AndroidRuntimePackRuntime>CoreCLR</_AndroidRuntimePackRuntime>
+  </PropertyGroup>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -27,6 +27,7 @@
   <Import Project="Microsoft.Android.Sdk.DefaultProperties.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props"
       Condition="Exists('$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props') And '$(DesignTimeBuild)' != 'true' "/>
-  <Import Project="Microsoft.Android.Sdk.NativeAOT.targets" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' And '$(DesignTimeBuild)' != 'true' " />
+  <Import Project="Microsoft.Android.Sdk.CoreCLR.targets"   Condition=" '$(_AndroidRuntime)' == 'CoreCLR' " />
+  <Import Project="Microsoft.Android.Sdk.NativeAOT.targets" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' " />
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -81,6 +81,22 @@
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
+    "Microsoft.Android.Runtime.CoreCLR.35.android-arm": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.CoreCLR.35.android-arm64": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.CoreCLR.35.android-x86": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.CoreCLR.35.android-x64": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
     "Microsoft.Android.Runtime.NativeAOT.35.android-arm": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
@@ -114,6 +130,22 @@
       "version": "@WORKLOAD_VERSION@"
     },
     "Microsoft.Android.Runtime.Mono.36.android-x64": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.CoreCLR.36.android-arm": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.CoreCLR.36.android-arm64": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.CoreCLR.36.android-x86": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.CoreCLR.36.android-x64": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -106,6 +106,21 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void BasicApplicationOtherRuntime ([Values (true, false)] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+				// Add locally downloaded CoreCLR packs
+				ExtraNuGetConfigSources = {
+					Path.Combine (XABuildPaths.BuildOutputDirectory, "nuget-unsigned"),
+				}
+			};
+			proj.SetProperty ("UseMonoRuntime", "false"); // Enables CoreCLR
+			var b = CreateApkBuilder ();
+			Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+		}
+
+		[Test]
 		public void NativeAOT ()
 		{
 			var proj = new XamarinAndroidApplicationProject {


### PR DESCRIPTION
This is a step towards Android projects using `UseMonoRuntime=false` successfully:

1. Create new packs such as `Microsoft.Android.Runtime.CoreCLR.[api].[rid]`

2. Ensure a project *builds* with `UseMonoRuntime=false` in both `Debug` and `Release` configurations.

3. The project will not be able to run successfully yet.

(Significant work required for no. 3)