### PR TITLE
[Xamarin.Android.Build.Tasks] make "managed typemap" runtime agnostic

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -46,7 +46,6 @@ projects that use the Microsoft.Android framework in .NET 6+.
       />
       <_AndroidRuntimePackAssemblies
           Include="$(_MonoAndroidNETOutputRoot)$(AndroidLatestStableApiLevel)\System.IO.Hashing.dll"
-          Condition=" '$(AndroidRuntime)' == 'NativeAOT' "
           NoSymbols="true"
       />
       <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(AndroidLatestStableApiLevel)\Mono.Android.Export.dll" />

--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
@@ -37,7 +37,7 @@ static partial class JavaInteropRuntime
 			var settings    = new DiagnosticSettings ();
 			settings.AddDebugDotnetLog ();
 
-			var typeManager = new NativeAotTypeManager ();
+			var typeManager = new ManagedTypeManager ();
 			var options = new NativeAotRuntimeOptions {
 				EnvironmentPointer          = jnienv,
 				TypeManager                 = typeManager,

--- a/src/Microsoft.Android.Runtime.NativeAOT/Java.Interop/JreRuntime.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Java.Interop/JreRuntime.cs
@@ -58,7 +58,7 @@ namespace Java.Interop {
 				throw new InvalidOperationException ($"Member `{nameof (NativeAotRuntimeOptions)}.{nameof (NativeAotRuntimeOptions.JvmLibraryPath)}` must be set.");
 
 #if NET
-			builder.TypeManager     ??= new NativeAotTypeManager ();
+			builder.TypeManager     ??= new ManagedTypeManager ();
 #endif  // NET
 
 			builder.ValueManager            ??= new ManagedValueManager ();

--- a/src/Microsoft.Android.Runtime.NativeAOT/Microsoft.Android.Runtime.NativeAOT.csproj
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Microsoft.Android.Runtime.NativeAOT.csproj
@@ -38,7 +38,6 @@
   <Target Name="_CopyToPackDirs">
     <ItemGroup>
       <_RuntimePackFiles Include="$(OutputPath)Microsoft.Android.Runtime.NativeAOT.dll" AndroidRID="%(AndroidAbiAndRuntimeFlavor.AndroidRID)" AndroidRuntime="%(AndroidAbiAndRuntimeFlavor.AndroidRuntime)" />
-      <_RuntimePackFiles Include="$(OutputPath)System.IO.Hashing.dll" AndroidRID="%(AndroidAbiAndRuntimeFlavor.AndroidRID)" AndroidRuntime="%(AndroidAbiAndRuntimeFlavor.AndroidRuntime)" />
     </ItemGroup>
     <Message Importance="high" Text="$(TargetPath) %(AndroidAbiAndRuntimeFlavor.AndroidRID)" />
     <Copy

--- a/src/Microsoft.Android.Sdk.ILLink/TypeMappingStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/TypeMappingStep.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Android.Sdk.ILLink;
 /// </summary>
 public class TypeMappingStep : BaseStep
 {
-	const string AssemblyName = "Microsoft.Android.Runtime.NativeAOT";
-	const string TypeName = "Microsoft.Android.Runtime.TypeMapping";
+	const string AssemblyName = "Mono.Android";
+	const string TypeName = "Microsoft.Android.Runtime.ManagedTypeMapping";
 	const string SystemIOHashingAssemblyPathCustomData = "SystemIOHashingAssemblyPath";
 	readonly IDictionary<string, List<TypeDefinition>> TypeMappings = new Dictionary<string, List<TypeDefinition>> (StringComparer.Ordinal);
-	AssemblyDefinition? MicrosoftAndroidRuntimeNativeAot;
+	AssemblyDefinition? MonoAndroidAssembly;
 
 	delegate ulong HashMethod (ReadOnlySpan<byte> data, long seed = 0);
 	HashMethod? _hashMethod;
@@ -36,8 +36,7 @@ public class TypeMappingStep : BaseStep
 	protected override void ProcessAssembly (AssemblyDefinition assembly)
 	{
 		if (assembly.Name.Name == AssemblyName) {
-			MicrosoftAndroidRuntimeNativeAot = assembly;
-			return;
+			MonoAndroidAssembly = assembly;
 		}
 		if (Annotations?.GetAction (assembly) == AssemblyAction.Delete)
 			return;
@@ -51,11 +50,11 @@ public class TypeMappingStep : BaseStep
 	{
 		Context.LogMessage ($"Writing {TypeMappings.Count} typemap entries");
 
-		if (MicrosoftAndroidRuntimeNativeAot is null) {
+		if (MonoAndroidAssembly is null) {
 			throw new InvalidOperationException ($"Unable to find {AssemblyName} assembly");
 		}
 
-		var module = MicrosoftAndroidRuntimeNativeAot.MainModule;
+		var module = MonoAndroidAssembly.MainModule;
 		var type = module.GetType (TypeName);
 		if (type is null) {
 			throw new InvalidOperationException ($"Unable to find {TypeName} type");

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -512,7 +512,7 @@ namespace Android.Runtime {
 		[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Type.GetType() can never statically know the string value parsed from parameter 'methods'.")]
 		[UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = "Delegate.CreateDelegate() can never statically know the string value parsed from parameter 'methods'.")]
 		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Delegate.CreateDelegate() can never statically know the string value parsed from parameter 'methods'.")]
-		public void RegisterNativeMembers (
+		public override void RegisterNativeMembers (
 				JniType nativeClass,
 				[DynamicallyAccessedMembers (MethodsAndPrivateNested)] Type type,
 				ReadOnlySpan<char> methods)

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -23,8 +23,8 @@ namespace Android.Runtime {
 		internal AndroidRuntime (IntPtr jnienv,
 				IntPtr vm,
 				IntPtr classLoader,
-				JniRuntime.JniTypeManager? typeManager,
-				JniRuntime.JniValueManager? valueManager,
+				JniRuntime.JniTypeManager typeManager,
+				JniRuntime.JniValueManager valueManager,
 				bool jniAddNativeMethodRegistrationAttributePresent)
 			: base (new AndroidRuntimeOptions (jnienv,
 					vm,
@@ -95,16 +95,16 @@ namespace Android.Runtime {
 		public AndroidRuntimeOptions (IntPtr jnienv,
 				IntPtr vm,
 				IntPtr classLoader,
-				JniRuntime.JniTypeManager? typeManager,
-				JniRuntime.JniValueManager? valueManager,
+				JniRuntime.JniTypeManager typeManager,
+				JniRuntime.JniValueManager valueManager,
 				bool jniAddNativeMethodRegistrationAttributePresent)
 		{
 			EnvironmentPointer      = jnienv;
 			ClassLoader             = new JniObjectReference (classLoader, JniObjectReferenceType.Global);
 			InvocationPointer       = vm;
 			ObjectReferenceManager  = new AndroidObjectReferenceManager ();
-			TypeManager             = typeManager ?? new AndroidTypeManager (jniAddNativeMethodRegistrationAttributePresent);
-			ValueManager            = valueManager ?? new AndroidValueManager ();
+			TypeManager             = typeManager;
+			ValueManager            = valueManager;
 			UseMarshalMemberBuilder = false;
 			JniAddNativeMethodRegistrationAttributePresent = jniAddNativeMethodRegistrationAttributePresent;
 		}

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -9,6 +9,7 @@ using Java.Interop;
 using Java.Interop.Tools.TypeNameMappings;
 
 using Microsoft.Android.Runtime;
+using RuntimeFeature = Microsoft.Android.Runtime.RuntimeFeature;
 
 namespace Android.Runtime
 {
@@ -110,12 +111,21 @@ namespace Android.Runtime
 			java_class_loader = args->grefLoader;
 
 			BoundExceptionType = (BoundExceptionType)args->ioExceptionType;
+			JniRuntime.JniTypeManager typeManager;
+			JniRuntime.JniValueManager valueManager;
+			if (RuntimeFeature.ManagedTypeMap) {
+				typeManager = new ManagedTypeManager ();
+				valueManager = new ManagedValueManager ();
+			} else {
+				typeManager = new AndroidTypeManager (args->jniAddNativeMethodRegistrationAttributePresent != 0);
+				valueManager = RuntimeType == DotNetRuntimeType.MonoVM ? new AndroidValueManager () : new ManagedValueManager ();
+			}
 			androidRuntime = new AndroidRuntime (
 					args->env,
 					args->javaVm,
 					args->grefLoader,
-					null,
-					RuntimeType != DotNetRuntimeType.MonoVM ? new ManagedValueManager () : null,
+					typeManager,
+					valueManager,
 					args->jniAddNativeMethodRegistrationAttributePresent != 0
 			);
 			ValueManager = androidRuntime.ValueManager;

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -79,7 +79,7 @@ namespace Android.Runtime
 			JniType.GetCachedJniType (ref jniType, className);
 
 			ReadOnlySpan<char> methods = new ReadOnlySpan<char> ((void*) methods_ptr, methods_len);
-			((AndroidTypeManager)androidRuntime!.TypeManager).RegisterNativeMembers (jniType, type, methods);
+			androidRuntime!.TypeManager.RegisterNativeMembers (jniType, type, methods);
 		}
 
 		// NOTE: should have different name than `Initialize` to avoid:

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -114,11 +114,11 @@ namespace Android.Runtime
 			JniRuntime.JniTypeManager typeManager;
 			JniRuntime.JniValueManager valueManager;
 			if (RuntimeFeature.ManagedTypeMap) {
-				typeManager = new ManagedTypeManager ();
-				valueManager = new ManagedValueManager ();
+				typeManager     = new ManagedTypeManager ();
+				valueManager    = new ManagedValueManager ();
 			} else {
-				typeManager = new AndroidTypeManager (args->jniAddNativeMethodRegistrationAttributePresent != 0);
-				valueManager = RuntimeType == DotNetRuntimeType.MonoVM ? new AndroidValueManager () : new ManagedValueManager ();
+				typeManager     = new AndroidTypeManager (args->jniAddNativeMethodRegistrationAttributePresent != 0);
+				valueManager    = RuntimeType == DotNetRuntimeType.MonoVM ? new AndroidValueManager () : new ManagedValueManager ();
 			}
 			androidRuntime = new AndroidRuntime (
 					args->env,

--- a/src/Mono.Android/ILLink/ILLink.Substitutions.xml
+++ b/src/Mono.Android/ILLink/ILLink.Substitutions.xml
@@ -4,5 +4,9 @@
       <method signature="System.Boolean get_NegotiateAuthenticationIsEnabled()" body="stub" feature="Xamarin.Android.Net.UseNegotiateAuthentication" featurevalue="false" value="false" />
       <method signature="System.Boolean get_NegotiateAuthenticationIsEnabled()" body="stub" feature="Xamarin.Android.Net.UseNegotiateAuthentication" featurevalue="true" value="true" />
     </type>
+    <type fullname="Microsoft.Android.Runtime.RuntimeFeature">
+      <method signature="System.Boolean get_ManagedTypeMap()" body="stub" feature="Microsoft.Android.Runtime.RuntimeFeature.ManagedTypeMap" featurevalue="false" value="false" />
+      <method signature="System.Boolean get_ManagedTypeMap()" body="stub" feature="Microsoft.Android.Runtime.RuntimeFeature.ManagedTypeMap" featurevalue="true" value="true" />
+    </type>
   </assembly>
 </linker>

--- a/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeManager.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Java.Interop;
@@ -5,13 +7,13 @@ using Java.Interop.Tools.TypeNameMappings;
 
 namespace Microsoft.Android.Runtime;
 
-partial class NativeAotTypeManager : JniRuntime.JniTypeManager {
+class ManagedTypeManager : JniRuntime.JniTypeManager {
 
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 	internal const DynamicallyAccessedMemberTypes Methods = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
 	internal const DynamicallyAccessedMemberTypes MethodsAndPrivateNested = Methods | DynamicallyAccessedMemberTypes.NonPublicNestedTypes;
 
-	public NativeAotTypeManager ()
+	public ManagedTypeManager ()
 	{
 	}
 
@@ -127,7 +129,7 @@ partial class NativeAotTypeManager : JniRuntime.JniTypeManager {
 
 	protected override IEnumerable<Type> GetTypesForSimpleReference (string jniSimpleReference)
 	{
-		if (TypeMapping.TryGetType (jniSimpleReference, out var target)) {
+		if (ManagedTypeMapping.TryGetType (jniSimpleReference, out var target)) {
 			yield return target;
 		}
 		foreach (var t in base.GetTypesForSimpleReference (jniSimpleReference)) {
@@ -141,7 +143,7 @@ partial class NativeAotTypeManager : JniRuntime.JniTypeManager {
 			yield return r;
 		}
 
-		if (TypeMapping.TryGetJniName (type, out var jniName)) {
+		if (ManagedTypeMapping.TryGetJniName (type, out var jniName)) {
 			yield return jniName;
 		}
 	}

--- a/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeMapping.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeMapping.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -8,7 +9,7 @@ using Android.Runtime;
 
 namespace Microsoft.Android.Runtime;
 
-internal static class TypeMapping
+internal static class ManagedTypeMapping
 {
 	internal static bool TryGetType (string jniName, [NotNullWhen (true)] out Type? type)
 	{

--- a/src/Mono.Android/Microsoft.Android.Runtime/RuntimeFeature.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/RuntimeFeature.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Android.Runtime;
+
+static class RuntimeFeature
+{
+	const string FeatureSwitchPrefix = "Microsoft.Android.Runtime.RuntimeFeature.";
+
+	[FeatureSwitchDefinition ($"{FeatureSwitchPrefix}{nameof (ManagedTypeMap)}")]
+	internal static bool ManagedTypeMap { get; } =
+		AppContext.TryGetSwitch ($"{FeatureSwitchPrefix}{nameof (ManagedTypeMap)}", out bool isEnabled) ? isEnabled : false;
+}

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -349,7 +349,10 @@
     <Compile Include="Java.Util.Concurrent.Atomic\AtomicInteger.cs" />
     <Compile Include="Java.Util.Concurrent.Atomic\AtomicLong.cs" />
     <Compile Include="Javax.Microedition.Khronos.Egl\EGLContext.cs" />
+    <Compile Include="Microsoft.Android.Runtime\ManagedTypeManager.cs" />
+    <Compile Include="Microsoft.Android.Runtime\ManagedTypeMapping.cs" />
     <Compile Include="Microsoft.Android.Runtime\ManagedValueManager.cs" />
+    <Compile Include="Microsoft.Android.Runtime\RuntimeFeature.cs" />
     <Compile Include="Org.Apache.Http.Impl.Conn\DefaultClientConnection.cs" />
     <Compile Include="Org.Apache.Http.Impl.Cookie\BasicClientCookie.cs" />
     <Compile Include="System.Drawing/PointConverter.cs" />
@@ -373,6 +376,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.IO.Hashing" Version="$(SystemIOHashingPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -415,6 +419,7 @@
       <_RefExtras Include="$(OutputPath)*.*" Exclude="$(OutputPath)*.dll" />
       <_SourceFiles Include="$(OutputPath)Mono.Android.*" />
       <_SourceFiles Include="$(OutputPath)Java.Interop.*" />
+      <_SourceFiles Include="$(OutputPath)System.IO.Hashing.dll" />
       <_RuntimePackFiles Include="@(_SourceFiles)" AndroidRID="%(AndroidAbiAndRuntimeFlavor.AndroidRID)" AndroidRuntime="%(AndroidAbiAndRuntimeFlavor.AndroidRuntime)" />
     </ItemGroup>
     <Copy

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -43,6 +43,7 @@
     <AndroidClassParser>class-parse</AndroidClassParser>
     <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
     <_AndroidJcwCodegenTarget Condition=" '$(_AndroidJcwCodegenTarget)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' ">XAJavaInterop1</_AndroidJcwCodegenTarget>
+    <_AndroidTypeMapImplementation Condition=" '$(_AndroidTypeMapImplementation)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' ">llvm-ir</_AndroidTypeMapImplementation>
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods Condition=" '$(AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods)' == '' ">true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
     <AndroidBoundInterfacesContainTypes Condition=" '$(AndroidBoundInterfacesContainTypes)' == '' ">true</AndroidBoundInterfacesContainTypes>
     <AndroidBoundInterfacesContainConstants Condition=" '$(AndroidBoundInterfacesContainConstants)' == '' ">true</AndroidBoundInterfacesContainConstants>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -87,7 +87,7 @@ This file contains the .NET 5-specific targets to customize ILLink
           Type="MonoDroid.Tuner.FixLegacyResourceDesignerStep"
       />
       <_TrimmerCustomSteps
-          Condition=" '$(_AndroidRuntime)' == 'NativeAOT' "
+          Condition=" '$(_AndroidTypeMapImplementation)' == 'managed' "
           Include="$(_AndroidLinkerCustomStepAssembly)"
           AfterStep="CleanStep"
           Type="Microsoft.Android.Sdk.ILLink.TypeMappingStep"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -13,6 +13,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
   <PropertyGroup>
     <_AndroidRuntimePackRuntime>NativeAOT</_AndroidRuntimePackRuntime>
     <_AndroidJcwCodegenTarget Condition=" '$(_AndroidJcwCodegenTarget)' == '' ">JavaInterop1</_AndroidJcwCodegenTarget>
+    <_AndroidTypeMapImplementation Condition=" '$(_AndroidTypeMapImplementation)' == '' ">managed</_AndroidTypeMapImplementation>
     <!-- .NET SDK gives: error NETSDK1191: A runtime identifier for the property 'PublishAot' couldn't be inferred. Specify a rid explicitly. -->
     <AllowPublishAotWithoutRuntimeIdentifier Condition=" '$(AllowPublishAotWithoutRuntimeIdentifier)' == '' ">true</AllowPublishAotWithoutRuntimeIdentifier>
     <!-- NativeAOT's targets currently gives an error about cross-compilation -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
@@ -12,6 +12,7 @@ See: https://github.com/dotnet/runtime/blob/b13715b6984889a709ba29ea8a1961db469f
 
   <PropertyGroup>
     <_BinaryRuntimeConfigPath>$(IntermediateOutputPath)$(ProjectRuntimeConfigFileName).bin</_BinaryRuntimeConfigPath>
+    <_AndroidUseManagedTypeMap Condition=" '$(_AndroidTypeMapImplementation)' == 'managed' ">true</_AndroidUseManagedTypeMap>
   </PropertyGroup>
 
   <ItemGroup>
@@ -44,6 +45,10 @@ See: https://github.com/dotnet/runtime/blob/b13715b6984889a709ba29ea8a1961db469f
     <!-- https://github.com/dotnet/runtime/commit/fecf3eeffd3650566555e15292f9df0d3abcdfc6 -->
     <RuntimeHostConfigurationOption Include="Microsoft.Extensions.DependencyInjection.DisableDynamicEngine"
         Value="$(AndroidAvoidEmitForPerformance)"
+        Trim="true"
+    />
+    <RuntimeHostConfigurationOption Include="Microsoft.Android.Runtime.RuntimeFeature.ManagedTypeMap"
+        Value="$([MSBuild]::ValueOrDefault('$(_AndroidUseManagedTypeMap)', 'false'))"
         Trim="true"
     />
   </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -160,6 +160,9 @@ namespace Xamarin.Android.Build.Tests
 
 			var linkedMonoAndroidAssembly = Path.Combine (intermediate, "android-arm64", "linked", "Mono.Android.dll");
 			FileAssert.Exists (linkedMonoAndroidAssembly);
+			var javaClassNames = new List<string> ();
+			var types = new List<TypeReference> ();
+
 			using (var assembly = AssemblyDefinition.ReadAssembly (linkedMonoAndroidAssembly)) {
 				var typeName = "Android.App.Activity";
 				var methodName = "GetOnCreate_Landroid_os_Bundle_Handler";
@@ -167,19 +170,11 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsNotNull (type, $"{linkedMonoAndroidAssembly} should contain {typeName}");
 				var method = type.Methods.FirstOrDefault (m => m.Name == methodName);
 				Assert.IsNotNull (method, $"{linkedMonoAndroidAssembly} should contain {typeName}.{methodName}");
-			}
 
-			var javaClassNames = new List<string> ();
-			var types = new List<TypeReference> ();
-
-			var linkedRuntimeAssembly = Path.Combine (intermediate, "android-arm64", "linked", "Microsoft.Android.Runtime.NativeAOT.dll");
-			FileAssert.Exists (linkedRuntimeAssembly);
-			using (var assembly = AssemblyDefinition.ReadAssembly (linkedRuntimeAssembly)) {
-				var type = assembly.MainModule.Types.FirstOrDefault (t => t.Name == "TypeMapping");
-				Assert.IsNotNull (type, $"{linkedRuntimeAssembly} should contain TypeMapping");
-
-				var method = type.Methods.FirstOrDefault (m => m.Name == "GetJniNameByTypeNameHashIndex");
-				Assert.IsNotNull (method, "TypeMapping should contain GetJniNameByTypeNameHashIndex");
+				type = assembly.MainModule.Types.FirstOrDefault (t => t.Name == "ManagedTypeMapping");
+				Assert.IsNotNull (type, $"{linkedMonoAndroidAssembly} should contain ManagedTypeMapping");
+				method = type.Methods.FirstOrDefault (m => m.Name == "GetJniNameByTypeNameHashIndex");
+				Assert.IsNotNull (method, $"{type.Name} should contain GetJniNameByTypeNameHashIndex");
 
 				foreach (var i in method.Body.Instructions) {
 					if (i.OpCode != Mono.Cecil.Cil.OpCodes.Ldstr)
@@ -192,7 +187,7 @@ namespace Xamarin.Android.Build.Tests
 				}
 
 				method = type.Methods.FirstOrDefault (m => m.Name == "GetTypeByJniNameHashIndex");
-				Assert.IsNotNull (method, "TypeMapping should contain GetTypeByJniNameHashIndex");
+				Assert.IsNotNull (method, $"{type.Name} should contain GetTypeByJniNameHashIndex");
 
 				foreach (var i in method.Body.Instructions) {
 					if (i.OpCode != Mono.Cecil.Cil.OpCodes.Ldtoken)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1610,6 +1610,7 @@ because xbuild doesn't support framework reference assemblies.
       GenerateNativeAssembly="$(_AndroidGenerateNativeAssembly)"
       IntermediateOutputDirectory="$(IntermediateOutputPath)"
       SkipJniAddNativeMethodRegistrationAttributeScan="$(_SkipJniAddNativeMethodRegistrationAttributeScan)"
+      TypemapImplementation="$(_AndroidTypeMapImplementation)"
       TypemapOutputDirectory="$(_NativeAssemblySourceDir)">
   </GenerateTypeMappings>
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -30,11 +30,17 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void DotNetRun ([Values (true, false)] bool isRelease)
+		[TestCase (true, "llvm-ir")]
+		[TestCase (false, "llvm-ir")]
+		[TestCase (true, "managed")]
+		// NOTE: TypeMappingStep is not yet setup for Debug mode
+		//[TestCase (false, "managed")]
+		public void DotNetRun (bool isRelease, string typemapImplementation)
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease
 			};
+			proj.SetProperty ("_AndroidTypeMapImplementation", typemapImplementation);
 			using var builder = CreateApkBuilder ();
 			builder.Save (proj);
 


### PR DESCRIPTION
For NativeAOT, we implemented a "managed" typemap that is trimmer-safe.

In order to test its performance characteristics, we can make this typemap useable for Mono and CoreCLR as well:

* Move `NativeAotTypeManager`, `NativeAotValueManager`, and `TypeMapping` types to `Mono.Android.dll`

* Rename `NativeAot*` to `Managed*`

* Add a new private `$(_AndroidTypeMapImplementation)` MSBuild property that can be set to `llvm-ir` or `managed`.

* Add a new trimmer feature flag `Microsoft.Android.Runtime.RuntimeFeature.ManagedTypeMap` that when `true` uses the managed typemap on any runtime.

I added a test that verifies `dotnet run` succeeds for all typemap implementations.

Note that NativeAOT will *only* support the managed typemap.