### PR TITLE
[release/8.0.4xx] [build] stop installing Xamarin.Android

### DIFF
--- a/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
@@ -38,7 +38,6 @@ jobs:
   - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
     parameters:
       installTestSlicer: true
-      installLegacyXamarinAndroid: true
       xaSourcePath: ${{ parameters.xaSourcePath }}
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -6,7 +6,6 @@ parameters:
   installTestSlicer: false
   installApkDiff: true
   installLegacyDotNet: false
-  installLegacyXamarinAndroid: false
   updateMono: false
   androidSdkPlatforms: $(DefaultTestSdkPlatforms)
   repositoryAlias: 'self'
@@ -58,15 +57,6 @@ steps:
       arguments: --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes
       condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
       xaSourcePath: ${{ parameters.xaSourcePath }}
-
-- ${{ if eq(parameters.installLegacyXamarinAndroid, true) }}:
-  - template: /build-tools/automation/yaml-templates/install-dotnet-tool.yaml
-    parameters:
-      toolName: boots
-      version: $(BootsToolVersion)
-      continueOnError: false
-  - pwsh: $(Agent.ToolsDirectory)/boots --stable Xamarin.Android
-    displayName: install Xamarin.Android stable
 
 - template: /build-tools/automation/yaml-templates/run-xaprepare.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -38,7 +38,6 @@ stages:
       parameters:
         installTestSlicer: true
         installApkDiff: false
-        installLegacyXamarinAndroid: true
         updateMono: true
         xaSourcePath: ${{ parameters.xaSourcePath }}
         repositoryAlias: ${{ parameters.repositoryAlias }}

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -14,7 +14,7 @@ variables:
 - name: WindowsToolchainPdbArtifactName
   value: windows-toolchain-pdb
 - name: ApkDiffToolVersion
-  value: 0.0.15
+  value: 0.0.17
 - name: TestSlicerToolVersion
   value: 0.1.0-alpha7
 - name: BootsToolVersion


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10326490&view=logs&j=293e774d-1b3c-56a2-2db1-26d172f04ddd&t=b180d07a-099b-5dc9-8d17-5c88abaf95ba&l=11

The attempt to install Xamarin.Android is failing on macOS anyway, as it relies on a VS Mac updater service:

    Querying https://software.xamarin.com/Service/Updates?v=2&pv964ebddd-1ffe-47e7-8128-5ce17ffffb05=0&pv4569c276-1397-4adb-9485-82a7696df22e=0&pvd1ec039f-f3db-468b-a508-896d7c382999=0&pv0ab364ff-c0e9-43a8-8747-3afb02dc7731=0&level=Stable
    Retry attempt 1: System.Net.Http.HttpRequestException: Response status code does not indicate success: 404 (Not Found).
    at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
    at Boots.Core.HttpClientWithPolicy.DoGetXmlDocumentAsync(Uri uri, CancellationToken token) in D:\a\1\s\Boots.Core\HttpClientWithPolicy.cs:line 59
    at Polly.Timeout.AsyncTimeoutEngine.ImplementationAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, Func`2 timeoutProvider, TimeoutStrategy timeoutStrategy, Func`5 onTimeoutAsync, Boolean continueOnCapturedContext)
    at Polly.Timeout.AsyncTimeoutEngine.ImplementationAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, Func`2 timeoutProvider, TimeoutStrategy timeoutStrategy, Func`5 onTimeoutAsync, Boolean continueOnCapturedContext)
    at Polly.AsyncPolicy.ExecuteAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
    at Polly.Wrap.AsyncPolicyWrapEngine.<>c__DisplayClass3_0`1.<<ImplementationAsync>b__0>d.MoveNext()
    --- End of stack trace from previous location ---
    at Polly.Retry.AsyncRetryEngine.ImplementationAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, ExceptionPredicates shouldRetryExceptionPredicates, ResultPredicates`1 shouldRetryResultPredicates, Func`5 onRetryAsync, Int32 permittedRetryCount, IEnumerable`1 sleepDurationsEnumerable, Func`4 sleepDurationProvider, Boolean continueOnCapturedContext)

This *does* still work on Windows, taking about 5 minutes:

    Inferring .vsix from URL.
    Downloading https://download.visualstudio.microsoft.com/download/pr/a3846965-8f4c-42fa-b728-b6ea5f0a2a16/90d568134f0f5b472e5c085fc6573c76bd40231892a89eb7551940dcc055eb8a/Xamarin.Android.Sdk-13.2.2.0.vsix
    Writing to C:\Users\cloudtest\AppData\Local\Temp\rpcpoivh.dej.vsix
    Using path from vswhere: C:\Program Files\Microsoft Visual Studio\2022\Enterprise
    ...
    Deleting C:\Users\cloudtest\AppData\Local\Temp\rpcpoivh.dej.vsix
    Finishing: install Xamarin.Android stable

We probably don't even *need* to isntall it anymore. So, let's just remove this step.