### PR TITLE
[tests] ignore network errors in `CustomLinkDescriptionPreserve` test

### DIFF
--- a/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/HttpClientTest.cs
+++ b/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/HttpClientTest.cs
@@ -7,17 +7,24 @@ public class HttpClientTest
 	// [Test]
 	public static string Post ()
 	{
-		try
-		{
+		try {
 			var client = new HttpClient ();
 			var data = new StringContent ("{\"foo\": \"bar\" }", Encoding.UTF8, "application/json");
 			var response = client.PostAsync ("https://httpbin.org/post", data).Result;
 			response.EnsureSuccessStatusCode ();
 			var json = response.Content.ReadAsStringAsync ().Result;
 			return $"[PASS] {nameof (HttpClientTest)}.{nameof (Post)}";
+		} catch (HttpRequestException ex) {
+			switch (ex.StatusCode) {
+ 				case HttpStatusCode.InternalServerError:
+ 				case HttpStatusCode.BadGateway:
+ 				case HttpStatusCode.ServiceUnavailable:
+ 				case HttpStatusCode.GatewayTimeout:
+ 					return $"[IGNORE] {nameof (HttpClientTest)}.{nameof (Post)} {ex.StatusCode}: {ex}";
+ 			}
+			return $"[FAIL] {nameof (HttpClientTest)}.{nameof (Post)} FAILED: {ex}";
 		}
-		catch (Exception ex)
-		{
+		catch (Exception ex) {
 			return $"[FAIL] {nameof (HttpClientTest)}.{nameof (Post)} FAILED: {ex}";
 		}
 	}

--- a/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/HttpClientTest.cs
+++ b/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/HttpClientTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Net;
 using System.Net.Http;
 
 public class HttpClientTest

--- a/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/HttpClientTest.cs
+++ b/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/HttpClientTest.cs
@@ -12,20 +12,17 @@ public class HttpClientTest
 			var client = new HttpClient ();
 			var data = new StringContent ("{\"foo\": \"bar\" }", Encoding.UTF8, "application/json");
 			var response = client.PostAsync ("https://httpbin.org/post", data).Result;
-			response.EnsureSuccessStatusCode ();
-			var json = response.Content.ReadAsStringAsync ().Result;
-			return $"[PASS] {nameof (HttpClientTest)}.{nameof (Post)}";
-		} catch (HttpRequestException ex) {
-			switch (ex.StatusCode) {
+			switch (response.StatusCode) {
  				case HttpStatusCode.InternalServerError:
  				case HttpStatusCode.BadGateway:
  				case HttpStatusCode.ServiceUnavailable:
  				case HttpStatusCode.GatewayTimeout:
- 					return $"[IGNORE] {nameof (HttpClientTest)}.{nameof (Post)} {ex.StatusCode}: {ex}";
+ 					return $"[IGNORE] {nameof (HttpClientTest)}.{nameof (Post)} {response.StatusCode}";
  			}
-			return $"[FAIL] {nameof (HttpClientTest)}.{nameof (Post)} FAILED: {ex}";
-		}
-		catch (Exception ex) {
+			response.EnsureSuccessStatusCode ();
+			var json = response.Content.ReadAsStringAsync ().Result;
+			return $"[PASS] {nameof (HttpClientTest)}.{nameof (Post)}";
+		} catch (Exception ex) {
 			return $"[FAIL] {nameof (HttpClientTest)}.{nameof (Post)} FAILED: {ex}";
 		}
 	}


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11188869&view=ms.vss-test-web.build-test-results-tab&runId=124545813&resultId=100000&paneView=debug

This test can randomly fail with:

    03-13 20:25:44.700  2623  2623 I XALINKERTESTS: [FAIL] HttpClientTest.Post FAILED: System.Net.Http.HttpRequestException: net_http_message_not_success_statuscode_reason, 503, Service Temporarily Unavailable
    03-13 20:25:44.700  2623  2623 I XALINKERTESTS:    at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
    03-13 20:25:44.700  2623  2623 I XALINKERTESTS:    at HttpClientTest.Post()

I made this test print an `[IGNORE]` result if this occurs, similar to what we did in 455ec0a4f.