### PR TITLE
[XABT] Refactor manifest merging and ACW map generation out of `GenerateJavaStubs`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateACWMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateACWMap.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using System.Collections.Concurrent;
+using System.Linq;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks;
+
+public class GenerateACWMap : AndroidTask
+{
+	public override string TaskPrefix => "ACW";
+
+	[Required]
+	public string AcwMapFile { get; set; } = "";
+
+	[Required]
+	public string IntermediateOutputDirectory { get; set; } = "";
+
+	public override bool RunTask ()
+	{
+		// Retrieve the stored NativeCodeGenState
+		var nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>> (
+			MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory),
+			RegisteredTaskObjectLifetime.Build
+		);
+
+		// We only need the first architecture, since this task is architecture-agnostic
+		var templateCodeGenState = nativeCodeGenStates.First ().Value;
+
+		var acwMapGen = new ACWMapGenerator (Log);
+
+		if (!acwMapGen.Generate (templateCodeGenState, AcwMapFile)) {
+			Log.LogDebugMessage ("ACW map generation failed");
+		}
+
+		if (Log.HasLoggedErrors) {
+			// Ensure that on a rebuild, we don't *skip* the `_GenerateJavaStubs` target,
+			// by ensuring that the target outputs have been deleted.
+			Files.DeleteFile (AcwMapFile, Log);
+		}
+
+		return !Log.HasLoggedErrors;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -15,7 +15,6 @@ using Java.Interop.Tools.TypeNameMappings;
 
 using Xamarin.Android.Tools;
 using Microsoft.Android.Build.Tasks;
-using Java.Interop.Tools.JavaCallableWrappers.Adapters;
 using System.Threading.Tasks;
 using System.Collections.Concurrent;
 
@@ -36,9 +35,6 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem[] ResolvedUserAssemblies { get; set; }
 
 		[Required]
-		public string AcwMapFile { get; set; }
-
-		[Required]
 		public ITaskItem [] FrameworkDirectories { get; set; }
 
 		[Required]
@@ -54,39 +50,19 @@ namespace Xamarin.Android.Tasks
 		public bool LinkingEnabled { get; set; }
 		public bool HaveMultipleRIDs { get; set; }
 		public bool EnableMarshalMethods { get; set; }
-		public string ManifestTemplate { get; set; }
-		public string[] MergedManifestDocuments { get; set; }
 
 		public bool Debug { get; set; }
-		public bool MultiDex { get; set; }
-		public string ApplicationLabel { get; set; }
-		public string PackageName { get; set; }
-		public string VersionName { get; set; }
-		public string VersionCode { get; set; }
-		public string [] ManifestPlaceholders { get; set; }
-
-		public string AndroidSdkDir { get; set; }
 
 		public string AndroidSdkPlatform { get; set; }
 		public string OutputDirectory { get; set; }
-		public string MergedAndroidManifestOutput { get; set; }
-
-		public bool EmbedAssemblies { get; set; }
-		public bool NeedsInternet   { get; set; }
 
 		public bool ErrorOnCustomJavaObject { get; set; }
-
-		public string BundledWearApplicationName { get; set; }
 
 		public string PackageNamingPolicy { get; set; }
 
 		public string ApplicationJavaClass { get; set; }
 
 		public bool SkipJniAddNativeMethodRegistrationAttributeScan { get; set; }
-
-		public string CheckedBuild { get; set; }
-
-		public string SupportedOSPlatformVersion { get; set; }
 
 		public ITaskItem[] Environments { get; set; }
 
@@ -97,9 +73,6 @@ namespace Xamarin.Android.Tasks
 		public string AndroidRuntime { get; set; } = "";
 
 		public string CodeGenerationTarget { get; set; } = "";
-
-		[Required]
-		public string TargetName { get; set; } = "";
 
 		AndroidRuntime androidRuntime;
 		JavaPeerStyle codeGenerationTarget;
@@ -117,13 +90,6 @@ namespace Xamarin.Android.Tasks
 				Log.LogCodedError (string.Format ("XA{0:0000}", e.Code), e.MessageWithoutCode);
 				if (MonoAndroidHelper.LogInternalExceptions)
 					Log.LogMessage (e.ToString ());
-			}
-
-			if (Log.HasLoggedErrors) {
-				// Ensure that on a rebuild, we don't *skip* the `_GenerateJavaStubs` target,
-				// by ensuring that the target outputs have been deleted.
-				Files.DeleteFile (MergedAndroidManifestOutput, Log);
-				Files.DeleteFile (AcwMapFile, Log);
 			}
 
 			return !Log.HasLoggedErrors;
