### PR TITLE
[build] Address CVE-2024-43485

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Irony" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.12.1" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.13.1" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.CodeDom" />
     <PackageReference Include="System.IO.Hashing" Version="$(SystemIOHashingPackageVersion)" />


### PR DESCRIPTION
Context: https://github.com/advisories/GHSA-8g4q-xg66-9fp4

Address CVE-2024-43485 by updating NuGet.ProjectModel to v6.13.1, which
brings in System.Text.Json v8.0.5.