### PR TITLE
[CoreCLR] Override GetInvokerTypeCore in AndroidTypeManager

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -260,6 +260,7 @@ namespace Android.Runtime {
 
 		bool jniAddNativeMethodRegistrationAttributePresent;
 
+		const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 		const DynamicallyAccessedMemberTypes Methods = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
 		const DynamicallyAccessedMemberTypes MethodsAndPrivateNested = Methods | DynamicallyAccessedMemberTypes.NonPublicNestedTypes;
 
@@ -390,6 +391,19 @@ namespace Android.Runtime {
 					TargetJniMethodParameterCount   = paramCount,
 					TargetJniMethodInstanceToStatic = method.is_static,
 			};
+		}
+
+		[return: DynamicallyAccessedMembers (Constructors)]
+		protected override Type? GetInvokerTypeCore (
+			[DynamicallyAccessedMembers (Constructors)]
+			Type type)
+		{
+			if (type.IsInterface || type.IsAbstract) {
+				return JavaObjectExtensions.GetInvokerType (type)
+					?? base.GetInvokerTypeCore (type);
+			}
+
+			return null;
 		}
 
 		delegate Delegate GetCallbackHandler ();


### PR DESCRIPTION
This is a follow-up to #9973
Replaces #9977 (CI was failing due to long branch name)

This PR fixes the following crash at the startup of `dotnet new maui -sc` when the `AndroidTypeManager` is used:
```
--------- beginning of crash
03-27 09:57:38.276 25497 25497 E AndroidRuntime: FATAL EXCEPTION: main
03-27 09:57:38.276 25497 25497 E AndroidRuntime: Process: com.companyname.testmaui, PID: 25497
03-27 09:57:38.276 25497 25497 E AndroidRuntime: android.runtime.JavaProxyThrowable: [System.MemberAccessException]: Acc_CreateAbstEx, Android.Views.LayoutInflater
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at System.Reflection.RuntimeConstructorInfo.CheckCanCreateInstance + 0x3c(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at System.Reflection.RuntimeConstructorInfo.ThrowNoInvokeException + 0x0(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at System.Reflection.RuntimeConstructorInfo.Invoke + 0xe(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at System.Reflection.ConstructorInfo.Invoke + 0x0(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at Microsoft.Android.Runtime.ManagedValueManager.TryCreatePeer + 0x3b(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at Java.Interop.JniRuntime+JniValueManager.TryCreatePeerInstance + 0x19(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at Java.Interop.JniRuntime+JniValueManager.CreatePeerInstance + 0x5a(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at Java.Interop.JniRuntime+JniValueManager.CreatePeer + 0x150(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at Java.Interop.JniRuntime+JniValueManager.GetPeer + 0x169(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at Java.Lang.Object.GetObject + 0x1d(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at Java.Lang.Object._GetObject + 0x19(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at Java.Lang.Object.GetObject + 0x1(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at Android.Views.LayoutInflater.From + 0x3f(Unknown Source)
03-27 09:57:38.276 25497 25497 E AndroidRuntime: at Microsoft.Maui.Platform.MauiContextExtensions.GetLayoutInflater + 0x2b(Unknown Source)
...
```

`AndroidTypeManager` didn't override the `GetInvokerTypeCore` method and the base implementation of this method in `JniTypeManager` only looks at `JniTypeSignatureAttribute` to find the invoker type. `LayoutInflater` doesn't have this attribute and it relies on the logic in `JavaObjectExtensions.GetInvokerType`. This method will look for the invoker based on a naming convention by adding the `Invoker` suffix to the original type name.

This PR adds an override of `GetInvokerTypeCore` which calls `JavaObjectExtensions.GetInvokerType` when needed to keep backwards compatibility.