### PR TITLE
[Xamarin.Android.Build.Tasks] use copilot to opt into NRT

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,107 @@
+# Instructions for AIs
+
+This repository is .NET for Android.
+
+This is the main branch targeting .NET 10.
+
+## Nullable Reference Types
+
+When opting C# code into nullable reference types:
+
+* Add `#nullable enable` at the top of the file.
+
+* Don't *ever* use `!` to handle `null`!
+
+* Declare variables non-nullable, and check for `null` at entry points.
+
+* Use `throw new ArgumentNullException (nameof (parameter))` in `netstandard2.0` projects.
+
+* Use `ArgumentNullException.ThrowIfNull (parameter)` in Android projects that will be .NET 10+.
+
+* `[Required]` properties in MSBuild task classes should always be non-nullable with a default value.
+
+* Non-`[Required]` properties should be nullable and have null-checks in C# code using them.
+
+* For MSBuild task properties like:
+
+```csharp
+public string NonRequiredProperty { get; set; }
+public ITaskItem [] NonRequiredItemGroup { get; set; }
+
+[Output]
+public string OutputProperty { get; set; }
+[Output]
+public ITaskItem [] OutputItemGroup { get; set; }
+
+[Required]
+public string RequiredProperty { get; set; }
+[Required]
+public ITaskItem [] RequiredItemGroup { get; set; }
+```
+
+Fix them such as:
+
+```csharp
+public string? NonRequiredProperty { get; set; }
+public ITaskItem []? NonRequiredItemGroup { get; set; }
+
+[Output]
+public string? OutputProperty { get; set; }
+[Output]
+public ITaskItem []? OutputItemGroup { get; set; }
+
+[Required]
+public string RequiredProperty { get; set; } = "";
+[Required]
+public ITaskItem [] RequiredItemGroup { get; set; } = [];
+```
+
+If you see a `string.IsNullOrEmpty()` check:
+
+```csharp
+if (!string.IsNullOrEmpty (NonRequiredProperty)) {
+    // Code here
+}
+```
+
+Convert this to:
+
+```csharp
+if (NonRequiredProperty is { Length: > 0 }) {
+    // Code here
+}
+```
+
+## Formatting
+
+C# code uses tabs (not spaces) and the Mono code-formatting style defined in `.editorconfig`
+
+* Your mission is to make diffs as absolutely as small as possible, preserving existing code formatting.
+
+* If you encounter additional spaces or formatting within existing code blocks, LEAVE THEM AS-IS.
+
+* If you encounter code comments, LEAVE THEM AS-IS.
+
+* Place a space prior to any parentheses `(` or `[`
+
+* Use `""` for empty string and *not* `string.Empty`
+
+* Use `[]` for empty arrays and *not* `Array.Empty<T>()`
+
+Examples of properly formatted code:
+
+```csharp
+Foo ();
+Bar (1, 2, "test");
+myarray [0] = 1;
+
+if (someValue) {
+    // Code here
+}
+
+try {
+    // Code here
+} catch (Exception e) {
+    // Code here
+}
+```

--- a/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Collections.Generic;
@@ -15,32 +17,32 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "DX8";
 
 		[Required]
-		public string JarPath { get; set; }
+		public string JarPath { get; set; } = "";
 
 		/// <summary>
 		/// Output for *.dex files. R8 can be invoked for just --main-dex-list-output, so this is not [Required]
 		/// </summary>
-		public string OutputDirectory { get; set; }
+		public string OutputDirectory { get; set; } = "";
 
 		/// <summary>
 		/// It is loaded to calculate --min-api, which is used by desugaring part to determine which levels of desugaring it performs.
 		/// </summary>
-		public string AndroidManifestFile { get; set; }
+		public string AndroidManifestFile { get; set; } = "";
 
 		// general d8 feature options.
 		public bool Debug { get; set; }
 		public bool EnableDesugar { get; set; } = true;
 
 		// Java libraries to embed or reference
-		public string ClassesZip { get; set; }
+		public string ClassesZip { get; set; } = "";
 		[Required]
-		public string JavaPlatformJarPath { get; set; }
-		public ITaskItem [] JavaLibrariesToEmbed { get; set; }
-		public ITaskItem [] AlternativeJarLibrariesToEmbed { get; set; }
-		public ITaskItem [] JavaLibrariesToReference { get; set; }
-		public ITaskItem [] MapDiagnostics { get; set; }
+		public string JavaPlatformJarPath { get; set; } = "";
+		public ITaskItem [] JavaLibrariesToEmbed { get; set; } = [];
+		public ITaskItem [] AlternativeJarLibrariesToEmbed { get; set; } = [];
+		public ITaskItem [] JavaLibrariesToReference { get; set; } = [];
+		public ITaskItem [] MapDiagnostics { get; set; } = [];
 
-		public string ExtraArguments { get; set; }
+		public string ExtraArguments { get; set; } = "";
 
 		protected override string GenerateCommandLineCommands ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
