### PR TITLE
[Mono.Android-Tests] Fix empty files issue.

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.OS/HandlerTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.OS/HandlerTest.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using Android.OS;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.RuntimeTests {
+
+	[TestFixture]
+	public class HandlerTest {
+
+		[Test]
+		public void RemoveDisposedInstance ()
+		{
+      using (var t = new HandlerThread ("RemoveDisposedInstance")) {
+        t.Start ();
+        using (var h = new Handler (t.Looper)) {
+    			var e = new ManualResetEvent (false);
+          Java.Lang.Runnable r = null;
+          r = new Java.Lang.Runnable (() => {
+            e.Set ();
+            r.Dispose ();
+          });
+          h.Post (r.Run);
+          e.WaitOne ();
+        }
+        
+        t.QuitSafely ();
+      }
+		}
+	}
+}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Localization/LocalizationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Localization/LocalizationTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Globalization;
+using System.Threading;
+using NUnit.Framework;
+
+namespace Xamarin.Android.RuntimeTests
+{
+	[TestFixture]
+	public class LocalizationTests
+	{
+		// https://bugzilla.xamarin.com/show_bug.cgi?id=31705
+		[Test]
+		public void EmbeddedResources_ShouldBeLocalized ()
+		{
+			CultureInfo culture = Thread.CurrentThread.CurrentCulture;
+			CultureInfo uiCulture = Thread.CurrentThread.CurrentUICulture;
+
+			Assert.AreEqual ("a", AppResources.String1, "Embedded string resource did not contain expected value.");
+
+			Thread.CurrentThread.CurrentCulture = new CultureInfo ("it-IT");
+			Thread.CurrentThread.CurrentUICulture = new CultureInfo ("it-IT");
+
+			Assert.AreEqual ("b", AppResources.String1,
+				"Embedded string resource did not contain expected value after changing CultureInfo.");
+
+			Thread.CurrentThread.CurrentCulture = culture;
+			Thread.CurrentThread.CurrentUICulture = uiCulture;
+		}
+	}
+}


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9758

While enabling new tests for `Mono.Android-Tests`, git somehow ate my files and made them all empty.  I fixed the ones that CI found but didn't notice the other empty files.

Add the content of these files back.

Verified on CI run that the 2 new tests are indeed being run and succeed.