### PR TITLE
[release/8.0.4xx] Prefer JDK 17.0.14

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -45,6 +45,9 @@
 
     <!-- Mono components -->
     <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == ''">false</AndroidEnableProfiler>
+
+    <!-- External property overrides -->
+    <_AndroidJdkDownloadVersion Condition=" '$(_AndroidJdkDownloadVersion)' == '' ">17.0.14</_AndroidJdkDownloadVersion>
   </PropertyGroup>
 
   <!--  User-facing configuration-specific defaults -->


### PR DESCRIPTION
Updates `InstallAndroidDependencies` to install JDK 17.0.14 over 17.0.8.

We should be able to set the JDK version that is installed via the
`InstallAndroidDependencies` -> `_InstallAndroidJdk` target without
updating monodroid.