### PR TITLE
Try to preserve the app cache on uninstall.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2977,6 +2977,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_DeployAppBundle"
     Condition=" '$(AndroidPackageFormat)' == 'aab' "
     DependsOnTargets="_BuildApkSet">
+  <!-- Try to uninstall but save the cache -->
   <AndroidAdb
       Condition=" '$(EmbedAssembliesIntoApk)' == 'true' "
       ContinueOnError="True"
@@ -2988,7 +2989,20 @@ because xbuild doesn't support framework reference assemblies.
   >
     <Output TaskParameter="Result" PropertyName="_UninstallResult" />
   </AndroidAdb>
-   <AndroidAdb
+  <!-- The previous attempt failed. So yry to uninstall but save the cache using cmd package uninstall -k -->
+  <AndroidAdb
+      Condition=" '$(EmbedAssembliesIntoApk)' == 'true' And '$(_UninstallResult)' == 'false' "
+      ContinueOnError="True"
+      ToolExe="$(AdbToolExe)"
+      ToolPath="$(AdbToolPath)"
+      AdbTarget="$(AdbTarget)"
+      Command="shell cmd package uninstall -k"
+      Arguments="$(_AndroidPackage)"
+  >
+    <Output TaskParameter="Result" PropertyName="_UninstallResult" />
+  </AndroidAdb>
+  <!-- adb really can't uninstall this app with the cache intact, we need to completely uninstall it. -->
+  <AndroidAdb
       Condition=" '$(EmbedAssembliesIntoApk)' == 'true' And '$(_UninstallResult)' == 'false' "
       ContinueOnError="True"
       ToolExe="$(AdbToolExe)"


### PR DESCRIPTION
Context #9259

Due to various reasons `adb` may not be able to preserve the app cache on uninstall. To work around this we have to use the `-k` flag to uninstall the app when using the `cmd package uninstall` call. This will keep the app data and cache on the device.

However this might also fail. So in that case we need to completely uninstall the app and then install it again.