@@ -275,137 +241,18 @@ namespace Xamarin.Android.Tasks
 			// Set for use by <GeneratePackageManagerJava/> task later
 			NativeCodeGenState.TemplateJniAddNativeMethodRegistrationAttributePresent = templateCodeGenState.JniAddNativeMethodRegistrationAttributePresent;
 
-			var acwMapGen = new ACWMapGenerator (Log);
-			if (!acwMapGen.Generate (templateCodeGenState, AcwMapFile)) {
-				Log.LogDebugMessage ("ACW map generation failed");
-			}
-
-			IList<string> additionalProviders = MergeManifest (templateCodeGenState, MaybeGetArchAssemblies (userAssembliesPerArch, templateCodeGenState.TargetArch));
-			GenerateAdditionalProviderSources (templateCodeGenState, additionalProviders);
-
-			if (useMarshalMethods) {
-				// Save NativeCodeGenState for <GeneratePackageManagerJava/> task later
-				Log.LogDebugMessage ($"Saving {nameof (NativeCodeGenState)} to {nameof (NativeCodeGenStateRegisterTaskKey)}");
-				BuildEngine4.RegisterTaskObjectAssemblyLocal (ProjectSpecificTaskObjectKey (NativeCodeGenStateRegisterTaskKey), nativeCodeGenStates, RegisteredTaskObjectLifetime.Build);
-			} else {
-				// Otherwise, dispose all XAAssemblyResolvers
-				Log.LogDebugMessage ($"Disposing all {nameof (NativeCodeGenState)}.{nameof (NativeCodeGenState.Resolver)}");
-				foreach (var state in nativeCodeGenStates.Values) {
-					state.Resolver.Dispose ();
-				}
-			}
-
-			Dictionary<string, ITaskItem> MaybeGetArchAssemblies (Dictionary<AndroidTargetArch, Dictionary<string, ITaskItem>> dict, AndroidTargetArch arch)
-			{
-				if (!dict.TryGetValue (arch, out Dictionary<string, ITaskItem> archDict)) {
-					return new Dictionary<string, ITaskItem> (StringComparer.OrdinalIgnoreCase);
-				}
-
-				return archDict;
-			}
+			// Save NativeCodeGenState for later tasks
+			Log.LogDebugMessage ($"Saving {nameof (NativeCodeGenState)} to {nameof (NativeCodeGenStateRegisterTaskKey)}");
+			BuildEngine4.RegisterTaskObjectAssemblyLocal (MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (NativeCodeGenStateRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory), nativeCodeGenStates, RegisteredTaskObjectLifetime.Build);
 		}
 
