### PR TITLE
Make the NativeAOT debugger script more flexible

### DIFF
--- a/samples/NativeAOT/runwithdebugger.ps1
+++ b/samples/NativeAOT/runwithdebugger.ps1
@@ -37,12 +37,22 @@ $env:ANDROID_NDK_HOME = $_DEF_NDK_HOME
 # Kill any existing lldb-server processes
 $null = & $ADB shell "run-as net.dot.hellonativeaot killall -q -9 lldb-server" 
 
+$DEVICE_ARCH = & $ADB shell uname -m
+if ( $DEVICE_ARCH -match "aarch64" ) {
+    $CLANG_PREFIX=aarch64-linux-android21
+} elseif ( $DEVICE_ARCH -match "x86_64" ) {
+    $CLANG_PREFIX=x86_64-linux-android21
+} else {
+    Write-Error "Error: unsupported device architecture $DEVICE_ARCH"
+    exit 1
+}
+
 # Get the appropriate path for Windows NDK
-$NDK_CLANG_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\windows-x86_64\bin\clang"
+$NDK_CLANG_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\windows-x86_64\bin\$CLANG_PREFIX-clang"
 if (-not (Test-Path $NDK_CLANG_PATH)) {
-    $NDK_CLANG_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\linux-x86_64\bin\clang"
+    $NDK_CLANG_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\linux-x86_64\bin\$CLANG_PREFIX-clang"
     if (-not (Test-Path $NDK_CLANG_PATH)) {
-        $NDK_CLANG_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\darwin-x86_64\bin\clang"
+        $NDK_CLANG_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\darwin-x86_64\bin\$CLANG_PREFIX-clang"
         if (-not (Test-Path $NDK_CLANG_PATH)) {
             Write-Error "Could not find clang in any of the expected NDK locations"
             exit 1

--- a/samples/NativeAOT/runwithdebugger.ps1
+++ b/samples/NativeAOT/runwithdebugger.ps1
@@ -39,9 +39,9 @@ $null = & $ADB shell "run-as net.dot.hellonativeaot killall -q -9 lldb-server"
 
 $DEVICE_ARCH = & $ADB shell uname -m
 if ( $DEVICE_ARCH -match "aarch64" ) {
-    $CLANG_PREFIX = aarch64-linux-android21
+    $CLANG_PREFIX = "aarch64-linux-android21"
 } elseif ( $DEVICE_ARCH -match "x86_64" ) {
-    $CLANG_PREFIX = x86_64-linux-android21
+    $CLANG_PREFIX = "x86_64-linux-android21"
 } else {
     Write-Error "Error: unsupported device architecture $DEVICE_ARCH"
     exit 1

--- a/samples/NativeAOT/runwithdebugger.ps1
+++ b/samples/NativeAOT/runwithdebugger.ps1
@@ -39,9 +39,9 @@ $null = & $ADB shell "run-as net.dot.hellonativeaot killall -q -9 lldb-server"
 
 $DEVICE_ARCH = & $ADB shell uname -m
 if ( $DEVICE_ARCH -match "aarch64" ) {
-    $CLANG_PREFIX=aarch64-linux-android21
+    $CLANG_PREFIX = aarch64-linux-android21
 } elseif ( $DEVICE_ARCH -match "x86_64" ) {
-    $CLANG_PREFIX=x86_64-linux-android21
+    $CLANG_PREFIX = x86_64-linux-android21
 } else {
     Write-Error "Error: unsupported device architecture $DEVICE_ARCH"
     exit 1

--- a/samples/NativeAOT/runwithdebugger.ps1
+++ b/samples/NativeAOT/runwithdebugger.ps1
@@ -38,20 +38,21 @@ $env:ANDROID_NDK_HOME = $_DEF_NDK_HOME
 $null = & $ADB shell "run-as net.dot.hellonativeaot killall -q -9 lldb-server" 
 
 # Get the appropriate path for Windows NDK
-$NDK_LLDB_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\windows-x86_64\lib\clang\19\lib\linux\aarch64\lldb-server"
-if (-not (Test-Path $NDK_LLDB_PATH)) {
-    $NDK_LLDB_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\linux-x86_64\lib\clang\19\lib\linux\aarch64\lldb-server"
-    if (-not (Test-Path $NDK_LLDB_PATH)) {
-        $NDK_LLDB_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\darwin-x86_64\lib\clang\19\lib\linux\aarch64\lldb-server"
-        if (-not (Test-Path $NDK_LLDB_PATH)) {
-            Write-Error "Could not find lldb-server in any of the expected NDK locations"
+$NDK_CLANG_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\windows-x86_64\bin\clang"
+if (-not (Test-Path $NDK_CLANG_PATH)) {
+    $NDK_CLANG_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\linux-x86_64\bin\clang"
+    if (-not (Test-Path $NDK_CLANG_PATH)) {
+        $NDK_CLANG_PATH = "$env:ANDROID_NDK_HOME\toolchains\llvm\prebuilt\darwin-x86_64\bin\clang"
+        if (-not (Test-Path $NDK_CLANG_PATH)) {
+            Write-Error "Could not find clang in any of the expected NDK locations"
             exit 1
         }
     }
 }
 
+$NDK_LLDB_PATH= & $NDK_CLANG_PATH -print-file-name=lldb-server
 # Push lldb-server to device
-& $ADB push $NDK_LLDB_PATH /data/local/tmp/lldb-server
+& $ADB push "$NDK_LLDB_PATH" /data/local/tmp/lldb-server
 & $ADB shell run-as net.dot.hellonativeaot cp /data/local/tmp/lldb-server .
 & $ADB forward tcp:5039 tcp:5039
 

--- a/samples/NativeAOT/runwithdebugger.sh
+++ b/samples/NativeAOT/runwithdebugger.sh
@@ -25,7 +25,21 @@ export ANDROID_NDK_HOME
 # This script is used to run the NativeAOT sample with the debugger attached.
 # It is used by the CI system to verify that the debugger works with NativeAOT.
 adb shell run-as net.dot.hellonativeaot killall -9 lldb-server > /dev/null 2>&1 || true
-adb push $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/lib/clang/19/lib/linux/aarch64/lldb-server /data/local/tmp/lldb-server
+
+case $(uname) in
+    Linux) TOOLCHAIN_OS=linux-x86_64 ;;
+    Darwin) TOOLCHAIN_OS=darwine-x86_64 ;;
+esac
+
+if [ -n "${ANDROID_NDK_HOME}" ]; then
+    ANDROID_NDK_DIR="${ANDROID_NDK_HOME}"
+elif [ -n "${ANDROID_NDK_ROOT}" ]; then
+    ANDROID_NDK_DIR="${ANDROID_NDK_ROOT}"
+elif [ -n "${ANDROID_NDK_PATH}" ]; then
+    ANDROID_NDK_DIR="${ANDROID_NDK_PATH}"
+fi
+
+adb push "$("${ANDROID_NDK_DIR}/toolchains/llvm/prebuilt/${TOOLCHAIN_OS}/bin/clang" -print-file-name=lldb-server)" /data/local/tmp/lldb-server
 adb shell run-as net.dot.hellonativeaot cp /data/local/tmp/lldb-server .
 adb forward tcp:5039 tcp:5039
 


### PR DESCRIPTION
Make it able to detect the OS-specific path to the NDK toolchain binaries, 
as well as the path to the NDK root directory using a number of environment 
variables used at one time or another for this purpose.

Instead of hard-coding path to the `lldb-server` binary, which is located in 
a versioned directory, use `clang` itself to print full path to the binary, 
thus making the script LLVM version agnostic.

Additionally, detect the attached device's architecture and use the correct
`lldb-server` binary.