### PR TITLE
[NativeAOT] Improve managed type map

### DIFF
--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/TypeMapping.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/TypeMapping.cs
@@ -26,13 +26,6 @@ internal static class TypeMapping
 			throw new InvalidOperationException ($"Type with hash {hash} not found.");
 		}
 
-		// ensure this is not a hash collision
-		var resolvedJavaClassName = GetJavaClassNameByIndex (TypeIndexToJavaClassNameIndex [typeIndex]);
-		if (resolvedJavaClassName != javaClassName) {
-			type = null;
-			return false;
-		}
-
 		return true;
 	}
 
@@ -58,13 +51,6 @@ internal static class TypeMapping
 			throw new InvalidOperationException ($"Java class name with hash {hash} not found.");
 		}
 
-		// ensure this is not a hash collision
-		var resolvedType = GetTypeByIndex (JavaClassNameIndexToTypeIndex [javaClassNameIndex]);
-		if (resolvedType?.AssemblyQualifiedName != type.AssemblyQualifiedName) {
-			className = null;
-			return false;
-		}
-
 		return true;
 	}
 
@@ -85,8 +71,6 @@ internal static class TypeMapping
 	// Replaced by src/Microsoft.Android.Sdk.ILLink/TypeMappingStep.cs
 	private static ReadOnlySpan<ulong> JavaClassNameHashes => throw new NotImplementedException ();
 	private static ReadOnlySpan<ulong> TypeNameHashes => throw new NotImplementedException ();
-	private static ReadOnlySpan<int> JavaClassNameIndexToTypeIndex => throw new NotImplementedException ();
-	private static ReadOnlySpan<int> TypeIndexToJavaClassNameIndex => throw new NotImplementedException ();
 	private static Type? GetTypeByIndex (int index) => throw new NotImplementedException ();
 	private static string? GetJavaClassNameByIndex (int index) => throw new NotImplementedException ();
 }

--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/TypeMapping.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/TypeMapping.cs
@@ -38,7 +38,12 @@ internal static class TypeMapping
 
 	internal static bool TryGetJavaClassName (Type type, [NotNullWhen (true)] out string? className)
 	{
-		string name = $"{type.FullName}, {type.Assembly.GetName ().Name}";
+		string? name = type.AssemblyQualifiedName;
+		if (name is null) {
+			className = null;
+			return false;
+		}
+
 		ulong hash = Hash (name);
 
 		// the hashes array is sorted and all the hashes are unique

--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/TypeMapping.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/TypeMapping.cs
@@ -38,13 +38,8 @@ internal static class TypeMapping
 
 	internal static bool TryGetJavaClassName (Type type, [NotNullWhen (true)] out string? className)
 	{
-		string? fullName = type.FullName;
-		if (fullName is null) {
-			className = null;
-			return false;
-		}
-
-		ulong hash = Hash (fullName);
+		string name = $"{type.FullName}, {type.Assembly.GetName ().Name}";
+		ulong hash = Hash (name);
 
 		// the hashes array is sorted and all the hashes are unique
 		int javaClassNameIndex = MemoryExtensions.BinarySearch (TypeNameHashes, hash);
@@ -60,7 +55,7 @@ internal static class TypeMapping
 
 		// ensure this is not a hash collision
 		var resolvedType = GetTypeByIndex (JavaClassNameIndexToTypeIndex [javaClassNameIndex]);
-		if (resolvedType?.FullName != type.FullName) {
+		if (resolvedType?.AssemblyQualifiedName != type.AssemblyQualifiedName) {
 			className = null;
 			return false;
 		}
@@ -68,9 +63,9 @@ internal static class TypeMapping
 		return true;
 	}
 
-	private static ulong Hash (string javaClassName)
+	private static ulong Hash (string value)
 	{
-		ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes (javaClassName.AsSpan ());
+		ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes (value.AsSpan ());
 		ulong hash = XxHash3.HashToUInt64 (bytes);
 
 		// The bytes in the hashes array are stored as little endian. If the target platform is big endian,

--- a/src/Microsoft.Android.Sdk.ILLink/TypeMappingStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/TypeMappingStep.cs
@@ -71,12 +71,12 @@ public class TypeMappingStep : BaseStep
 		GenerateGetTypeByIndex (types);
 
 		// .NET -> Java mapping
-		KeyValuePair<string, List<TypeDefinition>>[] orderedManagedToJavaMapping = TypeMappings.OrderBy (kvp => Hash (SelectTypeDefinition(kvp.Key, kvp.Value).FullName)).ToArray ();
+		var orderedManagedToJavaMapping = TypeMappings.OrderBy (kvp => Hash (GetTypeName (SelectTypeDefinition (kvp.Key, kvp.Value)))).ToArray ();
 
-		var dotnetTypeNameHashes = orderedManagedToJavaMapping.Select (kvp => Hash (SelectTypeDefinition(kvp.Key, kvp.Value).FullName)).ToArray ();
+		var dotnetTypeNameHashes = orderedManagedToJavaMapping.Select (kvp => Hash (GetTypeName (SelectTypeDefinition (kvp.Key, kvp.Value)))).ToArray ();
 		GenerateHashes (dotnetTypeNameHashes, methodName: "get_TypeNameHashes");
 
-		string[] javaClassNames = orderedManagedToJavaMapping.Select (kvp => kvp.Key).ToArray ();
+		var javaClassNames = orderedManagedToJavaMapping.Select (kvp => kvp.Key).ToArray ();
 		GenerateGetJavaClassNameByIndex (javaClassNames);
 
 		// Generate remap arrays
@@ -242,6 +242,13 @@ public class TypeMappingStep : BaseStep
 			}
 
 			return arrayType;
+		}
+
+		string GetTypeName (TypeDefinition type)
+		{
+			var fullName = type.FullName.Replace ('/', '.').Replace ('+', '.');
+			var assemblyName = type.Module.Assembly.Name.Name;
+			return $"{fullName}, {assemblyName}";
 		}
 	}
 

