### PR TITLE
[Trimming] Put code for resolving HttpMessageHandler type name behind feature switch

### DIFF
--- a/src/Mono.Android/ILLink/ILLink.Substitutions.xml
+++ b/src/Mono.Android/ILLink/ILLink.Substitutions.xml
@@ -8,5 +8,9 @@
       <method signature="System.Boolean get_ManagedTypeMap()" body="stub" feature="Microsoft.Android.Runtime.RuntimeFeature.ManagedTypeMap" featurevalue="false" value="false" />
       <method signature="System.Boolean get_ManagedTypeMap()" body="stub" feature="Microsoft.Android.Runtime.RuntimeFeature.ManagedTypeMap" featurevalue="true" value="true" />
     </type>
+    <type fullname="Microsoft.Android.Runtime.RuntimeFeature">
+      <method signature="System.Boolean get_XaHttpClientHandlerTypeEnvironmentVariable()" body="stub" feature="Microsoft.Android.Runtime.RuntimeFeature.XaHttpClientHandlerTypeEnvironmentVariable" featurevalue="false" value="false" />
+      <method signature="System.Boolean get_XaHttpClientHandlerTypeEnvironmentVariable()" body="stub" feature="Microsoft.Android.Runtime.RuntimeFeature.XaHttpClientHandlerTypeEnvironmentVariable" featurevalue="true" value="true" />
+    </type>
   </assembly>
 </linker>

--- a/src/Mono.Android/Microsoft.Android.Runtime/RuntimeFeature.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/RuntimeFeature.cs
@@ -10,4 +10,9 @@ static class RuntimeFeature
 	[FeatureSwitchDefinition ($"{FeatureSwitchPrefix}{nameof (ManagedTypeMap)}")]
 	internal static bool ManagedTypeMap { get; } =
 		AppContext.TryGetSwitch ($"{FeatureSwitchPrefix}{nameof (ManagedTypeMap)}", out bool isEnabled) ? isEnabled : false;
+
+	[FeatureSwitchDefinition ($"{FeatureSwitchPrefix}{nameof (XaHttpClientHandlerTypeEnvironmentVariable)}")]
+	[FeatureGuard (typeof (RequiresUnreferencedCodeAttribute))]
+	internal static bool XaHttpClientHandlerTypeEnvironmentVariable { get; } =
+		AppContext.TryGetSwitch ($"{FeatureSwitchPrefix}{nameof (XaHttpClientHandlerTypeEnvironmentVariable)}", out bool isEnabled) ? isEnabled : false;
 }

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
@@ -51,6 +51,10 @@ See: https://github.com/dotnet/runtime/blob/b13715b6984889a709ba29ea8a1961db469f
         Value="$([MSBuild]::ValueOrDefault('$(_AndroidUseManagedTypeMap)', 'false'))"
         Trim="true"
     />
+    <RuntimeHostConfigurationOption Include="Microsoft.Android.Runtime.RuntimeFeature.XaHttpClientHandlerTypeEnvironmentVariable"
+        Value="$([MSBuild]::ValueOrDefault('$(_AndroidUseXaHttpClientHandlerTypeEnvironmentVariable)', 'false'))"
+        Trim="true"
+    />
   </ItemGroup>
 
   <Target Name="_ParseRuntimeConfigFiles"


### PR DESCRIPTION
We support passing the HTTP message handler _type name_ via the `AndroidHttpClientHandlerType` or the `XA_HTTP_CLIENT_HANDLER_TYPE` environment variable. This is not compatible with trimming by default and while we can make sure this type is preserved by IL Link via custom trimmer steps, there is no reasonable way to do this for NativeAOT.

I suggest disabling the handler type lookup via `XA_HTTP_CLIENT_HANDLER_TYPE` env variable by default and introducing a feature switch to re-enable this feature. The `GetHttpMessageHandler()` method would simply return an instance of `AndroidMessageHandler` by default.

If this is deemed too drastic, we could only disable the feature switch for NativeAOT.

Open question and follow-up work:
- is VS still showing the old dropdown which would set `AndroidHttpClientHandlerType` instead of a checkbox for `UseNativeHttpHandler`?
- we have custom trimmer steps to preserve the type in `AndroidHttpClientHandlerType` somewhere, that should be skipped if the feature switch is not enabled