### PR TITLE
[XABT] Refactor `<LinkAssembliesNoShrink>`/`<AssemblyModifierPipeline>` tasks to use an actual pipeline.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
@@ -32,7 +32,7 @@ namespace MonoDroid.Tuner
 		public bool ProcessAssembly (AssemblyDefinition assembly, StepContext context)
 		{
 			// Only run this step on user Android assemblies
-			if (context.IsFrameworkAssembly || !context.IsAndroidAssembly)
+			if (!context.IsAndroidUserAssembly)
 				return false;
 
 			return AddKeepAlives (assembly);

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
@@ -11,6 +11,9 @@ using Xamarin.Android.Tasks;
 namespace MonoDroid.Tuner
 {
 	public class AddKeepAlivesStep : BaseStep
+#if !ILLINK
+		, IAssemblyModifierPipelineStep
+#endif  // !ILLINK
 	{
 
 		protected override void ProcessAssembly (AssemblyDefinition assembly)
@@ -24,6 +27,17 @@ namespace MonoDroid.Tuner
 					Annotations.SetAction (assembly, AssemblyAction.Save);
 			}
 		}
+
+#if !ILLINK
+		public bool ProcessAssembly (AssemblyDefinition assembly, StepContext context)
+		{
+			// Only run this step on user Android assemblies
+			if (context.IsFrameworkAssembly || !context.IsAndroidAssembly)
+				return false;
+
+			return AddKeepAlives (assembly);
+		}
+#endif  // !ILLINK
 
 		internal bool AddKeepAlives (AssemblyDefinition assembly)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -21,6 +21,9 @@ namespace MonoDroid.Tuner
 	/// NOTE: this step is subclassed so it can be called directly from Xamarin.Android.Build.Tasks
 	/// </summary>
 	public class FixAbstractMethodsStep : BaseMarkHandler
+#if !ILLINK
+		, IAssemblyModifierPipelineStep
+#endif  // !ILLINK
 	{
 		public override void Initialize (LinkContext context, MarkContext markContext)
 		{
@@ -78,6 +81,17 @@ namespace MonoDroid.Tuner
 			}
 			return changed;
 		}
+
+#if !ILLINK
+		public bool ProcessAssembly (AssemblyDefinition assembly, StepContext context)
+		{
+			// Only run this step on non-main user Android assemblies
+			if (context.IsMainAssembly || context.IsFrameworkAssembly || !context.IsAndroidAssembly)
+				return false;
+
+			return FixAbstractMethods (assembly);
+		}
+#endif  // !ILLINK
 
 		readonly HashSet<string> warnedAssemblies = new (StringComparer.Ordinal);
 

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -86,7 +86,7 @@ namespace MonoDroid.Tuner
 		public bool ProcessAssembly (AssemblyDefinition assembly, StepContext context)
 		{
 			// Only run this step on non-main user Android assemblies
-			if (context.IsMainAssembly || context.IsFrameworkAssembly || !context.IsAndroidAssembly)
+			if (context.IsMainAssembly || !context.IsAndroidUserAssembly)
 				return false;
 
 			return FixAbstractMethods (assembly);

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixLegacyResourceDesignerStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixLegacyResourceDesignerStep.cs
@@ -74,7 +74,7 @@ namespace MonoDroid.Tuner
 		public bool ProcessAssembly (AssemblyDefinition assembly, Xamarin.Android.Tasks.StepContext context)
 		{
 			// Only run this step on non-main user Android assemblies
-			if (context.IsMainAssembly || context.IsFrameworkAssembly || !context.IsAndroidAssembly)
+			if (context.IsMainAssembly || !context.IsAndroidUserAssembly)
 				return false;
 
 			return ProcessAssemblyDesigner (assembly);

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixLegacyResourceDesignerStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixLegacyResourceDesignerStep.cs
@@ -21,6 +21,9 @@ using Resources = Xamarin.Android.Tasks.Properties.Resources;
 namespace MonoDroid.Tuner
 {
 	public class FixLegacyResourceDesignerStep : LinkDesignerBase
+#if !ILLINK
+		, Xamarin.Android.Tasks.IAssemblyModifierPipelineStep
+#endif  // !ILLINK
 	{
 		internal const string DesignerAssemblyName = "_Microsoft.Android.Resource.Designer";
 		internal const string DesignerAssemblyNamespace = "_Microsoft.Android.Resource.Designer";
@@ -66,6 +69,17 @@ namespace MonoDroid.Tuner
 				designerLoaded = true;
 			}
 		}
+
+#if !ILLINK
+		public bool ProcessAssembly (AssemblyDefinition assembly, Xamarin.Android.Tasks.StepContext context)
+		{
+			// Only run this step on non-main user Android assemblies
+			if (context.IsMainAssembly || context.IsFrameworkAssembly || !context.IsAndroidAssembly)
+				return false;
+
+			return ProcessAssemblyDesigner (assembly);
+		}
+#endif  // !ILLINK
 
 		internal override bool ProcessAssemblyDesigner (AssemblyDefinition assembly)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Tasks;
 /// are run *after* the linker has run. Additionally, this task is run by
 /// LinkAssembliesNoShrink to modify assemblies when ILLink is not used.
 /// </summary>
-public partial class AssemblyModifierPipeline : AndroidTask
+public class AssemblyModifierPipeline : AndroidTask
 {
 	public override string TaskPrefix => "AMP";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
@@ -20,16 +20,8 @@ namespace Xamarin.Android.Tasks;
 /// are run *after* the linker has run. Additionally, this task is run by
 /// LinkAssembliesNoShrink to modify assemblies when ILLink is not used.
 /// </summary>
-public class AssemblyModifierPipeline : AndroidTask
+public partial class AssemblyModifierPipeline : AndroidTask
 {
-	// Names of assemblies which don't have Mono.Android.dll references, or are framework assemblies, but which must
-	// be scanned for Java types.
-	static readonly HashSet<string> SpecialAssemblies = new HashSet<string> (StringComparer.OrdinalIgnoreCase) {
-			"Java.Interop.dll",
-			"Mono.Android.dll",
-			"Mono.Android.Runtime.dll",
-		};
-
 	public override string TaskPrefix => "AMP";
 
 	public string ApplicationJavaClass { get; set; } = "";
@@ -66,6 +58,12 @@ public class AssemblyModifierPipeline : AndroidTask
 	[Required]
 	public ITaskItem [] SourceFiles { get; set; } = [];
 
+	/// <summary>
+	/// $(TargetName) would be "AndroidApp1" with no extension
+	/// </summary>
+	[Required]
+	public string TargetName { get; set; } = "";
+
 	protected JavaPeerStyle codeGenerationTarget;
 
 	public override bool RunTask ()
@@ -86,14 +84,14 @@ public class AssemblyModifierPipeline : AndroidTask
 
 		Dictionary<AndroidTargetArch, Dictionary<string, ITaskItem>> perArchAssemblies = MonoAndroidHelper.GetPerArchAssemblies (ResolvedAssemblies, Array.Empty<string> (), validate: false);
 
-		RunState? runState = null;
+		AssemblyPipeline? pipeline = null;
 		var currentArch = AndroidTargetArch.None;
 
 		for (int i = 0; i < SourceFiles.Length; i++) {
 			ITaskItem source = SourceFiles [i];
-			AndroidTargetArch sourceArch = GetValidArchitecture (source);
+			AndroidTargetArch sourceArch = MonoAndroidHelper.GetRequiredValidArchitecture (source);
 			ITaskItem destination = DestinationFiles [i];
-			AndroidTargetArch destinationArch = GetValidArchitecture (destination);
+			AndroidTargetArch destinationArch = MonoAndroidHelper.GetRequiredValidArchitecture (destination);
 
 			if (sourceArch != destinationArch) {
 				throw new InvalidOperationException ($"Internal error: assembly '{sourceArch}' targets architecture '{sourceArch}', while destination assembly '{destination}' targets '{destinationArch}' instead");
@@ -102,38 +100,39 @@ public class AssemblyModifierPipeline : AndroidTask
 			// Each architecture must have a different set of context classes, or otherwise only the first instance of the assembly may be rewritten.
 			if (currentArch != sourceArch) {
 				currentArch = sourceArch;
-				runState?.Dispose ();
+				pipeline?.Dispose ();
 
 				var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: ReadSymbols, loadReaderParameters: readerParameters);
-				runState = new RunState (resolver);
 
 				// Add SearchDirectories for the current architecture's ResolvedAssemblies
 				foreach (var kvp in perArchAssemblies [sourceArch]) {
 					ITaskItem assembly = kvp.Value;
 					var path = Path.GetFullPath (Path.GetDirectoryName (assembly.ItemSpec));
-					if (!runState.resolver.SearchDirectories.Contains (path)) {
-						runState.resolver.SearchDirectories.Add (path);
+					if (!resolver.SearchDirectories.Contains (path)) {
+						resolver.SearchDirectories.Add (path);
 					}
 				}
 
 				// Set up the FixAbstractMethodsStep and AddKeepAlivesStep
-				var context = new MSBuildLinkContext (runState.resolver, Log);
+				var context = new MSBuildLinkContext (resolver, Log);
+				pipeline = new AssemblyPipeline (resolver);
 
-				CreateRunState (runState, context);
+				BuildPipeline (pipeline, context);
 			}
 
 			Directory.CreateDirectory (Path.GetDirectoryName (destination.ItemSpec));
 
-			RunPipeline (source, destination, runState!, writerParameters);
+			RunPipeline (pipeline!, source, destination, writerParameters);
 		}
 
-		runState?.Dispose ();
+		pipeline?.Dispose ();
 
 		return !Log.HasLoggedErrors;
 	}
 
-	protected virtual void CreateRunState (RunState runState, MSBuildLinkContext context)
+	protected virtual void BuildPipeline (AssemblyPipeline pipeline, MSBuildLinkContext context)
 	{
+		// FindJavaObjectsStep
 		var findJavaObjectsStep = new FindJavaObjectsStep (Log) {
 			ApplicationJavaClass = ApplicationJavaClass,
 			ErrorOnCustomJavaObject = ErrorOnCustomJavaObject,
@@ -141,108 +140,45 @@ public class AssemblyModifierPipeline : AndroidTask
 		};
 
 		findJavaObjectsStep.Initialize (context);
-
-		runState.findJavaObjectsStep = findJavaObjectsStep;
+		pipeline.Steps.Add (findJavaObjectsStep);
 	}
 
-	protected virtual void RunPipeline (ITaskItem source, ITaskItem destination, RunState runState, WriterParameters writerParameters)
+	void RunPipeline (AssemblyPipeline pipeline, ITaskItem source, ITaskItem destination, WriterParameters writerParameters)
 	{
-		var destinationJLOXml = JavaObjectsXmlFile.GetJavaObjectsXmlFilePath (destination.ItemSpec);
+		var assembly = pipeline.Resolver.GetAssembly (source.ItemSpec);
 
-		if (!TryScanForJavaObjects (source, destination, runState, writerParameters)) {
-			// Even if we didn't scan for Java objects, we still write an empty .xml file for later steps
-			JavaObjectsXmlFile.WriteEmptyFile (destinationJLOXml, Log);
+		var context = new StepContext (source, destination) {
+			CodeGenerationTarget = codeGenerationTarget,
+			EnableMarshalMethods = EnableMarshalMethods,
+			IsAndroidAssembly = MonoAndroidHelper.IsAndroidAssembly (source),
+			IsDebug = Debug,
+			IsFrameworkAssembly = MonoAndroidHelper.IsFrameworkAssembly (source),
+			IsMainAssembly = Path.GetFileNameWithoutExtension (source.ItemSpec) == TargetName,
+			IsUserAssembly = ResolvedUserAssemblies.Any (a => a.ItemSpec == source.ItemSpec),
+		};
+
+		var changed = pipeline.Run (assembly, context);
+
+		if (changed) {
+			Log.LogDebugMessage ($"Saving modified assembly: {destination.ItemSpec}");
+			Directory.CreateDirectory (Path.GetDirectoryName (destination.ItemSpec));
+			writerParameters.WriteSymbols = assembly.MainModule.HasSymbols;
+			assembly.Write (destination.ItemSpec, writerParameters);
+		} else {
+			// If we didn't write a modified file, copy the original to the destination
+			CopyIfChanged (source, destination);
 		}
 	}
 
-	bool TryScanForJavaObjects (ITaskItem source, ITaskItem destination, RunState runState, WriterParameters writerParameters)
+	void CopyIfChanged (ITaskItem source, ITaskItem destination)
 	{
-		if (!ShouldScanAssembly (source))
-			return false;
+		if (MonoAndroidHelper.CopyAssemblyAndSymbols (source.ItemSpec, destination.ItemSpec)) {
+			Log.LogDebugMessage ($"Copied: {destination.ItemSpec}");
+		} else {
+			Log.LogDebugMessage ($"Skipped unchanged file: {destination.ItemSpec}");
 
-		var destinationJLOXml = JavaObjectsXmlFile.GetJavaObjectsXmlFilePath (destination.ItemSpec);
-		var assemblyDefinition = runState.resolver!.GetAssembly (source.ItemSpec);
-
-		var scanned = runState.findJavaObjectsStep!.ProcessAssembly (assemblyDefinition, destinationJLOXml);
-
-		return scanned;
-	}
-
-	bool ShouldScanAssembly (ITaskItem source)
-	{
-		// Skip this assembly if it is not an Android assembly
-		if (!IsAndroidAssembly (source)) {
-			Log.LogDebugMessage ($"Skipping assembly '{source.ItemSpec}' because it is not an Android assembly");
-			return false;
-		}
-
-		// When marshal methods or non-JavaPeerStyle.XAJavaInterop1 are in use we do not want to skip non-user assemblies (such as Mono.Android) - we need to generate JCWs for them during
-		// application build, unlike in Debug configuration or when marshal methods are disabled, in which case we use JCWs generated during Xamarin.Android
-		// build and stored in a jar file.
-		var useMarshalMethods = !Debug && EnableMarshalMethods;
-		var shouldSkipNonUserAssemblies = !useMarshalMethods && codeGenerationTarget == JavaPeerStyle.XAJavaInterop1;
-
-		if (shouldSkipNonUserAssemblies && !ResolvedUserAssemblies.Any (a => a.ItemSpec == source.ItemSpec)) {
-			Log.LogDebugMessage ($"Skipping assembly '{source.ItemSpec}' because it is not a user assembly and we don't need JLOs from non-user assemblies");
-			return false;
-		}
-
-		return true;
-	}
-
-	bool IsAndroidAssembly (ITaskItem source)
-	{
-		string name = Path.GetFileName (source.ItemSpec);
-
-		if (SpecialAssemblies.Contains (name))
-			return true;
-
-		return MonoAndroidHelper.IsMonoAndroidAssembly (source);
-	}
-
-	AndroidTargetArch GetValidArchitecture (ITaskItem item)
-	{
-		AndroidTargetArch ret = MonoAndroidHelper.GetTargetArch (item);
-		if (ret == AndroidTargetArch.None) {
-			throw new InvalidOperationException ($"Internal error: assembly '{item}' doesn't target any architecture.");
-		}
-
-		return ret;
-	}
-
-	protected sealed class RunState : IDisposable
-	{
-		public DirectoryAssemblyResolver resolver;
-		public FixAbstractMethodsStep? fixAbstractMethodsStep = null;
-		public AddKeepAlivesStep? addKeepAliveStep = null;
-		public FixLegacyResourceDesignerStep? fixLegacyResourceDesignerStep = null;
-		public FindJavaObjectsStep? findJavaObjectsStep = null;
-		bool disposed_value;
-
-		public RunState (DirectoryAssemblyResolver resolver)
-		{
-			this.resolver = resolver;
-		}
-
-		private void Dispose (bool disposing)
-		{
-			if (!disposed_value) {
-				if (disposing) {
-					resolver?.Dispose ();
-					fixAbstractMethodsStep = null;
-					fixLegacyResourceDesignerStep = null;
-					addKeepAliveStep = null;
-					findJavaObjectsStep = null;
-				}
-				disposed_value = true;
-			}
-		}
-
-		public void Dispose ()
-		{
-			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-			Dispose (disposing: true);
-			GC.SuppressFinalize (this);
+			// NOTE: We still need to update the timestamp on this file, or this target would run again
+			File.SetLastWriteTimeUtc (destination.ItemSpec, DateTime.UtcNow);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -1,9 +1,5 @@
 #nullable enable
 using System;
-using System.IO;
-using Microsoft.Android.Build.Tasks;
-using Microsoft.Build.Framework;
-using Mono.Cecil;
 using Mono.Linker.Steps;
 using MonoDroid.Tuner;
 
@@ -15,91 +11,35 @@ namespace Xamarin.Android.Tasks
 	/// </summary>
 	public class LinkAssembliesNoShrink : AssemblyModifierPipeline
 	{
-		// Names of assemblies which don't have Mono.Android.dll references, or are framework assemblies, but which must
 		public override string TaskPrefix => "LNS";
-
-		/// <summary>
-		/// $(TargetName) would be "AndroidApp1" with no extension
-		/// </summary>
-		[Required]
-		public string TargetName { get; set; } = "";
 
 		public bool AddKeepAlives { get; set; }
 
 		public bool UseDesignerAssembly { get; set; }
 
-		protected override void CreateRunState (RunState runState, MSBuildLinkContext context)
+		protected override void BuildPipeline (AssemblyPipeline pipeline, MSBuildLinkContext context)
 		{
-			// Create the additional steps that we want to run since ILLink won't be run
+			// FixAbstractMethodsStep
 			var fixAbstractMethodsStep = new FixAbstractMethodsStep ();
 			fixAbstractMethodsStep.Initialize (context, new EmptyMarkContext ());
-			runState.fixAbstractMethodsStep = fixAbstractMethodsStep;
+			pipeline.Steps.Add (fixAbstractMethodsStep);
 
-			var addKeepAliveStep = new AddKeepAlivesStep ();
-			addKeepAliveStep.Initialize (context);
-			runState.addKeepAliveStep = addKeepAliveStep;
-
-			var fixLegacyResourceDesignerStep = new FixLegacyResourceDesignerStep ();
-			fixLegacyResourceDesignerStep.Initialize (context);
-			runState.fixLegacyResourceDesignerStep = fixLegacyResourceDesignerStep;
-
-			// base must be called to initialize AssemblyModifierPipeline steps
-			base.CreateRunState (runState, context);
-		}
-
-		protected override void RunPipeline (ITaskItem source, ITaskItem destination, RunState runState, WriterParameters writerParameters)
-		{
-			if (!TryModifyAssembly (source, destination, runState, writerParameters)) {
-				// If we didn't write a modified file, copy the original to the destination
-				CopyIfChanged (source, destination);
+			// FixLegacyResourceDesignerStep
+			if (UseDesignerAssembly) {
+				var fixLegacyResourceDesignerStep = new FixLegacyResourceDesignerStep ();
+				fixLegacyResourceDesignerStep.Initialize (context);
+				pipeline.Steps.Add (fixLegacyResourceDesignerStep);
 			}
 
-			// base must be called to run AssemblyModifierPipeline steps
-			base.RunPipeline (source, destination, runState, writerParameters);
-		}
-
-		bool TryModifyAssembly (ITaskItem source, ITaskItem destination, RunState runState, WriterParameters writerParameters)
-		{
-			var assemblyName = Path.GetFileNameWithoutExtension (source.ItemSpec);
-
-			// In .NET 6+, we can skip the main assembly
-			if (!AddKeepAlives && assemblyName == TargetName)
-				return false;
-
-			if (MonoAndroidHelper.IsFrameworkAssembly (source))
-				return false;
-
-			// Only run steps on "MonoAndroid" assemblies
-			if (MonoAndroidHelper.IsMonoAndroidAssembly (source)) {
-				AssemblyDefinition assemblyDefinition = runState.resolver!.GetAssembly (source.ItemSpec);
-
-				bool save = runState.fixAbstractMethodsStep!.FixAbstractMethods (assemblyDefinition);
-				if (UseDesignerAssembly)
-					save |= runState.fixLegacyResourceDesignerStep!.ProcessAssemblyDesigner (assemblyDefinition);
-				if (AddKeepAlives)
-					save |= runState.addKeepAliveStep!.AddKeepAlives (assemblyDefinition);
-				if (save) {
-					Log.LogDebugMessage ($"Saving modified assembly: {destination.ItemSpec}");
-					Directory.CreateDirectory (Path.GetDirectoryName (destination.ItemSpec));
-					writerParameters.WriteSymbols = assemblyDefinition.MainModule.HasSymbols;
-					assemblyDefinition.Write (destination.ItemSpec, writerParameters);
-					return true;
-				}
+			// AddKeepAlivesStep
+			if (AddKeepAlives) {
+				var addKeepAliveStep = new AddKeepAlivesStep ();
+				addKeepAliveStep.Initialize (context);
+				pipeline.Steps.Add (addKeepAliveStep);
 			}
 
-			return false;
-		}
-
-		void CopyIfChanged (ITaskItem source, ITaskItem destination)
-		{
-			if (MonoAndroidHelper.CopyAssemblyAndSymbols (source.ItemSpec, destination.ItemSpec)) {
-				Log.LogDebugMessage ($"Copied: {destination.ItemSpec}");
-			} else {
-				Log.LogDebugMessage ($"Skipped unchanged file: {destination.ItemSpec}");
-
-				// NOTE: We still need to update the timestamp on this file, or this target would run again
-				File.SetLastWriteTimeUtc (destination.ItemSpec, DateTime.UtcNow);
-			}
+			// Ensure the <AssemblyModifierPipeline> task's steps are added
+			base.BuildPipeline (pipeline, context);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyPipeline.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Java.Interop.Tools.Cecil;
+using Java.Interop.Tools.JavaCallableWrappers;
+using Microsoft.Build.Framework;
+using Mono.Cecil;
+
+namespace Xamarin.Android.Tasks;
+
+public class AssemblyPipeline : IDisposable
+{
+	bool disposed_value;
+
+	public List<IAssemblyModifierPipelineStep> Steps { get; } = [];
+	public DirectoryAssemblyResolver Resolver { get; }
+
+	public AssemblyPipeline (DirectoryAssemblyResolver resolver)
+	{
+		Resolver = resolver;
+	}
+
+	public bool Run (AssemblyDefinition assembly, StepContext context)
+	{
+		var changed = false;
+
+		foreach (var step in Steps)
+			changed |= step.ProcessAssembly (assembly, context);
+
+		return changed;
+	}
+
+	protected virtual void Dispose (bool disposing)
+	{
+		if (!disposed_value) {
+			if (disposing) {
+				Resolver?.Dispose ();
+			}
+
+			disposed_value = true;
+		}
+	}
+
+	public void Dispose ()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose (bool disposing)' method
+		Dispose (disposing: true);
+		GC.SuppressFinalize (this);
+	}
+}
+
+public interface IAssemblyModifierPipelineStep
+{
+	bool ProcessAssembly (AssemblyDefinition assembly, StepContext context);
+}
+
+public class StepContext
+{
+	public JavaPeerStyle CodeGenerationTarget { get; set; }
+	public ITaskItem Destination { get; }
+	public bool EnableMarshalMethods { get; set; }
+	public bool IsAndroidAssembly { get; set; }
+	public bool IsDebug { get; set; }
+	public bool IsFrameworkAssembly { get; set; }
+	public bool IsMainAssembly { get; set; }
+	public bool IsUserAssembly { get; set; }
+	public ITaskItem Source { get; }
+
+	public StepContext (ITaskItem source, ITaskItem destination)
+	{
+		Source = source;
+		Destination = destination;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyPipeline.cs
@@ -66,6 +66,8 @@ public class StepContext
 	public bool IsUserAssembly { get; set; }
 	public ITaskItem Source { get; }
 
+	public bool IsAndroidUserAssembly => IsAndroidAssembly && IsUserAssembly;
+
 	public StepContext (ITaskItem source, ITaskItem destination)
 	{
 		Source = source;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Linker.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Android.Tasks
 		static readonly HashSet<string> KnownAssemblyNames = new (StringComparer.OrdinalIgnoreCase) {
 			"Mono.Android",
 			"Mono.Android.Export",
+			"Mono.Android.Runtime",
 			"Java.Interop",
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -278,19 +278,13 @@ namespace Xamarin.Android.Tasks
 		}
 
 #if MSBUILD
-		// Names of assemblies which don't have Mono.Android.dll references, or are framework assemblies, but which
-		// could have Java types.
-		static readonly HashSet<string> SpecialAssemblies = new HashSet<string> (StringComparer.OrdinalIgnoreCase) {
-			"Java.Interop.dll",
-			"Mono.Android.dll",
-			"Mono.Android.Runtime.dll",
-		};
-
 		public static bool IsAndroidAssembly (ITaskItem source)
 		{
-			string name = Path.GetFileName (source.ItemSpec);
+			string name = Path.GetFileNameWithoutExtension (source.ItemSpec);
 
-			if (SpecialAssemblies.Contains (name))
+			// Check for assemblies which may not be built against the Android profile (`netXX-android`)
+			// but could still contain Android binding code (like Mono.Android).
+			if (KnownAssemblyNames.Contains (name))
 				return true;
 
 			return IsMonoAndroidAssembly (source);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -278,6 +278,24 @@ namespace Xamarin.Android.Tasks
 		}
 
 #if MSBUILD
+		// Names of assemblies which don't have Mono.Android.dll references, or are framework assemblies, but which
+		// could have Java types.
+		static readonly HashSet<string> SpecialAssemblies = new HashSet<string> (StringComparer.OrdinalIgnoreCase) {
+			"Java.Interop.dll",
+			"Mono.Android.dll",
+			"Mono.Android.Runtime.dll",
+		};
+
+		public static bool IsAndroidAssembly (ITaskItem source)
+		{
+			string name = Path.GetFileName (source.ItemSpec);
+
+			if (SpecialAssemblies.Contains (name))
+				return true;
+
+			return IsMonoAndroidAssembly (source);
+		}
+
 		public static bool IsMonoAndroidAssembly (ITaskItem assembly)
 		{
 			// NOTE: look for both MonoAndroid and Android
@@ -554,6 +572,18 @@ namespace Xamarin.Android.Tasks
 		}
 
 		public static AndroidTargetArch GetTargetArch (ITaskItem asmItem) => AbiToTargetArch (GetAssemblyAbi (asmItem));
+
+
+		public static AndroidTargetArch GetRequiredValidArchitecture (ITaskItem item)
+		{
+			AndroidTargetArch ret = GetTargetArch (item);
+
+			if (ret == AndroidTargetArch.None) {
+				throw new InvalidOperationException ($"Internal error: assembly '{item}' doesn't target any architecture.");
+			}
+
+			return ret;
+		}
 #endif // MSBUILD
 
 		static string GetToolsRootDirectoryRelativePath (string androidBinUtilsDirectory)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1511,7 +1511,8 @@ because xbuild doesn't support framework reference assemblies.
       ReadSymbols="$(_AndroidLinkAssembliesReadSymbols)"
       ResolvedAssemblies="@(_AllResolvedAssemblies)"
       ResolvedUserAssemblies="@(ResolvedUserAssemblies)"
-      SourceFiles="@(ResolvedAssemblies)">
+      SourceFiles="@(ResolvedAssemblies)"
+      TargetName="$(TargetName)">
   </AssemblyModifierPipeline>
 
   <Touch Files="$(_AdditionalPostLinkerStepsFlag)" AlwaysCreate="true" />


### PR DESCRIPTION
In order to continue moving forward with moving tasks from the `<GenerateJavaStubs>` task to our "additional linker steps", we need a more flexible assembly scanning/modification pipeline.  

Specifically, we will need to run "RewriteMarshalMethods" in the `<AssemblyModifierPipeline>` task so that it happens for both linked and non-linked builds.  However, we want to run it:

- After the `FindJavaObjectsStep` step in the `<AssemblyModifierPipeline>` pipeline.
- In the same loop as the other assembly modification steps in the `<LinkAssembliesNoShrink>` task (which is before `<AssemblyModifierPipeline>` steps run) so that we do not need to write the assemblies twice.

Although we could achieve these goals with enough hacks, instead refactor the steps into a proper, flexible "pipeline".

This pipeline provides the features we need:
- Steps from both tasks can be run in any order
- Steps from both tasks can modify assemblies, and only 1 write call will happen

Additionally, encapsulate the "should this step run on this assembly" logic to each step, so that the pipeline doesn't need to know about each step's requirements.