### PR TITLE
Don't try to copy files that no longer exist

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
@@ -69,8 +69,6 @@ namespace Xamarin.Android.Prepare
 				filesToCopyPreserveRelative.AddRange (Directory.GetFiles (javaInteropBuildConfigDir, "*.props"));
 			}
 
-			filesToCopyPreserveRelative.AddRange (Directory.GetFiles (Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "src", "native", "monodroid"), "*.include.*"));
-
 			var buildConfigDir = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "bin", $"Build{context.Configuration}");
 			if (Directory.Exists (buildConfigDir)) {
 				foreach (var fileMatch in buildConfigFiles) {


### PR DESCRIPTION
Context: b7e21ad40bed68db17065734fcf31ee6d6e0c1ae

b7e21ad4 moved `src/native/monodroid/` to `src/native/mono/monodroid` in order to
add a parallel tree for the CoreCLR host. However, the `xaprepare` code which used
to copy certain files from that directory wasn't updated, resulting in errors on
CI similar to:

    Step Xamarin.Android.Prepare.Step_CopyExtraResultFilesForCI failed: Could not find a part of the path '/Users/runner/work/1/s/src/native/monodroid'.
    System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_CopyExtraResultFilesForCI failed: Could not find a part of the path '/Users/runner/work/1/s/src/native/monodroid'.
      ---> System.IO.DirectoryNotFoundException: Could not find a part of the path '/Users/runner/work/1/s/src/native/monodroid'.

Fix the error by removing the offending line from `xaprepare` completely, as we no
longer have any `*.include.*` files there. There used to be serialized mono config
and library mapping files here, but we no longer use them.