### PR TITLE
Fix Debugger timeout on 32 bit devices.

### DIFF
--- a/src/native/mono/monodroid/monodroid-glue.cc
+++ b/src/native/mono/monodroid/monodroid-glue.cc
@@ -521,14 +521,14 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] JNIEnv *env, [[maybe_unuse
 		else
 			loglevel = options.loglevel;
 
-		char *debug_arg = Util::monodroid_strdup_printf (
-			"--debugger-agent=transport=dt_socket,loglevel=%d,address=%s:%d,%sembedding=1,timeout=%d",
+		char *debug_arg = strdup (std::format (
+			"--debugger-agent=transport=dt_socket,loglevel={},address={}:{},{}embedding=1,timeout={}",
 			loglevel,
 			options.host,
 			options.sdb_port,
 			options.server ? "server=y," : "",
 			options.timeout_time
-		);
+		).c_str ());
 
 		char *debug_options [2] = {
 			debug_arg,


### PR DESCRIPTION
Context https://github.com/dotnet/android/issues/9573

Not sure why, but we are getting an odd problem were the `timeout` value we pass to mono for the debugger is not long enough. This is causing the debugger to timeout.

What we see is `timeout=3` rather than `timeout=1740583188`. Lets upgrade to use `std:format` to see if that helps as it with automatically take care of the conversion for us.