### PR TITLE
[Mono.Android] pass in `Context` at startup

### DIFF
--- a/src/Mono.Android/Android.App/Application.cs
+++ b/src/Mono.Android/Android.App/Application.cs
@@ -14,16 +14,16 @@ namespace Android.App {
 				if (_context != null)
 					return _context;
 
-				IntPtr klass = JNIEnv.FindClass ("mono/MonoPackageManager");
-				try {
-					IntPtr field  = JNIEnv.GetStaticFieldID (klass, "Context", "Landroid/content/Context;");
-					IntPtr lref   = JNIEnv.GetStaticObjectField (klass, field);
-					return _context = Java.Lang.Object.GetObject<Context> (lref, JniHandleOwnership.TransferLocalRef)!;
-				} finally {
-					JNIEnv.DeleteGlobalRef (klass);
-				}
+				var lref = ContextHandle;
+				if (lref == IntPtr.Zero)
+					throw new InvalidOperationException ("Application.ContextHandle is not set!");
+					
+				return _context = Java.Lang.Object.GetObject<Context> (lref, JniHandleOwnership.TransferLocalRef)!;
 			}
+			internal set => _context = value;
 		}
+
+		internal static IntPtr ContextHandle { get; set; }
 
 		static SyncContext? _sync;
 		public static SynchronizationContext SynchronizationContext {

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -32,6 +32,7 @@ namespace Android.Runtime
 			public bool            jniRemappingInUse;
 			public bool            marshalMethodsEnabled;
 			public IntPtr          grefGCUserPeerable;
+			public IntPtr          applicationContext;
 		}
 #pragma warning restore 0649
 
@@ -92,6 +93,7 @@ namespace Android.Runtime
 
 			Logger.SetLogCategories ((LogCategories)args->logCategories);
 
+			Android.App.Application.ContextHandle = args->applicationContext;
 			gref_gc_threshold = args->grefGcThreshold;
 
 			jniRemappingInUse = args->jniRemappingInUse;

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -24,8 +24,6 @@ public class MonoPackageManager {
 	static Object lock = new Object ();
 	static boolean initialized;
 
-	static android.content.Context Context;
-
 	public static void LoadApplication (Context context)
 	{
 		synchronized (lock) {
@@ -40,9 +38,6 @@ public class MonoPackageManager {
 				apks = new String[] { runtimePackage.sourceDir };
 			}
 
-			if (context instanceof android.app.Application) {
-				Context = context;
-			}
 			if (!initialized) {
 				android.content.IntentFilter timezoneChangedFilter  = new android.content.IntentFilter (
 						android.content.Intent.ACTION_TIMEZONE_CHANGED
@@ -126,7 +121,8 @@ public class MonoPackageManager {
 						loader,
 						MonoPackageManager_Resources.Assemblies,
 						isEmulator (),
-						haveSplitApks
+						haveSplitApks,
+						context
 					);
 
 				net.dot.android.ApplicationRegistration.registerApplications ();

--- a/src/java-runtime/java/mono/android/Runtime.java
+++ b/src/java-runtime/java/mono/android/Runtime.java
@@ -25,7 +25,8 @@ public class Runtime {
 		ClassLoader loader,
 		String[] assemblies,
 		boolean isEmulator,
-		boolean haveSplitApks
+		boolean haveSplitApks,
+		android.content.Context context
 	);
 	public static native void register (String managedType, java.lang.Class nativeClass, String methods);
 	public static native void notifyTimeZoneChanged ();

--- a/src/native/mono/monodroid/mono_android_Runtime.h
+++ b/src/native/mono/monodroid/mono_android_Runtime.h
@@ -21,7 +21,7 @@ JNIEXPORT void JNICALL Java_mono_android_Runtime_init
  * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;ILjava/lang/ClassLoader;[Ljava/lang/String;IZZ)V
  */
 JNIEXPORT void JNICALL Java_mono_android_Runtime_initInternal
-  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jint, jobject, jobjectArray, jboolean, jboolean);
+  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jint, jobject, jobjectArray, jboolean, jboolean, jobject);
 
 /*
  * Class:     mono_android_Runtime

--- a/src/native/mono/monodroid/monodroid-glue-internal.hh
+++ b/src/native/mono/monodroid/monodroid-glue-internal.hh
@@ -101,6 +101,7 @@ namespace xamarin::android::internal
 			bool            jniRemappingInUse;
 			bool            marshalMethodsEnabled;
 			jobject         grefGCUserPeerable;
+			jobject         applicationContext;
 		};
 
 		using jnienv_initialize_fn = void (*) (JnienvInitializeArgs*);
@@ -119,7 +120,7 @@ namespace xamarin::android::internal
 		static void Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
 		                                             jstring runtimeNativeLibDir, jobjectArray appDirs, jint localDateTimeOffset,
 		                                             jobject loader, jobjectArray assembliesJava, jboolean isEmulator,
-		                                             jboolean haveSplitApks) noexcept;
+		                                             jboolean haveSplitApks, jobject context) noexcept;
 
 		static jint Java_JNI_OnLoad (JavaVM *vm, void *reserved) noexcept;
 
@@ -185,7 +186,7 @@ namespace xamarin::android::internal
 		static void set_debug_options () noexcept;
 		static void parse_gdb_options () noexcept;
 		static void mono_runtime_init (JNIEnv *env, dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN>& runtime_args) noexcept;
-		static void init_android_runtime (JNIEnv *env, jclass runtimeClass, jobject loader) noexcept;
+		static void init_android_runtime (JNIEnv *env, jclass runtimeClass, jobject loader, jobject context) noexcept;
 		static void set_environment_variable_for_directory (const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode) noexcept;
 
 		static void set_environment_variable_for_directory (const char *name, jstring_wrapper &value) noexcept
@@ -205,7 +206,7 @@ namespace xamarin::android::internal
 		static MonoDomain* create_and_initialize_domain (JNIEnv* env, jclass runtimeClass, jstring_array_wrapper &runtimeApks,
 		                                          jstring_array_wrapper &assemblies, jobjectArray assembliesBytes, jstring_array_wrapper &assembliesPaths,
 		                                          jobject loader, bool is_root_domain, bool force_preload_assemblies,
-		                                          bool have_split_apks) noexcept;
+		                                          bool have_split_apks, jobject context) noexcept;
 
 		static void gather_bundled_assemblies (jstring_array_wrapper &runtimeApks, size_t *out_user_assemblies_count, bool have_split_apks) noexcept;
 		static bool should_register_file (const char *filename);


### PR DESCRIPTION
Calling `Android.App.Application.Context` currently reads the `mono.MonoPackageManager.Context` field, which is set on startup by a `ContentProvider`. `mono.MonoPackageManager` does not exist in NativeAOT (or CoreCLR), so let's approach this differently.

Each `ContentProvider` can pass in the context to `JNIEnvInit` on startup, then the first call to `Android.App.Application.Context` does not have to read a field any longer as we already have the handle in managed code.