### PR TITLE
Update AndroidNetPreviousVersion to 35.0.50 and 34.0.148

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,8 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
+    <add key="darc-pub-dotnet-android-1719a35" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1719a35b/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-android-cdb777a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-cdb777a0/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!-- ensure only the sources defined below are used -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,9 +21,9 @@
       <Sha>864dffa259f3931b3d51dea0db54a2488ae455ba</Sha>
     </Dependency>
     <!-- Previous .NET Android version -->
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.24">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.50">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>4b20432d95ea8965a41cc73997e459d7fa561233</Sha>
+      <Sha>1719a35b8a0348a4a8dd0061cfc4dd7fe6612a3c</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,10 +13,10 @@
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.25109.3</MicrosoftDotNetCecilPackageVersion>
     <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
     <!-- Previous .NET Android version -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.24</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.50</MicrosoftAndroidSdkWindowsPackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftAndroidSdkWindowsPackageVersion)</AndroidNetPreviousVersion>
     <!-- To be removed before .NET 10 GA -->
-    <AndroidNet8PreviousVersion>34.0.147</AndroidNet8PreviousVersion>
+    <AndroidNet8PreviousVersion>34.0.148</AndroidNet8PreviousVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->


### PR DESCRIPTION
.NET 8 Changes: https://github.com/dotnet/android/compare/a8cd27e430e55df3e3c1e3a43d35c11d9512a2db...cdb777a0c306e3e0668f847433f82144d7ca745f
.NET 9 Changes: http://github.com/dotnet/android/compare/4b20432d95ea8965a41cc73997e459d7fa561233...1719a35b8a0348a4a8dd0061cfc4dd7fe6612a3c

Updates the previous .NET for Android SDK versions to the packages that
will be shipping in the upcoming VS 17.14 preview 2 release.