### PR TITLE
$(AndroidPackVersionSuffix)=preview.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>35.99.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.2</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.3</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>

--- a/Documentation/guides/HowToBranch.md
+++ b/Documentation/guides/HowToBranch.md
@@ -2,31 +2,31 @@
 
 Context: [dotnet/maui#589][0]
 
-Let's say that it's time for a hypothetical ".NET 6 Preview 42". The
+Let's say that it's time for a hypothetical ".NET 10 Preview 42". The
 sequence of events would be:
 
-1. [dotnet/installer][1] branches `release/6.0.1xx-preview42`
+1. [dotnet/installer][1] branches `release/10.0.1xx-preview42`
 
-2. Builds are available on Maestro for `xamarin-android` to consume.
+2. Builds are available on Maestro for `dotnet/android` to consume.
 
-3. `xamarin-android` branches `release/6.0.1xx-preview42`. GitHub Web
+3. `dotnet/android` branches `release/10.0.1xx-preview42`. GitHub Web
    UI is fine for this.
 
-4. Subscribe to Maestro updates for [dotnet/installer][1] `release/6.0.1xx-preview42`:
+4. Subscribe to Maestro updates for [dotnet/installer][1] `release/10.0.1xx-preview42`:
 
 ```bash
-$ darc add-subscription --channel ".NET 6.0.1xx SDK Preview 42" --target-branch "release/6.0.1xx-preview42" --source-repo https://github.com/dotnet/installer --target-repo https://github.com/xamarin/xamarin-android
+darc add-subscription --channel ".NET 10.0.1xx SDK Preview 42" --target-branch "release/10.0.1xx-preview42" --source-repo https://github.com/dotnet/sdk --target-repo https://github.com/dotnet/android
 ```
 
-5. Publish Maestro updates for `xamarin-android/release/6.0.1xx-preview42`:
+5. Publish Maestro updates for `dotnet/android/release/10.0.1xx-preview42`:
 
 ```bash
-$ darc add-default-channel --channel ".NET 6.0.1xx SDK Preview 42" --branch "release/6.0.1xx-preview42" --repo https://github.com/xamarin/xamarin-android
+darc add-default-channel --channel ".NET 10.0.1xx SDK Preview 42" --branch "release/10.0.1xx-preview42" --repo https://github.com/dotnet/android
 ```
 
 See [eng/README.md][2] for details on `darc` commands.
 
-6. Open a PR to `xamarin-android/main`, such that
+6. Open a PR to `dotnet/android/main`, such that
    `$(AndroidPackVersionSuffix)` in `Directory.Build.props` is
    incremented to the *next* version: `preview.43`. You may also need
    to update `$(AndroidPackVersion)` if `main` needs to target a new


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/10.0.1xx-preview2

We branched for .NET 10 Preview 2 from ea8d2a7a into `release/10.0.1xx-preview2`; the main branch is now .NET 10 Preview 3.

I also updated `HowToBranch.md` as it was out of date.