### PR TITLE
[nativeaot] default to `$(PublishAotUsingRuntimePack)=true`

### DIFF
--- a/samples/NativeAOT/NativeAOT.csproj
+++ b/samples/NativeAOT/NativeAOT.csproj
@@ -11,9 +11,8 @@
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <!-- Default to arm64 device -->
     <RuntimeIdentifier>android-arm64</RuntimeIdentifier>
-    <!-- Current required properties for NativeAOT -->
+    <!-- Only property required to opt into NativeAOT -->
     <PublishAot>true</PublishAot>
-    <PublishAotUsingRuntimePack>true</PublishAotUsingRuntimePack>
   </PropertyGroup>
 
   <!-- Settings for CI -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -29,7 +29,7 @@
     <_AndroidRuntime Condition=" '$(PublishAot)' == 'true' and '$(UseMonoRuntime)' != 'true' ">NativeAOT</_AndroidRuntime>
     <_AndroidRuntime Condition=" '$(PublishAot)' != 'true' and '$(UseMonoRuntime)' != 'true' ">CoreCLR</_AndroidRuntime>
     <_AndroidRuntime Condition=" '$(_AndroidRuntime)' == '' ">MonoVM</_AndroidRuntime>
-    <PublishAotUsingRuntimePack Condition=" '$(PublishAotUsingRuntimePack)' == '' and '$(_AndroidRuntime)' == 'NativeAOT' ">true</PublishAotUsingRuntime>
+    <PublishAotUsingRuntimePack Condition=" '$(PublishAotUsingRuntimePack)' == '' and '$(_AndroidRuntime)' == 'NativeAOT' ">true</PublishAotUsingRuntimePack>
     <!-- HACK: make dotnet restore include Microsoft.NETCore.App.Runtime.NativeAOT.linux-bionic-arm64 -->
     <_IsPublishing Condition=" '$(_IsPublishing)' == '' and '$(_AndroidRuntime)' == 'NativeAOT' ">true</_IsPublishing>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -29,6 +29,7 @@
     <_AndroidRuntime Condition=" '$(PublishAot)' == 'true' and '$(UseMonoRuntime)' != 'true' ">NativeAOT</_AndroidRuntime>
     <_AndroidRuntime Condition=" '$(PublishAot)' != 'true' and '$(UseMonoRuntime)' != 'true' ">CoreCLR</_AndroidRuntime>
     <_AndroidRuntime Condition=" '$(_AndroidRuntime)' == '' ">MonoVM</_AndroidRuntime>
+    <PublishAotUsingRuntimePack Condition=" '$(PublishAotUsingRuntimePack)' == '' and '$(_AndroidRuntime)' == 'NativeAOT' ">true</PublishAotUsingRuntime>
     <!-- HACK: make dotnet restore include Microsoft.NETCore.App.Runtime.NativeAOT.linux-bionic-arm64 -->
     <_IsPublishing Condition=" '$(_IsPublishing)' == '' and '$(_AndroidRuntime)' == 'NativeAOT' ">true</_IsPublishing>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -133,7 +133,6 @@ namespace Xamarin.Android.Build.Tests
 				}
 			};
 			proj.SetProperty ("PublishAot", "true");
-			proj.SetProperty ("PublishAotUsingRuntimePack", "true");
 			proj.SetProperty ("AndroidNdkDirectory", AndroidNdkPath);
 			proj.SetProperty ("_ExtraTrimmerArgs", "--verbose");
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/blob/d4baff4c6847a413e6a9c60089edfff50611ea9b/dotnet/targets/Xamarin.Shared.Sdk.props#L192

`$(PublishAotUsingRuntimePack)` needs to be `true` for any NativeAOT scenario on mobile. This setting is more useful for desktop platforms, as you aren't cross-compiling anything. Desktop builds can potentially use the packs from the .NET SDK as the host and target match.

xamarin/xamarin-macios also defaults `$(PublishAotUsingRuntimePack)=true` when `$(PublishAot)=true`, so we should be safe to follow suit.