### PR TITLE
[ci] Fail build if any untracked files written in git tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ Novell
 *.patch
 *.keystore
 /omnisharp.json
+src/native/CMakePresets.json
+src/native/clr/host/generate-pinvoke-tables
+src/native/clr/host/pinvoke-tables.include.generated
+src/native/mono/pinvoke-override/generate-pinvoke-tables
+src/native/mono/pinvoke-override/pinvoke-tables.include.generated
+dotnet-install.ps1

--- a/build-tools/automation/yaml-templates/fail-on-dirty-tree.yaml
+++ b/build-tools/automation/yaml-templates/fail-on-dirty-tree.yaml
@@ -9,14 +9,14 @@ steps:
     # Run this to log the output for the user
     git status
 
-    # Run this to error the build if untracked files
-    $process= git status --porcelain --untracked-files=no
+    # Run this to error the build if modified/untracked files exist
+    $process= git status --porcelain
 
     if ($process)
     {
-        Write-Host "##vso[task.logissue type=error]git tree has modified tracked files."
+        Write-Host "##vso[task.logissue type=error]git tree has modified or untracked files."
         Write-Host "##vso[task.complete result=Failed;]"
     }
-  displayName: Ensure no modified committed files
+  displayName: Ensure no modified/untracked files
   workingDirectory: ${{ parameters.xaSourcePath }}
   condition: ${{ parameters.condition }}


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9661

Building on https://github.com/dotnet/android/pull/9661, we also shouldn't be writing build artifacts to the source tree.

Any files generated by the build should be placed in `/bin` or `/obj` folders rather than the source tree.

Violations fixed by putting the artifact in `.gitignore`.

## Current violations:

### Mac:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	src/native/CMakePresets.json
```

### Linux:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	src/native/CMakePresets.json
	src/native/clr/host/generate-pinvoke-tables
	src/native/clr/host/pinvoke-tables.include.generated
	src/native/mono/pinvoke-override/generate-pinvoke-tables
	src/native/mono/pinvoke-override/pinvoke-tables.include.generated
```

### Windows
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	dotnet-install.ps1
	src/native/CMakePresets.json
```