### PR TITLE
Switch more over to System.Text.Json

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -116,7 +116,6 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Mono.Options.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Mono.Options.pdb" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)MULTIDEX_JAR_LICENSE" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Newtonsoft.Json.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.Common.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.Configuration.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)NuGet.DependencyResolver.Core.dll" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Android.Tasks
 		};
 
 		[Required]
-		public string BaseZip { get; set; } = "";
+		public string BaseZip { get; set; }
 
 		public string? CustomBuildConfigFile { get; set; }
 
@@ -69,18 +69,18 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem []? MetaDataFiles { get; set; }
 
 		[Required]
-		public string Output { get; set; } = "";
+		public string Output { get; set; }
 
 		public string? UncompressedFileExtensions { get; set; }
 
-		string temp = "";
+		string temp;
 
 		public override bool RunTask ()
 		{
 			temp = Path.GetTempFileName ();
 			try {
 				var uncompressed = new List<string> (UncompressedByDefault);
-				if (UncompressedFileExtensions is { Length: > 0 }) {
+				if (!string.IsNullOrEmpty (UncompressedFileExtensions)) {
 					//NOTE: these are file extensions, that need converted to glob syntax
 					var split = UncompressedFileExtensions.Split (new char [] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries);
 					foreach (var extension in split) {
@@ -89,7 +89,7 @@ namespace Xamarin.Android.Tasks
 				}
 
 				JsonNode json = JsonNode.Parse ("{}")!;
-				if (CustomBuildConfigFile is { Length: > 0 } && File.Exists (CustomBuildConfigFile)) {
+				if (!string.IsNullOrEmpty (CustomBuildConfigFile) && File.Exists (CustomBuildConfigFile)) {
 					using Stream fs = File.OpenRead (CustomBuildConfigFile);
 					using JsonDocument doc = JsonDocument.Parse (fs, new JsonDocumentOptions { AllowTrailingCommas = true });
 					json = doc.RootElement.ToNode ();
@@ -131,7 +131,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("--modules ", string.Join (",", modules));
 			cmd.AppendSwitchIfNotNull ("--output ", Output);
 			cmd.AppendSwitchIfNotNull ("--config ", temp);
-			foreach (var file in MetaDataFiles ?? []) {
+			foreach (var file in MetaDataFiles ?? Array.Empty<ITaskItem> ()) {
 				cmd.AppendSwitch ($"--metadata-file={file.ItemSpec}");
 			}
 			return cmd;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -60,27 +60,27 @@ namespace Xamarin.Android.Tasks
 		};
 
 		[Required]
-		public string BaseZip { get; set; }
+		public string BaseZip { get; set; } = "";
 
-		public string CustomBuildConfigFile { get; set; }
+		public string? CustomBuildConfigFile { get; set; }
 
-		public string [] Modules { get; set; }
+		public string []? Modules { get; set; }
 
-		public ITaskItem [] MetaDataFiles { get; set; }
+		public ITaskItem []? MetaDataFiles { get; set; }
 
 		[Required]
-		public string Output { get; set; }
+		public string Output { get; set; } = "";
 
-		public string UncompressedFileExtensions { get; set; }
+		public string? UncompressedFileExtensions { get; set; }
 
-		string temp;
+		string temp = "";
 
 		public override bool RunTask ()
 		{
 			temp = Path.GetTempFileName ();
 			try {
 				var uncompressed = new List<string> (UncompressedByDefault);
-				if (!string.IsNullOrEmpty (UncompressedFileExtensions)) {
+				if (UncompressedFileExtensions is { Length: > 0 }) {
 					//NOTE: these are file extensions, that need converted to glob syntax
 					var split = UncompressedFileExtensions.Split (new char [] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries);
 					foreach (var extension in split) {
@@ -88,10 +88,11 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-				JsonNode json = JsonNode.Parse("{}");
-				if (!string.IsNullOrEmpty (CustomBuildConfigFile) && File.Exists (CustomBuildConfigFile)) {
+				JsonNode json = JsonNode.Parse ("{}")!;
+				if (CustomBuildConfigFile is { Length: > 0 } && File.Exists (CustomBuildConfigFile)) {
 					using Stream fs = File.OpenRead (CustomBuildConfigFile);
-					json = JsonNode.Parse (fs);
+					using JsonDocument doc = JsonDocument.Parse (fs, new JsonDocumentOptions { AllowTrailingCommas = true });
+					json = doc.RootElement.ToNode ();
 				}
 				var jsonAddition = new {
 					compression = new {
@@ -130,7 +131,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("--modules ", string.Join (",", modules));
 			cmd.AppendSwitchIfNotNull ("--output ", Output);
 			cmd.AppendSwitchIfNotNull ("--config ", temp);
-			foreach (var file in MetaDataFiles ?? Array.Empty<ITaskItem> ()) {
+			foreach (var file in MetaDataFiles ?? []) {
 				cmd.AppendSwitch ($"--metadata-file={file.ItemSpec}");
 			}
 			return cmd;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -1,7 +1,7 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -88,26 +88,24 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-				var json = JObject.FromObject (new { });
+				JsonNode json = JsonNode.Parse("{}");
 				if (!string.IsNullOrEmpty (CustomBuildConfigFile) && File.Exists (CustomBuildConfigFile)) {
-					using (StreamReader file = File.OpenText (CustomBuildConfigFile))
-					using (JsonTextReader reader = new JsonTextReader (file)) {
-						json = (JObject)JToken.ReadFrom(reader);
-					}
+					using Stream fs = File.OpenRead (CustomBuildConfigFile);
+					json = JsonNode.Parse (fs);
 				}
-				var jsonAddition = JObject.FromObject (new {
+				var jsonAddition = new {
 					compression = new {
 						uncompressedGlob = uncompressed,
 					}
-				});
-
-				var mergeSettings = new JsonMergeSettings () {
-					MergeArrayHandling = MergeArrayHandling.Union,
-					MergeNullValueHandling = MergeNullValueHandling.Ignore
 				};
-				json.Merge (jsonAddition, mergeSettings);
-				Log.LogDebugMessage ("BundleConfig.json: {0}", json);
-				File.WriteAllText (temp, json.ToString ());
+
+				var jsonAdditionDoc = JsonSerializer.SerializeToNode(jsonAddition);
+
+				var mergedJson = json.Merge(jsonAdditionDoc);
+				var output = mergedJson.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+
+				Log.LogDebugMessage ("BundleConfig.json: {0}", output);
+				File.WriteAllText (temp, output);
 
 				//NOTE: bundletool will not overwrite
 				if (File.Exists (Output))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -62,16 +62,16 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string BaseZip { get; set; }
 
-		public string? CustomBuildConfigFile { get; set; }
+		public string CustomBuildConfigFile { get; set; }
 
-		public string []? Modules { get; set; }
+		public string [] Modules { get; set; }
 
-		public ITaskItem []? MetaDataFiles { get; set; }
+		public ITaskItem [] MetaDataFiles { get; set; }
 
 		[Required]
 		public string Output { get; set; }
 
-		public string? UncompressedFileExtensions { get; set; }
+		public string UncompressedFileExtensions { get; set; }
 
 		string temp;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -99,10 +99,10 @@ namespace Xamarin.Android.Tasks
 					}
 				};
 
-				var jsonAdditionDoc = JsonSerializer.SerializeToNode(jsonAddition);
+				var jsonAdditionDoc = JsonSerializer.SerializeToNode (jsonAddition);
 
-				var mergedJson = json.Merge(jsonAdditionDoc);
-				var output = mergedJson.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+				var mergedJson = json.Merge (jsonAdditionDoc);
+				var output = mergedJson.ToJsonString (new JsonSerializerOptions { WriteIndented = true });
 
 				Log.LogDebugMessage ("BundleConfig.json: {0}", output);
 				File.WriteAllText (temp, output);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs
@@ -306,7 +306,7 @@ class MSBuildLoggingPomResolver : IProjectResolver
 	}
 }
 
-class MicrosoftNuGetPackageFinder
+partial class MicrosoftNuGetPackageFinder
 {
 	readonly PackageListFile? package_list;
 
@@ -319,7 +319,7 @@ class MicrosoftNuGetPackageFinder
 
 		try {
 			var json = File.ReadAllText (file);
-			package_list = JsonSerializer.Deserialize<PackageListFile> (json);
+			package_list = JsonSerializer.Deserialize<PackageListFile> (json, PackageListFileContext.Default.PackageListFile);
 		} catch (Exception ex) {
 			log.LogMessage ("There was an error reading 'microsoft-packages.json', Android NuGet suggestions will not be provided: {0}", ex);
 		}
@@ -343,6 +343,14 @@ class MicrosoftNuGetPackageFinder
 
 		[JsonPropertyName ("nugetId")]
 		public string? NuGetId { get; set; }
+	}
+
+	[JsonSourceGenerationOptions(WriteIndented = true)]
+	[JsonSerializable(typeof(PackageListFile))]
+	[JsonSerializable(typeof(List<Package>))]
+	[JsonSerializable(typeof(string))]
+	internal partial class PackageListFileContext : JsonSerializerContext
+	{
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs
@@ -11,7 +11,8 @@ using Java.Interop.Tools.Maven.Models;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using NuGet.ProjectModel;
 
 namespace Xamarin.Android.Tasks;
@@ -318,7 +319,7 @@ class MicrosoftNuGetPackageFinder
 
 		try {
 			var json = File.ReadAllText (file);
-			package_list = JsonConvert.DeserializeObject<PackageListFile> (json);
+			package_list = JsonSerializer.Deserialize<PackageListFile> (json);
 		} catch (Exception ex) {
 			log.LogMessage ("There was an error reading 'microsoft-packages.json', Android NuGet suggestions will not be provided: {0}", ex);
 		}
@@ -331,16 +332,16 @@ class MicrosoftNuGetPackageFinder
 
 	public class PackageListFile
 	{
-		[JsonProperty ("packages")]
+		[JsonPropertyName ("packages")]
 		public List<Package>? Packages { get; set; }
 	}
 
 	public class Package
 	{
-		[JsonProperty ("javaId")]
+		[JsonPropertyName ("javaId")]
 		public string? JavaId { get; set; }
 
-		[JsonProperty ("nugetId")]
+		[JsonPropertyName ("nugetId")]
 		public string? NuGetId { get; set; }
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs
@@ -332,20 +332,20 @@ partial class MicrosoftNuGetPackageFinder
 
 	public class PackageListFile
 	{
-		[JsonPropertyName ("packages")]
 		public List<Package>? Packages { get; set; }
 	}
 
 	public class Package
 	{
-		[JsonPropertyName ("javaId")]
 		public string? JavaId { get; set; }
-
-		[JsonPropertyName ("nugetId")]
 		public string? NuGetId { get; set; }
 	}
 
-	[JsonSourceGenerationOptions(WriteIndented = true)]
+	[JsonSourceGenerationOptions(
+		AllowTrailingCommas = true,
+		WriteIndented = true,
+		PropertyNameCaseInsensitive = true
+	)]
 	[JsonSerializable(typeof(PackageListFile))]
 	[JsonSerializable(typeof(List<Package>))]
 	[JsonSerializable(typeof(string))]

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JsonExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JsonExtensions.cs
@@ -5,54 +5,46 @@ using System.Text.Json.Nodes;
 
 public static class JsonExtensions
 {
-    public static JsonNode Merge(this JsonNode jsonBase, JsonNode jsonMerge)
+    public static JsonNode Merge (this JsonNode jsonBase, JsonNode jsonMerge)
     {
         if (jsonBase == null || jsonMerge == null)
             return jsonBase;
 
         switch (jsonBase)
         {
-            case JsonObject jsonBaseObj when jsonMerge is JsonObject jsonMergeObj:
-                {
-                    var mergeNodesArray = new KeyValuePair<string, JsonNode?>[jsonMergeObj.Count];
-                    int index = 0;
-                    foreach (var prop in jsonMergeObj)
-                    {
-                        mergeNodesArray[index++] = prop;
-                    }
-                    jsonMergeObj.Clear();
+            case JsonObject jsonBaseObj when jsonMerge is JsonObject jsonMergeObj: {
+                var mergeNodesArray = new KeyValuePair<string, JsonNode?> [jsonMergeObj.Count];
+                int index = 0;
+                foreach (var prop in jsonMergeObj) {
+                    mergeNodesArray [index++] = prop;
+                }
+                jsonMergeObj.Clear ();
 
-                    foreach (var prop in mergeNodesArray)
-                    {
-                        jsonBaseObj[prop.Key] = jsonBaseObj[prop.Key] switch
-                        {
-                            JsonObject jsonBaseChildObj when prop.Value is JsonObject jsonMergeChildObj => jsonBaseChildObj.Merge(jsonMergeChildObj),
-                            JsonArray jsonBaseChildArray when prop.Value is JsonArray jsonMergeChildArray => jsonBaseChildArray.Merge(jsonMergeChildArray),
-                            _ => prop.Value
-                        };
-                    }
-                    break;
+                foreach (var prop in mergeNodesArray) {
+                    jsonBaseObj [prop.Key] = jsonBaseObj [prop.Key] switch {
+                        JsonObject jsonBaseChildObj when prop.Value is JsonObject jsonMergeChildObj => jsonBaseChildObj.Merge (jsonMergeChildObj),
+                        JsonArray jsonBaseChildArray when prop.Value is JsonArray jsonMergeChildArray => jsonBaseChildArray.Merge (jsonMergeChildArray),
+                        _ => prop.Value
+                    };
                 }
-            case JsonArray jsonBaseArray when jsonMerge is JsonArray jsonMergeArray:
-                {
-                    var mergeNodesArray = new JsonNode?[jsonMergeArray.Count];
-                    int index = 0;
-                    foreach (var mergeNode in jsonMergeArray)
-                    {
-                        mergeNodesArray[index++] = mergeNode;
-                    }
-                    jsonMergeArray.Clear();
-                    foreach (var mergeNode in mergeNodesArray)
-                    {
-                        jsonBaseArray.Add(mergeNode);
-                    }
-                    break;
+                break;
+            }
+            case JsonArray jsonBaseArray when jsonMerge is JsonArray jsonMergeArray: {
+                var mergeNodesArray = new JsonNode? [jsonMergeArray.Count];
+                int index = 0;
+                foreach (var mergeNode in jsonMergeArray) {
+                    mergeNodesArray [index++] = mergeNode;
                 }
+                jsonMergeArray.Clear ();
+                foreach (var mergeNode in mergeNodesArray) {
+                    jsonBaseArray.Add (mergeNode);
+                }
+                break;
+            }
             default:
-                throw new ArgumentException($"The JsonNode type [{jsonBase.GetType().Name}] is incompatible for merging with the target/base " +
-                                            $"type [{jsonMerge.GetType().Name}]; merge requires the types to be the same.");
+                throw new ArgumentException ($"The JsonNode type [{jsonBase.GetType ().Name}] is incompatible for merging with the target/base " +
+                    $"type [{jsonMerge.GetType ().Name}]; merge requires the types to be the same.");
         }
-
         return jsonBase;
     }
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JsonExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JsonExtensions.cs
@@ -47,4 +47,41 @@ public static class JsonExtensions
         }
         return jsonBase;
     }
+
+    public static JsonNode? ToNode (this JsonElement element)
+    {
+        switch (element.ValueKind) {
+            case JsonValueKind.Object:
+                var obj = new JsonObject ();
+                foreach (JsonProperty prop in element.EnumerateObject()) {
+                    obj [prop.Name] = prop.Value.ToNode ();
+                }
+                return obj;
+
+            case JsonValueKind.Array:
+                var arr = new JsonArray();
+                foreach (JsonElement item in element.EnumerateArray ()) {
+                    arr.Add (item.ToNode ());
+                }
+                return arr;
+
+            case JsonValueKind.String:
+                return element.GetString ();
+
+            case JsonValueKind.Number:
+                return element.TryGetInt32 (out int intValue) ? intValue : element.GetDouble ();
+
+            case JsonValueKind.True:
+                return true;
+
+            case JsonValueKind.False:
+                return false;
+
+            case JsonValueKind.Null:
+                return null;
+
+            default:
+                throw new NotSupportedException ($"Unsupported JSON value kind: {element.ValueKind}");
+        }
+    }
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JsonExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JsonExtensions.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+public static class JsonExtensions
+{
+    public static JsonNode Merge(this JsonNode jsonBase, JsonNode jsonMerge)
+    {
+        if (jsonBase == null || jsonMerge == null)
+            return jsonBase;
+
+        switch (jsonBase)
+        {
+            case JsonObject jsonBaseObj when jsonMerge is JsonObject jsonMergeObj:
+                {
+                    var mergeNodesArray = new KeyValuePair<string, JsonNode?>[jsonMergeObj.Count];
+                    int index = 0;
+                    foreach (var prop in jsonMergeObj)
+                    {
+                        mergeNodesArray[index++] = prop;
+                    }
+                    jsonMergeObj.Clear();
+
+                    foreach (var prop in mergeNodesArray)
+                    {
+                        jsonBaseObj[prop.Key] = jsonBaseObj[prop.Key] switch
+                        {
+                            JsonObject jsonBaseChildObj when prop.Value is JsonObject jsonMergeChildObj => jsonBaseChildObj.Merge(jsonMergeChildObj),
+                            JsonArray jsonBaseChildArray when prop.Value is JsonArray jsonMergeChildArray => jsonBaseChildArray.Merge(jsonMergeChildArray),
+                            _ => prop.Value
+                        };
+                    }
+                    break;
+                }
+            case JsonArray jsonBaseArray when jsonMerge is JsonArray jsonMergeArray:
+                {
+                    var mergeNodesArray = new JsonNode?[jsonMergeArray.Count];
+                    int index = 0;
+                    foreach (var mergeNode in jsonMergeArray)
+                    {
+                        mergeNodesArray[index++] = mergeNode;
+                    }
+                    jsonMergeArray.Clear();
+                    foreach (var mergeNode in mergeNodesArray)
+                    {
+                        jsonBaseArray.Add(mergeNode);
+                    }
+                    break;
+                }
+            default:
+                throw new ArgumentException($"The JsonNode type [{jsonBase.GetType().Name}] is incompatible for merging with the target/base " +
+                                            $"type [{jsonMerge.GetType().Name}]; merge requires the types to be the same.");
+        }
+
+        return jsonBase;
+    }
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MamJsonParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MamJsonParser.cs
@@ -57,10 +57,11 @@ namespace Xamarin.Android.Tasks
 				GetReplacementMethods ());
 		}
 
-		static JsonObject ReadJson (string path)
+		static JsonNode ReadJson (string path)
 		{
-			using (var f = File.OpenRead (path)) {
-				return JsonNode.Parse (f)!.AsObject ();
+			using (var fs = File.OpenRead (path)) {
+				using JsonDocument doc = JsonDocument.Parse (fs, new JsonDocumentOptions { AllowTrailingCommas = true });
+				return doc.RootElement.ToNode () ?? JsonNode.Parse ("{}")!;
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Irony" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.CodeDom" />
     <PackageReference Include="System.IO.Hashing" Version="$(SystemIOHashingPackageVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />


### PR DESCRIPTION
* JsonElement is read only. This is why we convert them to JsonNode. 
* JsonNode.Parse does NOT have the same features as JsonDocument.Parse. e.g you CANNOT tell it to ignore trailing comma's. It will just throw an exception. This is the reason why we have to load the .json via JsonDocument and then call the extension method `.ToNode ()` on the Root JsonElement to convert it to a JsonNode.  (We use JsonNode to do the merging).