-		void GenerateAdditionalProviderSources (NativeCodeGenState codeGenState, IList<string> additionalProviders)
+		internal static Dictionary<string, ITaskItem> MaybeGetArchAssemblies (Dictionary<AndroidTargetArch, Dictionary<string, ITaskItem>> dict, AndroidTargetArch arch)
 		{
-			if (androidRuntime != Xamarin.Android.Tasks.AndroidRuntime.CoreCLR) {
-				// Create additional runtime provider java sources.
-				bool isMonoVM = androidRuntime == Xamarin.Android.Tasks.AndroidRuntime.MonoVM;
-				string providerTemplateFile = isMonoVM ?
-					"MonoRuntimeProvider.Bundled.java" :
-					"NativeAotRuntimeProvider.java";
-				string providerTemplate = GetResource (providerTemplateFile);
-
-				foreach (var provider in additionalProviders) {
-					var contents = providerTemplate.Replace (isMonoVM ? "MonoRuntimeProvider" : "NativeAotRuntimeProvider", provider);
-					var real_provider = isMonoVM ?
-						Path.Combine (OutputDirectory, "src", "mono", provider + ".java") :
-						Path.Combine (OutputDirectory, "src", "net", "dot", "jni", "nativeaot", provider + ".java");
-					Files.CopyIfStringChanged (contents, real_provider);
-				}
-			} else {
-				Log.LogDebugMessage ($"Skipping android.content.ContentProvider generation for: {androidRuntime}");
+			if (!dict.TryGetValue (arch, out Dictionary<string, ITaskItem> archDict)) {
+				return new Dictionary<string, ITaskItem> (StringComparer.OrdinalIgnoreCase);
 			}
 
-			// For NativeAOT, generate JavaInteropRuntime.java
-			if (androidRuntime == Xamarin.Android.Tasks.AndroidRuntime.NativeAOT) {
-				const string fileName = "JavaInteropRuntime.java";
-				string template = GetResource (fileName);
-				var contents = template.Replace ("@MAIN_ASSEMBLY_NAME@", TargetName);
-				var path = Path.Combine (OutputDirectory, "src", "net", "dot", "jni", "nativeaot", fileName);
-				Log.LogDebugMessage ($"Writing: {path}");
-				Files.CopyIfStringChanged (contents, path);
-			}
-
-			// Create additional application java sources.
-			StringWriter regCallsWriter = new StringWriter ();
-			regCallsWriter.WriteLine ("// Application and Instrumentation ACWs must be registered first.");
-			foreach (TypeDefinition type in codeGenState.JavaTypesForJCW) {
-				if (JavaNativeTypeManager.IsApplication (type, codeGenState.TypeCache) || JavaNativeTypeManager.IsInstrumentation (type, codeGenState.TypeCache)) {
-					if (codeGenState.Classifier != null && !codeGenState.Classifier.FoundDynamicallyRegisteredMethods (type)) {
-						continue;
-					}
-
-					string javaKey = JavaNativeTypeManager.ToJniName (type, codeGenState.TypeCache).Replace ('/', '.');
-					regCallsWriter.WriteLine (
-						codeGenerationTarget == JavaPeerStyle.XAJavaInterop1 ?
-							"\t\tmono.android.Runtime.register (\"{0}\", {1}.class, {1}.__md_methods);" :
-							"\t\tnet.dot.jni.ManagedPeer.registerNativeMembers ({1}.class, {1}.__md_methods);",
-						type.GetAssemblyQualifiedName (codeGenState.TypeCache),
-						javaKey
-					);
-				}
-			}
-			regCallsWriter.Close ();
-
-			var real_app_dir = Path.Combine (OutputDirectory, "src", "net", "dot", "android");
-			string applicationTemplateFile = "ApplicationRegistration.java";
-			SaveResource (
-				applicationTemplateFile,
-				applicationTemplateFile,
-				real_app_dir,
-				template => template.Replace ("// REGISTER_APPLICATION_AND_INSTRUMENTATION_CLASSES_HERE", regCallsWriter.ToString ())
-			);
-		}
-
-		IList<string> MergeManifest (NativeCodeGenState codeGenState, Dictionary<string, ITaskItem> userAssemblies)
-		{
-			var manifest = new ManifestDocument (ManifestTemplate) {
-				PackageName = PackageName,
-				VersionName = VersionName,
-				ApplicationLabel = ApplicationLabel ?? PackageName,
-				Placeholders = ManifestPlaceholders,
-				Resolver = codeGenState.Resolver,
-				SdkDir = AndroidSdkDir,
-				TargetSdkVersion = AndroidSdkPlatform,
-				MinSdkVersion = MonoAndroidHelper.ConvertSupportedOSPlatformVersionToApiLevel (SupportedOSPlatformVersion).ToString (),
-				Debug = Debug,
-				MultiDex = MultiDex,
-				NeedsInternet = NeedsInternet,
-				AndroidRuntime = androidRuntime,
-			};
-			// Only set manifest.VersionCode if there is no existing value in AndroidManifest.xml.
-			if (manifest.HasVersionCode) {
-				Log.LogDebugMessage ($"Using existing versionCode in: {ManifestTemplate}");
-			} else if (!string.IsNullOrEmpty (VersionCode)) {
-				manifest.VersionCode = VersionCode;
-			}
-			manifest.Assemblies.AddRange (userAssemblies.Values.Select (item => item.ItemSpec));
-
-			if (!String.IsNullOrWhiteSpace (CheckedBuild)) {
-				// We don't validate CheckedBuild value here, this will be done in BuildApk. We just know that if it's
-				// on then we need android:debuggable=true and android:extractNativeLibs=true
-				manifest.ForceDebuggable = true;
-				manifest.ForceExtractNativeLibs = true;
-			}
-
-			IList<string> additionalProviders = manifest.Merge (Log, codeGenState.TypeCache, codeGenState.AllJavaTypes, ApplicationJavaClass, EmbedAssemblies, BundledWearApplicationName, MergedManifestDocuments);
-
-			// Only write the new manifest if it actually changed
-			if (manifest.SaveIfChanged (Log, MergedAndroidManifestOutput)) {
-				Log.LogDebugMessage ($"Saving: {MergedAndroidManifestOutput}");
-			}
-
-			return additionalProviders;
+			return archDict;
 		}
 
 		(bool success, NativeCodeGenState? stubsState) GenerateJavaSourcesAndMaybeClassifyMarshalMethods (AndroidTargetArch arch, Dictionary<string, ITaskItem> assemblies, Dictionary<string, ITaskItem> userAssemblies, bool useMarshalMethods, bool generateJavaCode)
@@ -462,20 +309,6 @@ namespace Xamarin.Android.Tasks
 
 			var rewriter = new MarshalMethodsAssemblyRewriter (Log, state.TargetArch, state.Classifier, state.Resolver);
 			rewriter.Rewrite (brokenExceptionTransitionsEnabled);
-		}
-
-		string GetResource (string resource)
-		{
-			using (var stream = GetType ().Assembly.GetManifestResourceStream (resource))
-			using (var reader = new StreamReader (stream))
-				return reader.ReadToEnd ();
-		}
-
-		void SaveResource (string resource, string filename, string destDir, Func<string, string> applyTemplate)
-		{
-			string template = GetResource (resource);
-			template = applyTemplate (template);
-			Files.CopyIfStringChanged (template, Path.Combine (destDir, filename));
 		}
 
 		void WriteTypeMappings (NativeCodeGenState state)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMainAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMainAndroidManifest.cs
