### PR TITLE
[Mono.Android] Fix build warnings related to networking code

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -338,7 +338,7 @@ namespace Android.Runtime {
 		{
 			[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Preserved by the MarkJavaObjects trimmer step.")]
 			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-			static Type TypeGetType (string typeName) =>
+			static Type? TypeGetType (string typeName) =>
 				Type.GetType (typeName, throwOnError: false);
 
 			if (httpMessageHandlerType is null) {

--- a/src/Mono.Android/Xamarin.Android.Net/NegotiateAuthenticationHelper.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/NegotiateAuthenticationHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
@@ -32,9 +31,9 @@ namespace Xamarin.Android.Net
 
 			IEnumerable<AuthenticationData> authenticationData = handler.RequestedAuthentication ?? Array.Empty<AuthenticationData> ();
 			foreach (var auth in authenticationData) {
-				if (TryGetSupportedAuthType (auth.Challenge, out var authType)) {
+				if (request.RequestUri is Uri requestUri && TryGetSupportedAuthType (auth.Challenge, out var authType)) {
 					var credentials = auth.UseProxyAuthentication ? handler.Proxy?.Credentials : handler.Credentials;
-					var correspondingCredential = credentials?.GetCredential (request.RequestUri, authType);
+					var correspondingCredential = credentials?.GetCredential (requestUri, authType);
 
 					if (correspondingCredential != null) {
 						requestedAuth = new RequestedNegotiateAuthenticationData {
@@ -78,8 +77,13 @@ namespace Xamarin.Android.Net
 			}
 		}
 
-		static bool TryGetSupportedAuthType (string challenge, out string authType)
+		static bool TryGetSupportedAuthType (string? challenge, out string authType)
 		{
+			if (challenge is null) {
+				authType = string.Empty;
+				return false;
+			}
+			
 			var spaceIndex = challenge.IndexOf (' ');
 			authType = spaceIndex == -1 ? challenge : challenge.Substring (0, spaceIndex);
 


### PR DESCRIPTION
This PR fixes several build warnings which pollute the build logs:
```
/../dotnet/android/src/Mono.Android/Xamarin.Android.Net/NegotiateAuthenticationHelper.cs(35,34): warning CS8604: Possible null reference argument for parameter 'challenge' in 'bool NegotiateAuthenticationHelper.TryGetSupportedAuthType(string challenge, out string authType)'.
/../dotnet/android/src/Mono.Android/Xamarin.Android.Net/NegotiateAuthenticationHelper.cs(37,64): warning CS8604: Possible null reference argument for parameter 'uri' in 'NetworkCredential? ICredentials.GetCredential(Uri uri, string authType)'.
/../dotnet/android/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs(31,56): warning CS8604: Possible null reference argument for parameter 'trustManagers' in 'IX509TrustManager ServerCertificateCustomValidator.FindX509TrustManager(ITrustManager[] trustManagers, out int index)'.
/../dotnet/android/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs(58,70): warning CS8602: Dereference of a possibly null reference.
/../dotnet/android/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs(90,12): warning CS8602: Dereference of a possibly null reference.
/../dotnet/android/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs(90,62): warning CS8602: Dereference of a possibly null reference.
/../dotnet/android/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs(110,34): warning SYSLIB0057: 'X509Certificate2.X509Certificate2(byte[])' is obsolete: 'Loading certificate data through the constructor or Import is obsolete. Use X509CertificateLoader instead to load certificates.' (https://aka.ms/dotnet-warnings/SYSLIB0057)
/../dotnet/android/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs(342,5): warning CS8603: Possible null reference return.
```

One of the more significant changes in this PR is the usage of the new .NET 9 API for loading X509 certificates [`X509CertificateLoader.LoadCertificate (data)`](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificateloader.loadcertificate?view=net-9.0)