### PR TITLE
[XABT] Use precompiled `.dex` files when available.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -83,6 +83,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         IntermediateOutputPath="$(IntermediateOutputPath)"
         AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
         MapDiagnostics="@(_AndroidR8MapDiagnostics)"
+        DisablePrecompiledDex="$(_AndroidDisablePrecompiledDex)"
     />
     <D8
         Condition=" '$(_UseR8)' != 'True' "


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/9534

We already ship `.dex` versions for the 3 `.jar` files that get used in `dotnet new android`.

- `mono.android.dex`
- `java_runtime_net6.dex`
- `libSystem.Security.Cryptography.Native.Android.dex`

Today these `.dex` versions seem unused.  If we modify `D8` to look for a `foo.dex` next to any `foo.jar` it's asked to embed, we can use these precompiled `.dex` files instead.

Using them instead of the `.jar` variants appears to save ~1.7s on a FastDev build:

| Scenario (`_CompileToDalvik` target timings)        | PR      | main    |
| --------------- | ------- | ------- |
| Full            | 2.06 s  | 3.78 s  |
| NoChanges       | not run | not run |
| ChangeResource  | not run | not run |
| AddResource     | 1.96 s  | 3.73 s  |
| ChangeCSharp    | not run | not run |
| ChangeCSharpJLO | 1.99 s  | 3.8 s   |

Additionally provides `$(_AndroidDisablePrecompiledDex)` as an escape hatch.