@@ -13,7 +13,7 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks;
 
-public class GenerateMergedAndroidManifest : AndroidTask
+public class GenerateMainAndroidManifest : AndroidTask
 {
 	public override string TaskPrefix => "GMM";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMergedAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMergedAndroidManifest.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Java.Interop.Tools.Cecil;
+using Java.Interop.Tools.JavaCallableWrappers;
+using Java.Interop.Tools.TypeNameMappings;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+using Mono.Cecil;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks;
+
+public class GenerateMergedAndroidManifest : AndroidTask
+{
+	public override string TaskPrefix => "GMM";
+
+	[Required]
+	public string AndroidRuntime { get; set; } = "";
+	public string? AndroidSdkDir { get; set; }
+	public string? AndroidSdkPlatform { get; set; }
+	public string? ApplicationJavaClass { get; set; }
+	public string? ApplicationLabel { get; set; }
+	public string? BundledWearApplicationName { get; set; }
+	public string? CheckedBuild { get; set; }
+	public string CodeGenerationTarget { get; set; } = "";
+	public bool Debug { get; set; }
+	public bool EmbedAssemblies { get; set; }
+	public bool EnableMarshalMethods { get; set; }
+	[Required]
+	public string IntermediateOutputDirectory { get; set; } = "";
+	public string []? ManifestPlaceholders { get; set; }
+	public string? ManifestTemplate { get; set; }
+	public string? MergedAndroidManifestOutput { get; set; }
+	public string []? MergedManifestDocuments { get; set; }
+	public bool MultiDex { get; set; }
+	public bool NeedsInternet { get; set; }
+	public string? OutputDirectory { get; set; }
+	public string? PackageName { get; set; }
+	[Required]
+	public ITaskItem [] ResolvedUserAssemblies { get; set; } = [];
+	[Required]
+	public string [] SupportedAbis { get; set; } = [];
+	public string? SupportedOSPlatformVersion { get; set; }
+	[Required]
+	public string TargetName { get; set; } = "";
+	public string? VersionCode { get; set; }
+	public string? VersionName { get; set; }
+
+	AndroidRuntime androidRuntime;
+	JavaPeerStyle codeGenerationTarget;
+
+	bool UseMarshalMethods => !Debug && EnableMarshalMethods;
+
+	public override bool RunTask ()
+	{
+		// Retrieve the stored NativeCodeGenState
+		var nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>> (
+			MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory),
+			RegisteredTaskObjectLifetime.Build
+		);
+
+		// We only need the first architecture, since this task is architecture-agnostic
+		var templateCodeGenState = nativeCodeGenStates.First ().Value;
+
+		var userAssembliesPerArch = MonoAndroidHelper.GetPerArchAssemblies (ResolvedUserAssemblies, SupportedAbis, validate: true);
+
+		androidRuntime = MonoAndroidHelper.ParseAndroidRuntime (AndroidRuntime);
+		codeGenerationTarget = MonoAndroidHelper.ParseCodeGenerationTarget (CodeGenerationTarget);
+
+		// Generate the merged manifest
+		var additionalProviders = MergeManifest (templateCodeGenState, GenerateJavaStubs.MaybeGetArchAssemblies (userAssembliesPerArch, templateCodeGenState.TargetArch));
+		GenerateAdditionalProviderSources (templateCodeGenState, additionalProviders);
+
+		// Marshal methods needs this data in the <GeneratePackageManagerJava/> later,
+		// but if we're not using marshal methods we need to dispose of the resolver.
+		if (!UseMarshalMethods) {
+			Log.LogDebugMessage ($"Disposing all {nameof (NativeCodeGenState)}.{nameof (NativeCodeGenState.Resolver)}");
+
+			foreach (var state in nativeCodeGenStates.Values) {
+				state.Resolver.Dispose ();
+			}
+		}
+
+		if (Log.HasLoggedErrors) {
+			// Ensure that on a rebuild, we don't *skip* the `_GenerateJavaStubs` target,
+			// by ensuring that the target outputs have been deleted.
+			Files.DeleteFile (MergedAndroidManifestOutput, Log);
+		}
+
+		return !Log.HasLoggedErrors;
+	}
+
+	IList<string> MergeManifest (NativeCodeGenState codeGenState, Dictionary<string, ITaskItem> userAssemblies)
+	{
+		var manifest = new ManifestDocument (ManifestTemplate) {
+			PackageName = PackageName,
+			VersionName = VersionName,
+			ApplicationLabel = ApplicationLabel ?? PackageName,
+			Placeholders = ManifestPlaceholders,
+			Resolver = codeGenState.Resolver,
+			SdkDir = AndroidSdkDir,
+			TargetSdkVersion = AndroidSdkPlatform,
+			MinSdkVersion = MonoAndroidHelper.ConvertSupportedOSPlatformVersionToApiLevel (SupportedOSPlatformVersion).ToString (),
+			Debug = Debug,
+			MultiDex = MultiDex,
+			NeedsInternet = NeedsInternet,
+			AndroidRuntime = androidRuntime,
+		};
+		// Only set manifest.VersionCode if there is no existing value in AndroidManifest.xml.
+		if (manifest.HasVersionCode) {
+			Log.LogDebugMessage ($"Using existing versionCode in: {ManifestTemplate}");
+		} else if (!string.IsNullOrEmpty (VersionCode)) {
+			manifest.VersionCode = VersionCode;
+		}
+		manifest.Assemblies.AddRange (userAssemblies.Values.Select (item => item.ItemSpec));
+
+		if (!String.IsNullOrWhiteSpace (CheckedBuild)) {
+			// We don't validate CheckedBuild value here, this will be done in BuildApk. We just know that if it's
+			// on then we need android:debuggable=true and android:extractNativeLibs=true
+			manifest.ForceDebuggable = true;
+			manifest.ForceExtractNativeLibs = true;
+		}
+
+		IList<string> additionalProviders = manifest.Merge (Log, codeGenState.TypeCache, codeGenState.AllJavaTypes, ApplicationJavaClass, EmbedAssemblies, BundledWearApplicationName, MergedManifestDocuments);
+
+		// Only write the new manifest if it actually changed
+		if (manifest.SaveIfChanged (Log, MergedAndroidManifestOutput)) {
+			Log.LogDebugMessage ($"Saving: {MergedAndroidManifestOutput}");
+		}
+
+		return additionalProviders;
+	}
+
+	void GenerateAdditionalProviderSources (NativeCodeGenState codeGenState, IList<string> additionalProviders)
+	{
+		if (androidRuntime != Xamarin.Android.Tasks.AndroidRuntime.CoreCLR) {
+			// Create additional runtime provider java sources.
+			bool isMonoVM = androidRuntime == Xamarin.Android.Tasks.AndroidRuntime.MonoVM;
+			string providerTemplateFile = isMonoVM ?
+				"MonoRuntimeProvider.Bundled.java" :
+				"NativeAotRuntimeProvider.java";
+			string providerTemplate = GetResource (providerTemplateFile);
+
+			foreach (var provider in additionalProviders) {
+				var contents = providerTemplate.Replace (isMonoVM ? "MonoRuntimeProvider" : "NativeAotRuntimeProvider", provider);
+				var real_provider = isMonoVM ?
+					Path.Combine (OutputDirectory, "src", "mono", provider + ".java") :
+					Path.Combine (OutputDirectory, "src", "net", "dot", "jni", "nativeaot", provider + ".java");
+				Files.CopyIfStringChanged (contents, real_provider);
+			}
+		} else {
+			Log.LogDebugMessage ($"Skipping android.content.ContentProvider generation for: {androidRuntime}");
+		}
+
+		// For NativeAOT, generate JavaInteropRuntime.java
+		if (androidRuntime == Xamarin.Android.Tasks.AndroidRuntime.NativeAOT) {
+			const string fileName = "JavaInteropRuntime.java";
+			string template = GetResource (fileName);
+			var contents = template.Replace ("@MAIN_ASSEMBLY_NAME@", TargetName);
+			var path = Path.Combine (OutputDirectory, "src", "net", "dot", "jni", "nativeaot", fileName);
+			Log.LogDebugMessage ($"Writing: {path}");
+			Files.CopyIfStringChanged (contents, path);
+		}
+
+		// Create additional application java sources.
+		StringWriter regCallsWriter = new StringWriter ();
+		regCallsWriter.WriteLine ("// Application and Instrumentation ACWs must be registered first.");
+		foreach (TypeDefinition type in codeGenState.JavaTypesForJCW) {
+			if (JavaNativeTypeManager.IsApplication (type, codeGenState.TypeCache) || JavaNativeTypeManager.IsInstrumentation (type, codeGenState.TypeCache)) {
+				if (codeGenState.Classifier != null && !codeGenState.Classifier.FoundDynamicallyRegisteredMethods (type)) {
+					continue;
+				}
+
+				string javaKey = JavaNativeTypeManager.ToJniName (type, codeGenState.TypeCache).Replace ('/', '.');
+				regCallsWriter.WriteLine (
+					codeGenerationTarget == JavaPeerStyle.XAJavaInterop1 ?
+						"\t\tmono.android.Runtime.register (\"{0}\", {1}.class, {1}.__md_methods);" :
+						"\t\tnet.dot.jni.ManagedPeer.registerNativeMembers ({1}.class, {1}.__md_methods);",
+					type.GetAssemblyQualifiedName (codeGenState.TypeCache),
+					javaKey
+				);
+			}
+		}
+		regCallsWriter.Close ();
+
+		var real_app_dir = Path.Combine (OutputDirectory, "src", "net", "dot", "android");
+		string applicationTemplateFile = "ApplicationRegistration.java";
+		SaveResource (
+			applicationTemplateFile,
+			applicationTemplateFile,
+			real_app_dir,
+			template => template.Replace ("// REGISTER_APPLICATION_AND_INSTRUMENTATION_CLASSES_HERE", regCallsWriter.ToString ())
+		);
+	}
+
+	string GetResource (string resource)
+	{
+		using (var stream = GetType ().Assembly.GetManifestResourceStream (resource))
+		using (var reader = new StreamReader (stream))
+			return reader.ReadToEnd ();
+	}
+
+	void SaveResource (string resource, string filename, string destDir, Func<string, string> applyTemplate)
+	{
+		string template = GetResource (resource);
+		template = applyTemplate (template);
+		Files.CopyIfStringChanged (template, Path.Combine (destDir, filename));
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -44,6 +44,9 @@ namespace Xamarin.Android.Tasks
 		public string EnvironmentOutputDirectory { get; set; }
 
 		[Required]
+		public string IntermediateOutputDirectory { get; set; } = "";
+
+		[Required]
 		public string MainAssembly { get; set; }
 
 		[Required]
@@ -309,7 +312,7 @@ namespace Xamarin.Android.Tasks
 			ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>? nativeCodeGenStates = null;
 			if (enableMarshalMethods) {
 				nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>> (
-					ProjectSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateRegisterTaskKey),
+					MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory),
 					RegisteredTaskObjectLifetime.Build
 				);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -769,5 +769,7 @@ namespace Xamarin.Android.Tasks
 			// Default is XAJavaInterop1
 			return JavaPeerStyle.XAJavaInterop1;
 		}
