### PR TITLE
[HelloWorld] Fix app install

### DIFF
--- a/samples/HelloWorld/HelloWorld/Properties/AndroidManifest.xml
+++ b/samples/HelloWorld/HelloWorld/Properties/AndroidManifest.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.android.helloworld">
-	<uses-sdk android:minSdkVersion="21" />
 	<application android:allowBackup="true" android:icon="@mipmap/icon" android:label="@string/app_name" android:extractNativeLibs="false">
 	</application>
 </manifest>


### PR DESCRIPTION
When I try installing `samples/HelloWorld`, installation fails:

	./dotnet-local.sh build -t:Install samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
	  HelloWorld.DotNet failed with 2 error(s) (139.4s) → samples/HelloWorld/HelloWorld/bin/Debug/net10.0-android/HelloWorld.DotNet.dll
	    /Users/jon/Developer/src/dotnet/android/bin/Debug/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/Xamarin.Android.Common.targets(2824,3): error MSB6006: "adb" exited with code 1.
	    /Users/jon/Developer/src/dotnet/android/bin/Debug/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/Xamarin.Android.Common.targets(2824,3): error XAAADB0000:
	      Serving...
	      All files should be loaded. Notifying the device.
	      adb: failed to install bin/Debug/net10.0-android/com.xamarin.android.helloworld-Signed.apk: Failure [INSTALL_FAILED_VERIFICATION_FAILURE: Install not allowed for file
	      :///data/app/vmdl911578471.tmp]
	      Performing Incremental Install
	      Failure [INSTALL_FAILED_DEPRECATED_SDK_VERSION: App package must target at least SDK version 24, but found 21]
	      Performing Streamed Install

If I look at the device screen, it shows a dialog:

> ⛨ Google Play Protect
> **Unsafe app blocked**
> ⬣ HelloWorld
> This app was built for an older version of Android and doesn't
> include the latest privacy protections
> More options ˯
> Installing this app may put your device at risk.
> Learn more about Play Protect
> [Install anyway]
> [**Got it**]

[Developer Guidance for Google Play Protect Warnings][0] states:

> **Reason for this notification**: These Play Protect warnings will
> show only if the app's [targetSdkVersion][1] is more than 2 versions
> lower than the current Android API level.

Updating `Properties/AndroidManifest.xml` to *remove* the `<uses-sdk/>` element allows .NET for Android to use its default logic, causing the "final" `AndroidManifest.xml` to contain:

	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="35" />

This allows the app to install without error:

	% ./dotnet-local.sh build -t:Install samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
	Restore complete (1.9s)
	  HelloLibrary.DotNet succeeded (1.5s) → samples/HelloWorld/HelloLibrary/bin/Debug/net10.0-android/HelloLibrary.DotNet.dll
	  HelloLibrary.DotNet succeeded (0.1s) → samples/HelloWorld/HelloLibrary/bin/Debug/net10.0-android/HelloLibrary.DotNet.dll
	  HelloWorld.DotNet succeeded (52.9s) → samples/HelloWorld/HelloWorld/bin/Debug/net10.0-android/HelloWorld.DotNet.dll

	Build succeeded in 57.8s

[0]: https://developers.google.com/android/play-protect/warning-dev-guidance
[1]: https://developer.android.com/guide/topics/manifest/uses-sdk-element.html#target