### PR TITLE
Bump to dotnet/android-tools/main@0658bc63

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@77445b27f654230a2dfb1af8326a6e1e0bb1f64a
+DevDiv/android-platform-support:main@8b8d0a556383eb32afb6429f965fe5b25cc92056


### PR DESCRIPTION
Changes: https://github.com/dotnet/android-tools/compare/ac8d0ee46e6f3bc3833577eff9a2190fa1cc52bc...0658bc63ebbc5a7ec08f54f903c0ea2fe832c6aa

  * dotnet/android-tools@0658bc6: [Xamarin.Android.Tools.AndroidSdk] OS-specific dirs are OS-specific (dotnet/android-tools#250)