### PR TITLE
[NUnitLite] remove `Assembly.CodeBase` usage

### DIFF
--- a/src-ThirdParty/NUnitLite/Internal/AssemblyHelper.cs
+++ b/src-ThirdParty/NUnitLite/Internal/AssemblyHelper.cs
@@ -52,11 +52,6 @@ namespace NUnit.Framework.Internal
         /// <returns>The path.</returns>
         public static string GetAssemblyPath(Assembly assembly)
         {
-            string codeBase = assembly.CodeBase;
-
-            if (IsFileUri(codeBase))
-                return GetAssemblyPathFromCodeBase(codeBase);
-
             return assembly.Location;
         }
 #endif
@@ -94,41 +89,6 @@ namespace NUnit.Framework.Internal
             return assembly.GetName();
 #endif
         }
-
-        #endregion
-
-        #region Helper Methods
-
-#if !NETCF
-        private static bool IsFileUri(string uri)
-        {
-            return uri.ToLower().StartsWith(Uri.UriSchemeFile);
-        }
-
-        // Public for testing purposes
-        public static string GetAssemblyPathFromCodeBase(string codeBase)
-        {
-            // Skip over the file:// part
-            int start = Uri.UriSchemeFile.Length + Uri.SchemeDelimiter.Length;
-
-            bool isWindows = System.IO.Path.DirectorySeparatorChar == '\\';
-
-            if (codeBase[start] == '/') // third slash means a local path
-            {
-                // Handle Windows Drive specifications
-                if (isWindows && codeBase[start + 2] == ':')
-                    ++start;
-                // else leave the last slash so path is absolute
-            }
-            else // It's either a Windows Drive spec or a share
-            {
-                if (!isWindows || codeBase[start + 1] != ':')
-                    start -= 2; // Back up to include two slashes
-            }
-
-            return codeBase.Substring(start);
-        }
-#endif
 
         #endregion
     }


### PR DESCRIPTION
Running `Mono.Android-Tests` on NativeAOT crashes with:

    02-27 14:32:47.590  9008  9024 E NUnit   : Error: System.NotSupportedException: NotSupported_CodeBase (TaskId:30)
    02-27 14:32:47.590  9008  9024 E NUnit   :    at System.Reflection.Runtime.Assemblies.RuntimeAssemblyInfo.get_CodeBase() + 0x34 (TaskId:30)
    02-27 14:32:47.590  9008  9024 E NUnit   :    at NUnit.Framework.Internal.AssemblyHelper.GetAssemblyPath(Assembly) + 0x10 (TaskId:30)
    02-27 14:32:47.590  9008  9024 E NUnit   :    at NUnit.Framework.Internal.NUnitLiteTestAssemblyBuilder.Build(Assembly, IDictionary) + 0x8c (TaskId:30)
    02-27 14:32:47.590  9008  9024 E NUnit   :    at NUnit.Framework.Internal.NUnitLiteTestAssemblyRunner.Load(Assembly, IDictionary) + 0x28 (TaskId:30)
    02-27 14:32:47.590  9008  9024 E NUnit   :    at Xamarin.Android.UnitTests.NUnit.NUnitTestRunner.Run(IList`1) + 0x1ac (TaskId:30)
    02-27 14:32:47.590  9008  9024 E NUnit   :    at Xamarin.Android.UnitTests.TestInstrumentation`1.RunTests(Bundle&) + 0xc8 (TaskId:30)
    02-27 14:32:47.590  9008  9024 E NUnit   :    at Xamarin.Android.UnitTests.TestInstrumentation`1.OnStart() + 0x48 (TaskId:30)

It appears we can just remove all usage of `Assembly.CodeBase` from this file to get past this error.