### PR TITLE
[Xamarin.Android.Build.Tasks] emit XA1040 for experimental runtimes

### DIFF
--- a/Documentation/docs-mobile/messages/xa1040.md
+++ b/Documentation/docs-mobile/messages/xa1040.md
@@ -28,5 +28,4 @@ To silence this warning, you can either:
 * Use MonoVM by removing `$(UseMonoRuntime)=false` or
   `$(PublishAot)=true` from your project file.
 
-* Set `$(AndroidAllowExperimentalRuntime)` to `true` in your project
-  file.
+* Set `$(EnablePreviewFeatures)` to `true` in your project file.

--- a/Documentation/docs-mobile/messages/xa1040.md
+++ b/Documentation/docs-mobile/messages/xa1040.md
@@ -8,8 +8,8 @@ ms.date: 02/24/2025
 ## Example messages
 
 ```
-warning XA1040: The CoreCLR runtime is currently experimental in .NET for Android.
-warning XA1040: The NativeAOT runtime is currently experimental in .NET for Android.
+warning XA1040: The CoreCLR runtime on Android is an experimental feature and not yet suitable for production use. File issues at: https://github.com/dotnet/android/issues
+warning XA1040: The NativeAOT runtime on Android is an experimental feature and not yet suitable for production use. File issues at: https://github.com/dotnet/android/issues
 ```
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa1040.md
+++ b/Documentation/docs-mobile/messages/xa1040.md
@@ -1,0 +1,32 @@
+---
+title: .NET for Android warning XA1040
+description: XA1040 warning code
+ms.date: 02/24/2025
+---
+# .NET for Android warning XA1040
+
+## Example messages
+
+```
+warning XA1040: The CoreCLR runtime is currently experimental in .NET for Android.
+warning XA1040: The NativeAOT runtime is currently experimental in .NET for Android.
+```
+
+## Issue
+
+MonoVM is the default, supported runtime for .NET for Android.
+
+Other runtimes are currently experimental, such as:
+
+* CoreCLR, used via `$(UseMonoRuntime)=false`
+* NativeAOT, used via `$(PublishAot)=true`
+
+## Solution
+
+To silence this warning, you can either:
+
+* Use MonoVM by removing `$(UseMonoRuntime)=false` or
+  `$(PublishAot)=true` from your project file.
+
+* Set `$(AndroidAllowExperimentalRuntime)` to `true` in your project
+  file.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -885,7 +885,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The {0} runtime is currently experimental in .NET for Android.
+        ///   Looks up a localized string similar to The {0} runtime on Android is an experimental feature and not yet suitable for production use. File issues at: https://github.com/dotnet/android/issues
         /// </summary>
         public static string XA1040 {
             get {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -885,6 +885,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The {0} runtime is currently experimental in .NET for Android.
+        /// </summary>
+        public static string XA1040 {
+            get {
+                return ResourceManager.GetString("XA1040", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 and higher will only support a single AppDomain, so this API will no longer be available in .NET for Android once .NET 6 is released..
         /// </summary>
         public static string XA2000 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1017,7 +1017,7 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
     <comment>The following are literal names and should not be translated: Android Support, AndroidX, .NET.</comment>
   </data>
   <data name="XA1040" xml:space="preserve">
-    <value>The {0} runtime is currently experimental in .NET for Android.</value>
+    <value>The {0} runtime on Android is an experimental feature and not yet suitable for production use. File issues at: https://github.com/dotnet/android/issues</value>
     <comment>The following are literal names and should not be translated: .NET.
 {0} - The name of the .NET runtime, such as CoreCLR or NativeAOT.</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1016,6 +1016,11 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
     <value>The Android Support libraries are not supported in .NET 9 and later, please migrate to AndroidX. See https://aka.ms/net-android/androidx for more details.</value>
     <comment>The following are literal names and should not be translated: Android Support, AndroidX, .NET.</comment>
   </data>
+  <data name="XA1040" xml:space="preserve">
+    <value>The {0} runtime is currently experimental in .NET for Android.</value>
+    <comment>The following are literal names and should not be translated: .NET.
+{0} - The name of the .NET runtime, such as CoreCLR or NativeAOT.</comment>
+  </data>
   <data name="XA4241" xml:space="preserve">
     <value>Java dependency '{0}' is not satisfied.</value>
     <comment>The following are literal names and should not be translated: Java.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -556,7 +556,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <AndroidWarning Code="XA1040"
       ResourceName="XA1040"
       FormatArguments="$(_AndroidRuntime)"
-      Condition=" '$(_AndroidRuntime)' != 'MonoVM' and '$(AndroidAllowExperimentalRuntime)' != 'true' "
+      Condition=" '$(_AndroidRuntime)' != 'MonoVM' and '$(EnablePreviewFeatures)' != 'true' "
   />
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -553,6 +553,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       FormatArguments="AndroidFastDeploymentType;9"
       Condition=" '$(AndroidFastDeploymentType)' != '' "
   />
+  <AndroidWarning Code="XA1040"
+      ResourceName="XA1040"
+      FormatArguments="$(_AndroidRuntime)"
+      Condition=" '$(_AndroidRuntime)' != 'MonoVM' and '$(AndroidAllowExperimentalRuntime)' != 'true' "
+  />
 </Target>
 
 <Target Name="_CheckNonIdealConfigurations"


### PR DESCRIPTION
MonoVM is currently the default (and supported!) runtime for .NET for Android. Emit `XA1040` when the user opts into using the experimental runtimes, such as:

* `$(UseMonoRuntime)=false` CoreCLR
* `$(PublishAot)=true` NativeAOT

If desired, you can opt out of the warning completely with `$(AndroidAllowExperimentalRuntime)=true`, or use existing MSBuild mechanisms to suppress it.