### PR TITLE
[tests] fix `InstallAndroidDependenciesTest("GoogleV2")`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -108,7 +108,8 @@ namespace Xamarin.Android.Build.Tests
 			var d = XDocument.Load (r);
 
 			var platformToolsPackage    = d.Root.Elements ("remotePackage")
-				.Where (e => "platform-tools" == (string) e.Attribute("path"))
+				.Where (e => "platform-tools" == (string) e.Attribute("path") &&
+					"android-sdk-preview-license" != (string) e.Element ("uses-license")?.Attribute ("ref"))
 				.FirstOrDefault ();
 
 			var revision    = platformToolsPackage.Element ("revision");


### PR DESCRIPTION
This test has started failing as soon as a `platform-tools` 36.0.0 appeared on Google's feed:

    _AndroidSdkDirectory was not set to new SDK path C:\a\_work\1\a\TestRelease\03-28_03.15.36\temp\InstallAndroidDependenciesTestGoogleV2\android-sdk. Please check the task output in 'install-deps.log'
    Expected: True
    But was:  False

I'm guessing this is because it is still "preview":

    <remotePackage path="platform-tools">
      <type-details xsi:type="generic:genericDetailsType"/>
      <revision>
        <major>36</major>
        <minor>0</minor>
        <micro>0</micro>
      </revision>
      <display-name>Android SDK Platform-Tools</display-name>
      <uses-license ref="android-sdk-preview-license"/>

As the `.binlog` shows:

    Component Android SDK Platform-Tools r36.0.0 not present on the system
    Component Android SDK Platform-Tools r35.0.2 not present on the system

And then the next build refuses to use the SDK, due to `adb.exe` missing?

    ValidateAndroidSdkLocation: for locator=constructor param, path=`C:\a\_work\1\a\TestRelease\03-28_03.15.36\temp\InstallAndroidDependenciesTestGoogleV2\android-sdk`, result=False
    ValidateAndroidSdkLocation: for locator=preferred path, path=``, result=False
    Looking for Android SDK...
    ValidateAndroidSdkLocation: for locator=all paths, path=`C:\Android\android-sdk`, found adb `C:\Android\android-sdk\platform-tools\adb.EXE`
    ...
    ResolveSdks Outputs:
      AndroidSdkPath: C:\Android\android-sdk

If I change the `GetCurrentPlatformToolsVersion()` method to ignore entries with:

    <uses-license ref="android-sdk-preview-license"/>

Then the test passes for me locally.

It seems reasonable to ignore "preview" versions of `platform-tools` for this test.