### PR TITLE
Bump to dotnet/sdk/main@9762fd30 10.0.100-preview.4.25174.4

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,8 +4,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
-    <add key="darc-pub-dotnet-android-1719a35" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1719a35b/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-android-cdb777a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-cdb777a0/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!-- ensure only the sources defined below are used -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.3.25162.16">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.4.25174.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>aab7eba3d468a4c6329d8317a8561e52bd07c23b</Sha>
+      <Sha>9762fd303cbf129e0fdf63ac129d91f4f8b06c3a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="10.0.0-preview.3.25155.15" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="10.0.0-preview.4.25173.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>666e9188f5e11f4a59708b5f18ff611aa950d965</Sha>
+      <Sha>a50b4a078439c518d1074c43ff4740f528d37fea</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.3.25155.15" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.4.25173.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>666e9188f5e11f4a59708b5f18ff611aa950d965</Sha>
+      <Sha>a50b4a078439c518d1074c43ff4740f528d37fea</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-10.0.100.Transport" Version="10.0.0-preview.3.25155.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,10 +1,10 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftNETSdkPackageVersion>10.0.100-preview.3.25162.16</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-preview.4.25174.4</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETILLinkTasksPackageVersion>10.0.0-preview.3.25155.15</MicrosoftNETILLinkTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.3.25155.15</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>10.0.0-preview.4.25173.3</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.4.25173.3</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>10.0.0-beta.24476.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportVersion>10.0.0-preview.3.25155.1</MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportVersion>


### PR DESCRIPTION
Changes: https://github.com/dotnet/sdk/compare/aab7eba3d4...9762fd303c
Changes: https://github.com/dotnet/runtime/compare/666e9188f5...a50b4a0784

Updates:

* .NET SDK: 10.0.100-preview.3.25162.16 to 10.0.100-preview.4.25174.4
* .NET Runtime: 10.0.0-preview.3.25155.15 to 10.0.0-preview.4.25173.3

Maestro PRs are not triggering automatically, so I made this one manually:

    > darc update-dependencies --id 261486
    Looking up build with BAR id 261486
    Updating 'Microsoft.NET.Sdk': '10.0.100-preview.3.25162.16' => '10.0.100-preview.4.25174.4' (from build '20250324.4' of 'https://github.com/dotnet/sdk')
    Checking for coherency updates...
    Local dependencies updated based on build with BAR id 261486 (20250324.4 from https://github.com/dotnet/sdk@main)

    > darc update-dependencies --coherency-only
    Checking for coherency updates...
    Updating 'Microsoft.NETCore.App.Ref': '10.0.0-preview.3.25155.15' => '10.0.0-preview.4.25173.3' to ensure coherency with Microsoft.NET.Sdk@10.0.100-preview.4.25174.4
    Updating 'Microsoft.NET.ILLink.Tasks': '10.0.0-preview.3.25155.15' => '10.0.0-preview.4.25173.3' to ensure coherency with Microsoft.NET.Sdk@10.0.100-preview.4.25174.4
    Local dependencies updated from channel ''.

The `dotnet-android-*` feeds from the `NuGet.config` are expected to be able to be removed, as those versions were released.