+
+		public static object GetProjectBuildSpecificTaskObjectKey (object key, string workingDirectory, string intermediateOutputPath) => (key, workingDirectory, intermediateOutputPath);
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -62,12 +62,14 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.CreateTypeManagerJava" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.FilterAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.FindLayoutsToBind" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.GenerateACWMap" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateLayoutBindings" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateLibraryResources" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateManagedAidlProxies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateResourceDesigner" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateResourceDesignerAssembly" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateJavaStubs" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.GenerateMergedAndroidManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GeneratePackageManagerJava" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetAndroidDefineConstants" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetAppSettingsDirectory" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -1518,39 +1520,57 @@ because xbuild doesn't support framework reference assemblies.
       ResolvedAssemblies="@(_ResolvedAssemblies)"
       ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
       ErrorOnCustomJavaObject="$(AndroidErrorOnCustomJavaObject)"
-      ManifestTemplate="$(_AndroidManifestAbs)"
-      MergedManifestDocuments="@(_MergedManifestDocuments)"
       Debug="$(AndroidIncludeDebugSymbols)"
-      MultiDex="$(AndroidEnableMultiDex)"
-      NeedsInternet="$(AndroidNeedsInternetPermission)"
       AndroidSdkPlatform="$(_AndroidApiLevel)"
