### PR TITLE
[XABT] remove `$(_AndroidUseLibZipSharp)=true` default value

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -140,9 +140,6 @@
 
     <!-- profiler won't work without internet permission, we must thus force it -->
     <AndroidNeedsInternetPermission Condition=" '$(AndroidEnableProfiler)' == 'true' ">True</AndroidNeedsInternetPermission>
-
-    <!-- FIXME: error ANDZA0000: 01-30 21:38:27.669 38611 159726 W zip     : WARNING: header mismatch -->
-    <_AndroidUseLibZipSharp Condition=" '$(_AndroidUseLibZipSharp)' == '' ">true</_AndroidUseLibZipSharp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' and '$(GenerateApplicationManifest)' == 'true' ">
     <!-- Default to 1, if blank -->


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/112017
Context: https://github.com/dotnet/runtime/pull/113306

In .NET 10 Preview 1, when using System.IO.Compression to create `.apk` files, `zipalign` was giving the error:

    01-30 21:38:27.669 38611 159726 W zip     : WARNING: header mismatch

To workaround, we temporarily set `$(_AndroidUseLibZipSharp)=true`.

We think this is fixed now, so partially revert f3ef4fe0.