### PR TITLE
[Microsoft.Android.Runtime.NativeAOT] Parse debug.mono.log

### DIFF
--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/DiagnosticSettings.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/DiagnosticSettings.cs
@@ -1,0 +1,136 @@
+using System.IO;
+using System.Text;
+using System.Runtime.InteropServices;
+
+using Java.Interop;
+
+namespace Microsoft.Android.Runtime;
+
+struct DiagnosticSettings {
+
+	public  bool    LogJniLocalReferences;
+	private string? LrefPath;
+
+	public  bool    LogJniGlobalReferences;
+	private string? GrefPath;
+
+	private TextWriter?     GrefLrefLog;
+
+
+	public  TextWriter? GrefLog {
+		get {
+			if (!LogJniGlobalReferences) {
+				return null;
+			}
+			return ((LrefPath != null && LrefPath == GrefPath)
+					? GrefLrefLog ??= CreateWriter (LrefPath)
+					: null)
+				??
+				((GrefPath != null)
+					? CreateWriter (GrefPath)
+					: null)
+				??
+				new LogcatTextWriter (AndroidLogLevel.Debug, "NativeAot:GREF");
+		}
+	}
+
+	public  TextWriter? LrefLog {
+		get {
+			if (!LogJniLocalReferences) {
+				return null;
+			}
+			return ((LrefPath != null && LrefPath == GrefPath)
+					? GrefLrefLog ??= CreateWriter (LrefPath)
+					: null)
+				??
+				((LrefPath != null)
+					? CreateWriter (LrefPath)
+					: null)
+				??
+				new LogcatTextWriter (AndroidLogLevel.Debug, "NativeAot:LREF");
+		}
+	}
+
+	TextWriter? CreateWriter (string path)
+	{
+		try {
+			return File.CreateText (path);
+		}
+		catch (Exception e) {
+			AndroidLog.Print (AndroidLogLevel.Error, "NativeAot", $"Failed to open log file `{path}`: {e}");
+			return null;
+		}
+	}
+
+	public void AddDebugDotnetLog ()
+	{
+		Span<byte>  value   = stackalloc byte [RuntimeNativeMethods.PROP_VALUE_MAX];
+		if (!RuntimeNativeMethods.TryGetSystemProperty ("debug.dotnet.log"u8, ref value)) {
+			return;
+		}
+		AddParse (value);
+	}
+
+	void AddParse (ReadOnlySpan<byte> value)
+	{
+		while (TryGetNextValue (ref value, out var v)) {
+			if (v.SequenceEqual ("lref"u8)) {
+				LogJniLocalReferences = true;
+			}
+			else if (v.StartsWith ("lref="u8)) {
+				LogJniLocalReferences = true;
+				var path = v.Slice ("lref=".Length);
+				LrefPath = Encoding.UTF8.GetString (path);
+			}
+			else if (v.SequenceEqual ("gref"u8)) {
+				LogJniGlobalReferences = true;
+			}
+			else if (v.StartsWith ("gref="u8)) {
+				LogJniGlobalReferences = true;
+				var path = v.Slice ("gref=".Length);
+				GrefPath = Encoding.UTF8.GetString (path);
+			}
+			else if (v.SequenceEqual ("all"u8)) {
+				LogJniLocalReferences   = true;
+				LogJniGlobalReferences  = true;
+			}
+		}
+
+		bool TryGetNextValue (ref ReadOnlySpan<byte> value, out ReadOnlySpan<byte> next)
+		{
+			if (value.Length == 0) {
+				next  = default;
+				return false;
+			}
+			int c = value.IndexOf ((byte) ',');
+			if (c >= 0) {
+				next  = value.Slice (0, c);
+				value = value.Slice (c + 1);
+			}
+			else {
+				next  = value;
+				value = default;
+			}
+			return true;
+		}
+	}
+}
+
+static partial class RuntimeNativeMethods {
+
+	[LibraryImport ("c", EntryPoint="__system_property_get")]
+	static private partial int system_property_get (ReadOnlySpan<byte> name, Span<byte> value);
+
+	internal const int PROP_VALUE_MAX = 92;
+
+	internal static bool TryGetSystemProperty (ReadOnlySpan<byte> name, ref Span<byte> value)
+	{
+		int len     = system_property_get (name, value);
+		if (len <= 0) {
+			return false;
+		}
+
+		value   = value.Slice (0, len);
+		return true;
+	}
+}

--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
@@ -4,7 +4,15 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Android.Runtime;
 
