### PR TITLE
[java-runtime] move `MonoPackageManager.Context` to `ApplicationRegistration`

### DIFF
--- a/samples/NativeAOT/NativeAotRuntimeProvider.java
+++ b/samples/NativeAOT/NativeAotRuntimeProvider.java
@@ -1,6 +1,7 @@
 package net.dot.jni.nativeaot;
 
 import android.util.Log;
+import net.dot.android.ApplicationRegistration;
 
 public class NativeAotRuntimeProvider
     extends android.content.ContentProvider
@@ -20,9 +21,12 @@ public class NativeAotRuntimeProvider
     @Override
     public void attachInfo(android.content.Context context, android.content.pm.ProviderInfo info) {
         Log.d(TAG, "NativeAotRuntimeProvider.attachInfo(): calling JavaInteropRuntime.init()…");
+        if (context instanceof android.app.Application) {
+            ApplicationRegistration.Context = context;
+        }
         JavaInteropRuntime.init();
         // NOTE: only required for custom applications
-        net.dot.android.ApplicationRegistration.registerApplications();
+        ApplicationRegistration.registerApplications();
         super.attachInfo (context, info);
     }
 

--- a/src/Mono.Android/Android.App/Application.cs
+++ b/src/Mono.Android/Android.App/Application.cs
@@ -14,7 +14,7 @@ namespace Android.App {
 				if (_context != null)
 					return _context;
 
-				IntPtr klass = JNIEnv.FindClass ("mono/MonoPackageManager");
+				IntPtr klass = JNIEnv.FindClass ("net/dot/android/ApplicationRegistration");
 				try {
 					IntPtr field  = JNIEnv.GetStaticFieldID (klass, "Context", "Landroid/content/Context;");
 					IntPtr lref   = JNIEnv.GetStaticObjectField (klass, field);

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -18,13 +18,12 @@ import android.util.Log;
 import mono.android.Runtime;
 import mono.android.DebugRuntime;
 import mono.android.BuildConfig;
+import net.dot.android.ApplicationRegistration;
 
 public class MonoPackageManager {
 
 	static Object lock = new Object ();
 	static boolean initialized;
-
-	static android.content.Context Context;
 
 	public static void LoadApplication (Context context)
 	{
@@ -41,7 +40,7 @@ public class MonoPackageManager {
 			}
 
 			if (context instanceof android.app.Application) {
-				Context = context;
+				ApplicationRegistration.Context = context;
 			}
 			if (!initialized) {
 				android.content.IntentFilter timezoneChangedFilter  = new android.content.IntentFilter (
@@ -129,7 +128,7 @@ public class MonoPackageManager {
 						haveSplitApks
 					);
 
-				net.dot.android.ApplicationRegistration.registerApplications ();
+				ApplicationRegistration.registerApplications ();
 
 				initialized = true;
 			}

--- a/src/java-runtime/java/net/dot/android/ApplicationRegistration.java
+++ b/src/java-runtime/java/net/dot/android/ApplicationRegistration.java
@@ -2,6 +2,8 @@ package net.dot.android;
 
 public class ApplicationRegistration {
 
+	public static android.content.Context Context;
+
 	public static void registerApplications ()
 	{
 		// REGISTER_APPLICATION_AND_INSTRUMENTATION_CLASSES_HERE		


### PR DESCRIPTION
Calling `Android.App.Application.Context` currently reads the `mono.MonoPackageManager.Context` field, which is set on startup by a `ContentProvider`. `mono.MonoPackageManager` does not exist in NativeAOT (or CoreCLR), so let's move the field to:

* `net.dot.android.ApplicationRegistration.Context`

The `ApplicationRegistration` class is already used in NativeAOT, so this can work for all of the runtimes.