### PR TITLE
[Mono.Android] update more `TypeManager.GetClassName()` calls

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -205,7 +205,7 @@ namespace Android.Runtime {
 				IntPtr ctor = JNIEnv.GetMethodID (lrefClass, "<init>", jniCtorSignature);
 				if (ctor == IntPtr.Zero)
 					throw new ArgumentException (FormattableString.Invariant (
-						$"Could not find constructor JNI signature '{jniCtorSignature}' on type '{Java.Interop.TypeManager.GetClassName (lrefClass)}'."));
+						$"Could not find constructor JNI signature '{jniCtorSignature}' on type '{JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (lrefClass))}'."));
 				CallNonvirtualVoidMethod (instance, lrefClass, ctor, constructorParameters);
 			} finally {
 				DeleteLocalRef (lrefClass);
@@ -223,7 +223,7 @@ namespace Android.Runtime {
 			IntPtr ctor = JNIEnv.GetMethodID (jniClass, "<init>", signature);
 			if (ctor == IntPtr.Zero)
 				throw new ArgumentException (FormattableString.Invariant (
-					$"Could not find constructor JNI signature '{signature}' on type '{Java.Interop.TypeManager.GetClassName (jniClass)}'."));
+					$"Could not find constructor JNI signature '{signature}' on type '{JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (jniClass))}'."));
 			return JNIEnv.NewObject (jniClass, ctor, constructorParameters);
 		}
 
@@ -543,7 +543,7 @@ namespace Android.Runtime {
 			try {
 				if (!IsAssignableFrom (grefSource, lrefDest)) {
 					throw new InvalidCastException (FormattableString.Invariant (
-						$"Unable to cast from '{Java.Interop.TypeManager.GetClassName (grefSource)}' to '{Java.Interop.TypeManager.GetClassName (lrefDest)}'."));
+						$"Unable to cast from '{JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (grefSource))}' to '{JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (lrefDest))}'."));
 				}
 			} finally {
 				DeleteGlobalRef (grefSource);
@@ -558,7 +558,7 @@ namespace Android.Runtime {
 			try {
 				if (!IsAssignableFrom (lrefSource, grefDest)) {
 					throw new InvalidCastException (FormattableString.Invariant (
-						$"Unable to cast from '{Java.Interop.TypeManager.GetClassName (lrefSource)}' to '{Java.Interop.TypeManager.GetClassName (grefDest)}'."));
+						$"Unable to cast from '{JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (lrefSource))}' to '{JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (grefDest))}'."));
 				}
 			} finally {
 				DeleteGlobalRef (grefDest);
@@ -1167,7 +1167,7 @@ namespace Android.Runtime {
 				return IntPtr.Zero;
 
 			IntPtr grefArrayElementClass = GetArrayElementClass (values);
-			if (Java.Interop.TypeManager.GetClassName (grefArrayElementClass) == "mono/android/runtime/JavaObject") {
+			if (JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (grefArrayElementClass)) == "mono/android/runtime/JavaObject") {
 				DeleteGlobalRef (grefArrayElementClass);
 				grefArrayElementClass = NewGlobalRef (Java.Lang.Class.Object);
 			}


### PR DESCRIPTION
`Mono.Android` has various test failures under NativeAOT such as:

    02-28 16:35:29.583 18438 18456 I NUnit   : CastJavaLangObjectArrayToByteArrayThrows
    02-28 16:35:29.586 18438 18456 E NUnit   :      [FAIL]
    02-28 16:35:29.586 18438 18456 E NUnit   :  :   Expected: <System.InvalidCastException>
    02-28 16:35:29.586 18438 18456 E NUnit   :   But was:  <System.DllNotFoundException> (DllNotFound_Linux, xa-internal-api,
    02-28 16:35:29.586 18438 18456 E NUnit   : dlopen failed: library "xa-internal-api.so" not found
    02-28 16:35:29.586 18438 18456 E NUnit   : dlopen failed: library "libxa-internal-api.so" not found
    02-28 16:35:29.586 18438 18456 E NUnit   : dlopen failed: library "xa-internal-api" not found
    02-28 16:35:29.586 18438 18456 E NUnit   : dlopen failed: library "libxa-internal-api" not found
    02-28 16:35:29.586 18438 18456 E NUnit   : )
    02-28 16:35:29.586 18438 18456 E NUnit   :    at System.Runtime.InteropServices.NativeLibrary.LoadLibErrorTracker.Throw(String) + 0x4c
    02-28 16:35:29.586 18438 18456 E NUnit   :    at Internal.Runtime.CompilerHelpers.InteropHelpers.FixupModuleCell(InteropHelpers.ModuleFixupCell*) + 0x134
    02-28 16:35:29.586 18438 18456 E NUnit   :    at Internal.Runtime.CompilerHelpers.InteropHelpers.ResolvePInvokeSlow(InteropHelpers.MethodFixupCell*) + 0x40
    02-28 16:35:29.586 18438 18456 E NUnit   :    at Android.Runtime.RuntimeNativeMethods.monodroid_TypeManager_get_java_class_name(IntPtr klass) + 0x2c
    02-28 16:35:29.586 18438 18456 E NUnit   :    at Java.Interop.TypeManager.GetClassName(IntPtr) + 0x10
    02-28 16:35:29.586 18438 18456 E NUnit   :    at Android.Runtime.JNIEnv.AssertCompatibleArrayTypes(IntPtr, Type) + 0x58
    02-28 16:35:29.586 18438 18456 E NUnit   :    at Android.Runtime.JNIEnv.GetArray[T](IntPtr array_ptr) + 0x24
    02-28 16:35:29.586 18438 18456 E NUnit   :    at Java.LangTests.ObjectArrayMarshaling.<>c__DisplayClass0_0.<CastJavaLangObjectArrayToByteArrayThrows>b__0() + 0x18
    02-28 16:35:29.586 18438 18456 E NUnit   :    at NUnit.Framework.Assert.Throws(IResolveConstraint, TestDelegate, String, Object[]) + 0xc4
    02-28 16:35:29.586 18438 18456 E NUnit   :    at Java.LangTests.ObjectArrayMarshaling.CastJavaLangObjectArrayToByteArrayThrows() + 0x150
    02-28 16:35:29.586 18438 18456 E NUnit   :    at libMono.Android.NET-Tests!<BaseAddress>+0x152f704
    02-28 16:35:29.586 18438 18456 E NUnit   :    at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) + 0x10c

I updated the remaining calls in `JNIEnv.cs` to use `JniEnvironment.Types.GetJniTypeNameFromClass()` instead.