### PR TITLE
[build] see if we can allow long branch names

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -68,3 +68,5 @@ variables:
   value: 'cat != SystemApplication & cat != TimeZoneInfo & cat != Localization'
 - name: RunMAUITestJob
   value: true
+- name: MSBUILDLOGALLENVIRONMENTVARIABLES
+  value: 1

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -68,5 +68,3 @@ variables:
   value: 'cat != SystemApplication & cat != TimeZoneInfo & cat != Localization'
 - name: RunMAUITestJob
   value: true
-- name: MSBUILDLOGALLENVIRONMENTVARIABLES
-  value: 1

--- a/build-tools/create-packs/Directory.Build.props
+++ b/build-tools/create-packs/Directory.Build.props
@@ -13,8 +13,8 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- Ignore TargetFramework reference group related warnings, these are workload packs not functional NuGets. -->
     <NoWarn>$(NoWarn);NU5128;NU5131</NoWarn>
-    <!-- Allow NU5123 for pull requests -->
-    <NoWarn Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">$(NoWarn);NU5123</NoWarn>
+    <!-- Allow NU5123 for pull requests, which will have $SYSTEM_PULLREQUEST_ISFORK set to true or false -->
+    <NoWarn Condition=" '$(SYSTEM_PULLREQUEST_ISFORK)' != '' ">$(NoWarn);NU5123</NoWarn>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />

--- a/build-tools/create-packs/Directory.Build.props
+++ b/build-tools/create-packs/Directory.Build.props
@@ -14,7 +14,7 @@
     <!-- Ignore TargetFramework reference group related warnings, these are workload packs not functional NuGets. -->
     <NoWarn>$(NoWarn);NU5128;NU5131</NoWarn>
     <!-- Allow NU5123 for pull requests, which will have $SYSTEM_PULLREQUEST_ISFORK set to true or false -->
-    <NoWarn Condition=" '$(SYSTEM_PULLREQUEST_ISFORK)' != '' ">$(NoWarn);NU5123</NoWarn>
+    <!-- <NoWarn Condition=" '$(SYSTEM_PULLREQUEST_ISFORK)' != '' ">$(NoWarn);NU5123</NoWarn> -->
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />

--- a/build-tools/create-packs/Directory.Build.props
+++ b/build-tools/create-packs/Directory.Build.props
@@ -13,6 +13,8 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- Ignore TargetFramework reference group related warnings, these are workload packs not functional NuGets. -->
     <NoWarn>$(NoWarn);NU5128;NU5131</NoWarn>
+    <!-- Allow NU5123 for pull requests -->
+    <NoWarn Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">$(NoWarn);NU5123</NoWarn>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />

--- a/build-tools/create-packs/Directory.Build.props
+++ b/build-tools/create-packs/Directory.Build.props
@@ -13,8 +13,8 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- Ignore TargetFramework reference group related warnings, these are workload packs not functional NuGets. -->
     <NoWarn>$(NoWarn);NU5128;NU5131</NoWarn>
-    <!-- Allow NU5123 for pull requests, which will have $SYSTEM_PULLREQUEST_ISFORK set to true or false -->
-    <NoWarn Condition=" '$(SYSTEM_PULLREQUEST_ISFORK)' != '' ">$(NoWarn);NU5123</NoWarn>
+    <!-- Allow NU5123 for pull requests, which will run on the Xamarin.Android-PR pipeline -->
+    <NoWarn Condition=" '$(BUILD_DEFINITIONNAME)' == 'Xamarin.Android-PR' ">$(NoWarn);NU5123</NoWarn>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />

--- a/build-tools/create-packs/Directory.Build.props
+++ b/build-tools/create-packs/Directory.Build.props
@@ -14,7 +14,7 @@
     <!-- Ignore TargetFramework reference group related warnings, these are workload packs not functional NuGets. -->
     <NoWarn>$(NoWarn);NU5128;NU5131</NoWarn>
     <!-- Allow NU5123 for pull requests, which will have $SYSTEM_PULLREQUEST_ISFORK set to true or false -->
