### PR TITLE
[XABT] Move scanning for ACW map JLOs to `FindJavaObjectsStep`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FindJavaObjectsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FindJavaObjectsStep.cs
@@ -85,8 +85,10 @@ public class FindJavaObjectsStep : BaseStep
 		if (UseMarshalMethods)
 			reader_options.MethodClassifier = new MarshalMethodsClassifier (Context, Context.Resolver, Log);
 
-		foreach (var type in types)
-			wrappers.Add (CecilImporter.CreateType (type, Context, reader_options));
+		foreach (var type in types) {
+			var wrapper = CecilImporter.CreateType (type, Context, reader_options);
+			wrappers.Add (wrapper);
+		}
 
 		return wrappers;
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
@@ -147,11 +147,11 @@ public class AssemblyModifierPipeline : AndroidTask
 
 	protected virtual void RunPipeline (ITaskItem source, ITaskItem destination, RunState runState, WriterParameters writerParameters)
 	{
-		var destinationJLOXml = Path.ChangeExtension (destination.ItemSpec, ".jlo.xml");
+		var destinationJLOXml = JavaObjectsXmlFile.GetJavaObjectsXmlFilePath (destination.ItemSpec);
 
 		if (!TryScanForJavaObjects (source, destination, runState, writerParameters)) {
 			// Even if we didn't scan for Java objects, we still write an empty .xml file for later steps
-			FindJavaObjectsStep.WriteEmptyXmlFile (destinationJLOXml);
+			JavaObjectsXmlFile.WriteEmptyFile (destinationJLOXml, Log);
 		}
 	}
 
@@ -160,7 +160,7 @@ public class AssemblyModifierPipeline : AndroidTask
 		if (!ShouldScanAssembly (source))
 			return false;
 
-		var destinationJLOXml = Path.ChangeExtension (destination.ItemSpec, ".jlo.xml");
+		var destinationJLOXml = JavaObjectsXmlFile.GetJavaObjectsXmlFilePath (destination.ItemSpec);
 		var assemblyDefinition = runState.resolver!.GetAssembly (source.ItemSpec);
 
 		var scanned = runState.findJavaObjectsStep!.ProcessAssembly (assemblyDefinition, destinationJLOXml);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateACWMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateACWMap.cs
@@ -1,5 +1,7 @@
 #nullable enable
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Framework;
@@ -17,29 +19,68 @@ public class GenerateACWMap : AndroidTask
 	[Required]
 	public string IntermediateOutputDirectory { get; set; } = "";
 
+	[Required]
+	public ITaskItem [] ResolvedAssemblies { get; set; } = [];
+
+	// This property is temporary and is used to ensure that the new "linker step"
+	// JLO scanning produces the same results as the old process. It will be removed
+	// once the process is complete.
+	public bool RunCheckedBuild { get; set; }
+
+	[Required]
+	public string [] SupportedAbis { get; set; } = [];
+
 	public override bool RunTask ()
 	{
-		// Retrieve the stored NativeCodeGenState
-		var nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>> (
-			MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory),
-			RegisteredTaskObjectLifetime.Build
-		);
+		// Temporarily used to ensure we still generate the same as the old code
+		if (RunCheckedBuild) {
+			// Retrieve the stored NativeCodeGenState
+			var nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>> (
+				MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory),
+				RegisteredTaskObjectLifetime.Build
+			);
 
