### PR TITLE
[nativeaot] support multi-RID builds

### DIFF
--- a/samples/NativeAOT/NativeAOT.csproj
+++ b/samples/NativeAOT/NativeAOT.csproj
@@ -9,16 +9,12 @@
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
-    <!-- Default to arm64 device -->
-    <RuntimeIdentifier>android-arm64</RuntimeIdentifier>
     <!-- Only property required to opt into NativeAOT -->
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 
   <!-- Settings for CI -->
   <PropertyGroup Condition=" '$(RunningOnCI)' == 'true' ">
-    <!-- x86_64 emulator -->
-    <RuntimeIdentifier>android-x64</RuntimeIdentifier>
     <_NuGetFolderOnCI>..\..\bin\Build$(Configuration)\nuget-unsigned</_NuGetFolderOnCI>
     <RestoreAdditionalProjectSources Condition="Exists('$(_NuGetFolderOnCI)')">$(_NuGetFolderOnCI)</RestoreAdditionalProjectSources>
     <_FastDeploymentDiagnosticLogging>true</_FastDeploymentDiagnosticLogging>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -13,6 +13,8 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
   <PropertyGroup>
     <_AndroidRuntimePackRuntime>NativeAOT</_AndroidRuntimePackRuntime>
     <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">JavaInterop1</AndroidCodegenTarget>
+    <!-- .NET SDK gives: error NETSDK1191: A runtime identifier for the property 'PublishAot' couldn't be inferred. Specify a rid explicitly. -->
+    <AllowPublishAotWithoutRuntimeIdentifier Condition=" '$(AllowPublishAotWithoutRuntimeIdentifier)' == '' ">true</AllowPublishAotWithoutRuntimeIdentifier>
     <!-- NativeAOT's targets currently gives an error about cross-compilation -->
     <DisableUnsupportedError Condition=" $([MSBuild]::IsOSPlatform('windows')) and '$(DisableUnsupportedError)' == '' ">true</DisableUnsupportedError>
   </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -125,15 +125,8 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				ProjectName = "Hello",
-				IsRelease = true,
-				RuntimeIdentifier = "android-arm64",
-				// Add locally downloaded NativeAOT packs
-				ExtraNuGetConfigSources = {
-					Path.Combine (XABuildPaths.BuildOutputDirectory, "nuget-unsigned"),
-				}
 			};
-			proj.SetProperty ("PublishAot", "true");
-			proj.SetProperty ("AndroidNdkDirectory", AndroidNdkPath);
+			proj.SetPublishAot (true, AndroidNdkPath);
 			proj.SetProperty ("_ExtraTrimmerArgs", "--verbose");
 
 			// Required for java/util/ArrayList assertion below
@@ -149,16 +142,19 @@ namespace Xamarin.Android.Build.Tests
 			];
 			string[] mono_files = [
 				"lib/arm64-v8a/libmonosgen-2.0.so",
+				"lib/x86_64/libmonosgen-2.0.so",
 			];
 			string [] nativeaot_files = [
 				$"lib/arm64-v8a/lib{proj.ProjectName}.so",
 				"lib/arm64-v8a/libc++_shared.so",
+				$"lib/x86_64/lib{proj.ProjectName}.so",
+				"lib/x86_64/libc++_shared.so",
 			];
 
-			var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, proj.RuntimeIdentifier);
-			var output = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.RuntimeIdentifier);
+			var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
+			var output = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
 
-			var linkedMonoAndroidAssembly = Path.Combine (intermediate, "linked", "Mono.Android.dll");
+			var linkedMonoAndroidAssembly = Path.Combine (intermediate, "android-arm64", "linked", "Mono.Android.dll");
 			FileAssert.Exists (linkedMonoAndroidAssembly);
 			using (var assembly = AssemblyDefinition.ReadAssembly (linkedMonoAndroidAssembly)) {
 				var typeName = "Android.App.Activity";
@@ -170,7 +166,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			var typemap = new Dictionary<string, TypeReference> ();
-			var linkedRuntimeAssembly = Path.Combine (intermediate, "linked", "Microsoft.Android.Runtime.NativeAOT.dll");
+			var linkedRuntimeAssembly = Path.Combine (intermediate, "android-arm64", "linked", "Microsoft.Android.Runtime.NativeAOT.dll");
 			FileAssert.Exists (linkedRuntimeAssembly);
 			using (var assembly = AssemblyDefinition.ReadAssembly (linkedRuntimeAssembly)) {
 				var type = assembly.MainModule.Types.FirstOrDefault (t => t.Name == "NativeAotTypeManager");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -36,5 +36,6 @@ namespace Xamarin.ProjectTools
 		public const string _AndroidAllowDeltaInstall = "_AndroidAllowDeltaInstall";
 		public const string Nullable = "Nullable";
 		public const string ImplicitUsings = "ImplicitUsings";
+		public const string PublishAot = "PublishAot";
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -165,6 +165,30 @@ namespace Xamarin.ProjectTools
 			set { SetProperty (KnownProperties.AndroidEnableMarshalMethods, value.ToString ()); }
 		}
 
+		private bool PublishAot {
+			get { return string.Equals (GetProperty (KnownProperties.PublishAot), "True", StringComparison.OrdinalIgnoreCase); }
+			set { SetProperty (KnownProperties.PublishAot, value.ToString ()); }
+		}
+
+		/// <summary>
+		/// Sets properties required for $(PublishAot)=true
+		/// </summary>
+		public void SetPublishAot (bool value, string androidNdkPath)
+		{
+			IsRelease = value;
+			PublishAot = value;
+			SetProperty ("AndroidNdkDirectory", androidNdkPath);
+
+			// NuGet feed needed as Microsoft.Android.Runtime.NativeAOT packs not installed in workload by default
+			var source = Path.Combine (XABuildPaths.BuildOutputDirectory, "nuget-unsigned");
+			if (value) {
+				if (!ExtraNuGetConfigSources.Contains (source))
+					ExtraNuGetConfigSources.Add (source);
+			} else {
+				ExtraNuGetConfigSources.Remove (source);
+			}
+		}
+
 		public string AndroidManifest { get; set; }
 		public string LayoutMain { get; set; }
 		public string MainActivity { get; set; }


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/blob/68bf4cbabc023e5c2752ee4d5ce7e4a40929e748/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets#L227-L229

The only blocker for supporting `$(RuntimeIdentifiers)=android-arm64;android-x64` is the error message:

    error NETSDK1191: A runtime identifier for the property 'PublishAot' couldn't be inferred. Specify a rid explicitly.

We can set `$(AllowPublishAotWithoutRuntimeIdentifier)` by default, as this is not an error we'd ever want to show on Android.

After this change I can see the MSBuild terminal logger shows the two RIDs building in parallel:

    MyApp     IlcCompile (8.7s)
    MyApp     IlcCompile (8.6s)

And then the resulting `.apk` has both `lib/arm64-v8a` and `lib/x86_64`.

I also updated some of our MSBuild test infrastructure to make it easier to parameterize more MSBuild tests for `$(PublishAot)=true` in the future.

We'll likely want to do tests like:

    [Test]
    public void SomeTest ([Values (true, false)] bool publishAot)
    {
        var proj = new XamarinAndroidApplicationProject ();
        if (publishAot) {
            proj.SetPublishAot (true, AndroidNdkPath);
        }
        //...
    }