### PR TITLE
[Mono.Android] Generate API docs for API level 36

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -75,11 +75,11 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-35_r01",   apiLevel: "35", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-36_r01",   apiLevel: "36", pkgRevision: "1", isLatestStable: true),
 
-				new AndroidToolchainComponent ("source-35_r01",
-					destDir: Path.Combine ("sources", "android-35"),
+				new AndroidToolchainComponent ("source-36_r01",
+					destDir: Path.Combine ("sources", "android-36"),
 					pkgRevision: "1",
 					dependencyType: AndroidToolchainComponentType.BuildDependency,
-					buildToolVersion: "35.1"
+					buildToolVersion: "36.1"
 				),
 				new AndroidToolchainComponent ("docs-24_r01",
 					destDir: "docs",

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -239,7 +239,7 @@
 
   <PropertyGroup>
     <!-- Override these properties to generate docs against a specific API level -->
-    <DocsApiLevel Condition=" '$(DocsApiLevel)' == '' ">35</DocsApiLevel>
+    <DocsApiLevel Condition=" '$(DocsApiLevel)' == '' ">36</DocsApiLevel>
     <DocsPlatformId Condition=" '$(DocsPlatformId)' == '' ">$(DocsApiLevel)</DocsPlatformId>
     <DocsFxMoniker Condition=" '$(DocsFxMoniker)' == '' ">net-android-$(DocsApiLevel).0</DocsFxMoniker>
     <DocsExportOutput Condition=" '$(DocsExportOutput)' == '' ">$(_MonoAndroidNETDefaultOutDir)Mono.Android.xml</DocsExportOutput>


### PR DESCRIPTION
Updates xaprepare and Mono.Android to generate API Docs against
API-36 sources.