-		// We only need the first architecture, since this task is architecture-agnostic
-		var templateCodeGenState = nativeCodeGenStates.First ().Value;
+			// We only need the first architecture, since this task is architecture-agnostic
+			var templateCodeGenState = nativeCodeGenStates.First ().Value;
+
+			var acwMapGen = new ACWMapGenerator (Log);
+
+			if (!acwMapGen.Generate (templateCodeGenState, AcwMapFile)) {
+				Log.LogDebugMessage ("ACW map generation failed");
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		GenerateMap ();
+
+		return !Log.HasLoggedErrors;
+	}
+
+	void GenerateMap ()
+	{
+		// Get the set of assemblies for the "first" ABI. The ACW map is
+		// not ABI-specific, so we can use any ABI to generate the wrappers.
+		var allAssembliesPerArch = MonoAndroidHelper.GetPerArchAssemblies (ResolvedAssemblies, SupportedAbis, validate: true);
+		var singleArchAssemblies = allAssembliesPerArch.First ().Value.Values.ToList ();
+
+		var entries = new List<ACWMapEntry> ();
+
+		foreach (var assembly in singleArchAssemblies) {
+			var wrappersPath = JavaObjectsXmlFile.GetJavaObjectsXmlFilePath (assembly.ItemSpec);
+
+			if (!File.Exists (wrappersPath)) {
+				Log.LogError ($"'{wrappersPath}' not found.");
+				return;
+			}
+
+			var xml = JavaObjectsXmlFile.Import (wrappersPath, JavaObjectsXmlFileReadType.ACW);
+
+			entries.AddRange (xml.ACWMapEntries);
+		}
 
 		var acwMapGen = new ACWMapGenerator (Log);
 
-		if (!acwMapGen.Generate (templateCodeGenState, AcwMapFile)) {
-			Log.LogDebugMessage ("ACW map generation failed");
-		}
-
-		if (Log.HasLoggedErrors) {
-			// Ensure that on a rebuild, we don't *skip* the `_GenerateJavaStubs` target,
-			// by ensuring that the target outputs have been deleted.
-			Files.DeleteFile (AcwMapFile, Log);
-		}
-
-		return !Log.HasLoggedErrors;
+		acwMapGen.Generate (entries, AcwMapFile);
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateACWMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateACWMap.cs
@@ -74,7 +74,7 @@ public class GenerateACWMap : AndroidTask
 				return;
 			}
 
-			var xml = JavaObjectsXmlFile.Import (wrappersPath, JavaObjectsXmlFileReadType.ACW);
+			var xml = JavaObjectsXmlFile.Import (wrappersPath, JavaObjectsXmlFileReadType.AndroidResourceFixups);
 
 			entries.AddRange (xml.ACWMapEntries);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaCallableWrappers.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaCallableWrappers.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Java.Interop.Tools.JavaCallableWrappers;
-using Java.Interop.Tools.JavaCallableWrappers.Adapters;
 using Java.Interop.Tools.JavaCallableWrappers.CallableWrapperMembers;
 using Java.Interop.Tools.TypeNameMappings;
 using Microsoft.Android.Build.Tasks;
@@ -63,16 +62,21 @@ public class GenerateJavaCallableWrappers : AndroidTask
 		var sw = Stopwatch.StartNew ();
 
 		foreach (var assembly in assemblies) {
-			var assemblyPath = assembly.ItemSpec;
-			var assemblyName = Path.GetFileNameWithoutExtension (assemblyPath);
-			var wrappersPath = Path.Combine (Path.GetDirectoryName (assemblyPath), $"{assemblyName}.jlo.xml");
+			var wrappersPath = JavaObjectsXmlFile.GetJavaObjectsXmlFilePath (assembly.ItemSpec);
 
 			if (!File.Exists (wrappersPath)) {
 				Log.LogError ($"'{wrappersPath}' not found.");
 				return;
 			}
 
-			wrappers.AddRange (XmlImporter.Import (wrappersPath, out var _));
+			var xml = JavaObjectsXmlFile.Import (wrappersPath, JavaObjectsXmlFileReadType.JCW);
+
+			if (xml.JavaCallableWrappers.Count == 0) {
+				Log.LogDebugMessage ($"'{wrappersPath}' is empty, skipping.");
+				continue;
+			}
+
+			wrappers.AddRange (xml.JavaCallableWrappers);
 		}
 
 		Log.LogDebugMessage ($"Deserialized {wrappers.Count} Java callable wrappers in {sw.ElapsedMilliseconds}ms");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaCallableWrappers.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaCallableWrappers.cs
@@ -69,7 +69,7 @@ public class GenerateJavaCallableWrappers : AndroidTask
 				return;
 			}
 
