### PR TITLE
[darc] track previous .NET Android manifests

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -20,10 +20,14 @@
       <Uri>https://github.com/dotnet/cecil</Uri>
       <Sha>f7a78a77069262841fe3c3c6b89ff243fc43cefc</Sha>
     </Dependency>
-    <!-- Previous .NET Android version -->
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.61">
+    <!-- Previous .NET Android version(s) -->
+    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.61">
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>e7876a4f92d894b40c191a24c2b74f06d4bf4573</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-8.0.100" Version="34.0.154">
+      <Uri>https://github.com/dotnet/android</Uri>
+      <Sha>82d8938cf80f6d5fa6c28529ddfbdb753d805ab4</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,10 +13,11 @@
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.25125.1</MicrosoftDotNetCecilPackageVersion>
     <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
     <!-- Previous .NET Android version -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.61</MicrosoftAndroidSdkWindowsPackageVersion>
-    <AndroidNetPreviousVersion>$(MicrosoftAndroidSdkWindowsPackageVersion)</AndroidNetPreviousVersion>
+    <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.61</MicrosoftNETSdkAndroidManifest90100PackageVersion>
+    <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- To be removed before .NET 10 GA -->
-    <AndroidNet8PreviousVersion>34.0.154</AndroidNet8PreviousVersion>
+    <MicrosoftNETSdkAndroidManifest80100PackageVersion>34.0.154</MicrosoftNETSdkAndroidManifest80100PackageVersion>
+    <AndroidNet8PreviousVersion>$(MicrosoftNETSdkAndroidManifest80100PackageVersion)</AndroidNet8PreviousVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/28663

Previously we've been tracking:

    <!-- Previous .NET Android version -->
    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.61">
      <Uri>https://github.com/dotnet/android</Uri>
      <Sha>e7876a4f92d894b40c191a24c2b74f06d4bf4573</Sha>
    </Dependency>

And then for .NET 8, we just manually updated the
`$(AndroidNet8PreviousVersion)` property.

This makes it difficult for other repositories to *know* about the required NuGet feeds:

    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
    <!--  Begin: Package sources from dotnet-android -->
    <add key="darc-pub-dotnet-android-82d8938" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-82d8938c/nuget/v3/index.json" />
    <add key="darc-pub-dotnet-android-e7876a4" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-e7876a4f/nuget/v3/index.json" />
    <!--  End: Package sources from dotnet-android -->

In dotnet/maui or dotnet/performance, they would need to look at dotnet/android/main's NuGet.config to even figure out what is missing here:

    Workload installation failed: One or more errors occurred. (Version 35.0.61 of package microsoft.android.sdk.windows is not found in NuGet feeds

To solve this, we can track:

    <!-- Previous .NET Android version(s) -->
    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.61">
      <Uri>https://github.com/dotnet/android</Uri>
      <Sha>e7876a4f92d894b40c191a24c2b74f06d4bf4573</Sha>
    </Dependency>
    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-8.0.100" Version="34.0.154">
      <Uri>https://github.com/dotnet/android</Uri>
      <Sha>82d8938cf80f6d5fa6c28529ddfbdb753d805ab4</Sha>
    </Dependency>

Then consuming repositories could track with
`CoherentParentDependency="Microsoft.Android.Sdk.Windows"`:

    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-preview.3.11">
      <Uri>https://github.com/dotnet/android</Uri>
      <Sha>e71524ac874e90d9879661cafe230d8e99ba9cec</Sha>
    </Dependency>
    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.61" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
      <Uri>https://github.com/dotnet/android</Uri>
      <Sha>e7876a4f92d894b40c191a24c2b74f06d4bf4573</Sha>
    </Dependency>
    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-8.0.100" Version="34.0.154" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
      <Uri>https://github.com/dotnet/android</Uri>
      <Sha>82d8938cf80f6d5fa6c28529ddfbdb753d805ab4</Sha>
    </Dependency>

Once this change is merged, we would update `eng/Version.Details.xml` in consuming repositories. Afterwards, Maestro should be able to manage the feeds automatically.