### PR TITLE
[ci] Fix nightly build symbol artifact upload

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -115,7 +115,7 @@ stages:
           avdAbi: x86_64
           avdType: google_apis
     pool:
-      vmImage: $(HostedMacImage)
+      vmImage: $(HostedMacImageWithEmulator)
     workspace:
       clean: all
     steps:
@@ -186,7 +186,7 @@ stages:
     pool:
       name: $(SharedMacPool)
       demands:
-      - macOS.Name -equals $(SharedMacName)
+      - macOS.Name -equals Sequoia
       - macOS.Architecture -equals x64
     timeoutInMinutes: 120
     workspace:
@@ -239,7 +239,7 @@ stages:
     pool:
       name: $(SharedMacPool)
       demands:
-      - macOS.Name -equals $(SharedMacName)
+      - macOS.Name -equals Sequoia
       - macOS.Architecture -equals x64
     timeoutInMinutes: 150
     workspace:

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -92,7 +92,7 @@ steps:
   - task: PublishPipelineArtifact@1
     displayName: upload symbols nupkgs
     inputs:
-      artifactName: ${{ parameters.nugetArtifactName }}
+      artifactName: ${{ parameters.nugetArtifactName }}-symbols
       targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-unsigned-symbols
 
   - task: PublishPipelineArtifact@1

--- a/build-tools/automation/yaml-templates/start-stop-emulator.yaml
+++ b/build-tools/automation/yaml-templates/start-stop-emulator.yaml
@@ -18,6 +18,7 @@ steps:
       displayName: Start emulator
       continueOnError: ${{ parameters.startContinueOnError }}
       taskTimeoutInMinutes: ${{ parameters.taskTimeoutInMinutes }}
+      xaSourcePath: ${{ parameters.xaSourcePath }}
       project: ${{ parameters.xaSourcePath }}/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj
       ${{ if eq(parameters.specificImage, true) }}:
         arguments: >-
@@ -43,6 +44,7 @@ steps:
       condition: always()
       continueOnError: true
       taskTimeoutInMinutes: ${{ parameters.taskTimeoutInMinutes }}
+      xaSourcePath: ${{ parameters.xaSourcePath }}
       project: ${{ parameters.xaSourcePath }}/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj
       ${{ if eq(parameters.specificImage, true) }}:
         arguments: >-


### PR DESCRIPTION
Commit dc089720 broke the nightly build because the symbol upload step
was not using a unique artifact name.

The nightly hosted test pool has been updated to use x64 images and the
tests that run on the shared pool will now prefer Sequoia images.