### PR TITLE
[build] fix local `Microsoft.Android.Runtime.NativeAOT.csproj` builds

### DIFF
--- a/src/Microsoft.Android.Runtime.NativeAOT/Microsoft.Android.Runtime.NativeAOT.csproj
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Microsoft.Android.Runtime.NativeAOT.csproj
@@ -1,4 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\..\Configuration.props" />
   <Import Project="$(XamarinAndroidSourcePath)\build-tools\trim-analyzers\trim-analyzers.props" />
 
@@ -18,6 +20,8 @@
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
     <ProjectReference Include="..\Mono.Android\Mono.Android.csproj" />
   </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <!-- Copy runtime assemblies to bin/$(Configuration)/dotnet/packs folder -->
   <PropertyGroup Condition=" '$(AndroidApiLevel)' == '$(AndroidLatestStableApiLevel)' ">


### PR DESCRIPTION
Various folks building dotnet/android/main have been running into:

    Microsoft.Common.CurrentVersion.targets(5064,5): error MSB3030: Could not copy the file
    "…/dotnet/android/bin/Release/lib/packs/Microsoft.Android.Runtime.NativeAOT.35.android-arm64/35.99.0/runtimes/android-arm64/lib/net10.0/Microsoft.Android.Runtime.NativeAOT.dll" because it was not found.

And then were able to fix this by manually copying the file. It also somehow works fine on CI?!?

Reviewing a clean build, I noticed the `_CopyToPackDirs` target was *not* running for this project when doing a build.

Comparing against another project that *does* work, `Mono.Android.Export.csproj`, I remembered something that is missing and important...

If you want to replace `$(BuildDependsOn)`, then you need to do:

    <Project>
    <!-- At the top -->
    <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
    <!-- ... -->
    <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
    <!-- Update $(BuildDependsOn) here -->

You can only update `$(BuildDependsOn)` *after* importing `Sdk.targets`.