### PR TITLE
[XABT] Remove support for `$(_AndroidGenerateNativeAssembly)` = `false` (typemaps).

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
@@ -2,21 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Mono.Cecil;
-using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
 	class TypeMapGenerator
 	{
-		const string TypeMapMagicString = "XATS"; // Xamarin Android TypeMap
-		const string TypeMapIndexMagicString = "XATI"; // Xamarin Android Typemap Index
-		const uint TypeMapFormatVersion = 2; // Keep in sync with the value in src/monodroid/jni/xamarin-app.hh
-		const uint InvalidJavaToManagedMappingIndex = UInt32.MaxValue;
-
 		internal sealed class ModuleUUIDArrayComparer : IComparer<ModuleReleaseData>
 		{
 			int Compare (byte[] left, byte[] right)
@@ -43,7 +36,6 @@ namespace Xamarin.Android.Tasks
 			public string JavaName;
 			public string ManagedTypeName;
 			public uint Token;
-			public int AssemblyNameIndex = -1;
 			public int ModuleIndex = -1;
 			public bool SkipInJavaToManaged;
 		}
@@ -52,11 +44,9 @@ namespace Xamarin.Android.Tasks
 		{
 			public Guid Mvid;
 			public byte[] MvidBytes;
-			public AssemblyDefinition Assembly;
 			public TypeMapReleaseEntry[] Types;
 			public List<TypeMapReleaseEntry> DuplicateTypes;
 			public string AssemblyName;
-			public string OutputFilePath;
 
 			public Dictionary<string, TypeMapReleaseEntry> TypesScratch;
 		}
@@ -64,18 +54,17 @@ namespace Xamarin.Android.Tasks
 		internal sealed class TypeMapDebugEntry
 		{
 			public string JavaName;
-			public string JavaLabel;
 			public string ManagedName;
-			public string ManagedLabel;
-			public int JavaIndex;
-			public int ManagedIndex;
-			public TypeDefinition TypeDefinition;
 			public bool SkipInJavaToManaged;
 			public TypeMapDebugEntry DuplicateForJavaToManaged;
 
+			// This field is only used by the Cecil adapter for temp storage while reading.
+			// It is not used to create the typemap.
+			public TypeDefinition TypeDefinition;
+
 			public override string ToString ()
 			{
-				return $"TypeMapDebugEntry{{JavaName={JavaName}, ManagedName={ManagedName}, JavaIndex={JavaIndex}, ManagedIndex={ManagedIndex}, SkipInJavaToManaged={SkipInJavaToManaged}, DuplicateForJavaToManaged={DuplicateForJavaToManaged}}}";
+				return $"TypeMapDebugEntry{{JavaName={JavaName}, ManagedName={ManagedName}, SkipInJavaToManaged={SkipInJavaToManaged}, DuplicateForJavaToManaged={DuplicateForJavaToManaged}}}";
 			}
 		}
 
@@ -83,13 +72,8 @@ namespace Xamarin.Android.Tasks
 		internal sealed class ModuleDebugData
 		{
 			public uint EntryCount;
-			public uint JavaNameWidth;
-			public uint ManagedNameWidth;
 			public List<TypeMapDebugEntry> JavaToManagedMap;
 			public List<TypeMapDebugEntry> ManagedToJavaMap;
-			public string OutputFilePath;
-			public string ModuleName;
-			public byte[] ModuleNameBytes;
 		}
 
 		internal sealed class ReleaseGenerationState
@@ -117,9 +101,6 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		readonly Encoding outputEncoding;
-		readonly byte[] moduleMagicString;
-		readonly byte[] typemapIndexMagicString;
 		readonly TaskLoggingHelper log;
 		readonly NativeCodeGenState state;
 		readonly AndroidRuntime runtime;
@@ -131,12 +112,9 @@ namespace Xamarin.Android.Tasks
 			this.log = log ?? throw new ArgumentNullException (nameof (log));
 			this.state = state ?? throw new ArgumentNullException (nameof (state));
 			this.runtime = runtime;
-			outputEncoding = Files.UTF8withoutBOM;
-			moduleMagicString = outputEncoding.GetBytes (TypeMapMagicString);
-			typemapIndexMagicString = outputEncoding.GetBytes (TypeMapIndexMagicString);
 		}
 
