### PR TITLE
[coreclr] Initial support of R2R builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -124,19 +124,19 @@ namespace Xamarin.Android.Build.Tests
 		static object [] ReadyToRunConfigurationSource = new object [] {
 			new object[] {
 				/* isComposite */	true,
-				/* rid */			"android-x64"
+				/* rid */		"android-x64"
 			},
 			new object[] {
 				/* isComposite */	false,
-				/* rid */			"android-x64"
+				/* rid */		"android-x64"
 			},
 			new object[] {
 				/* isComposite */	true,
-				/* rid */			"android-arm64"
+				/* rid */		"android-arm64"
 			},
 			new object[] {
 				/* isComposite */	false,
-				/* rid */			"android-arm64"
+				/* rid */		"android-arm64"
 			}
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -342,13 +342,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <AndroidUseAssemblyStore Condition=" '$(AndroidUseAssemblyStore)' == '' ">true</AndroidUseAssemblyStore>
   <AndroidAotEnableLazyLoad Condition=" '$(AndroidAotEnableLazyLoad)' == '' And '$(AotAssemblies)' == 'true' And '$(AndroidIncludeDebugSymbols)' != 'true' ">True</AndroidAotEnableLazyLoad>
   <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and ('$(UsingMicrosoftNETSdkRazor)' == 'true') ">False</AndroidEnableMarshalMethods>
-  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' ">True</AndroidEnableMarshalMethods>
+  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' and '$(PublishReadyToRun)' != 'true' ">True</AndroidEnableMarshalMethods>
   <!-- NOTE: temporarily disable for NativeAOT for now, to get build passing -->
-  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and '$(_AndroidRuntime)' == 'NativeAOT' ">False</AndroidEnableMarshalMethods>
+  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and ('$(_AndroidRuntime)' == 'NativeAOT' or '$(PublishReadyToRun)' == 'true') ">False</AndroidEnableMarshalMethods>
 
-  <!-- NOTE: temporarily disable for CoreCLR for now, until we have an implementation that works
-       with the new runtime -->
-  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and '$(_AndroidRuntime)' == 'CoreCLR' ">False</AndroidEnableMarshalMethods>
   <_AndroidUseMarshalMethods Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' ">False</_AndroidUseMarshalMethods>
   <_AndroidUseMarshalMethods Condition=" '$(AndroidIncludeDebugSymbols)' != 'True' ">$(AndroidEnableMarshalMethods)</_AndroidUseMarshalMethods>
 
@@ -2062,7 +2059,7 @@ because xbuild doesn't support framework reference assemblies.
 
   <!-- Shrink Mono.Android.dll by removing attribute only needed for GenerateJavaStubs -->
   <RemoveRegisterAttribute
-    Condition="'$(AndroidLinkMode)' != 'None' and '$(AndroidIncludeDebugSymbols)' != 'true' and '$(AndroidStripILAfterAOT)' != 'true' and '$(_AndroidRuntime)' != 'NativeAOT' "
+    Condition="'$(AndroidLinkMode)' != 'None' and '$(AndroidIncludeDebugSymbols)' != 'true' and '$(AndroidStripILAfterAOT)' != 'true' and '$(_AndroidRuntime)' != 'NativeAOT' and '$(PublishReadyToRun)' != 'true' "
     ShrunkFrameworkAssemblies="@(_ShrunkAssemblies)" />
 
   <MakeDir Directories="$(MonoAndroidIntermediateAssemblyDir)shrunk" />


### PR DESCRIPTION
## Description

ReadyToRun deployments are enabled when:
1. `<PublishReadyToRun>true</PublishReadyToRun>` is added to the project file
3. App is published via: `dotnet publish`

Once enabled, the SDK injects necessary build tasks to perform AOT compilation of assemblies after their trimming and creation of R2R images during app publish.

## Problem

Currently, Android app build runs two assembly postprocessing build tasks (after R2R image generation): `RewriteMarshalMethods` and `RemoveRegisterAttribute` that are modifying assemblies with `Mono.Cecil`. However, altering R2R assemblies is not supported with Mono.Cecil and build fails via:
```
System.NotSupportedException: Writing mixed-mode assemblies is not supported
         at Mono.Cecil.ModuleWriter.Write(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
         at Mono.Cecil.ModuleWriter.WriteModule(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
         at Mono.Cecil.ModuleDefinition.Write(Stream stream, WriterParameters parameters)
         at Mono.Cecil.ModuleDefinition.Write(WriterParameters parameters)
         at Mono.Cecil.ModuleDefinition.Write()
         at Mono.Cecil.AssemblyDefinition.Write()
         at Xamarin.Android.Tasks.RemoveRegisterAttribute.RunTask() in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAtt
      ribute.cs:line 37
         at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.
      BaseTasks/AndroidTask.cs:line 25
```

## Changes

To enable R2R builds, this PR:
- disables running `RewriteMarshalMethods` and `RemoveRegisterAttribute` build tasks in ReadyToRun deployments
- adds new unit tests for R2R builds
- reenables unit tests for regular CoreCLR builds

## Future work

Investigate running R2R image generation build task after `RewriteMarshalMethods` and `RemoveRegisterAttribute` so that R2R builds could also benefit from the performance improvements these build tasks bring.