### PR TITLE
[Mono.Android-Tests] Ignore temporary HTTP errors in async test methods.

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -290,16 +290,27 @@ namespace Xamarin.Android.NetTests {
 		{
 			// These status codes all indicate a temporary network/server failure,
 			// so just ignore the test if we hit them.
-			switch (response.StatusCode) {
+			if (ShouldIgnoreSuccessStatusCode (response.StatusCode)) {
+				Assert.Ignore ($"Ignoring network/server failure: {response.StatusCode}");
+				return;
+			}
+
+			response.EnsureSuccessStatusCode ();
+		}
+
+		public bool ShouldIgnoreSuccessStatusCode (HttpStatusCode code)
+		{
+			// These status codes all indicate a temporary network/server failure,
+			// so just ignore the test if we hit them.
+			switch (code) {
 				case HttpStatusCode.InternalServerError:
 				case HttpStatusCode.BadGateway:
 				case HttpStatusCode.ServiceUnavailable:
 				case HttpStatusCode.GatewayTimeout:
-					Assert.Ignore ($"Ignoring network/server failure: {response.StatusCode}");
-					return;
+					return true;
 			}
 
-			response.EnsureSuccessStatusCode ();
+			return false;
 		}
 	}
 

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
@@ -231,6 +231,12 @@ namespace Xamarin.Android.NetTests
 			var client = new HttpClient (handler);
 			var result = await client.GetAsync ("https://httpbin.org/redirect-to?url=https://www.microsoft.com/");
 
+			// Our dated NUnit test runner doesn't handle Assert.Ignore in an async context, so just exit
+			if (ShouldIgnoreSuccessStatusCode (result.StatusCode)) {
+				Console.WriteLine ($"Ignoring {result.StatusCode} status code");
+				return;
+			}
+
 			EnsureSuccessStatusCode (result);
 
 			Assert.AreEqual (2, callbackCounter);
@@ -245,6 +251,12 @@ namespace Xamarin.Android.NetTests
 
 			var client = new HttpClient (handler);
 			var result = await client.GetAsync ("https://httpbin.org/redirect-to?url=https://www.microsoft.com/&status_code=308");
+
+			// Our dated NUnit test runner doesn't handle Assert.Ignore in an async context, so just exit
+			if (ShouldIgnoreSuccessStatusCode (result.StatusCode)) {
+				Console.WriteLine ($"Ignoring {result.StatusCode} status code");
+				return;
+			}
 
 			EnsureSuccessStatusCode (result);
 


### PR DESCRIPTION
In the never-ending saga of trying to ignore temporary HTTP errors in `Mono.Android-Tests` test methods, our [latest attempt](https://github.com/dotnet/android/pull/9871) uses `Assert.Ignore`.  Behind the scenes, `Assert.Ignore` breaks out of a test by throwing `NUnit.Framework.IgnoreException`.  However our very dated test runner doesn't seem to handle this exception properly when in an `async` `Task` test method, resulting in this test failure:

```
System.AggregateException : AggregateException_ctor_DefaultMessage (Ignoring network/server failure: ServiceUnavailable)
----> NUnit.Framework.IgnoreException : Ignoring network/server failure: ServiceUnavailable
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean )
   at System.Threading.Tasks.Task.Wait(Int32 , CancellationToken )
   at System.Threading.Tasks.Task.Wait()
   at NUnit.Framework.Internal.AsyncInvocationRegion.AsyncTaskInvocationRegion.WaitForPendingOperationsToComplete(Object invocationResult)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunAsyncTestMethod(TestExecutionContext context)
--IgnoreException
   at NUnit.Framework.Assert.Ignore(String message, Object[] args)
   at NUnit.Framework.Assert.Ignore(String message)
   at Xamarin.Android.NetTests.AndroidHandlerTestBase.EnsureSuccessStatusCode(HttpResponseMessage response)
   at Xamarin.Android.NetTests.AndroidMessageHandlerTests.ServerCertificateCustomValidationCallback_Redirects()
```

For the 2 `async Task` tests we have, instead check if the HTTP status code indicates we should ignore the test, and if so, just exit the test early.  It will show up as "Passed" instead of "Ignored", which isn't perfect, but better than "Failed".