### PR TITLE
[nativeaot] run Mono.Android-Tests

### DIFF
--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -211,6 +211,16 @@ stages:
     - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
+        testName: Mono.Android.NET_Tests-NativeAOT
+        project: tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+        testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)NativeAOT.xml
+        extraBuildArgs: -p:TestsFlavor=NativeAOT -p:PublishAot=true
+        artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
+        artifactFolder: $(DotNetTargetFramework)-NativeAOT
+
+    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(XA.Build.Configuration)
         testName: Xamarin.Android.JcwGen_Tests
         project: tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
         testResultsFiles: TestResult-Xamarin.Android.JcwGen_Tests-$(XA.Build.Configuration).xml

--- a/samples/NativeAOT/NativeAOT.csproj
+++ b/samples/NativeAOT/NativeAOT.csproj
@@ -12,12 +12,4 @@
     <!-- Only property required to opt into NativeAOT -->
     <PublishAot>true</PublishAot>
   </PropertyGroup>
-
-  <!-- Settings for CI -->
-  <PropertyGroup Condition=" '$(RunningOnCI)' == 'true' ">
-    <_NuGetFolderOnCI>..\..\bin\Build$(Configuration)\nuget-unsigned</_NuGetFolderOnCI>
-    <RestoreAdditionalProjectSources Condition="Exists('$(_NuGetFolderOnCI)')">$(_NuGetFolderOnCI)</RestoreAdditionalProjectSources>
-    <_FastDeploymentDiagnosticLogging>true</_FastDeploymentDiagnosticLogging>
-  </PropertyGroup>
-
 </Project>

--- a/tests/Mono.Android-Tests/Java.Interop-Tests/Java.InteropTests/AndroidValueManagerContractTests.cs
+++ b/tests/Mono.Android-Tests/Java.Interop-Tests/Java.InteropTests/AndroidValueManagerContractTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -11,9 +12,10 @@ using Java.Interop;
 using NUnit.Framework;
 
 namespace Java.InteropTests {
-	[TestFixture]
+	[TestFixture, Category ("NativeTypeMap")]
 	public class AndroidValueManagerContractTests : JniRuntimeJniValueManagerContract {
 
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		protected override Type ValueManagerType => typeof (Android.Runtime.AndroidValueManager);
 	}
 }

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -238,7 +238,7 @@ namespace Java.InteropTests
 			}
 		}
 
-		[Test]
+		[Test, Category ("Export")]
 		[Category ("CoreCLRIgnore")] //TODO: https://github.com/dotnet/android/issues/10069
 		public void CreateTypeWithExportedMethods ()
 		{
@@ -251,7 +251,7 @@ namespace Java.InteropTests
 			}
 		}
 
-		[Test]
+		[Test, Category ("Export")]
 		[Category ("CoreCLRIgnore")] //TODO: https://github.com/dotnet/android/issues/10069
 		public void ActivatedDirectObjectSubclassesShouldBeRegistered ()
 		{
@@ -407,7 +407,7 @@ namespace Java.InteropTests
 			Assert.IsNull (ignore_t2, string.Format ("No exception should be thrown [t2]! Got: {0}", ignore_t2));
 		}
 
-		[Test]
+		[Test, Category ("NativeTypeMap")]
 		public void JavaToManagedTypeMapping ()
 		{
 			Type m = Java.Interop.TypeManager.GetJavaToManagedType ("android/content/res/Resources");
@@ -416,7 +416,7 @@ namespace Java.InteropTests
 			Assert.AreEqual (null, m);
 		}
 
