### PR TITLE
[Mono.Android] use `Java.Lang.Object.GetObject<T>()`

### DIFF
--- a/src/Mono.Android/Android.Runtime/InputStreamInvoker.cs
+++ b/src/Mono.Android/Android.Runtime/InputStreamInvoker.cs
@@ -153,17 +153,10 @@ namespace Android.Runtime
 		
 		public static Stream? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
-			if (handle == IntPtr.Zero)
+			var inst = Java.Lang.Object.GetObject<Java.IO.InputStream> (handle, transfer);
+			if (inst is null)
 				return null;
-
-			var inst = (IJavaObject?) Java.Lang.Object.PeekObject (handle);
-
-			if (inst == null)
-				inst = (IJavaObject) Java.Interop.TypeManager.CreateInstance (handle, transfer);
-			else
-				JNIEnv.DeleteRef (handle, transfer);
-
-			return new InputStreamInvoker ((Java.IO.InputStream)inst);
+			return new InputStreamInvoker (inst);
 		}
 	}
 }

--- a/src/Mono.Android/Android.Runtime/OutputStreamInvoker.cs
+++ b/src/Mono.Android/Android.Runtime/OutputStreamInvoker.cs
@@ -129,17 +129,10 @@ namespace Android.Runtime
 
 		internal static Stream? FromNative (IntPtr handle, JniHandleOwnership transfer)
 		{
-			if (handle == IntPtr.Zero)
+			var inst = Java.Lang.Object.GetObject<Java.IO.OutputStream> (handle, transfer);
+			if (inst is null)
 				return null;
-
-			var inst = (IJavaObject?) Java.Lang.Object.PeekObject (handle);
-
-			if (inst == null)
-				inst = (IJavaObject) Java.Interop.TypeManager.CreateInstance (handle, transfer);
-			else
-				JNIEnv.DeleteRef (handle, transfer);
-
-			return new OutputStreamInvoker ((Java.IO.OutputStream)inst);
+			return new OutputStreamInvoker (inst);
 		}
 	}
 }

--- a/src/Mono.Android/Android.Runtime/XmlPullParserReader.cs
+++ b/src/Mono.Android/Android.Runtime/XmlPullParserReader.cs
@@ -32,14 +32,10 @@ namespace Android.Runtime
 		
 		static XmlResourceParserReader? FromNative (IntPtr handle, JniHandleOwnership transfer)
 		{
-			if (handle == IntPtr.Zero)
+			var inst = Java.Lang.Object.GetObject<Android.Content.Res.IXmlResourceParser> (handle, transfer);
+			if (inst is null)
 				return null;
-			var inst = (IJavaObject?) Java.Lang.Object.PeekObject (handle);
-			if (inst == null)
-				inst = (IJavaObject) Java.Interop.TypeManager.CreateInstance (handle, transfer);
-			else
-				JNIEnv.DeleteRef (handle, transfer);
-			return new XmlResourceParserReader (inst.JavaCast<Android.Content.Res.IXmlResourceParser> ()!);
+			return new XmlResourceParserReader (inst);
 		}
 	}
 	
@@ -393,14 +389,10 @@ namespace Android.Runtime
 		
 		static XmlReader? FromNative (IntPtr handle, JniHandleOwnership transfer)
 		{
-			if (handle == IntPtr.Zero)
+			var inst = Java.Lang.Object.GetObject<IXmlPullParser> (handle, transfer);
+			if (inst is null)
 				return null;
-			var inst = (IJavaObject?) Java.Lang.Object.PeekObject (handle);
-			if (inst == null)
-				inst = (IJavaObject) Java.Interop.TypeManager.CreateInstance (handle, transfer);
-			else
-				JNIEnv.DeleteRef (handle, transfer);
-			return new XmlPullParserReader (inst.JavaCast<IXmlPullParser> ()!);
+			return new XmlPullParserReader (inst);
 		}
 	}
 }


### PR DESCRIPTION
f800c1a6 was a step toward making `Java.Lang.Object.GetObject<T>()` to not call the static `Java.Interop.TypeManager.CreateInstance()` and go through a `JniRuntime.JniValueManager` instead.

Unfortunately, there are still a few types that manually call `TypeManager.CreateInstance()`, these will error when running with NativeAOT such as `Mono.Android.NET-Tests`:

    02-27 14:40:23.089  9462  9487 I NUnit   : AssetContents("asset1.txt","Asset1")
    02-27 14:40:23.093  9462  9487 E NUnit   :      [FAIL]
    02-27 14:40:23.093  9462  9487 E NUnit   :  : System.DllNotFoundException : DllNotFound_Linux, xa-internal-api,
    02-27 14:40:23.093  9462  9487 E NUnit   : dlopen failed: library "xa-internal-api.so" not found
    02-27 14:40:23.093  9462  9487 E NUnit   : dlopen failed: library "libxa-internal-api.so" not found
    02-27 14:40:23.093  9462  9487 E NUnit   : dlopen failed: library "xa-internal-api" not found
    02-27 14:40:23.093  9462  9487 E NUnit   : dlopen failed: library "libxa-internal-api" not found
    02-27 14:40:23.093  9462  9487 E NUnit   :    at System.Runtime.InteropServices.NativeLibrary.LoadLibErrorTracker.Throw(String) + 0x4c
    02-27 14:40:23.093  9462  9487 E NUnit   :    at Internal.Runtime.CompilerHelpers.InteropHelpers.FixupModuleCell(InteropHelpers.ModuleFixupCell*) + 0x134
    02-27 14:40:23.093  9462  9487 E NUnit   :    at Internal.Runtime.CompilerHelpers.InteropHelpers.ResolvePInvokeSlow(InteropHelpers.MethodFixupCell*) + 0x40
    02-27 14:40:23.093  9462  9487 E NUnit   :    at Android.Runtime.RuntimeNativeMethods.monodroid_TypeManager_get_java_class_name(IntPtr klass) + 0x2c
    02-27 14:40:23.093  9462  9487 E NUnit   :    at Java.Interop.TypeManager.GetClassName(IntPtr) + 0x10
    02-27 14:40:23.093  9462  9487 E NUnit   :    at Java.Interop.TypeManager.CreateInstance(IntPtr, JniHandleOwnership, Type) + 0x44
    02-27 14:40:23.093  9462  9487 E NUnit   :    at Android.Runtime.InputStreamInvoker.FromJniHandle(IntPtr handle, JniHandleOwnership transfer) + 0x60
    02-27 14:40:23.093  9462  9487 E NUnit   :    at Android.Content.Res.AssetManager.Open(String) + 0x88
    02-27 14:40:23.093  9462  9487 E NUnit   :    at Android.Content.ResTests.AssetManagerTests.AssetContents(String asset, String expected) + 0x34
    02-27 14:40:23.093  9462  9487 E NUnit   :    at libMono.Android.NET-Tests!<BaseAddress>+0x155be18
    02-27 14:40:23.093  9462  9487 E NUnit   :    at System.Reflection.DynamicInvokeInfo.InvokeWithFewArguments(IntPtr, Byte&, Byte&, Object[], BinderBundle, Boolean) + 0x84

Update `InputStreamInvoker`, `OutputStreamInvoker`, and `XmlPullParserReader` to use `Java.Lang.Object.GetObject<T>()` instead.