### PR TITLE
[Xamarin.Android.Build.Tasks] temporarily support .NET 8 in .NET 10

### DIFF
--- a/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
+++ b/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
@@ -36,12 +36,12 @@ about the various Microsoft.Android workloads.
     <ReplaceFileContents
         SourceFile="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.NET.Sdk.Android\WorkloadManifest.in.json"
         DestinationFile="$(WorkloadManifestJsonPath)"
-        Replacements="@WORKLOAD_VERSION@=$(WorkloadVersion);@NET_PREVIOUS_VERSION@=$(AndroidNetPreviousVersion)">
+        Replacements="@WORKLOAD_VERSION@=$(WorkloadVersion);@NET_PREVIOUS_VERSION@=$(AndroidNetPreviousVersion);@NET8_PREVIOUS_VERSION@=$(AndroidNet8PreviousVersion)">
     </ReplaceFileContents>
     <ReplaceFileContents
         SourceFile="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.NET.Sdk.Android\WorkloadManifest.in.targets"
         DestinationFile="$(WorkloadManifestTargetsPath)"
-        Replacements="@NET_PREVIOUS_VERSION@=$(AndroidNetPreviousVersion)">
+        Replacements="@NET_PREVIOUS_VERSION@=$(AndroidNetPreviousVersion);@NET8_PREVIOUS_VERSION@=$(AndroidNet8PreviousVersion)">
     </ReplaceFileContents>
 
     <ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,6 +15,8 @@
     <!-- Previous .NET Android version -->
     <MicrosoftAndroidSdkWindowsPackageVersion>35.0.24</MicrosoftAndroidSdkWindowsPackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftAndroidSdkWindowsPackageVersion)</AndroidNetPreviousVersion>
+    <!-- To be removed before .NET 10 GA -->
+    <AndroidNet8PreviousVersion>34.0.147</AndroidNet8PreviousVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -61,6 +61,19 @@
         "linux-arm64": "Microsoft.Android.Sdk.Linux"
       }
     },
+    "Microsoft.Android.Sdk.net8": {
+      "kind": "sdk",
+      "version": "@NET8_PREVIOUS_VERSION@",
+      "alias-to": {
+        "osx-x64": "Microsoft.Android.Sdk.Darwin",
+        "osx-arm64": "Microsoft.Android.Sdk.Darwin",
+        "win-x86": "Microsoft.Android.Sdk.Windows",
+        "win-x64": "Microsoft.Android.Sdk.Windows",
+        "win-arm64": "Microsoft.Android.Sdk.Windows",
+        "linux-x64": "Microsoft.Android.Sdk.Linux",
+        "linux-arm64": "Microsoft.Android.Sdk.Linux"
+      }
+    },
     "Microsoft.Android.Ref.35": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -6,6 +6,7 @@
       "packs": [
         "Microsoft.Android.Sdk.net10",
         "Microsoft.Android.Sdk.net9",
+        "Microsoft.Android.Sdk.net8",
         "Microsoft.Android.Ref.35",
         "Microsoft.Android.Runtime.Mono.35.android-arm",
         "Microsoft.Android.Runtime.Mono.35.android-arm64",

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -15,6 +15,8 @@
       ],
       "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" ],
       "extends" : [ 
+        "microsoft-net-runtime-android-net8",
+        "microsoft-net-runtime-android-aot-net8",
         "microsoft-net-runtime-android-net9",
         "microsoft-net-runtime-android-aot-net9",
         "microsoft-net-runtime-android",

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
@@ -26,7 +26,7 @@
     />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0')) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) ">
     <SdkSupportedTargetPlatformIdentifier Include="android" DisplayName="Android" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
@@ -4,8 +4,10 @@
         Condition=" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '10.0')) " />
     <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.net9"
         Condition=" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '9.0')) " />
+    <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.net8"
+        Condition=" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) " />
     <Import Project="Eol.targets" Sdk="Microsoft.Android.Sdk.net10"
-        Condition=" $([MSBuild]::VersionLessThanOrEquals($(TargetFrameworkVersion), '8.0')) " />
+        Condition=" $([MSBuild]::VersionLessThanOrEquals($(TargetFrameworkVersion), '7.0')) " />
   </ImportGroup>
 
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '9.0')) ">
@@ -13,6 +15,14 @@
         Update="Microsoft.Android"
         LatestRuntimeFrameworkVersion="@NET_PREVIOUS_VERSION@"
         TargetingPackVersion="@NET_PREVIOUS_VERSION@"
+    />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
+    <KnownFrameworkReference
+        Update="Microsoft.Android"
+        LatestRuntimeFrameworkVersion="@NET8_PREVIOUS_VERSION@"
+        TargetingPackVersion="@NET8_PREVIOUS_VERSION@"
     />
   </ItemGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -47,6 +47,11 @@ namespace Xamarin.Android.Build.Tests
 
 		static readonly object[] DotNetPackTargetFrameworks = new object[] {
 			new object[] {
+				"net8.0",
+				"android",
+				34,
+			},
+			new object[] {
 				"net9.0",
 				"android",
 				35,
@@ -146,6 +151,11 @@ public class JavaSourceTest {
 
 		static readonly object[] DotNetTargetFrameworks = new object[] {
 			new object[] {
+				"net8.0",
+				"android",
+				34,
+			},
+			new object[] {
 				"net9.0",
 				"android",
 				35,
@@ -200,7 +210,7 @@ public class JavaSourceTest {
 			var apiLevel = (int)data[2];
 
 			//FIXME: will revisit this in a future PR
-			if (dotnetVersion == "net9.0") {
+			if (dotnetVersion != "net10.0") {
 				Assert.Ignore ("error NETSDK1185: The Runtime Pack for FrameworkReference 'Microsoft.Android.Runtime.34.android-arm' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.");
 			}
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -899,7 +899,7 @@ namespace UnnamedProject
 		[Category ("WearOS")]
 		public void DotNetInstallAndRunPreviousSdk (
 				[Values (false, true)] bool isRelease,
-				[Vlaues ("net8.0-android", "net9.0-android") string targetFramework)
+				[Values ("net8.0-android", "net9.0-android")] string targetFramework)
 		{
 			var proj = new XamarinFormsAndroidApplicationProject () {
 				TargetFramework = targetFramework,

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -897,10 +897,12 @@ namespace UnnamedProject
 
 		[Test]
 		[Category ("WearOS")]
-		public void DotNetInstallAndRunPreviousSdk ([Values (false, true)] bool isRelease)
+		public void DotNetInstallAndRunPreviousSdk (
+				[Values (false, true)] bool isRelease,
+				[Vlaues ("net8.0-android", "net9.0-android") string targetFramework)
 		{
 			var proj = new XamarinFormsAndroidApplicationProject () {
-				TargetFramework = "net9.0-android",
+				TargetFramework = targetFramework,
 				IsRelease = isRelease,
 				EnableDefaultItems = true,
 			};


### PR DESCRIPTION
Context: https://github.com/dotnet/android-libraries/issues/1084#issuecomment-2627870179
Context: https://aka.ms/maui-support-policy

dotnet/android-libraries needs to build with:

    <TargetFrameworks>net8.0-android;net10.0-android</TargetFrameworks>

Typically each .NET release, we only support N-1 `$(TargetFrameworks)` and import `Eol.targets` to emit an error message on older versions.

We can make some .NET workload changes to support .NET 8 in a .NET 10 SDK until .NET 8 goes out of support in May.

I also updated some MSBuild tests to ensure .NET 8 projects build & run.