-      AndroidSdkDir="$(_AndroidSdkDirectory)"
-      PackageName="$(_AndroidPackage)"
-      VersionName="$(_AndroidVersionName)"
-      VersionCode="$(_AndroidVersionCode)"
-      ApplicationLabel="$(_ApplicationLabel)"
-      ManifestPlaceholders="$(AndroidManifestPlaceholders)"
       OutputDirectory="$(IntermediateOutputPath)android"
       TypemapOutputDirectory="$(_NativeAssemblySourceDir)"
       GenerateNativeAssembly="$(_AndroidGenerateNativeAssembly)"
-      MergedAndroidManifestOutput="$(_ManifestOutput)"
-      EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-      BundledWearApplicationName="$(BundledWearApplicationPackageName)"
       PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
       ApplicationJavaClass="$(AndroidApplicationJavaClass)"
       FrameworkDirectories="$(_XATargetFrameworkDirectories);$(_XATargetFrameworkDirectories)Facades"
-      AcwMapFile="$(_AcwMapFile)"
       SupportedAbis="@(_BuildTargetAbis)"
-      SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
       SkipJniAddNativeMethodRegistrationAttributeScan="$(_SkipJniAddNativeMethodRegistrationAttributeScan)"
-      CheckedBuild="$(_AndroidCheckedBuild)"
       EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
       LinkingEnabled="$(_LinkingEnabled)"
       HaveMultipleRIDs="$(_HaveMultipleRIDs)"
       IntermediateOutputDirectory="$(IntermediateOutputPath)"
