### PR TITLE
[Xamarin.Android.Build.Tasks] move .NET 8 support to `android-net8` workload

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -124,6 +124,7 @@
       <_NuGetSources Include="$(OutputPath.TrimEnd('\'))" />
       <_PreviewPacks Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' " Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.$(AndroidLatestUnstableApiLevel).*.nupkg" />
       <_InstallArguments Include="android" />
+      <_InstallArguments Include="android-net8" />
       <_InstallArguments Include="android-$(AndroidLatestUnstableApiLevel)" Condition=" '@(_PreviewPacks->Count())' != '0' " />
       <_InstallArguments Include="--skip-manifest-update" />
       <_InstallArguments Include="--skip-sign-check" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -6,7 +6,6 @@
       "packs": [
         "Microsoft.Android.Sdk.net10",
         "Microsoft.Android.Sdk.net9",
-        "Microsoft.Android.Sdk.net8",
         "Microsoft.Android.Ref.35",
         "Microsoft.Android.Runtime.Mono.35.android-arm",
         "Microsoft.Android.Runtime.Mono.35.android-arm64",
@@ -15,13 +14,21 @@
         "Microsoft.Android.Templates"
       ],
       "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" ],
-      "extends" : [ 
-        "microsoft-net-runtime-android-net8",
-        "microsoft-net-runtime-android-aot-net8",
+      "extends" : [
         "microsoft-net-runtime-android-net9",
         "microsoft-net-runtime-android-aot-net9",
         "microsoft-net-runtime-android",
         "microsoft-net-runtime-android-aot"
+      ]
+    },
+    "android-net8": {
+      "description": ".NET SDK Workload for building .NET 8 Android applications.",
+      "packs": [ "Microsoft.Android.Sdk.net8" ],
+      "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" ],
+      "extends" : [
+        "android",
+        "microsoft-net-runtime-android-net8",
+        "microsoft-net-runtime-android-aot-net8"
       ]
     },
     "android-36": {


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9777

The problem with #9777, is it increases our install size by something like ~700MB with the following packs:

* Microsoft.Android.Sdk.[platform] x 1 (current platform)
* Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.[RID] x 4 RIDs
* Microsoft.NETCore.App.Runtime.Mono.[RID] x 4 RIDs

Some of .NET MAUI's CI machines are extremely tight on disk space, and we promptly filled the disk!

Let's move these packs to a new `android-net8` workload, which can be installed separately.

dotnet/android-libraries could simply install:

    dotnet workload install android-net8

Which would provision both `android` and `android-net8` workloads.