### PR TITLE
[ci] Don't re-run `dotnet test` if there are no auto retry tests.

### DIFF
--- a/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
@@ -70,9 +70,23 @@ steps:
       custom: build-server
       arguments: shutdown
 
+  - pwsh: |
+      $filePath = "${{ parameters.testAssembly }}.runsettings"
+      $stringToFind = "dotnet-slicer-dummy-test-name"
+      if (Select-String -Path $filePath -Pattern $stringToFind) {
+          Write-Host "No tests to rerun"
+          Write-Host "##vso[task.setvariable variable=ShouldRetryTests]false"
+      } else {
+          Write-Host "Need to rerun failed tests"
+          Write-Host "##vso[task.setvariable variable=ShouldRetryTests]true"
+      }
+    displayName: Determine if we need to rerun failed tests
+    workingDirectory: ${{ parameters.xaSourcePath }}  
+  
   - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
     parameters:
       testRunTitle: ${{ parameters.testRunTitle }}-$(System.JobPositionInPhase) (Auto-Retry)
       testAssembly: ${{ parameters.testAssembly }}
       dotNetTestExtraArgs: --settings "${{ parameters.testAssembly }}.runsettings"
       xaSourcePath: ${{ parameters.xaSourcePath }}
+      condition: and(succeeded(), eq(variables['ShouldRetryTests'], 'true'))


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/d00b779a5b5f405af967d85e28e570e873631a6b

Commit https://github.com/dotnet/android/commit/d00b779a5b5f405af967d85e28e570e873631a6b added a unit test retry mechanism to address flaky emulator tests.  

This works by:

- Running the unit tests via `dotnet test`
- Running `dotnet-test-slicer` to create a test filter that only contains the failed tests
- Rerunning `dotnet test` with the filtered test list

In the case where there are no failed tests, a "dummy" filter is created that does not match any tests.

Most of the time this is fine and the `dotnet test` invocation with the dummy filter takes a couple of seconds to determine it has nothing to do and exits.  However, this ***no-op*** can ***itself*** hang, causing the build to hang for ~3 hours and eventually fail.  🤦 

Instead, add a check to see if the failed test list is empty and fully skip the `dotnet test` invocation if it is, avoiding the potential hang.

Result:

![image](https://github.com/user-attachments/assets/acb84d32-f2d5-4e56-bf63-8290c4777f04)
