### PR TITLE
[XABT] Don't run `_LinkAssembliesNoShrink` when `$(PublishTrimmed)` = `true`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -100,6 +100,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			var builder = CreateApkBuilder ();
+			builder.Verbosity = LoggerVerbosity.Detailed;
 			Assert.IsTrue (builder.Build (proj), "`dotnet build` should succeed");
 			builder.AssertHasNoWarnings ();
 
@@ -179,6 +180,14 @@ namespace Xamarin.Android.Build.Tests
 					helper.AssertContainsEntry ($"lib/{abi}/libaot-{proj.ProjectName}.dll.so");
 					helper.AssertContainsEntry ($"lib/{abi}/libaot-Mono.Android.dll.so");
 				}
+			}
+
+			if (isRelease) {
+				builder.Output.AssertTargetIsNotSkipped ("ILLink");
+				builder.Output.AssertTargetIsSkipped ("_LinkAssembliesNoShrink");
+			} else {
+				builder.Output.AssertTargetIsSkipped ("ILLink");
+				builder.Output.AssertTargetIsNotSkipped ("_LinkAssembliesNoShrink");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1464,7 +1464,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_LinkAssembliesNoShrink"
     DependsOnTargets="_LinkAssembliesNoShrinkInputs"
-    Condition="'$(AndroidLinkMode)' == 'None'"
+    Condition="'$(PublishTrimmed)' != 'true'"
     Inputs="@(ResolvedAssemblies);$(_AndroidBuildPropertiesCache)"
     Outputs="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')">
   <LinkAssembliesNoShrink


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/9526

Today, we need to run *either* `ILLink` or `_LinkAssembliesNoShrink`, however they have different triggers:

- [`ILLink` - `$(PublishTrimmed)` = `true`](https://github.com/dotnet/runtime/blob/f63d96e434576ae81a105a7e52634a877058b978/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets#L92-L96)
- `_LinkAssembliesNoShrink` - `$(AndroidLinkMode)` = `None`

These can get out of sync, particularly when using global properties, causing both to be run.  

Update `_LinkAssembliesNoShrink` to trigger when `$(PublishTrimmed)` != `true` to ensure that we don't run it if `ILLink` is being run.