-    <!-- <NoWarn Condition=" '$(SYSTEM_PULLREQUEST_ISFORK)' != '' ">$(NoWarn);NU5123</NoWarn> -->
+    <NoWarn Condition=" '$(SYSTEM_PULLREQUEST_ISFORK)' != '' ">$(NoWarn);NU5123</NoWarn>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -75,7 +75,7 @@
 
   <Target Name="CreateAllPacks"
       DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory;_CreateItemGroups;_CreatePreviewPacks;_CreateDefaultRefPack">
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidRID=%(_AndroidRIDs.Identity) -p:AndroidRuntime=%(_AndroidRIDs.Runtime) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/Microsoft.Android.Runtime.binlog -p:AndroidRID=%(_AndroidRIDs.Identity) -p:AndroidRuntime=%(_AndroidRIDs.Runtime) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -49,7 +49,7 @@
       <_GlobalProperties Include="-p:IncludeSymbols=False" />
     </ItemGroup>
     <PropertyGroup>
-      <_BinlogPrefix>-bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/msbuild-$([System.DateTime]::UtcNow.ToString('YYYYMMddThhmmss'))-</_BinlogPrefix>
+      <_BinlogPrefix>-bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/msbuild-$([System.DateTime]::UtcNow.ToString('yyyyMMddThhmmss'))-</_BinlogPrefix>
     </PropertyGroup>
   </Target>
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -49,7 +49,7 @@
       <_GlobalProperties Include="-p:IncludeSymbols=False" />
     </ItemGroup>
     <PropertyGroup>
-      <_BinlogPrefix>-bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/msbuild-$([System.DateTime]::UtcNow.ToString('yyyyMMddThhmmss'))-</_BinlogPrefix>
+      <_BinlogPrefix>-bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/msbuild-$([System.DateTime]::Now.ToString('yyyyMMddThhmmss'))-</_BinlogPrefix>
     </PropertyGroup>
   </Target>
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -49,7 +49,7 @@
       <_GlobalProperties Include="-p:IncludeSymbols=False" />
     </ItemGroup>
     <PropertyGroup>
-      <_BinlogPrefix>-bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/msbuild-$([System.DateTime]::UtcNow.ToString('YYYYMMddThhmmss'))</_BinlogPrefix>
+      <_BinlogPrefix>-bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/msbuild-$([System.DateTime]::UtcNow.ToString('YYYYMMddThhmmss'))-</_BinlogPrefix>
     </PropertyGroup>
   </Target>
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -48,6 +48,9 @@
       <_GlobalProperties Include="-p:Configuration=$(Configuration)" />
       <_GlobalProperties Include="-p:IncludeSymbols=False" />
     </ItemGroup>
+    <PropertyGroup>
+      <_BinlogPrefix>-bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/msbuild-$([System.DateTime]::UtcNow.ToString('YYYYMMddThhmmss'))</_BinlogPrefix>
+    </PropertyGroup>
   </Target>
 
   <Target Name="_CleanNuGetDirectory">
