### PR TITLE
[nativeaot] fix `.resx` files in apps

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -96,6 +96,7 @@ _ResolveAssemblies MSBuild target.
         ;ResolveAssemblyReferencesFindRelatedSatellites=false
         ;SkipCompilerExecution=true
         ;_OuterIntermediateAssembly=@(IntermediateAssembly)
+        ;_OuterIntermediateSatelliteAssembliesWithTargetPath=@(IntermediateSatelliteAssembliesWithTargetPath)
         ;_OuterOutputPath=$(OutputPath)
         ;_OuterIntermediateOutputPath=$(IntermediateOutputPath)
         ;_OuterCustomViewMapFile=$(_CustomViewMapFile)

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -98,6 +98,8 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <ResolvedFileToPublish Include="@(IlcCompileInput);@(_AndroidILLinkAssemblies)" RuntimeIdentifier="$(_OriginalRuntimeIdentifier)" />
       <!-- Include libc++ -->
       <ResolvedFileToPublish Include="$(_NdkSysrootDir)libc++_shared.so" RuntimeIdentifier="$(_OriginalRuntimeIdentifier)" />
+      <!-- Satellite assemblies -->
+      <IlcSatelliteAssembly Include="$(_OuterIntermediateSatelliteAssembliesWithTargetPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -527,7 +527,6 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
-				ProjectName = "MyApp",
 				OtherBuildItems = {
 					new BuildItem ("EmbeddedResource", "Foo.resx") {
 						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
@@ -540,7 +539,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			proj.SetPublishAot (publishAot, AndroidNdkPath);
 
 			using (var b = CreateApkBuilder ()) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
+				b.Verbosity = LoggerVerbosity.Diagnostic; // Needed for --satellite switch to appear in the log
 				b.Target = "Build";
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				b.Target = "SignAndroidPackage";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -523,10 +523,11 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 		}
 
 		[Test]
-		public void MissingSatelliteAssemblyInApp ()
+		public void MissingSatelliteAssemblyInApp ([Values (false, true)] bool publishAot)
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
+				ProjectName = "MyApp",
 				OtherBuildItems = {
 					new BuildItem ("EmbeddedResource", "Foo.resx") {
 						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
@@ -536,18 +537,26 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 					}
 				}
 			};
+			proj.SetPublishAot (publishAot, AndroidNdkPath);
 
 			using (var b = CreateApkBuilder ()) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
 				b.Target = "Build";
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				b.Target = "SignAndroidPackage";
 				Assert.IsTrue (b.Build (proj), "SignAndroidPackage should have succeeded.");
 
-				var apk = Path.Combine (Root, b.ProjectDirectory,
-					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
-				var helper = new ArchiveAssemblyHelper (apk);
-				foreach (string abi in proj.GetRuntimeIdentifiersAsAbis ()) {
-					Assert.IsTrue (helper.Exists ($"assemblies/{abi}/es/{proj.ProjectName}.resources.dll"), "Apk should contain satellite assemblies!");
+				if (publishAot) {
+					// Best idea thus far is to assert ILC's --satellite switch
+					var regex = $"--satellite:.+{proj.ProjectName}.resources.dll";
+					StringAssertEx.ContainsRegex (regex, b.LastBuildOutput, $"Build log should contain the pattern: {regex}");
+				} else {
+					var apk = Path.Combine (Root, b.ProjectDirectory,
+						proj.OutputPath, $"{proj.PackageName}-Signed.apk");
+					var helper = new ArchiveAssemblyHelper (apk);
+					foreach (string abi in proj.GetRuntimeIdentifiersAsAbis ()) {
+						Assert.IsTrue (helper.Exists ($"assemblies/{abi}/es/{proj.ProjectName}.resources.dll"), "Apk should contain satellite assemblies!");
+					}
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -175,7 +175,9 @@ namespace Xamarin.ProjectTools
 		/// </summary>
 		public void SetPublishAot (bool value, string androidNdkPath)
 		{
-			IsRelease = value;
+			// Only toggle IsRelease=true when value is true
+			if (value)
+				IsRelease = true;
 			PublishAot = value;
 			SetProperty ("AndroidNdkDirectory", androidNdkPath);
 


### PR DESCRIPTION
The `EmbeddedResources_ShouldBeLocalized()` test was failing under a NativeAOT context:

    Embedded string resource did not contain expected value after changing CultureInfo.
    String lengths are both 1. Strings differ at index 0.
    Expected: "b"
    But was:  "a"
    -----------^

After reviewing a `.binlog`, it appears the `_ComputeIlcCompileInputs` MSBuild target was not working as expected:

https://github.com/dotnet/runtime/blob/cc803458ab4dabf020b462873be5bf56f1640b1e/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets#L3-L11

`@(IntermediateSatelliteAssembliesWithTargetPath)` was blank!

The problem being the way Android has an "inner" build per RID:

* `@(IntermediateSatelliteAssembliesWithTargetPath)` is set in the "outer" build.

* `@(IntermediateSatelliteAssembliesWithTargetPath)` is blank in the "inner" build per RID.

* The "inner" build is where the ILC compiler runs, and so it doesn't see the current project's `*.resource.dll` file.

To fix this, we can pass `$(_OuterIntermediateSatelliteAssembliesWithTargetPath)` into the inner build.

I updated an MSBuild test to run normally and in a NativeAOT context.