-			var xml = JavaObjectsXmlFile.Import (wrappersPath, JavaObjectsXmlFileReadType.JCW);
+			var xml = JavaObjectsXmlFile.Import (wrappersPath, JavaObjectsXmlFileReadType.JavaCallableWrappers);
 
 			if (xml.JavaCallableWrappers.Count == 0) {
 				Log.LogDebugMessage ($"'{wrappersPath}' is empty, skipping.");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -277,15 +277,14 @@ namespace Xamarin.Android.Tasks
 			// Find every assembly that was scanned by the linker by looking at the .jlo.xml files
 			foreach (var assembly in ResolvedAssemblies) {
 				var assemblyPath = assembly.ItemSpec;
-				var assemblyName = Path.GetFileNameWithoutExtension (assemblyPath);
-				var wrappersPath = Path.Combine (Path.GetDirectoryName (assemblyPath), $"{assemblyName}.jlo.xml");
+				var wrappersPath = JavaObjectsXmlFile.GetJavaObjectsXmlFilePath (assembly.ItemSpec);
 
 				if (!File.Exists (wrappersPath))
 					Log.LogError ($"'{wrappersPath}' not found.");
 
-				XmlImporter.Import (wrappersPath, out var wasScanned);
+				var xml = JavaObjectsXmlFile.Import (wrappersPath, JavaObjectsXmlFileReadType.None);
 
-				if (wasScanned) {
+				if (xml.WasScanned) {
 					Log.LogDebugMessage ($"CompareScannedAssemblies: Found scanned assembly .jlo.xml '{assemblyPath}'");
 					linker_scanned_assemblies.Add (assembly.ItemSpec);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ACWMapGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ACWMapGenerator.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
-
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.TypeNameMappings;
 using Microsoft.Android.Build.Tasks;
@@ -33,7 +35,7 @@ class ACWMapGenerator
 		bool success = true;
 
 		using var acw_map = MemoryStreamPool.Shared.CreateStreamWriter ();
-		foreach (TypeDefinition type in javaTypes) {
+		foreach (TypeDefinition type in javaTypes.OrderBy (t => t.FullName.Replace ('/', '.'))) {
 			string managedKey = type.FullName.Replace ('/', '.');
 			string javaKey = JavaNativeTypeManager.ToJniName (type, cache).Replace ('/', '.');
 
@@ -79,7 +81,19 @@ class ACWMapGenerator
 		}
 
 		acw_map.Flush ();
-		Files.CopyIfStreamChanged (acw_map.BaseStream, acwMapFile);
+
+		// If there's conflicts, the "new way" file never got written, and will show up as
+		// "changed" in our comparison test, so skip it.
+		if (javaConflicts.Count > 0) {
+			return false;
+		}
+
+		if (Files.HasStreamChanged (acw_map.BaseStream, acwMapFile)) {
+			log.LogError ($"ACW map file '{acwMapFile}' changed");
+			Files.CopyIfStreamChanged (acw_map.BaseStream, acwMapFile + "2");
+		} else {
+			log.LogDebugMessage ($"ACW map file '{acwMapFile}' unchanged");
+		}
 
 		foreach (var kvp in managedConflicts) {
 			log.LogCodedWarning ("XA4214", Properties.Resources.XA4214, kvp.Key, string.Join (", ", kvp.Value));
@@ -98,5 +112,122 @@ class ACWMapGenerator
 		}
 
 		return success;
+	}
+
+	public void Generate (List<ACWMapEntry> javaTypes, string acwMapFile)
+	{
+		// We need to save a map of .NET type -> ACW type for resource file fixups
+		var managed = new Dictionary<string, ACWMapEntry> (javaTypes.Count, StringComparer.Ordinal);
+		var java = new Dictionary<string, ACWMapEntry> (javaTypes.Count, StringComparer.Ordinal);
+
+		var managedConflicts = new Dictionary<string, List<string>> (0, StringComparer.Ordinal);
+		var javaConflicts = new Dictionary<string, List<string>> (0, StringComparer.Ordinal);
+
+		using var acw_map = MemoryStreamPool.Shared.CreateStreamWriter ();
+
+		foreach (var type in javaTypes.OrderBy (t => t.ManagedKey)) {
+			string managedKey = type.ManagedKey;
+			string javaKey = type.JavaKey;
+
+			acw_map.Write (type.PartialAssemblyQualifiedName);
+			acw_map.Write (';');
+			acw_map.Write (javaKey);
+			acw_map.WriteLine ();
+
+			ACWMapEntry conflict;
+			bool hasConflict = false;
+
+			if (managed.TryGetValue (managedKey, out conflict)) {
+				if (!conflict.ModuleName.Equals (type.ModuleName)) {
+					if (!managedConflicts.TryGetValue (managedKey, out var list))
+						managedConflicts.Add (managedKey, list = new List<string> { conflict.PartialAssemblyName });
+					list.Add (type.PartialAssemblyName);
+				}
+				hasConflict = true;
+			}
+
+			if (java.TryGetValue (javaKey, out conflict)) {
+				if (!conflict.ModuleName.Equals(type.ModuleName)) {
+					if (!javaConflicts.TryGetValue (javaKey, out var list))
+						javaConflicts.Add (javaKey, list = new List<string> { conflict.AssemblyQualifiedName });
+					list.Add (type.AssemblyQualifiedName);
+				}
+				hasConflict = true;
+			}
+
+			if (!hasConflict) {
+				managed.Add (managedKey, type);
+				java.Add (javaKey, type);
+
+				acw_map.Write (managedKey);
+				acw_map.Write (';');
+				acw_map.Write (javaKey);
+				acw_map.WriteLine ();
+
+				acw_map.Write (type.CompatJniName);
+				acw_map.Write (';');
+				acw_map.Write (javaKey);
+				acw_map.WriteLine ();
+			}
+		}
+
+		acw_map.Flush ();
+
+		foreach (var kvp in managedConflicts) {
+			log.LogCodedWarning ("XA4214", Properties.Resources.XA4214, kvp.Key, string.Join (", ", kvp.Value));
+			log.LogCodedWarning ("XA4214", Properties.Resources.XA4214_Result, kvp.Key, kvp.Value [0]);
+		}
+
+		foreach (var kvp in javaConflicts) {
+			log.LogCodedError ("XA4215", Properties.Resources.XA4215, kvp.Key);
+
+			foreach (var typeName in kvp.Value) {
+				log.LogCodedError ("XA4215", Properties.Resources.XA4215_Details, kvp.Key, typeName);
+			}
+		}
+
+		// Don't write the output file if there are any errors so that
+		// future incremental builds will try again.
+		if (javaConflicts.Count > 0)
+			return;
+
+		Files.CopyIfStreamChanged (acw_map.BaseStream, acwMapFile);
+	}
+}
+
+class ACWMapEntry
+{
+	public string AssemblyQualifiedName { get; set; }
+	public string CompatJniName { get; set; }
+	public string JavaKey { get; set; }
+	public string ManagedKey { get; set; }
+	public string ModuleName { get; set; }
+	public string PartialAssemblyName { get; set; }
+	public string PartialAssemblyQualifiedName { get; set; }
+
+	public static ACWMapEntry Create (TypeDefinition type, TypeDefinitionCache cache)
+	{
+		return new ACWMapEntry {
+			AssemblyQualifiedName = type.GetAssemblyQualifiedName (cache),
+			CompatJniName = JavaNativeTypeManager.ToCompatJniName (type, cache).Replace ('/', '.'),
+			JavaKey = JavaNativeTypeManager.ToJniName (type, cache).Replace ('/', '.'),
+			ManagedKey = type.FullName.Replace ('/', '.'),
+			ModuleName = type.Module.Name,
+			PartialAssemblyName = type.GetPartialAssemblyName (cache),
+			PartialAssemblyQualifiedName = type.GetPartialAssemblyQualifiedName (cache),
+		};
+	}
+
+	public static ACWMapEntry Create (XElement type, string partialAssemblyName, string moduleName)
+	{
+		return new ACWMapEntry {
+			AssemblyQualifiedName = type.GetAttributeOrDefault ("assembly-qualified-name", string.Empty),
+			CompatJniName = type.GetAttributeOrDefault ("compat-jni-name", string.Empty),
+			JavaKey = type.GetAttributeOrDefault ("java-key", string.Empty),
+			ManagedKey = type.GetAttributeOrDefault ("managed-key", string.Empty),
+			ModuleName = moduleName,
+			PartialAssemblyName = partialAssemblyName,
+			PartialAssemblyQualifiedName = type.GetAttributeOrDefault ("partial-assembly-qualified-name", string.Empty),
+		};
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JavaObjectsXmlFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JavaObjectsXmlFile.cs
@@ -107,10 +107,10 @@ class JavaObjectsXmlFile
 		var xml = XDocument.Load (filename);
 
 		// We let callers specify which part(s) of the file they want to deserialize to save time
-		if (readType.HasFlag (JavaObjectsXmlFileReadType.JCW) && xml.Root?.Element ("jcw-types") is XElement jcw)
+		if (readType.HasFlag (JavaObjectsXmlFileReadType.JavaCallableWrappers) && xml.Root?.Element ("jcw-types") is XElement jcw)
 			file.JavaCallableWrappers.AddRange (XmlImporter.Import (jcw));
 
-		if (readType.HasFlag (JavaObjectsXmlFileReadType.ACW) && xml.Root?.Element ("acw-types") is XElement acw) {
+		if (readType.HasFlag (JavaObjectsXmlFileReadType.AndroidResourceFixups) && xml.Root?.Element ("acw-types") is XElement acw) {
 			var partialAssemblyName = acw.GetAttributeOrDefault ("partial-assembly-name", string.Empty);
 			var moduleName = acw.GetAttributeOrDefault ("module-name", string.Empty);
 
@@ -136,6 +136,6 @@ class JavaObjectsXmlFile
 enum JavaObjectsXmlFileReadType
 {
 	None = 0,
-	ACW = 1,
-	JCW = 2,
+	AndroidResourceFixups = 1,
+	JavaCallableWrappers = 2,
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JavaObjectsXmlFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JavaObjectsXmlFile.cs
@@ -1,0 +1,141 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using Java.Interop.Tools.JavaCallableWrappers.Adapters;
+using Java.Interop.Tools.JavaCallableWrappers.CallableWrapperMembers;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tasks;
+
+class JavaObjectsXmlFile
+{
+	static XmlWriterSettings settings = new XmlWriterSettings {
+		Indent = true,
+		NewLineOnAttributes = false,
+		OmitXmlDeclaration = true,
+	};
+
+	static readonly JavaObjectsXmlFile unscanned = new JavaObjectsXmlFile { WasScanned = false };
+
+	public List<ACWMapEntry> ACWMapEntries { get; } = [];
+	public List<CallableWrapperType> JavaCallableWrappers { get; } = [];
+	public bool WasScanned { get; private set; }
+
+	public void Export (string filename)
+	{
+		using var sw = MemoryStreamPool.Shared.CreateStreamWriter ();
+
+		using (var xml = XmlWriter.Create (sw, settings))
+			Export (xml);
+
+		sw.Flush ();
+
+		Files.CopyIfStreamChanged (sw.BaseStream, filename);
+	}
+
+	void Export (XmlWriter xml)
+	{
+		xml.WriteStartElement ("api");
+
+		ExportJCWTypes (xml);
+		ExportACWMappingTypes (xml);
+
+		xml.WriteEndElement ();
+	}
+
+	void ExportJCWTypes (XmlWriter xml)
+	{
+		if (JavaCallableWrappers.Count == 0)
+			return;
+
+		xml.WriteStartElement ("jcw-types");
+
+		XmlExporter.Export (xml, JavaCallableWrappers);
+
+		xml.WriteEndElement ();
+	}
+
+	void ExportACWMappingTypes (XmlWriter xml)
+	{
+		if (ACWMapEntries.Count == 0)
+			return;
+
+		var t = ACWMapEntries.First ();
+
+		xml.WriteStartElement ("acw-types");
+
+		xml.WriteAttributeStringIfNotDefault ("partial-assembly-name", t.PartialAssemblyName);
+		xml.WriteAttributeStringIfNotDefault ("module-name", t.ModuleName);
+
+		foreach (var type in ACWMapEntries) {
+			xml.WriteStartElement ("type");
+			xml.WriteAttributeStringIfNotDefault ("assembly-qualified-name", type.AssemblyQualifiedName);
+			xml.WriteAttributeStringIfNotDefault ("compat-jni-name", type.CompatJniName);
+			xml.WriteAttributeStringIfNotDefault ("java-key", type.JavaKey);
+			xml.WriteAttributeStringIfNotDefault ("managed-key", type.ManagedKey);
+			xml.WriteAttributeStringIfNotDefault ("partial-assembly-qualified-name", type.PartialAssemblyQualifiedName);
+			xml.WriteEndElement ();
+		}
+
+		xml.WriteEndElement ();
+	}
+
+	/// <summary>
+	/// Given an assembly path, return the path to the ".jlo.xml" file that should be next to it.
+	/// </summary>
+	public static string GetJavaObjectsXmlFilePath (string assemblyPath)
+		=> Path.ChangeExtension (assemblyPath, ".jlo.xml");
+
+	public static JavaObjectsXmlFile Import (string filename, JavaObjectsXmlFileReadType readType)
+	{
+		// If the file has zero length, then the assembly wasn't scanned because it couldn't contain JLOs.
+		// This check is much faster than loading and parsing an empty XML file.
+		var fi = new FileInfo (filename);
+
+		if (fi.Length == 0)
+			return unscanned;
+
+		var file = new JavaObjectsXmlFile {
+			WasScanned = true,
+		};
+
+		var xml = XDocument.Load (filename);
+
+		// We let callers specify which part(s) of the file they want to deserialize to save time
+		if (readType.HasFlag (JavaObjectsXmlFileReadType.JCW) && xml.Root?.Element ("jcw-types") is XElement jcw)
+			file.JavaCallableWrappers.AddRange (XmlImporter.Import (jcw));
+
+		if (readType.HasFlag (JavaObjectsXmlFileReadType.ACW) && xml.Root?.Element ("acw-types") is XElement acw) {
+			var partialAssemblyName = acw.GetAttributeOrDefault ("partial-assembly-name", string.Empty);
+			var moduleName = acw.GetAttributeOrDefault ("module-name", string.Empty);
+
+			foreach (var type in acw.Elements ("type")) {
+				var entry = ACWMapEntry.Create (type, partialAssemblyName, moduleName);
+				file.ACWMapEntries.Add (entry);
+			}
+		}
+
+		return file;
+	}
+
+	public static void WriteEmptyFile (string destination, TaskLoggingHelper log)
+	{
+		log.LogDebugMessage ($"Writing empty file '{destination}'");
+
+		// We write a zero byte file to indicate the file couldn't have JLO types and wasn't scanned
+		File.Create (destination).Dispose ();
+	}
+}
+
+[Flags]
+enum JavaObjectsXmlFileReadType
+{
+	None = 0,
+	ACW = 1,
+	JCW = 2,
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/UtilityExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/UtilityExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Xml;
+using System.Xml.Linq;
 using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Tasks;
@@ -42,5 +44,38 @@ static class UtilityExtensions
 			default:
 				throw new ArgumentOutOfRangeException (nameof (mode), mode, null);
 		}
+	}
+
+	public static T GetAttributeOrDefault<T> (this XElement xml, string name, T defaultValue)
+	{
+		var value = xml.Attribute (name)?.Value;
+
+		if (string.IsNullOrWhiteSpace (value))
+			return defaultValue;
+
+		return (T) Convert.ChangeType (value, typeof (T));
+	}
+
+	public static string GetRequiredAttribute (this XElement xml, string name)
+	{
+		var value = xml.Attribute (name)?.Value;
+
+		if (string.IsNullOrWhiteSpace (value))
+			throw new InvalidOperationException ($"Missing required attribute '{name}'");
+
+		return value!;  // NRT - Guarded by IsNullOrWhiteSpace check above
+	}
+
+	public static void WriteAttributeStringIfNotDefault (this XmlWriter xml, string name, string? value)
+	{
+		if (value.HasValue ())
+			xml.WriteAttributeString (name, value);
+	}
+
+	public static void WriteAttributeStringIfNotDefault (this XmlWriter xml, string name, bool value)
+	{
+		// If value is false, don't write the attribute, we'll default to false on import
+		if (value)
+			xml.WriteAttributeString (name, value.ToString ());
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1578,6 +1578,13 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="GeneratedJavaFilesOutput" ItemName="_GeneratedJavaFiles" />
   </GenerateJavaCallableWrappers>
 
+  <GenerateACWMap
+      AcwMapFile="$(_AcwMapFile)"
+      IntermediateOutputDirectory="$(IntermediateOutputPath)"
+      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      SupportedAbis="@(_BuildTargetAbis)">
+  </GenerateACWMap>
+
   <GenerateJavaStubs
       CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
       ResolvedAssemblies="@(_ResolvedAssemblies)"
@@ -1613,8 +1620,12 @@ because xbuild doesn't support framework reference assemblies.
   </GenerateTypeMappings>
 
   <GenerateACWMap
+      Condition=" '$(_AndroidJLOCheckedBuild)' == 'true' "
       AcwMapFile="$(_AcwMapFile)"
-      IntermediateOutputDirectory="$(IntermediateOutputPath)">
+      RunCheckedBuild="true"
+      IntermediateOutputDirectory="$(IntermediateOutputPath)"
+      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      SupportedAbis="@(_BuildTargetAbis)">
   </GenerateACWMap>
 
   <GenerateMainAndroidManifest


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9893

Building on https://github.com/dotnet/android/pull/9893, this moves the process of scanning for JLOs needed for the ACW map generation task to the `FindJavaObjectsStep` "linker step".

This process needs `interface` JLOs, which `JavaCallableWrappers` doesn't support.  Expanding the JCW serialization format to allow interfaces (and other ACW-needed data it didn't already support) resulted in a lot of extra processing and waste.

Instead, we expand the `.jlo.xml` file to have 2 sections, one for JCW needed data and one for ACW needed data:

```xml
<api>
  <jcw-types>
    <type name="MainActivity" package="crc645107ba1b8b6ee4d3" application_java_class="android.app.Application" mono_runtime_initialization="mono.MonoPackageManager.LoadApplication (context);" extends_type="android.app.Activity" partial_assembly_qualified_name="tempbuild.MainActivity, tempbuild">
      <constructors>
        <constructor name="MainActivity" method="n_.ctor:()V:" jni_signature="()V" managed_parameters="" retval="void" is_dynamically_registered="True" />
      </constructors>
      <methods>
        <method name="clone" method="n_clone:()Ljava/lang/Object;:GetCloneHandler" jni_signature="()Ljava/lang/Object;" retval="java.lang.Object" />
        <method name="onCreate" method="n_onCreate:(Landroid/os/Bundle;)V:GetOnCreate_Landroid_os_Bundle_Handler" jni_signature="(Landroid/os/Bundle;)V" params="android.os.Bundle p0" retval="void" super_call="p0" activate_call="p0" />
      </methods>
    </type>
  </jcw-types>
  <acw-types partial-assembly-name="tempbuild" module-name="tempbuild.dll">
    <type assembly-qualified-name="tempbuild.MainActivity, tempbuild, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" compat-jni-name="tempbuild.MainActivity" java-key="crc645107ba1b8b6ee4d3.MainActivity" managed-key="tempbuild.MainActivity" partial-assembly-qualified-name="tempbuild.MainActivity, tempbuild" />
  </acw-types>
</api>
```

Additionally, for assemblies that cannot contain JLOs that we do not need to scan, we no longer write an "empty" XML file like this: `<types was_scanned="False" />`.  Instead, we now write an actual empty (0 byte) file to disk, which saves build time when deserializing.  

Like https://github.com/dotnet/android/pull/9893, this temporarily leaves the old ACW map generation code in place, guarded behind the `$(_AndroidJLOCheckedBuild)` flag.  This flag generates the ACW map both the new and old way, and errors the build if there are differences.  (A consistent sort was added so that both maps are sorted the same.)

Requires https://github.com/dotnet/java-interop/pull/1325.
