### PR TITLE
[coreclr] Enable dumping `FastTiming` data with CoreCLR

### DIFF
--- a/src/native/clr/host/host-jni.cc
+++ b/src/native/clr/host/host-jni.cc
@@ -1,6 +1,7 @@
 #include <host/host.hh>
 #include <host/host-jni.hh>
 #include <shared/log_types.hh>
+#include <runtime-base/timing-internal.hh>
 
 using namespace xamarin::android;
 
@@ -15,11 +16,9 @@ JNI_OnLoad (JavaVM *vm, void *reserved)
 JNIEXPORT void
 JNICALL Java_mono_android_Runtime_dumpTimingData ([[maybe_unused]] JNIEnv *env, [[maybe_unused]] jclass klass)
 {
-	// if (internal_timing == nullptr) {
-	// 	return;
-	// }
-
-	// internal_timing.dump ();
+	if (FastTiming::enabled ()) [[unlikely]] {
+		internal_timing.dump ();
+	}
 }
 
 JNIEXPORT void

--- a/src/native/clr/host/typemap.cc
+++ b/src/native/clr/host/typemap.cc
@@ -212,7 +212,6 @@ auto TypeMapper::typemap_managed_to_java (const char *typeName, const uint8_t *m
 {
 	size_t total_time_index;
 	if (FastTiming::enabled ()) [[unlikely]] {
-		//timing = new Timing ();
 		total_time_index = internal_timing.start_event (TimingEventKind::ManagedToJava);
 	}
 
@@ -257,6 +256,11 @@ auto TypeMapper::find_java_to_managed_entry (hash_t name_hash) noexcept -> const
 [[gnu::flatten]]
 auto TypeMapper::typemap_java_to_managed (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept -> bool
 {
+	size_t total_time_index;
+	if (FastTiming::enabled ()) [[unlikely]] {
+		total_time_index = internal_timing.start_event (TimingEventKind::JavaToManaged);
+	}
+
 	if (java_type_name == nullptr || assembly_name == nullptr || managed_type_token_id == nullptr) [[unlikely]] {
 		if (java_type_name == nullptr) {
 			log_warn (
@@ -313,6 +317,10 @@ auto TypeMapper::typemap_java_to_managed (const char *java_type_name, char const
 		*managed_type_token_id,
 		optional_string (*assembly_name)
 	);
+
+	if (FastTiming::enabled ()) [[unlikely]] {
+		internal_timing.end_event (total_time_index);
+	}
 
 	return true;
 }


### PR DESCRIPTION
It seems that as part of refactoring and splitting the big CoreCLR host PR into pieces, the dumping of timing data got disabled for CoreCLR.

This PR reenables this feature so that we can measure startup performance of CoreCLR with https://github.com/grendello/XAPerfTestRunner/tree/master