--- a/src/Microsoft.Android.Sdk.ILLink/TypeMappingStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/TypeMappingStep.cs
@@ -247,7 +247,7 @@ public class TypeMappingStep : BaseStep
 		string GetTypeName (TypeDefinition type)
 		{
 			var fullName = type.FullName.Replace ('/', '.').Replace ('+', '.');
-			var assemblyName = type.Module.Assembly.Name.Name;
+			var assemblyName = type.Module.Assembly.FullName;
 			return $"{fullName}, {assemblyName}";
 		}
 	}

--- a/src/Microsoft.Android.Sdk.ILLink/TypeMappingStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/TypeMappingStep.cs
@@ -71,9 +71,9 @@ public class TypeMappingStep : BaseStep
 		GenerateGetTypeByIndex (types);
 
 		// .NET -> Java mapping
-		var orderedManagedToJavaMapping = TypeMappings.SelectMany(kvp => kvp.Value.Select (type => new KeyValuePair<string, TypeDefinition>(kvp.Key, type))).OrderBy (kvp => Hash (GetTypeName (kvp.Value))).ToArray ();
+		var orderedManagedToJavaMapping = TypeMappings.SelectMany(kvp => kvp.Value.Select (type => new KeyValuePair<string, TypeDefinition>(kvp.Key, type))).OrderBy (kvp => Hash (GetAssemblyQualifiedTypeName (kvp.Value))).ToArray ();
 
-		var dotnetTypeNameHashes = orderedManagedToJavaMapping.Select (kvp => Hash (GetTypeName (kvp.Value))).ToArray ();
+		var dotnetTypeNameHashes = orderedManagedToJavaMapping.Select (kvp => Hash (GetAssemblyQualifiedTypeName (kvp.Value))).ToArray ();
 		GenerateHashes (dotnetTypeNameHashes, methodName: "get_TypeNameHashes");
 
 		var javaClassNames = orderedManagedToJavaMapping.Select (kvp => kvp.Key).ToArray ();
@@ -217,7 +217,7 @@ public class TypeMappingStep : BaseStep
 			return arrayType;
 		}
 
-		string GetTypeName (TypeDefinition type)
+		string GetAssemblyQualifiedTypeName (TypeDefinition type)
 		{
 			var fullName = type.FullName.Replace ('/', '.').Replace ('+', '.');
 			var assemblyName = type.Module.Assembly.FullName;


### PR DESCRIPTION
This is a follow-up to #9856

#9846 showed that several tests are failing with the new managed type map. This PR addresses two of these issues:
1. Use assembly qualified type name instead of just full name for the managed -> Java mapping
2. Handle generic types correctly:
    - for managed -> java mapping, include all the different types which map to the same java class name (e.g., `JavaList` and `JavaList<object>` both map to `java/util/ArrayList`)
    - for java -> managed mapping, prefer non-generic base classes over generic subclasses (e.g., map `java/util/ArrayList` to `JavaList` instead of `JavaList<>`)

These changes now break roundtripping (`JavaList<T>` -> `java/util/ArrayList` -> `JavaList`). This broke the current way of checking for hash collisions. I haven't figured out a good way to replace these checks. Since we aren't checking hash collisions in native type maps, maybe we don't need to do the collision checks in the managed type map either.