-		public bool Generate (bool debugBuild, bool skipJniAddNativeMethodRegistrationAttributeScan, string outputDirectory, bool generateNativeAssembly)
+		public void Generate (bool debugBuild, bool skipJniAddNativeMethodRegistrationAttributeScan, string outputDirectory)
 		{
 			if (String.IsNullOrEmpty (outputDirectory)) {
 				throw new ArgumentException ("must not be null or empty", nameof (outputDirectory));
@@ -146,51 +124,14 @@ namespace Xamarin.Android.Tasks
 			state.JniAddNativeMethodRegistrationAttributePresent = skipJniAddNativeMethodRegistrationAttributeScan;
 			string typemapsOutputDirectory = Path.Combine (outputDirectory, "typemaps");
 			if (debugBuild) {
-				return GenerateDebug (skipJniAddNativeMethodRegistrationAttributeScan, typemapsOutputDirectory, generateNativeAssembly);
+				GenerateDebugNativeAssembly (typemapsOutputDirectory);
+				return;
 			}
 
-			return GenerateRelease (skipJniAddNativeMethodRegistrationAttributeScan, typemapsOutputDirectory);
+			GenerateRelease (typemapsOutputDirectory);
 		}
 
-		bool GenerateDebug (bool skipJniAddNativeMethodRegistrationAttributeScan, string outputDirectory, bool generateNativeAssembly)
-		{
-			if (generateNativeAssembly) {
-				return GenerateDebugNativeAssembly (skipJniAddNativeMethodRegistrationAttributeScan, outputDirectory);
-			}
-
-			// Debug builds which don't put typemaps in native assembly must output data files in architecture-specific
-			// subdirectories, so that fastdev can properly sync them to the device.
-			// The (empty) native assembly files, however, must still be generated in the usual directory.
-			return GenerateDebugFiles (
-				skipJniAddNativeMethodRegistrationAttributeScan,
-				typemapFilesOutputDirectory: Path.Combine (outputDirectory, MonoAndroidHelper.ArchToAbi (state.TargetArch)),
-				llFilesOutputDirectory: outputDirectory
-			);
-		}
-
-		bool GenerateDebugFiles (bool skipJniAddNativeMethodRegistrationAttributeScan, string typemapFilesOutputDirectory, string llFilesOutputDirectory)
-		{
-			var modules = TypeMapCecilAdapter.GetDebugModules (state, typemapFilesOutputDirectory, outputEncoding, out var maxModuleFileNameWidth);
-
-			foreach (ModuleDebugData module in modules.Values) {
-				PrepareDebugMaps (module);
-			}
-
-			string typeMapIndexPath = Path.Combine (typemapFilesOutputDirectory, "typemap.index");
-			using (var indexWriter = MemoryStreamPool.Shared.CreateBinaryWriter ()) {
-				OutputModules (modules, indexWriter, maxModuleFileNameWidth + 1);
-				indexWriter.Flush ();
-				Files.CopyIfStreamChanged (indexWriter.BaseStream, typeMapIndexPath);
-			}
-			GeneratedBinaryTypeMaps.Add (typeMapIndexPath);
-
-			var composer = new TypeMappingDebugNativeAssemblyGenerator (log, new ModuleDebugData ());
-			GenerateNativeAssembly (composer, composer.Construct (), llFilesOutputDirectory);
-
-			return true;
-		}
-
-		bool GenerateDebugNativeAssembly (bool skipJniAddNativeMethodRegistrationAttributeScan, string outputDirectory)
+		void GenerateDebugNativeAssembly (string outputDirectory)
 		{
 			(var javaToManaged, var managedToJava) = TypeMapCecilAdapter.GetDebugNativeEntries (state);
 
@@ -200,29 +141,14 @@ namespace Xamarin.Android.Tasks
 				ManagedToJavaMap = managedToJava,
 			};
 
-			PrepareDebugMaps (data);
+			data.JavaToManagedMap.Sort ((TypeMapDebugEntry a, TypeMapDebugEntry b) => String.Compare (a.JavaName, b.JavaName, StringComparison.Ordinal));
+			data.ManagedToJavaMap.Sort ((TypeMapDebugEntry a, TypeMapDebugEntry b) => String.Compare (a.ManagedName, b.ManagedName, StringComparison.Ordinal));
 
 			var composer = new TypeMappingDebugNativeAssemblyGenerator (log, data);
 			GenerateNativeAssembly (composer, composer.Construct (), outputDirectory);
-
-			return true;
 		}
 
