### PR TITLE
[Mono.Android-Tests] Ignore more types of temporary network/server failures.

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -286,12 +286,17 @@ namespace Xamarin.Android.NetTests {
 			}
 		}
 
-		void EnsureSuccessStatusCode (HttpResponseMessage response)
+		public void EnsureSuccessStatusCode (HttpResponseMessage response)
 		{
-			// If we hit a 502 (which is quite common on CI) just ignore the test
-			if (response.StatusCode == HttpStatusCode.BadGateway) {
-				Assert.Ignore ($"Ignoring network failure: {response.StatusCode}");
-				return;
+			// These status codes all indicate a temporary network/server failure,
+			// so just ignore the test if we hit them.
+			switch (response.StatusCode) {
+				case HttpStatusCode.InternalServerError:
+				case HttpStatusCode.BadGateway:
+				case HttpStatusCode.ServiceUnavailable:
+				case HttpStatusCode.GatewayTimeout:
+					Assert.Ignore ($"Ignoring network/server failure: {response.StatusCode}");
+					return;
 			}
 
 			response.EnsureSuccessStatusCode ();

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
@@ -231,8 +231,9 @@ namespace Xamarin.Android.NetTests
 			var client = new HttpClient (handler);
 			var result = await client.GetAsync ("https://httpbin.org/redirect-to?url=https://www.microsoft.com/");
 
+			EnsureSuccessStatusCode (result);
+
 			Assert.AreEqual (2, callbackCounter);
-			Assert.IsTrue (result.IsSuccessStatusCode);
 		}
 
 		[Test]
@@ -245,7 +246,8 @@ namespace Xamarin.Android.NetTests
 			var client = new HttpClient (handler);
 			var result = await client.GetAsync ("https://httpbin.org/redirect-to?url=https://www.microsoft.com/&status_code=308");
 
-			Assert.IsTrue (result.IsSuccessStatusCode);
+			EnsureSuccessStatusCode (result);
+
 			Assert.AreEqual ("https://www.microsoft.com/", result.RequestMessage.RequestUri.ToString ());
 		}
 


### PR DESCRIPTION
CI tests are failing with:

```
System.Net.Http.HttpRequestException : net_http_message_not_success_statuscode_reason, 503, Service Temporarily Unavailable
   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
   at Xamarin.Android.NetTests.AndroidHandlerTestBase.EnsureSuccessStatusCode(HttpResponseMessage response)
   at Xamarin.Android.NetTests.AndroidHandlerTestBase.Redirect_POST_With_Content_Works()
   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object , BindingFlags )
```

Add several additional HTTP 50X codes that indicate temporary network/server failures to the list of status codes that should be ignored in `EnsureSuccessStatusCode`.