### PR TITLE
[nativeaot] fix missing `PreserveLists\*.xml` files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -90,10 +90,7 @@ This file contains the .NET 5-specific targets to customize ILLink
           AfterStep="CleanStep"
           Type="Microsoft.Android.Sdk.ILLink.TypeMappingStep"
       />
-      <_PreserveLists Include="$(MSBuildThisFileDirectory)..\PreserveLists\*.xml" />
-      <TrimmerRootDescriptor
-          Condition=" '@(ResolvedFileToPublish->Count())' != '0' and '%(Filename)' != '' "
-          Include="@(_PreserveLists)" />
+      <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)..\PreserveLists\*.xml" />
       <TrimmerRootDescriptor Include="@(LinkDescription)" />
       <TrimmerRootAssembly Include="Microsoft.Android.Runtime.NativeAOT" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' " RootMode="All" />
     </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -565,9 +565,11 @@ class MemTest {
 
 		[Test]
 		[NonParallelizable]
-		public void BuildBasicApplicationAppCompat ()
+		public void BuildBasicApplicationAppCompat ([Values (true, false)] bool publishAot)
 		{
 			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetPublishAot (true, AndroidNdkPath);
+
 			var packages = proj.PackageReferences;
 			packages.Add (KnownPackages.AndroidXAppCompat);
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : AndroidX.AppCompat.App.AppCompatActivity");


### PR DESCRIPTION
A `dotnet new maui` project template fails to build with:

    obj\Release\net10.0-android\android-arm64\android\src\mono\android\runtime\InputStreamAdapter.java:4: error: InputStreamAdapter is not abstract and does not override abstract method read() in InputStream
    obj\Release\net10.0-android\android-arm64\android\src\mono\android\runtime\OutputStreamAdapter.java:4: error: OutputStreamAdapter is not abstract and does not override abstract method write(int) in OutputStream

I found I could also reproduce this issue with the `BuildBasicApplicationAppCompat()` MSBuild test.

After reviewing `.binlog` files, I found we weren't including `PreserveLists\*.xml` files *at all* in NativeAOT, as the `Condition` was false:

    <_PreserveLists Include="$(MSBuildThisFileDirectory)..\PreserveLists\*.xml" />
    <TrimmerRootDescriptor
        Condition=" '@(ResolvedFileToPublish->Count())' != '0' and '%(Filename)' != '' "
        Include="@(_PreserveLists)" />

9bc45b58 doesn't say why the `Condition` was added, but this was during early .NET 5 development. Some of this code may have been shared with Xamarin.Android back then.

We can simply remove the `Condition` to fix this, and the MSBuild test also passes.