### PR TITLE
[ci] Publish VS workload zips (#9870)

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -173,6 +173,8 @@
 
     <ItemGroup>
       <ItemsToPush Include="$(OutputPath)*.nupkg" />
+      <WorkloadArtifacts Include="$(OutputPath)*.zip" />
+      <ItemsToPush Include="@(WorkloadArtifacts)" PublishFlatContainer="true" RelativeBlobPath="android/$(AndroidPackVersionLong)/%(Filename)%(Extension)" />
     </ItemGroup>
 
     <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />

--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <TargetName>Microsoft.NET.Sdk.Android.Workload.@VSMAN_VERSION@</TargetName>
+    <TargetName>android.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@WORKLOAD_VERSION@</ManifestBuildVersion>
     <EnableSideBySideManifests>true</EnableSideBySideManifests>
     <UseVisualStudioComponentPrefix>false</UseVisualStudioComponentPrefix>


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/commit/96d7858cce242c5eea76028f3f051bb9ffda793c

Adds the VS manifest zips needed by the workload versions VS insertion
pipeline to Maestro publishing.

The first update to VS that includes these changes will have to be done
manually, as the manifest names are also changing to work with the new
pipeline.