### PR TITLE
[build] fix `MAUI Integration` job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -137,8 +137,8 @@ extends:
           parameters:
             xaSourcePath: $(Build.SourcesDirectory)/android
             androidSdkPlatforms: $(DefaultTestSdkPlatforms)
-            dotnetVersion: 9.0
-            dotnetQuality: preview
+            dotnetVersion: $(DotNetPreviewSdkVersion)
+            dotnetQuality: $(DotNetPreviewSdkQuality)
 
         - task: NuGetAuthenticate@1
           displayName: authenticate with azure artifacts
@@ -230,6 +230,7 @@ extends:
           condition: always()
           inputs:
             Contents: |
+              $(Build.SourcesDirectory)/android/bin/*$(XA.Build.Configuration)/*.*log
               $(Build.SourcesDirectory)/maui/artifacts/logs/**
             TargetFolder: $(Build.StagingDirectory)/logs
             flattenFolders: true
@@ -346,11 +347,10 @@ extends:
           clean: true
           submodules: recursive
 
-        - task: UseDotNet@2
-          displayName: Install .NET 10.x
-          inputs:
-            version: 10.x
-            includePreviewVersions: true
+        - template: /build-tools/automation/yaml-templates/use-dot-net.yaml@self
+          parameters:
+            version: $(DotNetPreviewSdkVersion)
+            quality: $(DotNetPreviewSdkQuality)
 
         # Download symbols to be published to the symbols artifact drop declared above
         - task: DownloadPipelineArtifact@2

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -75,6 +75,7 @@ steps:
 - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
   parameters:
     displayName: extract workload packs
+    xaSourcePath: ${{ parameters.xaSourcePath }}
     project: ${{ parameters.xaSourcePath }}/build-tools/create-packs/Microsoft.Android.Sdk.proj
     arguments: -t:ExtractWorkloadPacks -c ${{ parameters.configuration }} -v:n -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/extract-workloads.binlog
 

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -27,6 +27,10 @@ variables:
   value: 9.0
 - name: DotNetSdkQuality
   value: GA
+- name: DotNetPreviewSdkVersion
+  value: 10.0
+- name: DotNetPreviewSdkQuality
+  value: preview
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
@@ -134,7 +134,10 @@ namespace Xamarin.Android.Prepare
 		/// </summary>
 		protected virtual bool InitOS ()
 		{
-			JavaHome = Context.Instance.Properties.GetValue (KnownProperties.JavaSdkDirectory)?.Trim () ?? String.Empty;
+			JavaHome = Environment.GetEnvironmentVariable ("JI_JAVA_HOME") ?? String.Empty;
+			if (string.IsNullOrEmpty (JavaHome)) {
+				JavaHome = Context.Instance.Properties.GetValue (KnownProperties.JavaSdkDirectory)?.Trim () ?? String.Empty;
+			}
 			if (String.IsNullOrEmpty (JavaHome)) {
 				var androidToolchainDirectory = Context.Instance.Properties.GetValue (KnownProperties.AndroidToolchainDirectory)?.Trim () ?? String.Empty;
 				JavaHome = Path.Combine (androidToolchainDirectory, Configurables.Defaults.JdkFolder);


### PR DESCRIPTION
This is a list of things I fixed...

## dotnet/arcade tasks require .NET 10 ##

The `MAUI Integration` job looks to be failing, because we are
building with a .NET 9 SDK:

    C:\Users\cloudtest\.nuget\packages\microsoft.dotnet.arcade.sdk\10.0.0-beta.25212.1\tools\RepositoryValidation.proj(33,5): error MSB4018: The "Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath" task failed unexpectedly.
    System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
    File name: 'System.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
    at Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath.ExecuteImpl()
    at Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath.Execute() in /_/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs:line 32
    at Microsoft.Build.BackEnd.TaskExecutionHost.Execute()
    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(TaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)

Earlier in the log says:

    MSBuild executable path = "C:\Program Files\dotnet\sdk\9.0.202\MSBuild.dll"

Lets try .NET 10 and see if the problem goes away.

The fact we previously had `dotnetQuality: preview` in the yaml:

    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
      parameters:
        xaSourcePath: $(Build.SourcesDirectory)/android
        androidSdkPlatforms: $(DefaultTestSdkPlatforms)
        dotnetVersion: 9.0
        dotnetQuality: preview

This means we were using a preview version of .NET 9 while .NET 9 was
in development. Makes sense to move to .NET 10 now.

## Missing logs ##

When investigating the failures here, I noticed the `Copy logs` step
would say:

    found 0 files

I added an additional path:

    $(Build.SourcesDirectory)/android/bin/*$(XA.Build.Configuration)/*.*log

## Android SDK licenses fail ##

`xaprepare` was failing to accept Android SDK licenses, due to:

    ERROR: JAVA_HOME is set to an invalid directory: C:\Users\cloudtest\android-toolchain\jdk-21
    Please set the JAVA_HOME variable in your environment to match the
    location of your Java installation.

We had code checking `$(JavaSdkDirectory)` which looked to be blank,
then we fall back to:

    var androidToolchainDirectory = Context.Instance.Properties.GetValue (KnownProperties.AndroidToolchainDirectory)?.Trim () ?? String.Empty;
    JavaHome = Path.Combine (androidToolchainDirectory, Configurables.Defaults.JdkFolder);

Earlier in the build, we have a step that sets:

    set JAVA_HOME and JI_JAVA_HOME
    Setting variable 'JI_JAVA_HOME_DEFAULT' to 'C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\17.0.14-7\x64'
    Setting variable 'JAVA_HOME' and 'JI_JAVA_HOME' to 'C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\17.0.14-7\x64'

I updated `OS.cs` to look at `$JI_JAVA_HOME` first, which appears to
use the right path now.

## `dotnet.exe` not found ##

Next we got the error:

    The term 'C:\a_work\1\s\bin\Release\dotnet\dotnet.exe' is not recognized as the name of a cmdlet, function,
script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is
correct and try again.

The path above is missing `s\android\bin\Release\dotnet\dotnet.exe`,
where I noticed we were missing this in one yaml template:

    xaSourcePath: ${{ parameters.xaSourcePath }}