### PR TITLE
[Mono.Android] fix `JavaConvert.GetTypeMapping()` for NativeAOT

### DIFF
--- a/src/Mono.Android/Java.Interop/JavaConvert.cs
+++ b/src/Mono.Android/Java.Interop/JavaConvert.cs
@@ -208,7 +208,7 @@ namespace Java.Interop {
 		{
 			var lref = JniEnvironment.Types.GetObjectClass (new JniObjectReference (handle));
 			try {
-				string className = TypeManager.GetClassName (lref.Handle);
+				string className = JniEnvironment.Types.GetJniTypeNameFromClass (lref);
 				if (TypeMappings.TryGetValue (className, out var match))
 					return match;
 				if (JniEnvironment.Types.IsAssignableFrom (lref, new JniObjectReference (JavaDictionary.map_class)))


### PR DESCRIPTION
Mono.Android-Tests running on NativeAOT can have a failure such as:

    02-28 14:33:38.949 12544 12567 I NUnit   : Indexer
    02-28 14:33:38.952 12544 12567 E NUnit   :      [FAIL]
    02-28 14:33:38.952 12544 12567 E NUnit   :  : System.DllNotFoundException : DllNotFound_Linux, xa-internal-api,
    02-28 14:33:38.952 12544 12567 E NUnit   : dlopen failed: library "xa-internal-api.so" not found
    02-28 14:33:38.952 12544 12567 E NUnit   : dlopen failed: library "libxa-internal-api.so" not found
    02-28 14:33:38.952 12544 12567 E NUnit   : dlopen failed: library "xa-internal-api" not found
    02-28 14:33:38.952 12544 12567 E NUnit   : dlopen failed: library "libxa-internal-api" not found
    02-28 14:33:38.952 12544 12567 E NUnit   :    at System.Runtime.InteropServices.NativeLibrary.LoadLibErrorTracker.Throw(String) + 0x4c
    02-28 14:33:38.952 12544 12567 E NUnit   :    at Internal.Runtime.CompilerHelpers.InteropHelpers.FixupModuleCell(InteropHelpers.ModuleFixupCell*) + 0x134
    02-28 14:33:38.952 12544 12567 E NUnit   :    at Internal.Runtime.CompilerHelpers.InteropHelpers.ResolvePInvokeSlow(InteropHelpers.MethodFixupCell*) + 0x40
    02-28 14:33:38.952 12544 12567 E NUnit   :    at Android.Runtime.RuntimeNativeMethods.monodroid_TypeManager_get_java_class_name(IntPtr klass) + 0x2c
    02-28 14:33:38.952 12544 12567 E NUnit   :    at Java.Interop.TypeManager.GetClassName(IntPtr) + 0x10
    02-28 14:33:38.952 12544 12567 E NUnit   :    at Java.Interop.JavaConvert.GetTypeMapping(IntPtr) + 0x28
    02-28 14:33:38.952 12544 12567 E NUnit   :    at Java.Interop.JavaConvert.FromJniHandle(IntPtr handle, JniHandleOwnership transfer, Type targetType) + 0x84
    02-28 14:33:38.952 12544 12567 E NUnit   :    at Android.Runtime.JavaList.InternalGet(Int32, Type) + 0x90
    02-28 14:33:38.952 12544 12567 E NUnit   :    at Java.InteropTests.JavaListTest`1.Indexer() + 0xfc
    02-28 14:33:38.952 12544 12567 E NUnit   :    at libMono.Android.NET-Tests!<BaseAddress>+0x152f744
    02-28 14:33:38.952 12544 12567 E NUnit   :    at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) + 0x10c

We can update `JavaConvert.GetTypeMapping()` to use `JniEnvironment.Types.GetJniTypeNameFromClass()` the same way it is done in dotnet/java-interop:

https://github.com/dotnet/java-interop/blob/719e615910923bbce10e74b05bcc6b9585d4e176/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs#L214-L220

With this change the test passes:

    02-28 14:46:50.280 13091 13107 I NUnit   : Indexer
    02-28 14:46:50.281 13091 13107 I NUnit   :      Passed