-		[Test]
+		[Test, Category ("NativeTypeMap")]
 		public void ManagedToJavaTypeMapping ()
 		{
 			Type type = typeof(Activity);

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Lang/ObjectTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Lang/ObjectTest.cs
@@ -67,6 +67,7 @@ namespace Java.LangTests
 
 		[Test]
 		[Category ("CoreCLRIgnore")] //TODO: https://github.com/dotnet/android/issues/10069
+		[Category ("NativeAOTIgnore")] //TODO: https://github.com/dotnet/android/issues/10079
 		public void JnienvCreateInstance_RegistersMultipleInstances ()
 		{
 			using (var adapter = new CreateInstance_OverrideAbsListView_Adapter (Application.Context)) {

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -33,6 +33,8 @@
     <ExcludeCategories>DotNetIgnore</ExcludeCategories>
     <!-- TODO: https://github.com/dotnet/android/issues/10069 -->
     <ExcludeCategories Condition=" '$(UseMonoRuntime)' == 'false' ">$(ExcludeCategories):CoreCLRIgnore:SSL:NTLM:GCBridge:RuntimeConfig</ExcludeCategories>
+    <!-- TODO: https://github.com/dotnet/android/issues/10079 -->
+    <ExcludeCategories Condition=" '$(PublishAot)' == 'true' ">$(ExcludeCategories):NativeAOTIgnore:SSL:NTLM:GCBridge:AndroidClientHandler:Export:NativeTypeMap</ExcludeCategories>
     <!-- FIXME: LLVMIgnore https://github.com/dotnet/runtime/issues/89190 -->
     <ExcludeCategories Condition=" '$(EnableLLVM)' == 'true' ">$(ExcludeCategories):LLVMIgnore</ExcludeCategories>
     <ExcludeCategories Condition=" '$(EnableLLVM)' == 'true' ">$(ExcludeCategories):InetAccess:NetworkInterfaces</ExcludeCategories>

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System/AppContextTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System/AppContextTests.cs
@@ -49,6 +49,7 @@ namespace SystemTests
 		};
 
 		[Test]
+		[Category ("NativeAOTIgnore")] // These switches only exist in Mono & CoreCLR BCL assemblies
 		[TestCaseSource (nameof (TestPrivateSwitchesSource))]
 		public void TestPrivateSwitches (
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System/ExceptionTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System/ExceptionTest.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Android.RuntimeTests {
 
 		[Test]
 		[Category ("CoreCLRIgnore")] //TODO: https://github.com/dotnet/android/issues/10069
+		[Category ("NativeAOTIgnore")] // NativeAOT has very limited stack traces
 		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void InnerExceptionIsSet ()
 		{

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -147,6 +147,7 @@ namespace Xamarin.Android.NetTests {
 		}
 	}
 
+	[Category ("AndroidClientHandler")]
 	public abstract class AndroidHandlerTestBase : HttpClientHandlerTestBase
 	{
 		static IEnumerable<Exception> Exceptions (Exception e)
@@ -316,6 +317,7 @@ namespace Xamarin.Android.NetTests {
 	}
 
 	[TestFixture]
+	[Category ("AndroidClientHandler")]
 	public class AndroidClientHandlerTests : AndroidHandlerTestBase
 	{
 		protected override HttpMessageHandler CreateHandler ()

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -1062,6 +1062,7 @@ namespace Xamarin.Android.NetTests {
 	}
 
 	[TestFixture]
+	[Category ("AndroidClientHandler")]
 	public class AndroidClientHandlerIntegrationTests : HttpClientIntegrationTestBase
 	{
 		protected override AndroidHandlerSettingsAdapter CreateHandler ()


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/10079

This runs Mono.Android-Tests with `-p:PublishAot=true`.

I temporarily disabled the following tests:

* The `Java.Interop-Tests.dll` test assembly
* `GCBridge` category, related to a missing "GC Bridge"
* `SSL` and `NTLM` categories related to some http tests
* Some individual tests

These categories will probably *never need to* work on NativeAOT:

* `Export`: use of `Mono.Android.Export.dll`
* `AndroidClientHandler`: legacy `HttpClientHandler` implementation
* `NativeTypeMap`: as the managed typemap is trimmer safe
* `AppContextTests.TestPrivateSwitches` may not be relevant for NativeAOT

I left a `TODO` comment for each ignored test, to investigate in the future.