### PR TITLE
[ci] Use templates from DevDiv/Xamarin.yaml-templates

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -12,10 +12,9 @@ pr:
 resources:
   repositories:
   - repository: yaml-templates
-    type: github
-    name: xamarin/yaml-templates
+    type: git
+    name: DevDiv/Xamarin.yaml-templates
     ref: refs/heads/main
-    endpoint: xamarin
   - repository: android-platform-support
     type: git
     name: DevDiv/android-platform-support

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -16,10 +16,9 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
   - repository: yaml-templates
-    type: github
-    name: xamarin/yaml-templates
+    type: git
+    name: DevDiv/Xamarin.yaml-templates
     ref: refs/heads/main
-    endpoint: xamarin
   - repository: android-platform-support
     type: git
     name: DevDiv/android-platform-support


### PR DESCRIPTION
Updates the repo reference that provides common yaml templates from https://github.com/xamarin/yaml-templates
to
https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates