### PR TITLE
[tests] remove `runtimeconfig.template.json` in favor of `@(RuntimeHostConfigurationOption)`

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -206,6 +206,13 @@
     <AndroidNativeLibrary Include="..\libs\x86_64\libreuse-threads.so" />
   </ItemGroup>
 
+  <!-- Used by AppContextTests.cs -->
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="test_bool"    Value="true" />
+    <RuntimeHostConfigurationOption Include="test_integer" Value="42" />
+    <RuntimeHostConfigurationOption Include="test_string"  Value="foo" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(AndroidPackageFormat)' != 'aab' ">
     <TestApk Include="$(OutputPath)$(_MonoAndroidTestPackage)-Signed.apk">
       <Package>$(_MonoAndroidTestPackage)</Package>

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/runtimeconfig.template.json
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/runtimeconfig.template.json
@@ -1,7 +1,0 @@
-{
-    "configProperties": {
-        "test_bool": true,
-        "test_integer": 42,
-        "test_string": "foo"
-    }
-}


### PR DESCRIPTION
NativeAOT doesn't support `runtimeconfig.template.json` and it emits the build warning:

    D:\.nuget\packages\microsoft.dotnet.ilcompiler\10.0.0-preview.3.25152.2\build\Microsoft.NETCore.Native.Publish.targets(46,5):
    The published project has a runtimeconfig.template.json that is not supported by PublishAot. Move the configuration to the project file using RuntimeHostConfigurationOption.

So, instead of using `runtimeconfig.template.json` with contents:

    {
        "configProperties": {
            "test_bool": true,
            "test_integer": 42,
            "test_string": "foo"
        }
    }

You can simply define them in your `.csproj` as:

    <ItemGroup>
      <RuntimeHostConfigurationOption Include="test_bool"    Value="true" />
      <RuntimeHostConfigurationOption Include="test_integer" Value="42" />
      <RuntimeHostConfigurationOption Include="test_string"  Value="foo" />
    </ItemGroup>

Honestly, I think I prefer the MSBuild item group.

We don't necessarily care how the values are defined, just that these values at build time are set at runtime, and we can assert them in `AppContextTests.cs`.