@@ -22,27 +22,27 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// Output for *.dex files. R8 can be invoked for just --main-dex-list-output, so this is not [Required]
 		/// </summary>
-		public string OutputDirectory { get; set; } = "";
+		public string? OutputDirectory { get; set; }
 
 		/// <summary>
 		/// It is loaded to calculate --min-api, which is used by desugaring part to determine which levels of desugaring it performs.
 		/// </summary>
-		public string AndroidManifestFile { get; set; } = "";
+		public string? AndroidManifestFile { get; set; }
 
 		// general d8 feature options.
 		public bool Debug { get; set; }
 		public bool EnableDesugar { get; set; } = true;
 
 		// Java libraries to embed or reference
-		public string ClassesZip { get; set; } = "";
+		public string? ClassesZip { get; set; }
 		[Required]
 		public string JavaPlatformJarPath { get; set; } = "";
-		public ITaskItem [] JavaLibrariesToEmbed { get; set; } = [];
-		public ITaskItem [] AlternativeJarLibrariesToEmbed { get; set; } = [];
-		public ITaskItem [] JavaLibrariesToReference { get; set; } = [];
-		public ITaskItem [] MapDiagnostics { get; set; } = [];
+		public ITaskItem []? JavaLibrariesToEmbed { get; set; }
+		public ITaskItem []? AlternativeJarLibrariesToEmbed { get; set; }
+		public ITaskItem []? JavaLibrariesToReference { get; set; }
+		public ITaskItem []? MapDiagnostics { get; set; }
 