-		void PrepareDebugMaps (ModuleDebugData module)
-		{
-			module.JavaToManagedMap.Sort ((TypeMapDebugEntry a, TypeMapDebugEntry b) => String.Compare (a.JavaName, b.JavaName, StringComparison.Ordinal));
-			module.ManagedToJavaMap.Sort ((TypeMapDebugEntry a, TypeMapDebugEntry b) => String.Compare (a.ManagedName, b.ManagedName, StringComparison.Ordinal));
-
-			for (int i = 0; i < module.JavaToManagedMap.Count; i++) {
-				module.JavaToManagedMap[i].JavaIndex = i;
-			}
-
-			for (int i = 0; i < module.ManagedToJavaMap.Count; i++) {
-				module.ManagedToJavaMap[i].ManagedIndex = i;
-			}
-		}
-
-		bool GenerateRelease (bool skipJniAddNativeMethodRegistrationAttributeScan, string outputDirectory)
+		void GenerateRelease (string outputDirectory)
 		{
 			var genState = TypeMapCecilAdapter.GetReleaseGenerationState (state);
 
@@ -247,23 +173,12 @@ namespace Xamarin.Android.Tasks
 			};
 
 			GenerateNativeAssembly (composer, composer.Construct (), outputDirectory);
-
-			return true;
 		}
-
-		string GetOutputFilePath (string baseFileName, AndroidTargetArch arch) => $"{baseFileName}.{MonoAndroidHelper.ArchToAbi (arch)}.ll";
 
 		void GenerateNativeAssembly (LLVMIR.LlvmIrComposer composer, LLVMIR.LlvmIrModule typeMapModule, string baseFileName)
 		{
-			WriteNativeAssembly (
-				composer,
-				typeMapModule,
-				GetOutputFilePath (baseFileName, state.TargetArch)
-			);
-		}
+			string outputFile = $"{baseFileName}.{MonoAndroidHelper.ArchToAbi (state.TargetArch)}.ll";
 
