### PR TITLE
[Mono.Android] update `JNIEnv.GetJniName()`

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -477,10 +477,10 @@ namespace Android.Runtime {
 			if (type == null)
 				throw new ArgumentNullException ("type");
 
-			string? java = TypemapManagedToJava (type);
-			return java == null
+			var sig  = JNIEnvInit.androidRuntime?.TypeManager.GetTypeSignature (type) ?? default;
+			return sig == null
 				? JavaNativeTypeManager.ToJniName (type)
-				: java;
+				: sig.Name;
 		}
 
 		public static IntPtr ToJniHandle (IJavaObject? value)

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -477,7 +477,10 @@ namespace Android.Runtime {
 			if (type == null)
 				throw new ArgumentNullException ("type");
 
-			var sig  = JNIEnvInit.androidRuntime?.TypeManager.GetTypeSignature (type) ?? default;
+			JniTypeSignature sig = default;
+			if (!type.ContainsGenericParameters)
+				sig = JNIEnvInit.androidRuntime?.TypeManager.GetTypeSignature (type) ?? default;
+
 			return sig == null
 				? JavaNativeTypeManager.ToJniName (type)
 				: sig.Name;

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -481,7 +481,7 @@ namespace Android.Runtime {
 			if (!type.ContainsGenericParameters)
 				sig = JNIEnvInit.androidRuntime?.TypeManager.GetTypeSignature (type) ?? default;
 
-			return sig == null
+			return sig.SimpleReference == null
 				? JavaNativeTypeManager.ToJniName (type)
 				: sig.Name;
 		}


### PR DESCRIPTION
`JNIEnv.GetJniName()` would fail under NativeAOT, as `TypemapManagedToJava()` will eventually call a p/invoke that doesn't exist.

Update this method to go through the `JniRuntime.JniTypeManager.GetTypeSignature()`, abstraction that should be used instead.