### PR TITLE
[Xamarin.Android.Build.Tasks] unify `$(AndroidCodegenTarget)`

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -273,6 +273,9 @@ Possible values include:
   Xamarin.Android 6.1 or later. Xamarin.Android 6.1 and later bind
   `Mono.Android.dll` with this value.
 
+- **JavaInterop1**: experimental value, currently the default for the
+  NativeAOT runtime.
+
 The default value is `XAJavaInterop1`.
 
 ## AndroidCreatePackagePerAbi

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -40,8 +40,7 @@
     <!-- Bindings properties -->
     <!-- jar2xml is not supported -->
     <AndroidClassParser>class-parse</AndroidClassParser>
-    <!-- Anything other than XAJavaInterop1 is not supported -->
-    <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
+    <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' ">XAJavaInterop1</AndroidCodegenTarget>
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods Condition=" '$(AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods)' == '' ">true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
     <AndroidBoundInterfacesContainTypes Condition=" '$(AndroidBoundInterfacesContainTypes)' == '' ">true</AndroidBoundInterfacesContainTypes>
     <AndroidBoundInterfacesContainConstants Condition=" '$(AndroidBoundInterfacesContainConstants)' == '' ">true</AndroidBoundInterfacesContainConstants>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -12,7 +12,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
   <!-- Default property values for NativeAOT -->
   <PropertyGroup>
     <_AndroidRuntimePackRuntime>NativeAOT</_AndroidRuntimePackRuntime>
-    <_AndroidCodeGenerationTarget Condition=" '$(_AndroidCodeGenerationTarget)' == '' ">JavaInterop1</_AndroidCodeGenerationTarget>
+    <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">JavaInterop1</AndroidCodegenTarget>
     <!-- NativeAOT's targets currently gives an error about cross-compilation -->
     <DisableUnsupportedError Condition=" $([MSBuild]::IsOSPlatform('windows')) and '$(DisableUnsupportedError)' == '' ">true</DisableUnsupportedError>
   </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -47,7 +47,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == '' And '$(AndroidUseLatestPlatformSdk)' == 'False'">v5.0</TargetFrameworkVersion>
     <LangVersion Condition=" '$(LangVersion)' == '' ">8.0</LangVersion>
     <AndroidClassParser Condition=" '$(AndroidClassParser)' == '' ">jar2xml</AndroidClassParser>
-    <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
     <_AndroidIsBindingProject>True</_AndroidIsBindingProject>
   </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1508,7 +1508,7 @@ because xbuild doesn't support framework reference assemblies.
 
   <GenerateJavaStubs
       AndroidRuntime="$(_AndroidRuntime)"
-      CodeGenerationTarget="$(_AndroidCodeGenerationTarget)"
+      CodeGenerationTarget="$(AndroidCodegenTarget)"
       ResolvedAssemblies="@(_ResolvedAssemblies)"
       ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
       ErrorOnCustomJavaObject="$(AndroidErrorOnCustomJavaObject)"


### PR DESCRIPTION
dbb0b920 introduced `$(_AndroidCodeGenerationTarget)`, but I didn't notice that `$(AndroidCodegenTarget)` already exists!

Unify on `$(AndroidCodegenTarget)`, making the defaults:

* `$(AndroidCodegenTarget)=XAJavaInterop1` if blank, when not using NativeAOT

* `$(AndroidCodegenTarget)=JavaInterop1` if blank, when using NativeAOT