### PR TITLE
Enable MetricsSupport by default for non-Release builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -125,7 +125,7 @@
     <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == '' and '$(TrimMode)' == 'partial'">true</JsonSerializerIsReflectionEnabledByDefault>
     <!-- Set to disable throwing behavior, see: https://github.com/dotnet/runtime/issues/109724 -->
     <_DefaultValueAttributeSupport Condition="'$(_DefaultValueAttributeSupport)' == '' and '$(TrimMode)' == 'partial'">true</_DefaultValueAttributeSupport>
-    <MetricsSupport Condition="'$(MetricsSupport)' == ''">false</MetricsSupport>
+    <MetricsSupport Condition="'$(MetricsSupport)' == '' and '$(Configuration)' == 'Release'">false</MetricsSupport>
     <AndroidAvoidEmitForPerformance Condition="'$(AndroidAvoidEmitForPerformance)' == ''">$(AvoidEmitForPerformance)</AndroidAvoidEmitForPerformance>
     <AndroidAvoidEmitForPerformance Condition="'$(AndroidAvoidEmitForPerformance)' == ''">true</AndroidAvoidEmitForPerformance>
     <!-- Verify DI trimmability at development-time, but turn the validation off for production/trimmed builds. -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -125,7 +125,7 @@
     <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == '' and '$(TrimMode)' == 'partial'">true</JsonSerializerIsReflectionEnabledByDefault>
     <!-- Set to disable throwing behavior, see: https://github.com/dotnet/runtime/issues/109724 -->
     <_DefaultValueAttributeSupport Condition="'$(_DefaultValueAttributeSupport)' == '' and '$(TrimMode)' == 'partial'">true</_DefaultValueAttributeSupport>
-    <MetricsSupport Condition="'$(MetricsSupport)' == '' and '$(Configuration)' == 'Release'">false</MetricsSupport>
+    <MetricsSupport Condition="'$(MetricsSupport)' == '' and '$(Optimize)' == 'true'">false</MetricsSupport>
     <AndroidAvoidEmitForPerformance Condition="'$(AndroidAvoidEmitForPerformance)' == ''">$(AvoidEmitForPerformance)</AndroidAvoidEmitForPerformance>
     <AndroidAvoidEmitForPerformance Condition="'$(AndroidAvoidEmitForPerformance)' == ''">true</AndroidAvoidEmitForPerformance>
     <!-- Verify DI trimmability at development-time, but turn the validation off for production/trimmed builds. -->

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System/AppContextTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System/AppContextTests.cs
@@ -39,7 +39,11 @@ namespace SystemTests
 			new object [] {
 				/* className */    "System.Diagnostics.Metrics.Meter, System.Diagnostics.DiagnosticSource",
 				/* propertyName */ "<IsSupported>k__BackingField",
+#if DEBUG
+				/* expected */     true,
+#else   // !DEBUG
 				/* expected */     false,
+#endif  // !DEBUG
 			},
 		};
 


### PR DESCRIPTION
Primarily to light up the metrics when using .NET MAUI apps with .NET Aspire, but this will emit metrics for potential other purposes as well.

With this change the `MetricsSupport` property will only be set to `false` when the property has no value and the build is not a `Release` build.

That means, if the property is not explicitly set in the .NET MAUI project (or .NET for Android project) and the build is not a `Release` build, the property will be set to `true` (the default value) and emit metrics.

cc: @rolfbjarne I was informed you were going to disable this for iOS, so it might be good to keep this in mind as well for that!