@@ -63,25 +66,25 @@
 
   <Target Name="_CreateDefaultRefPack"
       Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidDefaultTargetDotnetApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(AndroidDefaultTargetDotnetApiLevel)\Mono.Android.dll') ">
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Ref.$(AndroidDefaultTargetDotnetApiLevel).binlog&quot; -p:AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
   </Target>
 
   <Target Name="_CreatePreviewPacks"
       DependsOnTargets="_CreateItemGroups"
       Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(AndroidLatestUnstableApiLevel)\Mono.Android.dll') ">
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=%(_AndroidRIDs.Identity) -p:AndroidRuntime=%(_AndroidRIDs.Runtime) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Runtime.%(_AndroidRIDs.Runtime).$(AndroidLatestUnstableApiLevel).%(_AndroidRIDs.Identity).binlog&quot; -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=%(_AndroidRIDs.Identity) -p:AndroidRuntime=%(_AndroidRIDs.Runtime) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Ref.$(AndroidLatestUnstableApiLevel).binlog&quot; -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
   </Target>
 
   <Target Name="CreateAllPacks"
       DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory;_CreateItemGroups;_CreatePreviewPacks;_CreateDefaultRefPack">
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/Microsoft.Android.Runtime.binlog -p:AndroidRID=%(_AndroidRIDs.Identity) -p:AndroidRuntime=%(_AndroidRIDs.Runtime) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Android.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Runtime.%(_AndroidRIDs.Runtime).$(AndroidLatestStableApiLevel).%(_AndroidRIDs.Identity).binlog&quot; -p:AndroidRID=%(_AndroidRIDs.Identity) -p:AndroidRuntime=%(_AndroidRIDs.Runtime) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Ref.$(AndroidLatestStableApiLevel).binlog&quot; &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Sdk.Linux.binlog&quot; -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Sdk.Darwin.binlog&quot; -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Sdk.Windows.binlog&quot; -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.NET.Sdk.Android.binlog&quot; &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Android.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Templates.binlog&quot; &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
     <ReplaceFileContents
         SourceFile="vs-workload.in.props"
         DestinationFile="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\vs-workload.props"

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <!-- Allow NU5123 for pull requests -->
+    <WarningsAsMessages Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">$(WarningsAsMessages);NU5123</WarningsAsMessages>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -1,8 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <!-- Allow NU5123 for pull requests -->
-    <WarningsAsMessages Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">$(WarningsAsMessages);NU5123</WarningsAsMessages>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" />

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
@@ -49,33 +49,9 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			}
 
 done:
-			CheckBranchLength ();
 			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (Branch)}: {Branch}");
 			return !Log.HasLoggedErrors;
 		}
-
-		void CheckBranchLength ()
-		{
-			// Trim generated dependabot branch names that are too long to produce useful package names
-			const int maxBranchLength = 32;
-			var lastSlashIndex = Branch.LastIndexOf ('/');
-			if (Branch.StartsWith ("dependabot") && lastSlashIndex != -1 && Branch.Length > maxBranchLength) {
-				Log.LogMessage ($"Trimming characters from the branch name at index {lastSlashIndex}: {Branch}");
-				Branch = Branch.Substring (lastSlashIndex + 1);
-			}
-
-			// Trim darc/Maestro branch names that are too long
-			// These will have a Guid in the branch name
-			if (IsTrimmedBranch () && Branch.Length > maxBranchLength) {
-				Log.LogMessage ($"Trimming to {maxBranchLength} characters from the branch name: {Branch}");
-				Branch = Branch.Substring (0, maxBranchLength);
-			}
-		}
-
-		bool IsTrimmedBranch () => 
-			TrimmedBranchPrefixes.Any (prefix => Branch.StartsWith (prefix, StringComparison.Ordinal));
-
-		static readonly string[] TrimmedBranchPrefixes = [ "darc-", "juno/" ];
 
 		protected override string GenerateCommandLineCommands ()
 		{


### PR DESCRIPTION
If you open a PR with a long branch name, it can error with:

    NuGet.Build.Tasks.Pack.targets(221,5): error NU5123: Warning As Error: The file 'package/services/metadata/core-properties/d9cd2ffb8cfc41bdbfe90e7dbc7228fb.psmdcp' path, name, or both are too long. Your package might not work without long file path support. Please shorten the file path or file name.

Let's ignore `NU5123` for pull requests.

I think the warning, in general, is good to know if we create a path inside a `.nupkg` that is too long. But for PRs, we should ignore it.

This also reverts some commits that "shorten" branch names, which should no longer be needed:

* 7651b64895ecf2812e85cd570b61f3950b3db09c
* 6d9b295652ef5292427cb15b2afce469c6ed940f

While making this work, I noticed that the `CreateAllPacks` target did not emit `.binlog` files.

I set it up to create them in the same format as we do in `make`:

    <PropertyGroup>
      <_BinlogPrefix>-bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/msbuild-$([System.DateTime]::Now.ToString('yyyyMMddThhmmss'))-</_BinlogPrefix>
    </PropertyGroup>

Then added a suffix with each specific project name.