### PR TITLE
[Xamarin.Android.Build.Tasks] introduce `$(_AndroidJcwCodegenTarget)`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -41,7 +41,8 @@
     <!-- Bindings properties -->
     <!-- jar2xml is not supported -->
     <AndroidClassParser>class-parse</AndroidClassParser>
-    <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' ">XAJavaInterop1</AndroidCodegenTarget>
+    <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
+    <_AndroidJcwCodegenTarget Condition=" '$(_AndroidJcwCodegenTarget)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' ">XAJavaInterop1</_AndroidJcwCodegenTarget>
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods Condition=" '$(AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods)' == '' ">true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
     <AndroidBoundInterfacesContainTypes Condition=" '$(AndroidBoundInterfacesContainTypes)' == '' ">true</AndroidBoundInterfacesContainTypes>
     <AndroidBoundInterfacesContainConstants Condition=" '$(AndroidBoundInterfacesContainConstants)' == '' ">true</AndroidBoundInterfacesContainConstants>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -12,7 +12,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
   <!-- Default property values for NativeAOT -->
   <PropertyGroup>
     <_AndroidRuntimePackRuntime>NativeAOT</_AndroidRuntimePackRuntime>
-    <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">JavaInterop1</AndroidCodegenTarget>
+    <_AndroidJcwCodegenTarget Condition=" '$(_AndroidJcwCodegenTarget)' == '' ">JavaInterop1</_AndroidJcwCodegenTarget>
     <!-- .NET SDK gives: error NETSDK1191: A runtime identifier for the property 'PublishAot' couldn't be inferred. Specify a rid explicitly. -->
     <AllowPublishAotWithoutRuntimeIdentifier Condition=" '$(AllowPublishAotWithoutRuntimeIdentifier)' == '' ">true</AllowPublishAotWithoutRuntimeIdentifier>
     <!-- NativeAOT's targets currently gives an error about cross-compilation -->

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1516,7 +1516,7 @@ because xbuild doesn't support framework reference assemblies.
 
   <GenerateJavaStubs
       AndroidRuntime="$(_AndroidRuntime)"
-      CodeGenerationTarget="$(AndroidCodegenTarget)"
+      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
       ResolvedAssemblies="@(_ResolvedAssemblies)"
       ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
       ErrorOnCustomJavaObject="$(AndroidErrorOnCustomJavaObject)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1375,7 +1375,7 @@ because xbuild doesn't support framework reference assemblies.
     <_AndroidJarAndDexDirectory>$(_XATargetFrameworkDirectories)</_AndroidJarAndDexDirectory>
   </PropertyGroup>
   <GetMonoPlatformJar
-      Condition=" '$(_AndroidUseMarshalMethods)' != 'True' and '$(AndroidCodegenTarget)' == 'XAJavaInterop1' "
+      Condition=" '$(_AndroidUseMarshalMethods)' != 'True' and '$(_AndroidJcwCodegenTarget)' == 'XAJavaInterop1' "
       TargetFrameworkDirectory="$(_AndroidJarAndDexDirectory)">
     <Output TaskParameter="MonoPlatformJarPath" PropertyName="MonoPlatformJarPath" />
     <Output TaskParameter="MonoPlatformDexPath" PropertyName="MonoPlatformDexPath" />
@@ -1404,12 +1404,12 @@ because xbuild doesn't support framework reference assemblies.
   />
 
   <Copy
-    Condition=" '$(_AndroidUseMarshalMethods)' != 'True' and '$(AndroidCodegenTarget)' == 'XAJavaInterop1' "
+    Condition=" '$(_AndroidUseMarshalMethods)' != 'True' and '$(_AndroidJcwCodegenTarget)' == 'XAJavaInterop1' "
     SourceFiles="$(MonoPlatformJarPath)"
     DestinationFiles="$(IntermediateOutputPath)android\bin\mono.android.jar"
     SkipUnchangedFiles="true" />
   <Touch
-    Condition=" '$(_AndroidUseMarshalMethods)' != 'True' and '$(AndroidCodegenTarget)' == 'XAJavaInterop1' "
+    Condition=" '$(_AndroidUseMarshalMethods)' != 'True' and '$(_AndroidJcwCodegenTarget)' == 'XAJavaInterop1' "
     Files="$(IntermediateOutputPath)android\bin\mono.android.jar" />
 
   <Touch Files="$(_AndroidStaticResourcesFlag)" AlwaysCreate="true" />
@@ -1419,7 +1419,7 @@ because xbuild doesn't support framework reference assemblies.
     <FileWrites Include="$(_AndroidIntermediateJavaSourceDirectory)mono\JavaInteropTypeManager.java" />
     <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)machine.config" />
     <FileWrites
-        Condition=" '$(_AndroidUseMarshalMethods)' != 'True' and '$(AndroidCodegenTarget)' == 'XAJavaInterop1' "
+        Condition=" '$(_AndroidUseMarshalMethods)' != 'True' and '$(_AndroidJcwCodegenTarget)' == 'XAJavaInterop1' "
         Include="$(IntermediateOutputPath)android\bin\mono.android.jar"
     />
     <FileWrites Include="$(_AndroidStaticResourcesFlag)" />
@@ -1551,7 +1551,7 @@ because xbuild doesn't support framework reference assemblies.
       ApplicationLabel="$(_ApplicationLabel)"
       BundledWearApplicationName="$(BundledWearApplicationPackageName)"
       CheckedBuild="$(_AndroidCheckedBuild)"
-      CodeGenerationTarget="$(AndroidCodegenTarget)"
+      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
       Debug="$(AndroidIncludeDebugSymbols)"
       EmbedAssemblies="$(EmbedAssembliesIntoApk)"
       EnableMarshalMethods="$(_AndroidUseMarshalMethods)"


### PR DESCRIPTION
d70db5b was *wrong* in that it merged two different things:

* Java stub generation's "codegen target" (once settable by an MSBuild property `$(_AndroidCodeGenerationTarget)`)

* C# generator's "codegen target" or `$(AndroidCodegenTarget)`

The problem was `$(_AndroidCodeGenerationTarget)` was just poorly named making me think it was the same as `$(AndroidCodegenTarget)`.

Partially revert d70db5b and use the name `$(_AndroidJcwCodegenTarget)` instead.

NativeAOT now defaults to `$(_AndroidJcwCodegenTarget)=JavaInterop1` and `$(AndroidCodegenTarget)=XAJavaInterop1`.