-      TargetName="$(TargetName)"
       Environments="@(_EnvironmentFiles)">
   </GenerateJavaStubs>
+
+
+  <GenerateACWMap
+      AcwMapFile="$(_AcwMapFile)"
+      IntermediateOutputDirectory="$(IntermediateOutputPath)">
+  </GenerateACWMap>
+
+  <GenerateMergedAndroidManifest
+      AndroidRuntime="$(_AndroidRuntime)"
+      AndroidSdkDir="$(_AndroidSdkDirectory)"
+      AndroidSdkPlatform="$(_AndroidApiLevel)"
+      ApplicationJavaClass="$(AndroidApplicationJavaClass)"
+      ApplicationLabel="$(_ApplicationLabel)"
+      BundledWearApplicationName="$(BundledWearApplicationPackageName)"
+      CheckedBuild="$(_AndroidCheckedBuild)"
+      CodeGenerationTarget="$(AndroidCodegenTarget)"
+      Debug="$(AndroidIncludeDebugSymbols)"
+      EmbedAssemblies="$(EmbedAssembliesIntoApk)"
+      EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
+      IntermediateOutputDirectory="$(IntermediateOutputPath)"
+      ManifestPlaceholders="$(AndroidManifestPlaceholders)"
+      ManifestTemplate="$(_AndroidManifestAbs)"
+      MergedAndroidManifestOutput="$(_ManifestOutput)"
+      MergedManifestDocuments="@(_MergedManifestDocuments)"
+      MultiDex="$(AndroidEnableMultiDex)"
+      NeedsInternet="$(AndroidNeedsInternetPermission)"
+      OutputDirectory="$(IntermediateOutputPath)android"
+      PackageName="$(_AndroidPackage)"
+      ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
+      SupportedAbis="@(_BuildTargetAbis)"
+      SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
+      TargetName="$(TargetName)"
+      VersionCode="$(_AndroidVersionCode)"
+      VersionName="$(_AndroidVersionName)">
+  </GenerateMergedAndroidManifest>
 
   <ItemGroup>
     <FileWrites Include="@(_TypeMapAssemblySource)" />
