### PR TITLE
[NativeAOT] Add DefaultUncaughtExceptionHandler

### DIFF
--- a/samples/NativeAOT/MainActivity.cs
+++ b/samples/NativeAOT/MainActivity.cs
@@ -22,5 +22,10 @@ public class MainActivity : Activity
         // An example of an Android API that uses a Java array
         var list = new ColorStateList (new int[][] { [ 0, 1 ]}, [0, 1]);
         Log.Debug ("NativeAOT", "MainActivity.OnCreate() ColorStateList: " + list);
+
+        var t = Intent?.Extras?.GetBoolean ("throw") ?? false;
+        if (t) {
+            throw new InvalidOperationException ("What happened?");
+        }
     }
 }

--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
@@ -33,6 +33,7 @@ static partial class JavaInteropRuntime
 	[UnmanagedCallersOnly (EntryPoint="Java_net_dot_jni_nativeaot_JavaInteropRuntime_init")]
 	static void init (IntPtr jnienv, IntPtr klass)
 	{
+		JniTransition   transition  = default;
 		try {
 			var settings    = new DiagnosticSettings ();
 			settings.AddDebugDotnetLog ();
@@ -50,9 +51,17 @@ static partial class JavaInteropRuntime
 
 			// Entry point into Mono.Android.dll
 			JNIEnvInit.InitializeJniRuntime (runtime);
+
+			transition  = new JniTransition (jnienv);
+
+			var handler = Java.Lang.Thread.DefaultUncaughtExceptionHandler;
+			Java.Lang.Thread.DefaultUncaughtExceptionHandler = new UncaughtExceptionMarshaler (handler);
+			AndroidLog.Print (AndroidLogLevel.Info, "JavaInteropRuntime", $"init: Thread.DefaultUncaughtExceptionHandler={Java.Lang.Thread.DefaultUncaughtExceptionHandler}");
 		}
 		catch (Exception e) {
 			AndroidLog.Print (AndroidLogLevel.Error, "JavaInteropRuntime", $"JavaInteropRuntime.init: error: {e}");
+			transition.SetPendingException (e);
 		}
+		transition.Dispose ();
 	}
 }

--- a/src/Microsoft.Android.Runtime.NativeAOT/UncaughtExceptionMarshaler.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/UncaughtExceptionMarshaler.cs
@@ -1,0 +1,20 @@
+using Java.Interop;
+
+namespace Microsoft.Android.Runtime;
+
+class UncaughtExceptionMarshaler (Java.Lang.Thread.IUncaughtExceptionHandler? OriginalHandler)
+	: Java.Lang.Object, Java.Lang.Thread.IUncaughtExceptionHandler
+{
+	public void UncaughtException (Java.Lang.Thread thread, Java.Lang.Throwable exception)
+	{
+		var e = (JniEnvironment.Runtime.ValueManager.PeekValue (exception.PeerReference) as System.Exception)
+			?? exception;
+
+		AndroidLog.Print (AndroidLogLevel.Fatal, "DOTNET", $"FATAL UNHANDLED EXCEPTION: {e}");
+
+		// TODO: https://github.com/dotnet/runtime/issues/102730
+		// ExceptionHandling.RaiseUnhandledExceptionEvent(e);
+
+		OriginalHandler?.UncaughtException (thread, exception);
+	}
+}


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/102730
Context: 1aa0ea7a8aef616d00e8467aa9eec83a1571cbd0

What should happen when an exception is thrown and not caught?

	partial class MainActivity {
	  protected override void OnCreate(Bundle? savedInstanceState) =>
	    throw new Exception("Uncaught exception");
	}

