### PR TITLE
[nativeaot] fix default `SynchronizationContext`

### DIFF
--- a/src/Mono.Android/Android.App/Application.cs
+++ b/src/Mono.Android/Android.App/Application.cs
@@ -8,6 +8,10 @@ namespace Android.App {
 
 	partial class Application {
 
+		static Application () {
+			// NOTE: do not remove, removes the beforefieldinit flag for JNIEnvInit.SetSynchronizationContext()
+		}
+
 		static Context? _context;
 		public static Context Context {
 			get {

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -86,6 +86,7 @@ namespace Android.Runtime
 		{
 			androidRuntime = runtime;
 			ValueManager = runtime.ValueManager;
+			SetSynchronizationContext ();
 		}
 
 		[UnmanagedCallersOnly]
@@ -136,8 +137,6 @@ namespace Android.Runtime
 		[DllImport ("xamarin-app")]
 		static extern unsafe void xamarin_app_init (IntPtr env, delegate* unmanaged <int, int, int, IntPtr*, void> get_function_pointer);
 
-		// NOTE: prevents Android.App.Application static ctor from running
-		[MethodImpl (MethodImplOptions.NoInlining)]
 		static void SetSynchronizationContext () =>
 			SynchronizationContext.SetSynchronizationContext (Android.App.Application.SynchronizationContext);
 	}


### PR DESCRIPTION
Running `Mono.Android-Tests` under NativeAOT has the test failure:

    03-04 23:06:20.021  6191  6211 I NUnit   : SynchronizationContext_Is_ThreadingSynchronizationContextCurrent
    03-04 23:06:20.032  6191  6211 E NUnit   : 	[FAIL]
    03-04 23:06:20.032  6191  6211 E NUnit   :  :   Expected: True
    03-04 23:06:20.032  6191  6211 E NUnit   :   But was:  False
    03-04 23:06:20.032  6191  6211 E NUnit   :    at libMono.Android.NET-Tests!<BaseAddress>+0x1482f63
    03-04 23:06:20.032  6191  6211 E NUnit   :    at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) + 0xf3

Initially, if we called `JNIEnvInit.SetSynchronizationContext()` at startup, this can result in the static ctor for
`Android.App.Application` running *too soon* before `JNIEnvInit.InitializeJniRuntime()` has completed.

To fix this:

* Add an empty `static ctor` to `Android.App.Application` to remove the `beforefieldinit` flag from the type.

* Call `JNIEnvInit.SetSynchronizationContext()` at startup for NativeAOT.

With this change in place, no crashes occur at startup and the test passes.