-		void WriteNativeAssembly (LLVMIR.LlvmIrComposer composer, LLVMIR.LlvmIrModule typeMapModule, string outputFile)
-		{
 			// TODO: each .ll file should have a comment which lists paths to all the DLLs that were used to generate
 			// the native code
 			using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {
@@ -275,113 +190,6 @@ namespace Xamarin.Android.Tasks
 					sw.Flush ();
 					Files.CopyIfStreamChanged (sw.BaseStream, outputFile);
 				}
-			}
-		}
-
-		// Binary index file format, all data is little-endian:
-		//
-		//  [Magic string]             # XATI
-		//  [Format version]           # 32-bit unsigned integer, 4 bytes
-		//  [Entry count]              # 32-bit unsigned integer, 4 bytes
-		//  [Module file name width]   # 32-bit unsigned integer, 4 bytes
-		//  [Index entries]            # Format described below, [Entry count] entries
-		//
-		// Index entry format:
-		//
-		//  [File name]<NUL>
-		//
-		// Where:
-		//
-		//   [File name] is right-padded with <NUL> characters to the [Module file name width] boundary.
-		//
-		void OutputModules (Dictionary<string, ModuleDebugData> modules, BinaryWriter indexWriter, int moduleFileNameWidth)
-		{
-			indexWriter.Write (typemapIndexMagicString);
-			indexWriter.Write (TypeMapFormatVersion);
-			indexWriter.Write (modules.Count);
-			indexWriter.Write (moduleFileNameWidth);
-
-			foreach (ModuleDebugData module in modules.Values) {
-				OutputModule (module);
-
-				string outputFilePath = Path.GetFileName (module.OutputFilePath);
-				indexWriter.Write (outputEncoding.GetBytes (outputFilePath));
-				PadField (indexWriter, outputFilePath.Length, moduleFileNameWidth);
-			}
-		}
-
-		void OutputModule (ModuleDebugData moduleData)
-		{
-			if (moduleData.JavaToManagedMap.Count == 0)
-				return;
-
-			using (var bw = MemoryStreamPool.Shared.CreateBinaryWriter ()) {
-				OutputModule (bw, moduleData);
-				bw.Flush ();
-				Files.CopyIfStreamChanged (bw.BaseStream, moduleData.OutputFilePath);
-			}
-			GeneratedBinaryTypeMaps.Add (moduleData.OutputFilePath);
-		}
-
-		// Binary file format, all data is little-endian:
-		//
-		//  [Magic string]                    # XATS
-		//  [Format version]                  # 32-bit unsigned integer, 4 bytes
-		//  [Entry count]                     # 32-bit unsigned integer, 4 bytes
-		//  [Java type name width]            # 32-bit unsigned integer, 4 bytes
-		//  [Managed type name width]         # 32-bit unsigned integer, 4 bytes
-		//  [Assembly name size]              # 32-bit unsigned integer, 4 bytes
-		//  [Assembly name]                   # Non-null terminated assembly name
-		//  [Java-to-managed map]             # Format described below, [Entry count] entries
-		//  [Managed-to-java map]             # Format described below, [Entry count] entries
-		//
-		// Java-to-managed map format:
-		//
-		//    [Java type name]<NUL>[Managed type table index]
-		//
-		//  Each name is padded with <NUL> to the width specified in the [Java type name width] field above.
-		//  Names are written without the size prefix, instead they are always terminated with a nul character
-		//  to make it easier and faster to handle by the native runtime.
-		//
-		//  Each [Managed type table index] is an unsigned 32-bit integer, 4 bytes
-		//
-		//
-		// Managed-to-java map is identical to the [Java-to-managed] table above, with the exception of the index
-		// pointing to the Java name table.
-		//
-		void OutputModule (BinaryWriter bw, ModuleDebugData moduleData)
-		{
-			if ((uint)moduleData.JavaToManagedMap.Count == InvalidJavaToManagedMappingIndex) {
-				throw new InvalidOperationException ($"Too many types in module {moduleData.ModuleName}");
-			}
-
-			bw.Write (moduleMagicString);
-			bw.Write (TypeMapFormatVersion);
-			bw.Write (moduleData.JavaToManagedMap.Count);
-			bw.Write (moduleData.JavaNameWidth);
-			bw.Write (moduleData.ManagedNameWidth);
-			bw.Write (moduleData.ModuleNameBytes.Length);
-			bw.Write (moduleData.ModuleNameBytes);
-
-			foreach (TypeMapDebugEntry entry in moduleData.JavaToManagedMap) {
-				bw.Write (outputEncoding.GetBytes (entry.JavaName));
-				PadField (bw, entry.JavaName.Length, (int)moduleData.JavaNameWidth);
-
-				TypeMapGenerator.TypeMapDebugEntry managedEntry = entry.DuplicateForJavaToManaged != null ? entry.DuplicateForJavaToManaged : entry;
-				bw.Write (managedEntry.SkipInJavaToManaged ? InvalidJavaToManagedMappingIndex : (uint)managedEntry.ManagedIndex);
-			}
-
-			foreach (TypeMapDebugEntry entry in moduleData.ManagedToJavaMap) {
-				bw.Write (outputEncoding.GetBytes (entry.ManagedName));
-				PadField (bw, entry.ManagedName.Length, (int)moduleData.ManagedNameWidth);
-				bw.Write (entry.JavaIndex);
-			}
-		}
-
-		void PadField (BinaryWriter bw, int valueWidth, int maxWidth)
-		{
-			for (int i = 0; i < maxWidth - valueWidth; i++) {
-				bw.Write ((byte)0);
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1564,7 +1564,6 @@ because xbuild doesn't support framework reference assemblies.
     <_LinkingEnabled Condition=" '$(AndroidLinkMode)' == 'None'">False</_LinkingEnabled>
     <_HaveMultipleRIDs Condition=" '$(RuntimeIdentifiers)' != '' ">True</_HaveMultipleRIDs>
     <_HaveMultipleRIDs Condition=" '$(RuntimeIdentifiers)' == '' ">False</_HaveMultipleRIDs>
-    <_AndroidGenerateNativeAssembly Condition=" '$(_AndroidGenerateNativeAssembly)' == '' ">True</_AndroidGenerateNativeAssembly>
   </PropertyGroup>
   <ItemGroup>
     <_MergedManifestDocuments Condition=" '$(AndroidManifestMerger)' == 'legacy' " Include="@(ExtractedManifestDocuments)" />
@@ -1607,7 +1606,6 @@ because xbuild doesn't support framework reference assemblies.
   <GenerateTypeMappings
       AndroidRuntime="$(_AndroidRuntime)"
       Debug="$(AndroidIncludeDebugSymbols)"
-      GenerateNativeAssembly="$(_AndroidGenerateNativeAssembly)"
       IntermediateOutputDirectory="$(IntermediateOutputPath)"
       SkipJniAddNativeMethodRegistrationAttributeScan="$(_SkipJniAddNativeMethodRegistrationAttributeScan)"
       TypemapImplementation="$(_AndroidTypeMapImplementation)"


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9292

In https://github.com/dotnet/android/pull/9292, we removed support for the "instant run" feature.  This feature required the use of typemaps that existed outside of the "native" assemblies (`$(_AndroidGenerateNativeAssembly)` = `false`).  This support is no longer needed, and in fact causes a build error if it is used:

```
Xamarin.Android.Common.targets(2132,3): error XA3006: Could not compile native assembly file: typemaps.x86_64.ll
```

As such, clean up our codebase to remove support for this.

Additionally, unused fields in the `Module[Debug|Release]Data` and `TypeMap[Debug|Release]Entry` data classes were removed to help make it clearer what data is required to generate typemaps.