-static class JavaInteropRuntime
+[Flags]
+enum DebugMonoLog {
+	None,
+	Gref = 1 << 0,
+	Lref = 1 << 1,
+	All  = Gref | Lref,
+}
+
+static partial class JavaInteropRuntime
 {
 	static JniRuntime? runtime;
 
@@ -34,14 +42,15 @@ static class JavaInteropRuntime
 	static void init (IntPtr jnienv, IntPtr klass)
 	{
 		try {
+			var log = GetDebugMonoLog ();
 			var typeManager = new NativeAotTypeManager ();
 			var options = new NativeAotRuntimeOptions {
 				EnvironmentPointer          = jnienv,
 				TypeManager                 = typeManager,
 				ValueManager                = new NativeAotValueManager (typeManager),
 				UseMarshalMemberBuilder     = false,
-				JniGlobalReferenceLogWriter = new LogcatTextWriter (AndroidLogLevel.Debug, "NativeAot:GREF"),
-				JniLocalReferenceLogWriter  = new LogcatTextWriter (AndroidLogLevel.Debug, "NativeAot:LREF"),
+				JniGlobalReferenceLogWriter = log.HasFlag (DebugMonoLog.Gref) ? new LogcatTextWriter (AndroidLogLevel.Debug, "NativeAot:GREF") : null,
+				JniLocalReferenceLogWriter  = log.HasFlag (DebugMonoLog.Lref) ? new LogcatTextWriter (AndroidLogLevel.Debug, "NativeAot:LREF") : null,
 			};
 			runtime = options.CreateJreVM ();
 
@@ -50,6 +59,60 @@ static class JavaInteropRuntime
 		}
 		catch (Exception e) {
 			AndroidLog.Print (AndroidLogLevel.Error, "JavaInteropRuntime", $"JavaInteropRuntime.init: error: {e}");
+		}
+	}
+
+	[LibraryImport ("c", EntryPoint="__system_property_get")]
+	static private partial int GetSystemProperty (ReadOnlySpan<byte> name, Span<byte> value);
+
+	static DebugMonoLog GetDebugMonoLog ()
+	{
+		Span<byte>  buffer  = stackalloc byte [PROP_VALUE_MAX];
+		int len     = GetSystemProperty ("debug.mono.log"u8, buffer);
+		if (len <= 0) {
+			return DebugMonoLog.None;
+		}
+
+		ReadOnlySpan<byte>  value   = buffer;
+		value = value.Slice (0, len);
+
+		return Parse (value);
+	}
+
+	const int PROP_VALUE_MAX = 92;
+
+	static DebugMonoLog Parse (ReadOnlySpan<byte> value)
+	{
+		DebugMonoLog log = default;
+
+		// warning CS9087: This returns a parameter by reference 'value' but it is not a ref parameter
+		// Use of `ref` is for my purposes, and shouldn't be visible to callers.
+#pragma warning disable CS9087
+		ReadOnlySpan<byte> v;
+		while (value.Length > 0 && (v = GetNextValue (ref value)).Length > 0) {
+			if (v.SequenceEqual ("lref"u8))
+				log |= DebugMonoLog.Lref;
+			else if (v.SequenceEqual ("gref"u8))
+				log |= DebugMonoLog.Gref;
+			else if (v.SequenceEqual ("all"u8))
+				log |= DebugMonoLog.All;
+		}
+#pragma warning restore CS9087
+		return log;
+
+		ReadOnlySpan<byte> GetNextValue (ref ReadOnlySpan<byte> value)
+		{
+			int c = value.IndexOf ((byte) ',');
+			if (c >= 0) {
+				var n = value.Slice (0, c);
+				value = value.Slice (c + 1);
+				return n;
+			}
+			else {
+				var n = value;
+				value = default;
+				return n;
+			}
 		}
 	}
 }

--- a/src/Microsoft.Android.Runtime.NativeAOT/Microsoft.Android.Runtime.NativeAOT.csproj
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Microsoft.Android.Runtime.NativeAOT.csproj
@@ -11,6 +11,7 @@
     <SignAssembly>true</SignAssembly>
     <OutputPath>$(_MonoAndroidNETDefaultOutDir)</OutputPath>
     <RootNamespace>Microsoft.Android.Runtime</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/java-interop/blob/9dea87dc1f3052ed0f9499c9858b27c83e7d139e/samples/Hello-NativeAOTFromAndroid/README.md

The NativeAOT sample and related `Microsoft.Android.Runtime.NativeAOT` assembly is based in part on the `Hello-NativeAOTFromAndroid` sample in dotnet/java-interop, which contains this comment about Logging:

> The (very!) extensive logging around JNI Global and Local
> references mean that this sample should not be used as-is for
> startup timing comparison.

…because `adb logcat` is absolutely *spammed* by LREF and GREF logs.

The "solution" in .NET for Android "proper" is to use the `debug.mono.log` system property to control logging.  By default, LREF and GREF logs are disabled, but can be enabled by setting the `debug.mono.log` system property property:

	adb shell setprop debug.mono.log gref       # only grefs
	adb shell setprop debug.mono.log lref,gref  # lrefs & grefs
	adb shell setprop debug.mono.log all        # EVERYTHING

Begin plumbing support for `debug.mono.log` into `JavaInteropRuntime`. This allows us to e.g. have LREF and GREF logging *disabled by default*, allowing for (somewhat) more representative startup timing comparisons, while allowing these logs to be enabled when needed.