What *previously* happened is that the app would exit, with an `AndroidRuntime` tag containing the Java-side exception, which will contain *some* managed info courtesy of 1aa0ea7a.

	I ActivityManager: Start proc 6911:net.dot.hellonativeaot/u0a205 for top-activity {net.dot.hellonativeaot/my.MainActivity}
	…
	D NativeAotRuntimeProvider: NativeAotRuntimeProvider()
	D NativeAotRuntimeProvider: NativeAotRuntimeProvider.attachInfo(): calling JavaInteropRuntime.init()…
	D JavaInteropRuntime: Loading NativeAOT.so...
	I JavaInteropRuntime: JNI_OnLoad()
	…
	D NativeAotRuntimeProvider: NativeAotRuntimeProvider.onCreate()
	D NativeAOT: Application..ctor(7fff01a958, DoNotTransfer)
	D NativeAOT: Application.OnCreate()
	…
	D NativeAOT: MainActivity.OnCreate()
	…
	D NativeAOT: MainActivity.OnCreate() ColorStateList: ColorStateList{mThemeAttrs=nullmChangingConfigurations=0mStateSpecs=[[0, 1]]mColors=[0, 1]mDefaultColor=0}
	D AndroidRuntime: Shutting down VM
	E AndroidRuntime: FATAL EXCEPTION: main
	E AndroidRuntime: Process: net.dot.hellonativeaot, PID: 6911
	E AndroidRuntime: net.dot.jni.internal.JavaProxyThrowable: System.InvalidOperationException: What happened?
	E AndroidRuntime:    at NativeAOT.MainActivity.OnCreate(Bundle savedInstanceState) + 0x2f4
	E AndroidRuntime:    at Android.App.Activity.n_OnCreate_Landroid_os_Bundle_(IntPtr jnienv, IntPtr native__this, IntPtr native_savedInstanceState) + 0xc8
	E AndroidRuntime:        at my.MainActivity.n_onCreate(Native Method)
	E AndroidRuntime:        at my.MainActivity.onCreate(MainActivity.java:28)
	E AndroidRuntime:        at android.app.Activity.performCreate(Activity.java:8595)
	E AndroidRuntime:        at android.app.Activity.performCreate(Activity.java:8573)
	E AndroidRuntime:        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1456)
	E AndroidRuntime:        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3805)
	E AndroidRuntime:        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3963)
	E AndroidRuntime:        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
	E AndroidRuntime:        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139)
	E AndroidRuntime:        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96)
	E AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2484)
	E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:106)
	E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:205)
	E AndroidRuntime:        at android.os.Looper.loop(Looper.java:294)
	E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:8225)
	E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
	E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:573)
	E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1049)
	W ActivityTaskManager:   Force finishing activity net.dot.hellonativeaot/my.MainActivity

What *won't* happen is that the [`AppDomain.UnhandledException`][0] event will ***not*** be raised

This is less than ideal, and will cause the
`InstallAndRunTests.SubscribeToAppDomainUnhandledException()` test to fail, once that test is enabled for NativeAOT.

*Begin* to address this by setting
`Java.Lang.Thread.DefaultUncaughtExceptionHandler` to a `Thread.IUncaughtExceptionHandler` instance which at least prints the exception to `adb logcat`.

Update `samples/NativeAOT` to demonstrate this, by using a new boolean `thrown` extra; if true, then `OnCreate()` throws:

	adb shell am start --ez throw 1 net.dot.hellonativeaot/my.MainActivity

`adb logcat` continues to have the `FATAL EXCEPTION` message from `AndroidRuntime`, as shown above, and `adb logcat` now also contains:

	F DOTNET  : FATAL UNHANDLED EXCEPTION: System.InvalidOperationException: What happened?
	F DOTNET  :    at NativeAOT.MainActivity.OnCreate(Bundle savedInstanceState) + 0x2f4
	F DOTNET  :    at Android.App.Activity.n_OnCreate_Landroid_os_Bundle_(IntPtr jnienv, IntPtr native__this, IntPtr native_savedInstanceState) + 0xc8

which prints out the managed exception that we would expect to be raised by `AppDomain.UnhandledException`, once that integration works.

TODO: once dotnet/runtime#102730 is fixed, update
`UncaughtExceptionMarshaler` to do whatever it needs to do to cause the `AppDomain.UnhandledException` event to be raised.

Update `JavaInteropRuntime.init()` to marshal excpetions back to Java, so that the process appropriately terminates if `init()` fails.

[0]: https://learn.microsoft.com/dotnet/api/system.appdomain.unhandledexception?view=net-9.0