### PR TITLE
[LLVM IR] Add support for Unicode strings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
@@ -203,6 +203,8 @@ namespace Xamarin.Android.Tasks
 
 		protected override void Construct (LlvmIrModule module)
 		{
+			module.DefaultStringGroup = "env";
+
 			MapStructures (module);
 
 			module.AddGlobalVariable ("format_tag", FORMAT_TAG, comment: $" 0x{FORMAT_TAG:x}");
@@ -211,7 +213,7 @@ namespace Xamarin.Android.Tasks
 			var envVars = new LlvmIrGlobalVariable (environmentVariables, "app_environment_variables") {
 				Comment = " Application environment variables array, name:value",
 			};
-			module.Add (envVars, stringGroupName: "env", stringGroupComment: " Application environment variables name:value pairs");
+			module.Add (envVars, stringGroupName: "env.var", stringGroupComment: " Application environment variables name:value pairs");
 
 			var sysProps = new LlvmIrGlobalVariable (systemProperties, "app_system_properties") {
 				Comment = " System properties defined by the application",

--- a/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssembliesNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssembliesNativeAssemblyGenerator.cs
@@ -149,6 +149,8 @@ namespace Xamarin.Android.Tasks
 
 		protected override void Construct (LlvmIrModule module)
 		{
+			module.DefaultStringGroup = "cas";
+
 			MapStructures (module);
 
 			InitCompressedAssemblies (

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JniRemappingAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JniRemappingAssemblyGenerator.cs
@@ -284,6 +284,8 @@ namespace Xamarin.Android.Tasks
 
 		protected override void Construct (LlvmIrModule module)
 		{
+			module.DefaultStringGroup = "jremap";
+
 			MapStructures (module);
 			List<StructureInstance<JniRemappingTypeReplacementEntry>>? typeReplacements;
 			List<StructureInstance<JniRemappingIndexTypeEntry>>? methodIndexTypes;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		public LlvmIrModule Construct ()
 		{
-			var module = new LlvmIrModule (cache);
+			var module = new LlvmIrModule (cache, Log);
 			Construct (module);
 			module.AfterConstruction ();
 			constructed = true;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -205,7 +205,10 @@ namespace Xamarin.Android.Tasks.LLVMIR
 						WriteCommentLine (context, $" '{info.Value}'");
 					}
 
-					WriteGlobalVariableStart (context, info);
+					WriteGlobalVariableName (context, info);
+
+					// Strings must always be local symbols, global variables will point to them
+					WriteVariableOptions (context, LlvmIrVariableOptions.LocalString);
 					context.Output.Write ('[');
 					context.Output.Write (size.ToString (CultureInfo.InvariantCulture));
 					context.Output.Write ($" x {info.IrType}] ");
@@ -253,7 +256,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			}
 		}
 
-		void WriteGlobalVariableStart (GeneratorWriteContext context, LlvmIrGlobalVariable variable)
+		void WriteGlobalVariableName (GeneratorWriteContext context, LlvmIrGlobalVariable variable)
 		{
 			if (!String.IsNullOrEmpty (variable.Comment)) {
 				WriteCommentLine (context, variable.Comment);
@@ -261,13 +264,27 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			context.Output.Write ('@');
 			context.Output.Write (variable.Name);
 			context.Output.Write (" = ");
+		}
 
-			LlvmIrVariableOptions options = variable.Options ?? LlvmIrGlobalVariable.DefaultOptions;
+		void WriteVariableOptions (GeneratorWriteContext context, LlvmIrVariableOptions options)
+		{
 			WriteLinkage (context, options.Linkage);
 			WritePreemptionSpecifier (context, options.RuntimePreemption);
 			WriteVisibility (context, options.Visibility);
 			WriteAddressSignificance (context, options.AddressSignificance);
 			WriteWritability (context, options.Writability);
+		}
+
+		void WriteVariableOptions (GeneratorWriteContext context, LlvmIrGlobalVariable variable, LlvmIrVariableOptions? defaultOptions = null)
+		{
+			LlvmIrVariableOptions options = variable.Options ?? defaultOptions ?? LlvmIrGlobalVariable.DefaultOptions;
+			WriteVariableOptions (context, options);
+		}
+
+		void WriteGlobalVariableStart (GeneratorWriteContext context, LlvmIrGlobalVariable variable)
+		{
+			WriteGlobalVariableName (context, variable);
+			WriteVariableOptions (context, variable, LlvmIrGlobalVariable.DefaultOptions);
 		}
 
 		void WriteGlobalVariable (GeneratorWriteContext context, LlvmIrGlobalVariable variable)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -326,11 +326,20 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				throw new InvalidOperationException ($"Internal error: variable '{variable.Name}'' of type {variable.Type} must not have a null value");
 			}
 
-			if (valueType != variable.Type && !LlvmIrModule.NameValueArrayType.IsAssignableFrom (variable.Type)) {
+			if (!IsValueAssignableFrom (valueType, variable) && !IsValueAssignableFrom (LlvmIrModule.NameValueArrayType, variable)) {
 				throw new InvalidOperationException ($"Internal error: variable type '{variable.Type}' is different to its value type, '{valueType}'");
 			}
 
 			WriteValue (context, valueType, variable);
+		}
+
+		bool IsValueAssignableFrom (Type valueType, LlvmIrVariable variable)
+		{
+			if (valueType != typeof(string) && valueType != typeof(StringHolder)) {
+				return valueType.IsAssignableFrom (variable.Type);
+			}
+
+			return variable.Type == typeof(string) || variable.Type == typeof(StringHolder);
 		}
 
 		ulong GetAggregateValueElementCount (GeneratorWriteContext context, LlvmIrVariable variable) => GetAggregateValueElementCount (context, variable.Type, variable.Value, variable as LlvmIrGlobalVariable);
@@ -717,7 +726,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				return;
 			}
 
-			if (type == typeof(string)) {
+			if (type == typeof(string) || type == typeof(StringHolder)) {
 				if (value == null) {
 					context.Output.Write ("null");
 					return;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrInstructions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrInstructions.cs
@@ -366,8 +366,8 @@ sealed class LlvmIrInstructions
 				throw new InvalidOperationException ($"Internal error: value type '{value.GetType ()}' for argument {index} to function '{function.Signature.Name}' is invalid. Expected '{parameter.Type}' or compatible");
 			}
 
-			if (value is string str) {
-				context.Output.Write (context.Module.LookupRequiredVariableForString (str).Reference);
+			if (value is string || value is StringHolder) {
+				context.Output.Write (context.Module.LookupRequiredVariableForString (StringHolder.AsHolder (value)).Reference);
 				return;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
@@ -267,10 +267,19 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		/// </summary>
 		public LlvmIrGlobalVariable AddGlobalVariable (Type type, string name, object? value, LlvmIrVariableOptions? options = null, string? comment = null)
 		{
-			var ret = new LlvmIrGlobalVariable (type, name, options) {
-				Value = value,
-				Comment = comment,
-			};
+			LlvmIrGlobalVariable ret;
+			if (type == typeof(string)) {
+				// The cast to `string?` is intentionally meant to throw if `value` type isn't a string.
+				ret = new LlvmIrStringVariable (name, new StringHolder ((string?)value)) {
+					Comment = comment,
+				};
+			} else {
+				ret = new LlvmIrGlobalVariable (type, name, options) {
+					Value = value,
+					Comment = comment,
+				};
+			}
+
 			Add (ret);
 			return ret;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
@@ -273,14 +273,15 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				ret = new LlvmIrStringVariable (name, new StringHolder ((string?)value)) {
 					Comment = comment,
 				};
+				AddStringGlobalVariable ((LlvmIrStringVariable)ret);
 			} else {
 				ret = new LlvmIrGlobalVariable (type, name, options) {
 					Value = value,
 					Comment = comment,
 				};
+				Add (ret);
 			}
 
-			Add (ret);
 			return ret;
 		}
 
@@ -401,19 +402,29 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			globalVariables.Add (variable);
 		}
 
+		void EnsureStringManager ()
+		{
+			if (stringManager == null) {
+				stringManager = new LlvmIrStringManager (log);
+			}
+		}
+
 		void AddStringGlobalVariable (LlvmIrStringVariable variable, string? stringGroupName = null, string? stringGroupComment = null, string? symbolSuffix = null)
 		{
-			RegisterString ((string)variable.Value, stringGroupName, stringGroupComment, symbolSuffix, variable.Encoding);
+			RegisterString (variable, stringGroupName, stringGroupComment, symbolSuffix);
 			AddStandardGlobalVariable (variable);
+		}
+
+		public void RegisterString (LlvmIrStringVariable variable, string? stringGroupName = null, string? stringGroupComment = null, string? symbolSuffix = null)
+		{
+			EnsureStringManager ();
+			stringManager.Add (variable, stringGroupName, stringGroupComment, symbolSuffix);
 		}
 
 		public void RegisterString (string value, string? stringGroupName = null, string? stringGroupComment = null, string? symbolSuffix = null,
 			LlvmIrStringEncoding encoding = LlvmIrStringEncoding.UTF8, StringComparison comparison = StringComparison.Ordinal)
 		{
-			if (stringManager == null) {
-				stringManager = new LlvmIrStringManager (log);
-			}
-
+			EnsureStringManager ();
 			stringManager.Add (value, stringGroupName, stringGroupComment, symbolSuffix, encoding, comparison);
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
@@ -272,7 +272,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			LlvmIrGlobalVariable ret;
 			if (type == typeof(string)) {
 				// The cast to `string?` is intentionally meant to throw if `value` type isn't a string.
-				ret = new LlvmIrStringVariable (name, new StringHolder ((string?)value)) {
+				ret = new LlvmIrStringVariable (name, new StringHolder ((string?)value), options) {
 					Comment = comment,
 				};
 				AddStringGlobalVariable ((LlvmIrStringVariable)ret);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
@@ -49,6 +49,8 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		public readonly LlvmIrTypeCache TypeCache;
 
+		public string? DefaultStringGroup { get; set; }
+
 		public LlvmIrModule (LlvmIrTypeCache cache, TaskLoggingHelper log)
 		{
 			this.log = log;
@@ -405,7 +407,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		void EnsureStringManager ()
 		{
 			if (stringManager == null) {
-				stringManager = new LlvmIrStringManager (log);
+				stringManager = new LlvmIrStringManager (log, DefaultStringGroup);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrStringEncoding.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrStringEncoding.cs
@@ -1,0 +1,7 @@
+namespace Xamarin.Android.Tasks.LLVMIR;
+
+enum LlvmIrStringEncoding
+{
+	UTF8,
+	Unicode,
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrStringManager.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrStringManager.cs
@@ -26,6 +26,12 @@ partial class LlvmIrModule
 			stringGroups.Add (defaultGroup);
 		}
 
+		public LlvmIrStringVariable Add (LlvmIrStringVariable variable, string? groupName = null, string? groupComment = null, string? symbolSuffix = null)
+		{
+			// Let it throw if Value isn't a StringHolder, it must be.
+			return Add((StringHolder)variable.Value, groupName, groupComment, symbolSuffix);
+		}
+
 		public LlvmIrStringVariable Add (string value, string? groupName = null, string? groupComment = null, string? symbolSuffix = null,
 			LlvmIrStringEncoding encoding = LlvmIrStringEncoding.UTF8, StringComparison comparison = StringComparison.Ordinal)
 		{
@@ -33,7 +39,11 @@ partial class LlvmIrModule
 				throw new ArgumentNullException (nameof (value));
 			}
 
-			var holder = new StringHolder (value, encoding, comparison);
+			return Add (new StringHolder (value, encoding, comparison), groupName, groupComment, symbolSuffix);
+		}
+
+		LlvmIrStringVariable Add (StringHolder holder, string? groupName = null, string? groupComment = null, string? symbolSuffix = null)
+		{
 			if (stringSymbolCache.TryGetValue (holder, out LlvmIrStringVariable? stringVar) && stringVar != null) {
 				return stringVar;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrStringManager.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrStringManager.cs
@@ -9,6 +9,8 @@ partial class LlvmIrModule
 {
 	protected class LlvmIrStringManager
 	{
+		readonly string defaultGroupName = "str";
+
 		Dictionary<StringHolder, LlvmIrStringVariable> stringSymbolCache = new Dictionary<StringHolder, LlvmIrStringVariable> ();
 		Dictionary<string, LlvmIrStringGroup> stringGroupCache = new Dictionary<string, LlvmIrStringGroup> (StringComparer.Ordinal);
 		List<LlvmIrStringGroup> stringGroups = new List<LlvmIrStringGroup> ();
@@ -18,9 +20,13 @@ partial class LlvmIrModule
 
 		public List<LlvmIrStringGroup> StringGroups => stringGroups;
 
-		public LlvmIrStringManager (TaskLoggingHelper log)
+		public LlvmIrStringManager (TaskLoggingHelper log, string? defaultStringGroup = null)
 		{
 			this.log = log;
+			if (!String.IsNullOrEmpty (defaultStringGroup)) {
+				defaultGroupName = defaultStringGroup;
+			}
+
 			defaultGroup = new LlvmIrStringGroup ();
 			stringGroupCache.Add (String.Empty, defaultGroup);
 			stringGroups.Add (defaultGroup);
@@ -52,7 +58,7 @@ partial class LlvmIrModule
 			string groupPrefix;
 			if (String.IsNullOrEmpty (groupName) || String.Compare ("str", groupName, StringComparison.Ordinal) == 0) {
 				group = defaultGroup;
-				groupPrefix = ".str";
+				groupPrefix = $".{defaultGroupName}";
 			} else if (!stringGroupCache.TryGetValue (groupName, out group) || group == null) {
 				group = new LlvmIrStringGroup (groupComment ?? groupName);
 				stringGroups.Add (group);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrStringManager.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrStringManager.cs
@@ -1,35 +1,40 @@
 using System;
 using System.Collections.Generic;
 
+using Microsoft.Build.Utilities;
+
 namespace Xamarin.Android.Tasks.LLVMIR;
 
 partial class LlvmIrModule
 {
 	protected class LlvmIrStringManager
 	{
-		Dictionary<string, LlvmIrStringVariable> stringSymbolCache = new Dictionary<string, LlvmIrStringVariable> (StringComparer.Ordinal);
+		Dictionary<StringHolder, LlvmIrStringVariable> stringSymbolCache = new Dictionary<StringHolder, LlvmIrStringVariable> ();
 		Dictionary<string, LlvmIrStringGroup> stringGroupCache = new Dictionary<string, LlvmIrStringGroup> (StringComparer.Ordinal);
 		List<LlvmIrStringGroup> stringGroups = new List<LlvmIrStringGroup> ();
 
 		LlvmIrStringGroup defaultGroup;
+		TaskLoggingHelper log;
 
 		public List<LlvmIrStringGroup> StringGroups => stringGroups;
 
-		public LlvmIrStringManager ()
+		public LlvmIrStringManager (TaskLoggingHelper log)
 		{
+			this.log = log;
 			defaultGroup = new LlvmIrStringGroup ();
 			stringGroupCache.Add (String.Empty, defaultGroup);
 			stringGroups.Add (defaultGroup);
 		}
 
-		public LlvmIrStringVariable Add (string value, string? groupName = null, string? groupComment = null, string? symbolSuffix = null)
+		public LlvmIrStringVariable Add (string value, string? groupName = null, string? groupComment = null, string? symbolSuffix = null,
+			LlvmIrStringEncoding encoding = LlvmIrStringEncoding.UTF8, StringComparison comparison = StringComparison.Ordinal)
 		{
 			if (value == null) {
 				throw new ArgumentNullException (nameof (value));
 			}
 
-			LlvmIrStringVariable? stringVar;
-			if (stringSymbolCache.TryGetValue (value, out stringVar) && stringVar != null) {
+			var holder = new StringHolder (value, encoding, comparison);
+			if (stringSymbolCache.TryGetValue (holder, out LlvmIrStringVariable? stringVar) && stringVar != null) {
 				return stringVar;
 			}
 
@@ -52,14 +57,14 @@ partial class LlvmIrModule
 				symbolName = $"{symbolName}_{symbolSuffix}";
 			}
 
-			stringVar = new LlvmIrStringVariable (symbolName, value);
+			stringVar = new LlvmIrStringVariable (symbolName, holder);
 			group.Strings.Add (stringVar);
-			stringSymbolCache.Add (value, stringVar);
+			stringSymbolCache.Add (holder, stringVar);
 
 			return stringVar;
 		}
 
-		public LlvmIrStringVariable? Lookup (string value)
+		public LlvmIrStringVariable? Lookup (StringHolder value)
 		{
 			if (stringSymbolCache.TryGetValue (value, out LlvmIrStringVariable? sv)) {
 				return sv;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrVariable.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrVariable.cs
@@ -301,8 +301,8 @@ class LlvmIrStringVariable : LlvmIrGlobalVariable
 	public string IrType { get; }
 	public bool IsConstantStringLiteral { get; }
 
-	public LlvmIrStringVariable (string name, StringHolder value)
-		: base (typeof(string), name, LlvmIrVariableOptions.LocalString)
+	public LlvmIrStringVariable (string name, StringHolder value, LlvmIrVariableOptions? options = null)
+		: base (typeof(string), name, options ?? LlvmIrVariableOptions.GlobalConstexprString)
 	{
 		Value = value;
 		Encoding = value.Encoding;
@@ -322,8 +322,8 @@ class LlvmIrStringVariable : LlvmIrGlobalVariable
 		}
 	}
 
-	public LlvmIrStringVariable (string name, string value, LlvmIrStringEncoding encoding, StringComparison comparison = StringComparison.Ordinal)
-		: this (name, new StringHolder (value, encoding, comparison))
+	public LlvmIrStringVariable (string name, string value, LlvmIrStringEncoding encoding, StringComparison comparison = StringComparison.Ordinal, LlvmIrVariableOptions? options = null)
+		: this (name, new StringHolder (value, encoding, comparison), options)
 	{}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrVariable.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrVariable.cs
@@ -302,7 +302,7 @@ class LlvmIrStringVariable : LlvmIrGlobalVariable
 	public bool IsConstantStringLiteral { get; }
 
 	public LlvmIrStringVariable (string name, StringHolder value, LlvmIrVariableOptions? options = null)
-		: base (typeof(string), name, options ?? LlvmIrVariableOptions.GlobalConstexprString)
+		: base (typeof(string), name, options ?? LlvmIrVariableOptions.GlobalConstantStringPointer)
 	{
 		Value = value;
 		Encoding = value.Encoding;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrVariable.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrVariable.cs
@@ -297,11 +297,34 @@ class LlvmIrGlobalVariable : LlvmIrVariable
 
 class LlvmIrStringVariable : LlvmIrGlobalVariable
 {
-	public LlvmIrStringVariable (string name, string value)
+	public LlvmIrStringEncoding Encoding { get; }
+	public string IrType { get; }
+	public bool IsConstantStringLiteral { get; }
+
+	public LlvmIrStringVariable (string name, StringHolder value)
 		: base (typeof(string), name, LlvmIrVariableOptions.LocalString)
 	{
 		Value = value;
+		Encoding = value.Encoding;
+
+		switch (value.Encoding) {
+			case LlvmIrStringEncoding.UTF8:
+				IrType = "i8";
+				IsConstantStringLiteral = true;
+				break;
+
+			case LlvmIrStringEncoding.Unicode:
+				IrType = "i16";
+				break;
+
+			default:
+				throw new InvalidOperationException ($"Internal error: unsupported string encoding {value.Encoding}");
+		}
 	}
+
+	public LlvmIrStringVariable (string name, string value, LlvmIrStringEncoding encoding, StringComparison comparison = StringComparison.Ordinal)
+		: this (name, new StringHolder (value, encoding, comparison))
+	{}
 }
 
 /// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/MemberInfoUtilities.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/MemberInfoUtilities.cs
@@ -34,6 +34,28 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			return true;
 		}
 
+		public static bool IsUnicodeString (this MemberInfo mi, LlvmIrTypeCache cache)
+		{
+			var attr = cache.GetNativeAssemblerAttribute (mi);
+			if (attr == null) {
+				return false;
+			}
+
+			return attr.IsUTF16;
+		}
+
+		public static LlvmIrStringEncoding GetStringEncoding (this MemberInfo mi, LlvmIrTypeCache cache)
+		{
+			const LlvmIrStringEncoding DefaultStringEncoding = LlvmIrStringEncoding.UTF8;
+
+			var attr = cache.GetNativeAssemblerAttribute (mi);
+			if (attr == null) {
+				return DefaultStringEncoding;
+			}
+
+			return attr.IsUTF16 ? LlvmIrStringEncoding.Unicode : DefaultStringEncoding;
+		}
+
 		public static bool ShouldBeIgnored (this MemberInfo mi, LlvmIrTypeCache cache)
 		{
 			var attr = cache.GetNativeAssemblerAttribute (mi);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/NativeAssemblerAttribute.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/NativeAssemblerAttribute.cs
@@ -35,6 +35,12 @@ namespace Xamarin.Android.Tasks
 		public bool NeedsPadding     { get; set; }
 
 		public LLVMIR.LlvmIrVariableNumberFormat NumberFormat { get; set; } = LLVMIR.LlvmIrVariableNumberFormat.Default;
+
+		/// <summary>
+		/// Taken into account only for fields of string types.  If set to <c>true</c>, the string is output as an UTF16 in
+		/// the native assembly file.
+		/// </summary>
+		public bool IsUTF16 { get; set; }
 	}
 
 	[AttributeUsage (AttributeTargets.Class, Inherited = true)]

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/StringHolder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/StringHolder.cs
@@ -34,15 +34,7 @@ class StringHolder : IComparable, IComparable<StringHolder>, IEquatable<StringHo
 		return holder;
 	}
 
-	public int CompareTo (object obj)
-	{
-		var holder = obj as StringHolder;
-		if (holder == null) {
-			return 1;
-		}
-
-		return CompareTo (holder);
-	}
+	public int CompareTo (object obj) => CompareTo (obj as StringHolder);
 
 	public int CompareTo (StringHolder? other)
 	{
@@ -83,15 +75,7 @@ class StringHolder : IComparable, IComparable<StringHolder>, IEquatable<StringHo
 		return hc ^ Encoding.GetHashCode ();
 	}
 
-	public override bool Equals (object obj)
-	{
-		var holder = obj as StringHolder;
-		if (holder == null) {
-			return false;
-		}
-
-		return Equals (holder);
-	}
+	public override bool Equals (object obj) => Equals (obj as StringHolder);
 
 	public bool Equals (StringHolder? other)
 	{
@@ -103,22 +87,22 @@ class StringHolder : IComparable, IComparable<StringHolder>, IEquatable<StringHo
 	}
 
 	public static bool operator > (StringHolder a, StringHolder b)
-        {
-                return a.CompareTo (b) > 0;
-        }
+	{
+		return a.CompareTo (b) > 0;
+	}
 
-        public static bool operator < (StringHolder a, StringHolder b)
-        {
-                return a.CompareTo (b) < 0;
-        }
+	public static bool operator < (StringHolder a, StringHolder b)
+	{
+		return a.CompareTo (b) < 0;
+	}
 
-        public static bool operator >= (StringHolder a, StringHolder b)
-        {
-                return a.CompareTo (b) >= 0;
-        }
+	public static bool operator >= (StringHolder a, StringHolder b)
+	{
+		return a.CompareTo (b) >= 0;
+	}
 
-        public static bool operator <= (StringHolder a, StringHolder b)
-        {
-                return a.CompareTo (b) <= 0;
-        }
+	public static bool operator <= (StringHolder a, StringHolder b)
+	{
+		return a.CompareTo (b) <= 0;
+	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/StringHolder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/StringHolder.cs
@@ -1,0 +1,124 @@
+using System;
+
+namespace Xamarin.Android.Tasks.LLVMIR;
+
+class StringHolder : IComparable, IComparable<StringHolder>, IEquatable<StringHolder>
+{
+	public LlvmIrStringEncoding Encoding { get; }
+	public string? Data { get; }
+
+	StringComparison comparison;
+
+	public StringHolder (string? data, LlvmIrStringEncoding encoding = LlvmIrStringEncoding.UTF8, StringComparison comparison = StringComparison.Ordinal)
+	{
+		Data = data;
+		Encoding = encoding;
+		this.comparison = comparison;
+	}
+
+	public static StringHolder AsHolder (object? value, LlvmIrStringEncoding encoding = LlvmIrStringEncoding.UTF8, StringComparison comparison = StringComparison.Ordinal)
+	{
+		if (value == null) {
+			return new StringHolder ((string)value);
+		}
+
+		StringHolder holder;
+		if (value is string) {
+			holder = new StringHolder ((string)value, encoding, comparison);
+		} else if (value is StringHolder) {
+			holder = (StringHolder)value;
+		} else {
+			throw new InvalidOperationException ($"Internal error: expected 'string' type, got '{value.GetType ()}' instead.");
+		}
+
+		return holder;
+	}
+
+	public int CompareTo (object obj)
+	{
+		var holder = obj as StringHolder;
+		if (holder == null) {
+			return 1;
+		}
+
+		return CompareTo (holder);
+	}
+
+	public int CompareTo (StringHolder? other)
+	{
+		if (other == null) {
+			return 1;
+		}
+
+		int encodingCompare = Encoding.CompareTo (other.Encoding);
+		if (Data == null) {
+			if (other.Data != null) {
+				// We are "smaller", because the other holder actually has a valid string
+				return -1;
+			}
+
+			// Both strings are null, so we care only about the encoding
+			return encodingCompare;
+		}
+
+		int dataCompare = other.Data == null ? Data.CompareTo (other.Data) : String.Compare (Data, other.Data, comparison);
+		// If encodings are identical, we compare strings, allowing any result of the comparisons
+		if (encodingCompare == 0) {
+			return dataCompare;
+		}
+
+		// However if encodings aren't the same, we mustn't allow Data comparison to return 0
+		// as the strings are **not** equal, even though their Data values are.  In this case,
+		// we fall back to encoding for comparison result.
+		return dataCompare != 0 ? dataCompare : encodingCompare;
+	}
+
+	public override int GetHashCode ()
+	{
+		int hc = 0;
+		if (Data != null) {
+			hc ^= Data.GetHashCode ();
+		}
+
+		return hc ^ Encoding.GetHashCode ();
+	}
+
+	public override bool Equals (object obj)
+	{
+		var holder = obj as StringHolder;
+		if (holder == null) {
+			return false;
+		}
+
+		return Equals (holder);
+	}
+
+	public bool Equals (StringHolder? other)
+	{
+		if (other == null || Encoding != other.Encoding) {
+			return false;
+		}
+
+		return String.Compare (Data, other.Data, comparison) == 0;
+	}
+
+	public static bool operator > (StringHolder a, StringHolder b)
+        {
+                return a.CompareTo (b) > 0;
+        }
+
+        public static bool operator < (StringHolder a, StringHolder b)
+        {
+                return a.CompareTo (b) < 0;
+        }
+
+        public static bool operator >= (StringHolder a, StringHolder b)
+        {
+                return a.CompareTo (b) >= 0;
+        }
+
+        public static bool operator <= (StringHolder a, StringHolder b)
+        {
+                return a.CompareTo (b) <= 0;
+        }
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
@@ -592,6 +592,8 @@ namespace Xamarin.Android.Tasks
 
 		protected override void Construct (LlvmIrModule module)
 		{
+			module.DefaultStringGroup = "mm";
+
 			MapStructures (module);
 
 			Init ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
@@ -129,6 +129,8 @@ namespace Xamarin.Android.Tasks
 
 		protected override void Construct (LlvmIrModule module)
 		{
+			module.DefaultStringGroup = "tmd";
+
 			MapStructures (module);
 
 			if (data.ManagedToJavaMap != null && data.ManagedToJavaMap.Count > 0) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingReleaseNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingReleaseNativeAssemblyGenerator.cs
@@ -189,6 +189,8 @@ namespace Xamarin.Android.Tasks
 
 		protected override void Construct (LlvmIrModule module)
 		{
+			module.DefaultStringGroup = "tmr";
+
 			MapStructures (module);
 
 			var cs = new ConstructionState ();


### PR DESCRIPTION
Another portion of code taken from https://github.com/dotnet/android/pull/9572 to make it smaller.

This adds support for Unicode strings to the LLVM IR generator, together with de-duplication and
support for outputting the same string encoded both as UTF-8 and Unicode.