-		public string ExtraArguments { get; set; } = "";
+		public string? ExtraArguments { get; set; }
 
 		protected override string GenerateCommandLineCommands ()
 		{
@@ -57,14 +57,14 @@ namespace Xamarin.Android.Tasks
 		{
 			var cmd = new CommandLineBuilder ();
 
-			if (!string.IsNullOrEmpty (JavaOptions)) {
+			if (JavaOptions is { Length: > 0 }) {
 				cmd.AppendSwitch (JavaOptions);
 			}
 			cmd.AppendSwitchIfNotNull ("-Xmx", JavaMaximumHeapSize);
 			cmd.AppendSwitchIfNotNull ("-classpath ", JarPath);
 			cmd.AppendSwitch (MainClass);
 
-			if (!string.IsNullOrEmpty (ExtraArguments))
+			if (ExtraArguments is { Length: > 0 })
 				cmd.AppendSwitch (ExtraArguments); // it should contain "--dex".
 			if (Debug)
 				cmd.AppendSwitch ("--debug");
@@ -72,7 +72,7 @@ namespace Xamarin.Android.Tasks
 				cmd.AppendSwitch ("--release");
 
 			//NOTE: if this is blank, we can omit --min-api in this call
-			if (!string.IsNullOrEmpty (AndroidManifestFile)) {
+			if (AndroidManifestFile is { Length: > 0 }) {
 				var doc = AndroidAppManifest.Load (AndroidManifestFile, MonoAndroidHelper.SupportedVersions);
 				if (doc.MinSdkVersion.HasValue) {
 					MinSdkVersion = doc.MinSdkVersion.Value;
@@ -92,7 +92,7 @@ namespace Xamarin.Android.Tasks
 				}
 			} else if (JavaLibrariesToEmbed != null) {
 				Log.LogDebugMessage ("  processing ClassesZip, JavaLibrariesToEmbed...");
-				if (!string.IsNullOrEmpty (ClassesZip) && File.Exists (ClassesZip)) {
+				if (ClassesZip is { Length: > 0 } && File.Exists (ClassesZip)) {
 					injars.Add (ClassesZip);
 				}
 				foreach (var jar in JavaLibrariesToEmbed) {
@@ -116,7 +116,7 @@ namespace Xamarin.Android.Tasks
 				foreach (var diagnostic in MapDiagnostics) {
 					var from = diagnostic.ItemSpec;
 					var to = diagnostic.GetMetadata ("To");
-					if (string.IsNullOrEmpty (from) || string.IsNullOrEmpty (to))
+					if (from is not { Length: > 0 } || to is not { Length: > 0 })
 						continue;
 					cmd.AppendSwitch ("--map-diagnostics");
 					cmd.AppendSwitch (from);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -23,18 +23,18 @@ namespace Xamarin.Android.Tasks
 
 		// multidex
 		public bool EnableMultiDex { get; set; }
-		public ITaskItem [] CustomMainDexListFiles { get; set; } = [];
-		public string MultiDexMainDexListFile { get; set; } = "";
+		public ITaskItem []? CustomMainDexListFiles { get; set; }
+		public string? MultiDexMainDexListFile { get; set; }
 
 		// proguard-like configuration settings
 		public bool EnableShrinking { get; set; } = true;
 		public bool IgnoreWarnings { get; set; }
-		public string AcwMapFile { get; set; } = "";
-		public string ProguardGeneratedReferenceConfiguration { get; set; } = "";
-		public string ProguardGeneratedApplicationConfiguration { get; set; } = "";
-		public string ProguardCommonXamarinConfiguration { get; set; } = "";
-		public string ProguardMappingFileOutput { get; set; } = "";
-		public string [] ProguardConfigurationFiles { get; set; } = [];
+		public string? AcwMapFile { get; set; }
+		public string? ProguardGeneratedReferenceConfiguration { get; set; }
+		public string? ProguardGeneratedApplicationConfiguration { get; set; }
+		public string? ProguardCommonXamarinConfiguration { get; set; }
+		public string? ProguardMappingFileOutput { get; set; }
+		public string []? ProguardConfigurationFiles { get; set; }
 
 		protected override string MainClass => "com.android.tools.r8.R8";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -17,22 +19,22 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "R8S";
 
 		[Required]
-		public string AndroidSdkBuildToolsPath { get; set; }
+		public string AndroidSdkBuildToolsPath { get; set; } = "";
 
 		// multidex
 		public bool EnableMultiDex { get; set; }
-		public ITaskItem [] CustomMainDexListFiles { get; set; }
-		public string MultiDexMainDexListFile { get; set; }
+		public ITaskItem [] CustomMainDexListFiles { get; set; } = [];
+		public string MultiDexMainDexListFile { get; set; } = "";
 
 		// proguard-like configuration settings
 		public bool EnableShrinking { get; set; } = true;
 		public bool IgnoreWarnings { get; set; }
-		public string AcwMapFile { get; set; }
-		public string ProguardGeneratedReferenceConfiguration { get; set; }
-		public string ProguardGeneratedApplicationConfiguration { get; set; }
-		public string ProguardCommonXamarinConfiguration { get; set; }
-		public string ProguardMappingFileOutput { get; set; }
-		public string [] ProguardConfigurationFiles { get; set; }
+		public string AcwMapFile { get; set; } = "";
+		public string ProguardGeneratedReferenceConfiguration { get; set; } = "";
+		public string ProguardGeneratedApplicationConfiguration { get; set; } = "";
+		public string ProguardCommonXamarinConfiguration { get; set; } = "";
+		public string ProguardMappingFileOutput { get; set; } = "";
+		public string [] ProguardConfigurationFiles { get; set; } = [];
 
 		protected override string MainClass => "com.android.tools.r8.R8";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -22,15 +22,15 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "RAT";
 
-		public string TargetPlatformVersion { get; set; } = "";
+		public string? TargetPlatformVersion { get; set; }
 
-		public string AndroidSdkPath { get; set; } = "";
+		public string? AndroidSdkPath { get; set; }
 
-		public string AndroidSdkBuildToolsVersion { get; set; } = "";
+		public string? AndroidSdkBuildToolsVersion { get; set; }
 
-		public string CommandLineToolsVersion { get; set; } = "";
+		public string? CommandLineToolsVersion { get; set; }
 
-		public string ProjectFilePath { get; set; } = "";
+		public string? ProjectFilePath { get; set; }
 
 		public string? SequencePointsMode { get; set; }
 
@@ -39,37 +39,37 @@ namespace Xamarin.Android.Tasks
 		public bool AndroidApplication { get; set; } = true;
 
 		[Output]
-		public string AndroidApiLevel { get; set; } = "";
+		public string? AndroidApiLevel { get; set; }
 
 		[Output]
 		public string? AndroidApiLevelName { get; set; }
 
 		[Output]
-		public string AndroidSdkBuildToolsPath { get; set; } = "";
+		public string? AndroidSdkBuildToolsPath { get; set; }
 
 		[Output]
-		public string AndroidSdkBuildToolsBinPath { get; set; } = "";
+		public string? AndroidSdkBuildToolsBinPath { get; set; }
 
 		[Output]
-		public string ZipAlignPath { get; set; } = "";
+		public string? ZipAlignPath { get; set; }
 
 		[Output]
-		public string AndroidSequencePointsMode { get; set; } = "";
+		public string? AndroidSequencePointsMode { get; set; }
 
 		[Output]
 		public string? LintToolPath { get; set; }
 
 		[Output]
-		public string ApkSignerJar { get; set; } = "";
+		public string? ApkSignerJar { get; set; }
 
 		[Output]
 		public bool AndroidUseApkSigner { get; set; }
 
 		[Output]
-		public string Aapt2Version { get; set; } = "";
+		public string? Aapt2Version { get; set; }
 
 		[Output]
-		public string Aapt2ToolPath { get; set; } = "";
+		public string? Aapt2ToolPath { get; set; }
 
 		protected static readonly bool IsWindows = Path.DirectorySeparatorChar == '\\';
 		protected static readonly string ZipAlign = IsWindows ? "zipalign.exe" : "zipalign";
@@ -90,7 +90,7 @@ namespace Xamarin.Android.Tasks
 			string toolsZipAlignPath = Path.Combine (AndroidSdkPath, "tools", ZipAlign);
 			bool findZipAlign = (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) && !File.Exists (toolsZipAlignPath);
 
-			var lintPaths = MonoAndroidHelper.AndroidSdk.GetCommandLineToolsPaths (CommandLineToolsVersion)
+			var lintPaths = MonoAndroidHelper.AndroidSdk.GetCommandLineToolsPaths (CommandLineToolsVersion ?? "")
 				.SelectMany (p => new[]{
 					p,
 					Path.Combine (p, "bin"),
@@ -104,7 +104,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			foreach (var dir in MonoAndroidHelper.AndroidSdk.GetBuildToolsPaths (AndroidSdkBuildToolsVersion)) {
+			foreach (var dir in MonoAndroidHelper.AndroidSdk.GetBuildToolsPaths (AndroidSdkBuildToolsVersion ?? "")) {
 				Log.LogDebugMessage ("Trying build-tools path: {0}", dir);
 				if (dir == null || !Directory.Exists (dir))
 					continue;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
@@ -20,54 +22,54 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "RAT";
 
-		public string TargetPlatformVersion { get; set; }
+		public string TargetPlatformVersion { get; set; } = "";
 
-		public string AndroidSdkPath { get; set; }
+		public string AndroidSdkPath { get; set; } = "";
 
-		public string AndroidSdkBuildToolsVersion { get; set; }
+		public string AndroidSdkBuildToolsVersion { get; set; } = "";
 
-		public string CommandLineToolsVersion { get; set; }
+		public string CommandLineToolsVersion { get; set; } = "";
 
-		public string ProjectFilePath { get; set; }
+		public string ProjectFilePath { get; set; } = "";
 
-		public string SequencePointsMode { get; set; }
+		public string? SequencePointsMode { get; set; }
 
 		public bool AotAssemblies { get; set; }
 
 		public bool AndroidApplication { get; set; } = true;
 
 		[Output]
-		public string AndroidApiLevel { get; set; }
+		public string AndroidApiLevel { get; set; } = "";
 
 		[Output]
-		public string AndroidApiLevelName { get; set; }
+		public string? AndroidApiLevelName { get; set; }
 
 		[Output]
-		public string AndroidSdkBuildToolsPath { get; set; }
+		public string AndroidSdkBuildToolsPath { get; set; } = "";
 
 		[Output]
-		public string AndroidSdkBuildToolsBinPath { get; set; }
+		public string AndroidSdkBuildToolsBinPath { get; set; } = "";
 
 		[Output]
-		public string ZipAlignPath { get; set; }
+		public string ZipAlignPath { get; set; } = "";
 
 		[Output]
-		public string AndroidSequencePointsMode { get; set; }
+		public string AndroidSequencePointsMode { get; set; } = "";
 
 		[Output]
-		public string LintToolPath { get; set; }
+		public string? LintToolPath { get; set; }
 
 		[Output]
-		public string ApkSignerJar { get; set; }
+		public string ApkSignerJar { get; set; } = "";
 
 		[Output]
 		public bool AndroidUseApkSigner { get; set; }
 
 		[Output]
-		public string Aapt2Version { get; set; }
+		public string Aapt2Version { get; set; } = "";
 
 		[Output]
-		public string Aapt2ToolPath { get; set; }
+		public string Aapt2ToolPath { get; set; } = "";
 
 		protected static readonly bool IsWindows = Path.DirectorySeparatorChar == '\\';
 		protected static readonly string ZipAlign = IsWindows ? "zipalign.exe" : "zipalign";
@@ -222,7 +224,7 @@ namespace Xamarin.Android.Tasks
 			// because the path to aapt2 is in the key and the value is a string.
 			var key = ($"{nameof (ResolveAndroidTooling)}.{nameof (Aapt2Version)}", aapt2Tool);
 			var cached = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.AppDomain) as string;
-			if (!string.IsNullOrEmpty (cached)) {
+			if (cached is { Length: > 0 }) {
 				Log.LogDebugMessage ($"Using cached value for {nameof (Aapt2Version)}: {cached}");
 				Aapt2Version = cached;
 				return true;
@@ -254,7 +256,10 @@ namespace Xamarin.Android.Tasks
 
 		protected int GetMaxStableApiLevel ()
 		{
-			return MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel;
+			var stableVersion = MonoAndroidHelper.SupportedVersions.MaxStableVersion;
+			if (stableVersion is null)
+				throw new ArgumentNullException ("MaxStableVersion");
+			return stableVersion.ApiLevel;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -47,9 +47,9 @@ namespace Xamarin.Android.Tasks
 		/// In Xamarin.Android, this is the path to ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v*.*\ that contains Mono.Android.dll
 		/// In .NET 6, this is dotnet\packs\Microsoft.Android.Sdk.Windows|Darwin\*\data\net6.0-android*\. Only contains AndroidApiInfo.xml
 		/// </summary>
-		public string [] ReferenceAssemblyPaths { get; set; } = [];
+		public string []? ReferenceAssemblyPaths { get; set; }
 
-		public string CommandLineToolsVersion { get; set; } = "";
+		public string? CommandLineToolsVersion { get; set; }
 
 		[Required]
 		public string MinimumSupportedJavaVersion   { get; set; } = "";
@@ -58,35 +58,35 @@ namespace Xamarin.Android.Tasks
 		public string LatestSupportedJavaVersion    { get; set; } = "";
 
 		[Output]
-		public string CommandLineToolsPath { get; set; } = "";
+		public string? CommandLineToolsPath { get; set; }
 
 		[Output]
-		public string AndroidNdkPath { get; set; } = "";
+		public string? AndroidNdkPath { get; set; }
 
 		[Output]
-		public string AndroidSdkPath { get; set; } = "";
+		public string? AndroidSdkPath { get; set; }
 
 		[Output]
-		public string JavaSdkPath { get; set; } = "";
+		public string? JavaSdkPath { get; set; }
 
 		[Output]
-		public string MonoAndroidToolsPath { get; set; } = "";
+		public string? MonoAndroidToolsPath { get; set; }
 
 		[Output]
-		public string MonoAndroidBinPath { get; set; } = "";
+		public string? MonoAndroidBinPath { get; set; }
 
 		[Output]
-		public string MonoAndroidLibPath { get; set; } = "";
+		public string? MonoAndroidLibPath { get; set; }
 
 		[Output]
-		public string AndroidBinUtilsPath { get; set; } = "";
+		public string? AndroidBinUtilsPath { get; set; }
 
 		public override bool RunTask ()
 		{
 			// OS X:    $prefix/lib/xamarin.android/xbuild/Xamarin/Android
 			// Windows: %ProgramFiles(x86)%\MSBuild\Xamarin\Android
 			if (string.IsNullOrEmpty (MonoAndroidToolsPath)) {
-				MonoAndroidToolsPath  = Path.GetDirectoryName (typeof (ResolveSdks).Assembly.Location) ?? "";
+				MonoAndroidToolsPath  = Path.GetDirectoryName (typeof (ResolveSdks).Assembly.Location);
 			}
 			MonoAndroidBinPath  = MonoAndroidHelper.GetOSBinPath () + Path.DirectorySeparatorChar;
 			MonoAndroidLibPath  = MonoAndroidHelper.GetOSLibPath () + Path.DirectorySeparatorChar;
@@ -95,7 +95,7 @@ namespace Xamarin.Android.Tasks
 			var minVersion      = Version.Parse (MinimumSupportedJavaVersion);
 			var maxVersion      = Version.Parse (LatestSupportedJavaVersion);
 
-			JavaSdkPath         = MonoAndroidHelper.GetJdkInfo (this.CreateTaskLogger (), JavaSdkPath, minVersion, maxVersion)?.HomePath ?? "";
+			JavaSdkPath         = MonoAndroidHelper.GetJdkInfo (this.CreateTaskLogger (), JavaSdkPath, minVersion, maxVersion)?.HomePath;
 
 			MonoAndroidHelper.RefreshSupportedVersions (ReferenceAssemblyPaths);
 
@@ -112,11 +112,11 @@ namespace Xamarin.Android.Tasks
 				return false;
 			}
 
-			AndroidNdkPath = MonoAndroidHelper.AndroidSdk.AndroidNdkPath ?? ""; // Allowed to be blank
+			AndroidNdkPath = MonoAndroidHelper.AndroidSdk.AndroidNdkPath;
 			AndroidSdkPath = MonoAndroidHelper.AndroidSdk.AndroidSdkPath;
 			JavaSdkPath    = MonoAndroidHelper.AndroidSdk.JavaSdkPath;
 
-			CommandLineToolsPath    = MonoAndroidHelper.AndroidSdk.GetCommandLineToolsPaths (CommandLineToolsVersion)
+			CommandLineToolsPath    = MonoAndroidHelper.AndroidSdk.GetCommandLineToolsPaths (CommandLineToolsVersion ?? "")
 				.FirstOrDefault () ??
 				Path.Combine (AndroidSdkPath, "tools");
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -1,3 +1,4 @@
+#nullable enable
 //
 // ResolveSdksTask.cs
 //
@@ -46,46 +47,46 @@ namespace Xamarin.Android.Tasks
 		/// In Xamarin.Android, this is the path to ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v*.*\ that contains Mono.Android.dll
 		/// In .NET 6, this is dotnet\packs\Microsoft.Android.Sdk.Windows|Darwin\*\data\net6.0-android*\. Only contains AndroidApiInfo.xml
 		/// </summary>
-		public string [] ReferenceAssemblyPaths { get; set; }
+		public string [] ReferenceAssemblyPaths { get; set; } = [];
 
-		public string CommandLineToolsVersion { get; set; }
-
-		[Required]
-		public string MinimumSupportedJavaVersion   { get; set; }
+		public string CommandLineToolsVersion { get; set; } = "";
 
 		[Required]
-		public string LatestSupportedJavaVersion    { get; set; }
+		public string MinimumSupportedJavaVersion   { get; set; } = "";
+
+		[Required]
+		public string LatestSupportedJavaVersion    { get; set; } = "";
 
 		[Output]
-		public string CommandLineToolsPath { get; set; }
+		public string CommandLineToolsPath { get; set; } = "";
 
 		[Output]
-		public string AndroidNdkPath { get; set; }
+		public string AndroidNdkPath { get; set; } = "";
 
 		[Output]
-		public string AndroidSdkPath { get; set; }
+		public string AndroidSdkPath { get; set; } = "";
 
 		[Output]
-		public string JavaSdkPath { get; set; }
+		public string JavaSdkPath { get; set; } = "";
 
 		[Output]
-		public string MonoAndroidToolsPath { get; set; }
+		public string MonoAndroidToolsPath { get; set; } = "";
 
 		[Output]
-		public string MonoAndroidBinPath { get; set; }
+		public string MonoAndroidBinPath { get; set; } = "";
 
 		[Output]
-		public string MonoAndroidLibPath { get; set; }
+		public string MonoAndroidLibPath { get; set; } = "";
 
 		[Output]
-		public string AndroidBinUtilsPath { get; set; }
+		public string AndroidBinUtilsPath { get; set; } = "";
 
 		public override bool RunTask ()
 		{
 			// OS X:    $prefix/lib/xamarin.android/xbuild/Xamarin/Android
 			// Windows: %ProgramFiles(x86)%\MSBuild\Xamarin\Android
 			if (string.IsNullOrEmpty (MonoAndroidToolsPath)) {
-				MonoAndroidToolsPath  = Path.GetDirectoryName (typeof (ResolveSdks).Assembly.Location);
+				MonoAndroidToolsPath  = Path.GetDirectoryName (typeof (ResolveSdks).Assembly.Location) ?? "";
 			}
 			MonoAndroidBinPath  = MonoAndroidHelper.GetOSBinPath () + Path.DirectorySeparatorChar;
 			MonoAndroidLibPath  = MonoAndroidHelper.GetOSLibPath () + Path.DirectorySeparatorChar;
@@ -94,7 +95,7 @@ namespace Xamarin.Android.Tasks
 			var minVersion      = Version.Parse (MinimumSupportedJavaVersion);
 			var maxVersion      = Version.Parse (LatestSupportedJavaVersion);
 
-			JavaSdkPath         = MonoAndroidHelper.GetJdkInfo (this.CreateTaskLogger (), JavaSdkPath, minVersion, maxVersion)?.HomePath;
+			JavaSdkPath         = MonoAndroidHelper.GetJdkInfo (this.CreateTaskLogger (), JavaSdkPath, minVersion, maxVersion)?.HomePath ?? "";
 
 			MonoAndroidHelper.RefreshSupportedVersions (ReferenceAssemblyPaths);
 
@@ -111,7 +112,7 @@ namespace Xamarin.Android.Tasks
 				return false;
 			}
 
-			AndroidNdkPath = MonoAndroidHelper.AndroidSdk.AndroidNdkPath;
+			AndroidNdkPath = MonoAndroidHelper.AndroidSdk.AndroidNdkPath ?? ""; // Allowed to be blank
 			AndroidSdkPath = MonoAndroidHelper.AndroidSdk.AndroidSdkPath;
 			JavaSdkPath    = MonoAndroidHelper.AndroidSdk.JavaSdkPath;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RuntimeIdentifierToAbi.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RuntimeIdentifierToAbi.cs
@@ -15,12 +15,12 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "RIAB";
 
-		public string RuntimeIdentifier { get; set; } = "";
+		public string? RuntimeIdentifier { get; set; }
 
-		public string [] RuntimeIdentifiers { get; set; } = [];
+		public string []? RuntimeIdentifiers { get; set; }
 
 		[Output]
-		public string SupportedAbis { get; set; } = "";
+		public string? SupportedAbis { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RuntimeIdentifierToAbi.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RuntimeIdentifierToAbi.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Android.Build.Tasks;
@@ -13,12 +15,12 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "RIAB";
 
-		public string RuntimeIdentifier { get; set; }
+		public string RuntimeIdentifier { get; set; } = "";
 
-		public string [] RuntimeIdentifiers { get; set; }
+		public string [] RuntimeIdentifiers { get; set; } = [];
 
 		[Output]
-		public string SupportedAbis { get; set; }
+		public string SupportedAbis { get; set; } = "";
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/SetNdkPathForIlc.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/SetNdkPathForIlc.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.IO;
 using Microsoft.Android.Build.Tasks;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
@@ -17,13 +17,13 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "VJV";
 
-		public string JavaSdkPath { get; set; } = "";
+		public string? JavaSdkPath { get; set; }
 
 		public string? JavaToolExe { get; set; }
 
 		public string? JavacToolExe { get; set; }
 
-		public string TargetPlatformVersion { get; set; } = "";
+		public string? TargetPlatformVersion { get; set; }
 
 		[Required]
 		public string LatestSupportedJavaVersion { get; set; } = "";
@@ -38,10 +38,10 @@ namespace Xamarin.Android.Tasks
 		public bool UseJavaExeVersion { get; set; } = true;
 
 		[Output]
-		public string MinimumRequiredJdkVersion { get; set; } = "";
+		public string? MinimumRequiredJdkVersion { get; set; }
 
 		[Output]
-		public string JdkVersion { get; set; } = "";
+		public string? JdkVersion { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.IO;
 using System.Text;
@@ -15,19 +17,19 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "VJV";
 
-		public string JavaSdkPath { get; set; }
+		public string JavaSdkPath { get; set; } = "";
 
-		public string JavaToolExe { get; set; }
+		public string? JavaToolExe { get; set; }
 
-		public string JavacToolExe { get; set; }
+		public string? JavacToolExe { get; set; }
 
-		public string TargetPlatformVersion { get; set; }
-
-		[Required]
-		public string LatestSupportedJavaVersion { get; set; }
+		public string TargetPlatformVersion { get; set; } = "";
 
 		[Required]
-		public string MinimumSupportedJavaVersion { get; set; }
+		public string LatestSupportedJavaVersion { get; set; } = "";
+
+		[Required]
+		public string MinimumSupportedJavaVersion { get; set; } = "";
 
 		/// <summary>
 		/// If true use the old method of calling `java -version` and `javac -version`
@@ -36,10 +38,10 @@ namespace Xamarin.Android.Tasks
 		public bool UseJavaExeVersion { get; set; } = true;
 
 		[Output]
-		public string MinimumRequiredJdkVersion { get; set; }
+		public string MinimumRequiredJdkVersion { get; set; } = "";
 
 		[Output]
-		public string JdkVersion { get; set; }
+		public string JdkVersion { get; set; } = "";
 
 		public override bool RunTask ()
 		{
@@ -101,7 +103,7 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		protected Version GetVersionFromTool (string javaExe, Regex versionRegex)
+		protected Version? GetVersionFromTool (string javaExe, Regex versionRegex)
 		{
 			// New code path, reads directly from `release` text file
 			if (!UseJavaExeVersion && GetVersionFromFile (javaExe, out var version)) {
@@ -130,7 +132,7 @@ namespace Xamarin.Android.Tasks
 			});
 			var versionInfo = sb.ToString ();
 			var versionNumberMatch = versionRegex.Match (versionInfo);
-			Version versionNumber;
+			Version? versionNumber;
 			if (versionNumberMatch.Success && Version.TryParse (versionNumberMatch.Groups ["version"]?.Value, out versionNumber)) {
 				BuildEngine4.RegisterTaskObject (key, versionNumber, RegisteredTaskObjectLifetime.AppDomain, allowEarlyCollection: false);
 				JdkVersion = versionNumberMatch.Groups ["version"].Value;
@@ -156,7 +158,7 @@ namespace Xamarin.Android.Tasks
 			using var stream = File.OpenRead (path);
 			using var reader = new StreamReader (stream);
 
-			string line;
+			string? line;
 			while ((line = reader.ReadLine ()) != null) {
 				const string JAVA_VERSION = "JAVA_VERSION=\"";
 				int index = line.IndexOf (JAVA_VERSION, StringComparison.OrdinalIgnoreCase);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Nullable.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Nullable.cs
@@ -1,0 +1,88 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xamarin.Android.Tools;
+
+#if MSBUILD
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+#endif
+
+namespace Xamarin.Android.Tasks;
+
+public partial class MonoAndroidHelper
+{
+	public static string GetExecutablePath (string? dir, string exe)
+	{
+		if (dir is not { Length: > 0 })
+			return exe;
+		foreach (var e in Executables (exe))
+			if (File.Exists (Path.Combine (dir, e)))
+				return e;
+		return exe;
+	}
+
+	public static IEnumerable<string> Executables (string executable)
+	{
+		var pathExt = Environment.GetEnvironmentVariable ("PATHEXT");
+		var pathExts = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+
+		if (pathExts is not null) {
+			foreach (var ext in pathExts)
+				yield return Path.ChangeExtension (executable, ext);
+		}
+		yield return executable;
+	}
+
+	public static JdkInfo? GetJdkInfo (Action<TraceLevel, string> logger, string? javaSdkPath, Version minSupportedVersion, Version maxSupportedVersion)
+	{
+		JdkInfo? info = null;
+		try {
+			info = new JdkInfo (javaSdkPath ?? "", logger:logger);
+		} catch {
+			info = JdkInfo.GetKnownSystemJdkInfos (logger)
+				.Where (jdk => jdk.Version >= minSupportedVersion && jdk.Version <= maxSupportedVersion)
+				.FirstOrDefault ();
+		}
+		return info;
+	}
+
+#if MSBUILD
+	public static void RefreshAndroidSdk (string? sdkPath, string? ndkPath, string? javaPath, TaskLoggingHelper? logHelper = null)
+	{
+		Action<TraceLevel, string> logger = (level, value) => {
+			var log = logHelper;
+			switch (level) {
+			case TraceLevel.Error:
+				if (log == null)
+					Console.Error.Write (value);
+				else
+					log.LogCodedError ("XA5300", "{0}", value);
+				break;
+			case TraceLevel.Warning:
+				if (log == null)
+					Console.WriteLine (value);
+				else
+					log.LogCodedWarning ("XA5300", "{0}", value);
+				break;
+			default:
+				if (log == null)
+					Console.WriteLine (value);
+				else
+					log.LogDebugMessage ("{0}", value);
+				break;
+			}
+		};
+		AndroidSdk  = new AndroidSdkInfo (logger, sdkPath, ndkPath, javaPath);
+	}
+
+	public static void RefreshSupportedVersions (string[]? referenceAssemblyPaths)
+	{
+		SupportedVersions   = new AndroidVersions (referenceAssemblyPaths ?? []);
+	}
+#endif  // MSBUILD
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -179,54 +179,6 @@ namespace Xamarin.Android.Tasks
 			return Path.Combine (toolsDir, "lib", $"host-{uname.Value}");
 		}
 
-#if MSBUILD
-		public static void RefreshAndroidSdk (string sdkPath, string ndkPath, string javaPath, TaskLoggingHelper logHelper = null)
-		{
-			Action<TraceLevel, string> logger = (level, value) => {
-				var log = logHelper;
-				switch (level) {
-				case TraceLevel.Error:
-					if (log == null)
-						Console.Error.Write (value);
-					else
-						log.LogCodedError ("XA5300", "{0}", value);
-					break;
-				case TraceLevel.Warning:
-					if (log == null)
-						Console.WriteLine (value);
-					else
-						log.LogCodedWarning ("XA5300", "{0}", value);
-					break;
-				default:
-					if (log == null)
-						Console.WriteLine (value);
-					else
-						log.LogDebugMessage ("{0}", value);
-					break;
-				}
-			};
-			AndroidSdk  = new AndroidSdkInfo (logger, sdkPath, ndkPath, javaPath);
-		}
-
-		public static void RefreshSupportedVersions (string[] referenceAssemblyPaths)
-		{
-			SupportedVersions   = new AndroidVersions (referenceAssemblyPaths);
-		}
-#endif  // MSBUILD
-
-		public static JdkInfo GetJdkInfo (Action<TraceLevel, string> logger, string javaSdkPath, Version minSupportedVersion, Version maxSupportedVersion)
-		{
-			JdkInfo info = null;
-			try {
-				info = new JdkInfo (javaSdkPath, logger:logger);
-			} catch {
-				info = JdkInfo.GetKnownSystemJdkInfos (logger)
-					.Where (jdk => jdk.Version >= minSupportedVersion && jdk.Version <= maxSupportedVersion)
-					.FirstOrDefault ();
-			}
-			return info;
-		}
-
 		class SizeAndContentFileComparer : IEqualityComparer<FileInfo>
 #if MSBUILD
 			, IEqualityComparer<ITaskItem>
@@ -511,29 +463,6 @@ namespace Xamarin.Android.Tasks
 				// On the other hand, xbuild has a bug and fails to parse '=' in the value, so we skip JAVA_TOOL_OPTIONS on Mono runtime.
 				new string [] { proguardHomeVariable, "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8" };
 		}
-
-		public static string GetExecutablePath (string dir, string exe)
-		{
-			if (string.IsNullOrEmpty (dir))
-				return exe;
-			foreach (var e in Executables (exe))
-				if (File.Exists (Path.Combine (dir, e)))
-					return e;
-			return exe;
-		}
-
-		public static IEnumerable<string> Executables (string executable)
-		{
-			var pathExt = Environment.GetEnvironmentVariable ("PATHEXT");
-			var pathExts = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
-
-			if (pathExts != null) {
-				foreach (var ext in pathExts)
-					yield return Path.ChangeExtension (executable, ext);
-			}
-			yield return executable;
-		}
-
 
 #if MSBUILD
 		public static string TryGetAndroidJarPath (TaskLoggingHelper log, string platform, bool designTimeBuild = false, bool buildingInsideVisualStudio = false, string targetFramework = "", string androidSdkDirectory = "")


### PR DESCRIPTION
Context: https://code.visualstudio.com/docs/copilot/copilot-customization

We have various MSBuild tasks that have not enabled C# nullable reference types. This is a bit tedious to do, so I tried VS Code Insiders and GitHub Copilot "Edits" to do this work. I did this for just a few files for now.

I introduced a new file `.github/copilot-instructions.md` to keep copilot from going off the rails! I mostly had to fight it to respect our code formatting, not delete comments, etc.

I would recommend the settings:

    "github.copilot.chat.codeGeneration.useInstructionFiles": true,
    "github.copilot.chat.codeGeneration.instructions": [
        {
          "file": ".editorconfig"
        },
        {
            "file": "README.md"
        }
    ],

* `github.copilot.chat.codeGeneration.useInstructionFiles`: enables the use of `.github/copilot-instructions.md`

* `github.copilot.chat.codeGeneration.instructions`: attaches `.editorconfig` and `README.md` so copilot has general context about this repo.

In the end it did a decent job, but I had to manually fix a few things.