### PR TITLE
Bump to dotnet/java-interop/main@6bc87e8b

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/dotnet/java-interop
-    branch = dev/jonp/jonp-dotnet-requires-plus-not-slash-take2
+    branch = main
 [submodule "external/libunwind"]
     path = external/libunwind
     url = https://github.com/libunwind/libunwind.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/dotnet/java-interop
-    branch = main
+    branch = dev/jonp/jonp-dotnet-requires-plus-not-slash-take2
 [submodule "external/libunwind"]
     path = external/libunwind
     url = https://github.com/libunwind/libunwind.git

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -225,6 +225,7 @@
         TargetImplementationPath="$(OutputPath)"
         ApiCompatibilityPath="$(ApiCompatibilityDir)"
         TargetFramework="$(TargetFramework)"
+        LinesToAdd="$(MSBuildThisFileDirectory)ApiCompatLinesToAdd.txt"
     />
     <Touch
         Files="$(IntermediateOutputPath)CheckApiCompatibility.stamp"


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9747

Changes: https://github.com/dotnet/java-interop/compare/dd3c1d0514addfe379f050627b3e97493e985da6...6bc87e8b55bc00ae1423a5ae92cf5db573fc76ed

  * dotnet/java-interop@6bc87e8b: [jcw-gen] Use `+` for nested types, not `/` (dotnet/java-interop#1304)

dotnet/java-interop@6bc87e8b is needed to unblock parts of #9747.

Additionally, two "quality of life" changes:

Firstly, update the `src/Mono.Android` build so that if there are
API breaks reported, the breakage is collated into 
`src/Mono.Android/ApiCompatLinesToAdd.txt` in a format that can be
directly copied into 
`tests/api-compatibility/acceptable-breakages-vReference-*.txt` if
deemed useful.

Previously, *all* changes were printed to the build log, which was
annoying to deal with because (1) there may be duplicates, and
(2) the lines would contain `TaskId`/etc. "noise" that would need to
be removed in order to be used.

Secondly, update `build-tools/xaprepare` to improve reliability when
running `Step_InstallDotNetPreview`.  `Step_InstallDotNetPreview`
will cache e.g. `dotnet-install.sh` into `$HOME/android-archives`,
but there was no logic to verify that it was still *valid*.

We've been seeing some recurring build failures in **macOS > Build**
such as:

	Downloading dotnet-install script...
	Warning: Using cached installation script found in '/Users/builder/android-archives/dotnet-install.sh'
	Discovering download URLs for dotnet SDK '10.0.100-preview.2.25102.3'...
	Downloading dotnet archive...
	dotnet archive URL https://dotnetcli.azureedge.net/dotnet/Sdk/10.0.100-preview.2.25102.3/dotnet-sdk-10.0.100-preview.2.25102.3-osx-arm64.tar.gz not found
	Downloading dotnet archive...
	dotnet archive URL https://dotnetcli.azureedge.net/dotnet/Sdk/10.0.100-preview.2.25102.3/dotnet-dev-osx-arm64.10.0.100-preview.2.25102.3.tar.gz not found
	Downloading dotnet archive...
	Warning: Failed to obtain dotnet archive size. HTTP status code: InternalServerError (500)
	Downloading dotnet archive...
	Warning: Failed to obtain dotnet archive size. HTTP status code: InternalServerError (500)
	  Error: Installation of dotnet SDK '10.0.100-preview.2.25102.3' failed.

	Step Xamarin.Android.Prepare.Step_InstallDotNetPreview failed
	System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_InstallDotNetPreview failed
	   at Xamarin.Android.Prepare.Scenario.Run(Context context, Log log) in /Users/builder/azdo/_work/8/s/xamarin-android/build-tools/xaprepare/xaprepare/Application/Scenario.cs:line 50
	   at Xamarin.Android.Prepare.Context.Execute() in /Users/builder/azdo/_work/8/s/xamarin-android/build-tools/xaprepare/xaprepare/Application/Context.cs:line 488
	   at Xamarin.Android.Prepare.App.Run(String[] args) in /Users/builder/azdo/_work/8/s/xamarin-android/build-tools/xaprepare/xaprepare/Main.cs:line 155

Indeed, [`dotnet-sdk-10.0.100-preview.2.25102.3-osx-arm64.tar.gz`][0]
no longer exists on <https://dotnetcli.azureedge.net>.

The problem, though, is that .NET changed the CDN that is used in the
past month, and that's not the correct URL.  A newer `dotnet-install.sh`
reports:

	% bash "…/dotnet-install.sh" "--version" "10.0.100-preview.2.25102.3" "--install-dir" "/Volumes/Xamarin-Work/src/dotnet/android/bin/Release/dotnet" "--verbose" "--dry-run
	…
	dotnet-install: Link 0: primary, 10.0.100-preview.2.25102.3, https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25102.3/dotnet-sdk-10.0.100-preview.2.25102.3-osx-x64.tar.gz
	dotnet-install: Link 1: legacy, 10.0.100-preview.2.25102.3, https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.2.25102.3/dotnet-dev-osx-x64.10.0.100-preview.2.25102.3.tar.gz
	dotnet-install: Link 2: primary, 10.0.100-preview.2.25102.3, https://ci.dot.net/public/Sdk/10.0.100-preview.2.25102.3/dotnet-sdk-10.0.100-preview.2.25102.3-osx-x64.tar.gz
	dotnet-install: Link 3: legacy, 10.0.100-preview.2.25102.3, https://ci.dot.net/public/Sdk/10.0.100-preview.2.25102.3/dotnet-dev-osx-x64.10.0.100-preview.2.25102.3.tar.gz

Note the different domain, <https://builds.dotnet.microsoft.com>!

Update `Step_InstallDotNetPreview` to try to install .NET potentially
*twice*: the first time using the cached `dotnet-install.sh`, and
*if that fails*, it tries again after downloading a *new*
`dotnet-install.sh`.

Hopefully this will fix the build failure on this machine!

[0]: https://dotnetcli.azureedge.net/dotnet/Sdk/10.0.100-preview.2.25102.3/dotnet-sdk-10.0.100-preview.2.25102.3-osx-arm64.tar.gz