### PR TITLE
[release/8.0.4xx] Update apkdiff to 0.0.17

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -14,7 +14,7 @@ variables:
 - name: WindowsToolchainPdbArtifactName
   value: windows-toolchain-pdb
 - name: ApkDiffToolVersion
-  value: 0.0.15
+  value: 0.0.17
 - name: TestSlicerToolVersion
   value: 0.1.0-alpha7
 - name: BootsToolVersion


### PR DESCRIPTION
Attempt to fix package signature verification failures for apkdiff that we've seen on the release/8.0.4xx branch.