### PR TITLE
Bump to 34.0.153 of the .NET 8 Android workload

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,14 +4,11 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
-    <add key="darc-pub-dotnet-android-cdb777a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-cdb777a0/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-android-fea9dcd" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-fea9dcd5/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-emsdk -->
-    <add key="darc-pub-dotnet-emsdk-dad5528" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-dad5528e/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-emsdk-dad5528-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-dad5528e-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-pub-dotnet-runtime-689f4e9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-689f4e9a/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!-- ensure only the sources defined below are used -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -25,9 +25,9 @@
       <Sha>aa3ae0d49da3cfb31a383f16303a3f2f0c3f1a19</Sha>
     </Dependency>
     <!-- Previous .NET Android version -->
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.148">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.0.153">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>cdb777a0c306e3e0668f847433f82144d7ca745f</Sha>
+      <Sha>fea9dcd5824c760485e39138b38999c303da8b56</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.25102.5</MicrosoftDotNetCecilPackageVersion>
     <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
     <!-- Previous .NET Android version -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.148</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>34.0.153</MicrosoftAndroidSdkWindowsPackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftAndroidSdkWindowsPackageVersion)</AndroidNetPreviousVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Changes: https://github.com/dotnet/android/compare/cdb777a0c306e3e0668f847433f82144d7ca745f...fea9dcd5824c760485e39138b38999c303da8b56

* [release/8.0.4xx] Update apkdiff to 0.0.17 (#9894)
* [release/8.0.4xx] Prefer JDK 17.0.14
* [release/8.0.4xx] [build] stop installing Xamarin.Android (#9895)
* Fix Debugger timeout on 32 bit devices. (#9881)