@@ -1754,6 +1774,7 @@ because xbuild doesn't support framework reference assemblies.
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserAssemblies)"
     SatelliteAssemblies="@(_AndroidResolvedSatellitePaths)"
+    IntermediateOutputDirectory="$(IntermediateOutputPath)"
     NativeLibraries="@(AndroidNativeLibrary);@(EmbeddedNativeLibrary);@(FrameworkNativeLibrary)"
     MonoComponents="@(_MonoComponent)"
     MainAssembly="$(TargetPath)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -69,7 +69,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateResourceDesigner" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateResourceDesignerAssembly" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateJavaStubs" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.GenerateMergedAndroidManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.GenerateMainAndroidManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GeneratePackageManagerJava" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetAndroidDefineConstants" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetAppSettingsDirectory" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -1543,7 +1543,7 @@ because xbuild doesn't support framework reference assemblies.
       IntermediateOutputDirectory="$(IntermediateOutputPath)">
   </GenerateACWMap>
 
-  <GenerateMergedAndroidManifest
+  <GenerateMainAndroidManifest
       AndroidRuntime="$(_AndroidRuntime)"
       AndroidSdkDir="$(_AndroidSdkDirectory)"
       AndroidSdkPlatform="$(_AndroidApiLevel)"
@@ -1570,7 +1570,7 @@ because xbuild doesn't support framework reference assemblies.
       TargetName="$(TargetName)"
       VersionCode="$(_AndroidVersionCode)"
       VersionName="$(_AndroidVersionName)">
-  </GenerateMergedAndroidManifest>
+  </GenerateMainAndroidManifest>
 
   <ItemGroup>
     <FileWrites Include="@(_TypeMapAssemblySource)" />


### PR DESCRIPTION
Begin breaking down the `<GenerateJavaStubs>` task into smaller, more manageable pieces by moving the manifest merging and ACW map generation into separate tasks.  Once this is complete, we should be able to start moving these steps that require Cecil assembly scanning into linker steps (or equivalent), eventually saving a Cecil assembly scan per build.

Additionally, create a new `GetProjectBuildSpecificTaskObjectKey` to be used with `GetRegisteredTaskObject`. This version additional uses `$(IntermediateOutpuPath)` in the key to help ensure data from multi-targeted builds (`net8.0-android,net9.0-android`) is not overwritten.