### PR TITLE
 Update Android workload versions to 35.0.61 and 34.0.154

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
+    <add key="darc-pub-dotnet-android-fea9dcd" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-fea9dcd5/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-android-3f3a5d2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-3f3a5d23/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,8 +4,8 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
-    <add key="darc-pub-dotnet-android-fea9dcd" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-fea9dcd5/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-android-3f3a5d2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-3f3a5d23/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-android-82d8938" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-82d8938c/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-android-e7876a4" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-e7876a4f/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!-- ensure only the sources defined below are used -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,8 +4,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
-    <add key="darc-pub-dotnet-android-1719a35" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1719a35b/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-android-cdb777a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-cdb777a0/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-android-3f3a5d2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-3f3a5d23/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!-- ensure only the sources defined below are used -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,9 +21,9 @@
       <Sha>f7a78a77069262841fe3c3c6b89ff243fc43cefc</Sha>
     </Dependency>
     <!-- Previous .NET Android version -->
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.50">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.59">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>1719a35b8a0348a4a8dd0061cfc4dd7fe6612a3c</Sha>
+      <Sha>3f3a5d23ae4296f1a6f577f632e366be688b13e5</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,9 +21,9 @@
       <Sha>f7a78a77069262841fe3c3c6b89ff243fc43cefc</Sha>
     </Dependency>
     <!-- Previous .NET Android version -->
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.59">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.61">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>3f3a5d23ae4296f1a6f577f632e366be688b13e5</Sha>
+      <Sha>e7876a4f92d894b40c191a24c2b74f06d4bf4573</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,10 +13,10 @@
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.25125.1</MicrosoftDotNetCecilPackageVersion>
     <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
     <!-- Previous .NET Android version -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.59</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.61</MicrosoftAndroidSdkWindowsPackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftAndroidSdkWindowsPackageVersion)</AndroidNetPreviousVersion>
     <!-- To be removed before .NET 10 GA -->
-    <AndroidNet8PreviousVersion>34.0.153</AndroidNet8PreviousVersion>
+    <AndroidNet8PreviousVersion>34.0.154</AndroidNet8PreviousVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,10 +13,10 @@
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.25125.1</MicrosoftDotNetCecilPackageVersion>
     <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
     <!-- Previous .NET Android version -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.50</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.59</MicrosoftAndroidSdkWindowsPackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftAndroidSdkWindowsPackageVersion)</AndroidNetPreviousVersion>
     <!-- To be removed before .NET 10 GA -->
-    <AndroidNet8PreviousVersion>34.0.148</AndroidNet8PreviousVersion>
+    <AndroidNet8PreviousVersion>34.0.153</AndroidNet8PreviousVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->


### PR DESCRIPTION
Bump previous Android SDK references for the upcoming April servicing release.

.NET 8 Changes: https://github.com/dotnet/android/compare/cdb777a0c306e3e0668f847433f82144d7ca745f...82d8938cf80f6d5fa6c28529ddfbdb753d805ab4
.NET 9 Changes: https://github.com/dotnet/android/compare/1719a35b8a0348a4a8dd0061cfc4dd7fe6612a3c...e7876a4f92d894b40c191a24c2b74f06d4bf4573