### PR TITLE
[release/10.0.1xx-preview3] [Mono.Android] prefix `Microsoft.Android.Runtime` namespace with `_`

### DIFF
--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/DiagnosticSettings.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/DiagnosticSettings.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 using Java.Interop;
 
-namespace Microsoft.Android.Runtime;
+namespace _Microsoft.Android.Runtime;
 
 struct DiagnosticSettings {
 

--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
@@ -2,7 +2,7 @@ using Android.Runtime;
 using Java.Interop;
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Android.Runtime;
+namespace _Microsoft.Android.Runtime;
 
 static partial class JavaInteropRuntime
 {

--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/Logging.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/Logging.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace Microsoft.Android.Runtime;
+namespace _Microsoft.Android.Runtime;
 
 internal sealed class LogcatTextWriter : TextWriter {
 

--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/NativeAotTypeManager.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/NativeAotTypeManager.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using Java.Interop;
 using Java.Interop.Tools.TypeNameMappings;
 
-namespace Microsoft.Android.Runtime;
+namespace _Microsoft.Android.Runtime;
 
 partial class NativeAotTypeManager : JniRuntime.JniTypeManager {
 

--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/TypeMapping.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/TypeMapping.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Android.Runtime;
 
-namespace Microsoft.Android.Runtime;
+namespace _Microsoft.Android.Runtime;
 
 internal static class TypeMapping
 {

--- a/src/Microsoft.Android.Runtime.NativeAOT/Java.Interop/JreRuntime.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Java.Interop/JreRuntime.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Microsoft.Android.Runtime;
+using _Microsoft.Android.Runtime;
 
 namespace Java.Interop {
 

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using Java.Interop;
 using Java.Interop.Tools.TypeNameMappings;
 
-using Microsoft.Android.Runtime;
+using _Microsoft.Android.Runtime;
 
 namespace Android.Runtime
 {

--- a/src/Mono.Android/Microsoft.Android.Runtime/ManagedValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/ManagedValueManager.cs
@@ -14,7 +14,7 @@ using System.Threading;
 using Android.Runtime;
 using Java.Interop;
 
-namespace Microsoft.Android.Runtime;
+namespace _Microsoft.Android.Runtime;
 
 class ManagedValueManager : JniRuntime.JniValueManager
 {


### PR DESCRIPTION
We introduced a new `internal` type in `Mono.Android.dll`:

    namespace Microsoft.Android.Runtime;

    class ManagedValueManager : JniRuntime.JniValueManager

Causes various C# compiler errors in dotnet/maui:

    D:\src\maui\src\Essentials\src\AppActions\AppActions.shared.cs(62,28):
    error CS0234: The type or namespace name 'Content' does not exist in the namespace 'Microsoft.Android' (are you missing an assembly reference?)

To fix this, we can prefix the namespace with `_`. We basically can never use a `Microsoft.Android.*` namespace in `Mono.Android.dll`.