### PR TITLE
Use CDN URL for dotnet-install script

### DIFF
--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -21,7 +21,7 @@ steps:
       $completed = $false
       while (-not $completed -and $currentAttempt -le $totalAttempts) {
           try {
-              $response = Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1 -PassThru
+              $response = Invoke-WebRequest -Uri "https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1 -PassThru
               if ($response.StatusCode -ne 200) {
                   throw
               }
@@ -46,7 +46,7 @@ steps:
   - bash: >
       DOTNET_ROOT=~/.dotnet/ &&
       (if [[ "${{ parameters.remove_dotnet }}" == "true" ]] ; then rm -rfv $DOTNET_ROOT; fi) &&
-      curl -L https://dot.net/v1/dotnet-install.sh --retry 5 --retry-max-time 300 > dotnet-install.sh &&
+      curl -L https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh --retry 5 --retry-max-time 300 > dotnet-install.sh &&
       chmod +x dotnet-install.sh &&
       ./dotnet-install.sh --channel ${{ parameters.version }} --quality ${{ parameters.quality }} --install-dir $DOTNET_ROOT --skip-non-versioned-files --verbose &&
       PATH="$DOTNET_ROOT:$PATH" &&

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Unix.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Prepare
 			// This is the "public" url that we really should be using, but it keeps failing with:
 			// AuthenticationException: The remote certificate is invalid because of errors in the certificate chain: RevocationStatusUnknown
 			// For now we'll grab it directly from GitHub
-			// public static readonly Uri DotNetInstallScript = new Uri ("https://dot.net/v1/dotnet-install.sh");
+			// public static readonly Uri DotNetInstallScript = new Uri ("https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh");
 			public static readonly Uri DotNetInstallScript = new Uri ("https://raw.githubusercontent.com/dotnet/install-scripts/refs/heads/main/src/dotnet-install.sh");
 		}
 	}

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Unix.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Android.Prepare
 			// AuthenticationException: The remote certificate is invalid because of errors in the certificate chain: RevocationStatusUnknown
 			// For now we'll grab it directly from GitHub
 			// public static readonly Uri DotNetInstallScript = new Uri ("https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh");
-			public static readonly Uri DotNetInstallScript = new Uri ("https://raw.githubusercontent.com/dotnet/install-scripts/refs/heads/main/src/dotnet-install.sh");
+			public static readonly Uri DotNetInstallScript = new Uri ("https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh");
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Windows.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Android.Prepare
 
 		partial class Urls
 		{
-			public static readonly Uri DotNetInstallScript = new Uri ("https://dot.net/v1/dotnet-install.ps1");
+			public static readonly Uri DotNetInstallScript = new Uri ("https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.ps1");
 		}
 	}
 }


### PR DESCRIPTION
The dot.net redirector has issues currently, using the CDN URL directly is more reliable anyway.