### PR TITLE
Bump to dotnet/java-interop/main@5852e6e3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/dotnet/java-interop
-    branch = main
+    branch = dev/jonp/jonp-Class.forName
 [submodule "external/libunwind"]
     path = external/libunwind
     url = https://github.com/libunwind/libunwind.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/dotnet/java-interop
-    branch = dev/jonp/jonp-Class.forName
+    branch = main
 [submodule "external/libunwind"]
     path = external/libunwind
     url = https://github.com/libunwind/libunwind.git


### PR DESCRIPTION
Fixes: https://github.com/dotnet/java-interop/issues/23

Changes: https://github.com/dotnet/java-interop/compare/bc44f085f6785abb2e3d2a9533a70b2f63d681b8...5852e6e398a6c96d42fff3ed4b8a5d4b5a0abf97

  * dotnet/java-interop@5852e6e3: [Java.Interop] Use `Class.forName()` as fallback to load Java classes (dotnet/java-interop#1326)
