### PR TITLE
[XABT] Ensure `$(DocumentationFile)` correctly uses `$(OutputPath)`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -27,7 +27,7 @@ It is shared between "legacy" binding projects and .NET 5 projects.
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(_UseLegacyJavadocImport)' != 'true' ">
-    <DocumentationFile Condition=" '$(DocumentationFile)' == '' and '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' ">$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+    <DocumentationFile Condition=" '$(DocumentationFile)' == '' and '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' ">$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))$(AssemblyName).xml</DocumentationFile>
     <NoWarn Condition=" '$(DocumentationFile)' != '' ">$(NoWarn);CS1573;CS1591</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9645

If a user specifies `$(OutputPath)` on the command line, it won't automatically get a trailing slash added to it because global properties can't be overwritten.  Ensure we add a trailing slash to `$(OutputPath)` when constructing `$(DocumentationFile)`.

This probably doesn't warrant a test case.

Tested locally with:
```
dotnet build -bl -p:OutputPath=C:\Users\jopobst\Desktop\maven_messaging\foo
```

`main`:
<img width="546" alt="foo" src="https://github.com/user-attachments/assets/c5d18b3b-cb9b-4a94-a83e-7cf5368d9889" />

This PR:
![image](https://github.com/user-attachments/assets/864778ca-49ed-4162-a3eb-ba0437716ce0)
