### PR TITLE
Bump to dotnet/android-tools/release/9.0.1xx@59cab872

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:release/9.0.1xx@2f5580c6e6121c5253098829b05a72ba36ae4da1
+DevDiv/android-platform-support:release/9.0.1xx@41f8660f009f6efe6c440100ecf13ce1e276177b


### PR DESCRIPTION
Changes: https://github.com/dotnet/android-tools/compare/ab657dfcebf2d80e422c25e91dd389ec4f2aa1bc...59cab872db5b9544d6e734120393f96be61940bf

  * dotnet/android-tools@59cab87: [Xamarin.Android.Tools.AndroidSdk] OS-specific dirs are OS-specific (dotnet/android-tools#250)
  * dotnet/android-tools@ab50990: [ci] Move PR build to dnceng public (dotnet/android-tools#249)