### PR TITLE
Update System.IO.Compression to use the best compression.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/UtilityExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/UtilityExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Runtime.InteropServices;
 using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Tasks;
@@ -14,7 +15,7 @@ static class UtilityExtensions
 				return System.IO.Compression.CompressionLevel.NoCompression;
 			case CompressionMethod.Default:
 			case CompressionMethod.Deflate:
-				return System.IO.Compression.CompressionLevel.Optimal;
+				return RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework") ? CompressionLevel.Optimal : (CompressionLevel) 3 /* SmallestSize */;
 			default:
 				throw new ArgumentOutOfRangeException (nameof (method), method, null);
 		}
@@ -25,6 +26,7 @@ static class UtilityExtensions
 		switch (level) {
 			case System.IO.Compression.CompressionLevel.NoCompression:
 				return CompressionMethod.Store;
+			case (System.IO.Compression.CompressionLevel)3: /* SmallestSize */
 			case System.IO.Compression.CompressionLevel.Optimal:
 				return CompressionMethod.Deflate;
 			default:


### PR DESCRIPTION
`System.IO.Compression` uses the default compression level which is not the Smallest compression level. This change updates the compression level to the best compression level since the size of the Apk is very important.

Unfortunately, the SmallestSize compression enum level is not available on `netstandard2.0`. So we have to use a cast to get it to work.