### PR TITLE
Test a project with a Space in the project Name

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -181,7 +181,7 @@ namespace Xamarin.Android.Tasks
 				if (!string.IsNullOrEmpty (EnumMetadataDirectory))
 					WriteLine (sw, $"--enummetadata=\"{EnumMetadataDirectory}\"");
 				if (!string.IsNullOrEmpty (AssemblyName))
-					WriteLine (sw, $"--assembly={AssemblyName}");
+					WriteLine (sw, $"--assembly=\"{AssemblyName}\"");
 
 				if (!NoStdlib) {
 					string fxpath = MonoAndroidFrameworkDirectories.Split (';').First (p => new DirectoryInfo (p).GetFiles ("mscorlib.dll").Any ());

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -30,6 +30,8 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
+				ProjectName = "Test Me",
+				RootNamespace = "Test.Me",
 				EnableDefaultItems = true,
 				ExtraNuGetConfigSources = {
 					// Microsoft.AspNetCore.Components.WebView is not in dotnet-public
@@ -82,7 +84,7 @@ namespace Xamarin.Android.Build.Tests
 						},
 			});
 			proj.OtherBuildItems.Add (new BuildItem ("Compile", default (Func<string>)) {
-						TextContent = () => InlineData.DesignerWithContents (proj.ProjectName, "Resource", "public partial", new string[] {"CancelButton"}),
+						TextContent = () => InlineData.DesignerWithContents (proj.RootNamespace ?? proj.ProjectName, "Resource", "public partial", new string[] {"CancelButton"}),
 						Update = () =>  "Resource.designer.cs",
 						Metadata = {
 							{ "DependentUpon", "Resource.resx" },

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -150,6 +150,28 @@ Console.WriteLine ($""{DateTime.UtcNow.AddHours(-30).Humanize(culture:c)}"");
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
+		[TestCase ("Test Me")]
+		// testing characters as per https://www.compart.com/en/unicode/category/Zs
+		[TestCase ("TestUnicodeSpace0020\u0020Me")]
+		// TODO these break with AOT error on windows
+		[TestCase ("TestUnicodeSpace2000\u2000Me")]
+		[TestCase ("TestUnicodeSpace2009\u2009Me")]
+		[TestCase ("TestUnicodeSpace2002\u2002Me")]
+		[TestCase ("TestUnicodeSpace2007\u2007Me")]
+		public void CheckProjectWithSpaceInNameWorks (string projectName)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				ProjectName = projectName,
+				RootNamespace = "Test.Me",
+			};
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "build failed");
+			}
+		}
+
+		[Test]
 		public void CheckClassesDexIsIncluded ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/InlineData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/InlineData.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Build.Tests
 using System;
 using System.Reflection;
 
-namespace @projectName@
+namespace @projectNamespace@
 {
 	[System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Resources.Tools.StronglyTypedResourceBuilder"", ""4.0.0.0"")]
 	[System.Diagnostics.DebuggerNonUserCodeAttribute()]
@@ -51,7 +51,7 @@ namespace @projectName@
 		internal static System.Resources.ResourceManager ResourceManager {
 			get {
 				if (object.Equals(null, resourceMan)) {
-					System.Resources.ResourceManager temp = new System.Resources.ResourceManager(""@projectName@.@className@"", typeof(@className@).GetTypeInfo().Assembly);
+					System.Resources.ResourceManager temp = new System.Resources.ResourceManager(""@projectNamespace@.@className@"", typeof(@className@).GetTypeInfo().Assembly);
 					resourceMan = temp;
 				}
 				return resourceMan;
@@ -87,7 +87,7 @@ namespace @projectName@
 			}
 		}
 
-		public static string DesignerWithContents (string projectName, string className, string modifier, string[] dataNames)
+		public static string DesignerWithContents (string projectNamespace, string className, string modifier, string[] dataNames)
 		{
 			var content = new StringBuilder ();
 			foreach (string data in dataNames) {
@@ -99,14 +99,14 @@ namespace @projectName@
 			}
 			return Designer.Replace ("@modifier@", modifier)
 				.Replace ("@className@", className)
-				.Replace ("@projectName@", projectName)
+				.Replace ("@projectNamespace@", projectNamespace)
 				.Replace ("@content@", content.ToString ());
 		}
 
-		public static void AddCultureResourceDesignerToProject (IShortFormProject proj, string projectName, string className, params string[] dataNames)
+		public static void AddCultureResourceDesignerToProject (IShortFormProject proj, string projectNamespace, string className, params string[] dataNames)
 		{
 			proj.OtherBuildItems.Add (new BuildItem.Source ($"{className}.Designer.cs") {
-				TextContent = () => InlineData.DesignerWithContents (projectName, className, "internal", dataNames)
+				TextContent = () => InlineData.DesignerWithContents (projectNamespace, className, "internal", dataNames)
 			});
 		}
 	}

--- a/tools/assembly-store-reader/AssemblyStoreManifestEntry.cs
+++ b/tools/assembly-store-reader/AssemblyStoreManifestEntry.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Android.AssemblyStore
 		public AssemblyStoreManifestEntry (string[] fields)
 		{
 			if (fields.Length != NumberOfFields) {
-				throw new ArgumentOutOfRangeException (nameof (fields), "Invalid number of fields");
+				throw new ArgumentOutOfRangeException (nameof (fields), $"Invalid number of fields. Expected {NumberOfFields} found {fields.Length}");
 			}
 
 			Hash32 = GetUInt32 (fields[Hash32FieldIndex]);

--- a/tools/assembly-store-reader/AssemblyStoreManifestReader.cs
+++ b/tools/assembly-store-reader/AssemblyStoreManifestReader.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.AssemblyStore
 {
 	class AssemblyStoreManifestReader
 	{
-		static readonly char[] fieldSplit = new char[] { ' ' };
+		static readonly char[] fieldSplit = new char[] { '\t' };
 
 		public List<AssemblyStoreManifestEntry> Entries                      { get; } = new List<AssemblyStoreManifestEntry> ();
 		public Dictionary<uint, AssemblyStoreManifestEntry> EntriesByHash32  { get; } = new Dictionary<uint, AssemblyStoreManifestEntry> ();

--- a/tools/assembly-store-reader/AssemblyStoreManifestReader.cs
+++ b/tools/assembly-store-reader/AssemblyStoreManifestReader.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.AssemblyStore
 {
 	class AssemblyStoreManifestReader
 	{
-		static readonly char[] fieldSplit = new char[] { '\t' };
+		static readonly char[] fieldSplit = new char[] { ' ' };
 
 		public List<AssemblyStoreManifestEntry> Entries                      { get; } = new List<AssemblyStoreManifestEntry> ();
 		public Dictionary<uint, AssemblyStoreManifestEntry> EntriesByHash32  { get; } = new Dictionary<uint, AssemblyStoreManifestEntry> ();


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1852953

There was a problem with the generator arguments not allowing for assembly names with spaces in them. 
So lets fix that by adding quotes to make sure the assembly name is parsed correctly. Also add a unit test to make sure we don't regress in the future.