### PR TITLE
[release/9.0.1xx] [build] use `javac -source 17 -target 17` (#9493)

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -135,8 +135,8 @@
     <TestsFlavor>$(_TestsProfiledAotName)$(_TestsAotName)</TestsFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <JavacSourceVersion>1.8</JavacSourceVersion>
-    <JavacTargetVersion>1.8</JavacTargetVersion>
+    <JavacSourceVersion>17</JavacSourceVersion>
+    <JavacTargetVersion>17</JavacTargetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <AndroidNdkFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidNdkDirectory)'))</AndroidNdkFullPath>

--- a/Configuration.props
+++ b/Configuration.props
@@ -135,8 +135,8 @@
     <TestsFlavor>$(_TestsProfiledAotName)$(_TestsAotName)</TestsFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <JavacSourceVersion>17</JavacSourceVersion>
-    <JavacTargetVersion>17</JavacTargetVersion>
+    <JavacSourceVersion>9</JavacSourceVersion>
+    <JavacTargetVersion>9</JavacTargetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <AndroidNdkFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidNdkDirectory)'))</AndroidNdkFullPath>

--- a/build-tools/scripts/Jar.targets
+++ b/build-tools/scripts/Jar.targets
@@ -33,7 +33,7 @@
       <_Jar>"$(JarPath)"</_Jar>
       <_Targets>-source $(JavacSourceVersion) -target $(JavacTargetVersion)</_Targets>
       <_DestDir>$(IntermediateOutputPath)__CreateTestJarFile-bin</_DestDir>
-      <_AndroidJar>-bootclasspath "$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar"</_AndroidJar>
+      <_AndroidJar>-classpath "$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar"</_AndroidJar>
       <_CP>-cp "$(_JavaInteropJarPath)"</_CP>
       <_JavacFilesResponse>$(IntermediateOutputPath)__javac_response.txt</_JavacFilesResponse>
     </PropertyGroup>

--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -37,7 +37,7 @@
       <_MonoAndroidRuntimeJar>$(MicrosoftAndroidSdkOutDir)java_runtime.jar</_MonoAndroidRuntimeJar>
     </PropertyGroup>
     <Exec
-        Command="&quot;$(JavaCPath)&quot; $(_Target) $(_D) -bootclasspath $(_AndroidJar)$(PathSeparator)&quot;$(_MonoAndroidJar)&quot;$(PathSeparator)&quot;$(_MonoAndroidRuntimeJar)&quot; @$(IntermediateOutputPath)jcw/classes.txt"
+        Command="&quot;$(JavaCPath)&quot; $(_Target) $(_D) -classpath $(_AndroidJar)$(PathSeparator)&quot;$(_MonoAndroidJar)&quot;$(PathSeparator)&quot;$(_MonoAndroidRuntimeJar)&quot; @$(IntermediateOutputPath)jcw/classes.txt"
     />
     <Exec
         Condition="Exists('$(_MonoAndroidJar)')"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaSourceUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaSourceUtils.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Android.Tasks
 
 			if (BootClassPath != null && BootClassPath.Any ()) {
 				var classpath = string.Join (Path.PathSeparator.ToString (), BootClassPath.Select (p => Path.GetFullPath (p.ItemSpec)));
-				AppendArg (response, "--bootclasspath");
+				AppendArg (response, "--classpath");
 				AppendArg (response, classpath);
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -53,8 +53,7 @@ namespace Xamarin.Android.Tasks
 			//   Running command: C:\Program Files (x86)\Java\jdk1.6.0_20\bin\javac.exe
 			//     "-J-Dfile.encoding=UTF8"
 			//     "-d" "bin\classes"
-			//     "-classpath" "C:\Users\Jonathan\Documents\Visual Studio 2010\Projects\AndroidMSBuildTest\AndroidMSBuildTest\obj\Debug\android\bin\mono.android.jar"
-			//     "-bootclasspath" "C:\Program Files (x86)\Android\android-sdk-windows\platforms\android-8\android.jar"
+			//     "-classpath" "C:\Users\Jonathan\Documents\Visual Studio 2010\Projects\AndroidMSBuildTest\AndroidMSBuildTest\obj\Debug\android\bin\mono.android.jar";"C:\Program Files (x86)\Android\android-sdk-windows\platforms\android-8\android.jar"
 			//     "-encoding" "UTF-8"
 			//     "@C:\Users\Jonathan\AppData\Local\Temp\tmp79c4ac38.tmp"
 
@@ -87,9 +86,13 @@ namespace Xamarin.Android.Tasks
 
 		protected override void WriteOptionsToResponseFile (StreamWriter sw)
 		{
+			var jars = new List<string> ();
+			if (Jars != null)
+				jars.AddRange (Jars.Select (i => i.ItemSpec.Replace (@"\", @"\\")));
+			jars.Add (JavaPlatformJarPath.Replace (@"\", @"\\"));
+
 			sw.WriteLine ($"-d \"{ClassesOutputDirectory.Replace (@"\", @"\\")}\"");
-			sw.WriteLine ("-classpath \"{0}\"", Jars == null || !Jars.Any () ? null : string.Join (Path.PathSeparator.ToString (), Jars.Select (i => i.ItemSpec.Replace (@"\", @"\\"))));
-			sw.WriteLine ("-bootclasspath \"{0}\"", JavaPlatformJarPath.Replace (@"\", @"\\"));
+			sw.WriteLine ("-classpath \"{0}\"", string.Join (Path.PathSeparator.ToString (), jars));
 			sw.WriteLine ($"-encoding UTF8");
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1593,7 +1593,7 @@ public class ToolbarEx {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed.");
 				var ext = b.IsUnix ? "" : ".exe";
-				var text = $"TestMe.java(1,8): javac{ext} error JAVAC0000:  error: class, interface, or enum expected";
+				var text = $"TestMe.java(1,8): javac{ext} error JAVAC0000:  error: class, interface, enum, or record expected";
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, text), "TestMe.java(1,8) expected");
 				text = $"TestMe2.java(1,41): javac{ext} error JAVAC0000:  error: ';' expected";
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, text), "TestMe2.java(1,41) expected");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1593,7 +1593,7 @@ public class ToolbarEx {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed.");
 				var ext = b.IsUnix ? "" : ".exe";
-				var text = $"TestMe.java(1,8): javac{ext} error JAVAC0000:  error: class, interface, enum, or record expected";
+				var text = $"TestMe.java(1,8): javac{ext} error JAVAC0000:  error: class, interface, or enum expected";
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, text), "TestMe.java(1,8) expected");
 				text = $"TestMe2.java(1,41): javac{ext} error JAVAC0000:  error: ';' expected";
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, text), "TestMe2.java(1,41) expected");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -27,8 +27,8 @@
 		<BundleToolVersion Condition="'$(BundleToolVersion)' == ''">@BUNDLETOOL_VERSION@</BundleToolVersion>
 		<_XamarinAndroidMSBuildDirectory>$(MSBuildThisFileDirectory)</_XamarinAndroidMSBuildDirectory>
 
-		<JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">1.8</JavacSourceVersion>
-		<JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">1.8</JavacTargetVersion>
+		<JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">17</JavacSourceVersion>
+		<JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">17</JavacTargetVersion>
 
 		<!-- Enable nuget package conflict resolution -->
 		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -27,8 +27,8 @@
 		<BundleToolVersion Condition="'$(BundleToolVersion)' == ''">@BUNDLETOOL_VERSION@</BundleToolVersion>
 		<_XamarinAndroidMSBuildDirectory>$(MSBuildThisFileDirectory)</_XamarinAndroidMSBuildDirectory>
 
-		<JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">17</JavacSourceVersion>
-		<JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">17</JavacTargetVersion>
+		<JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">9</JavacSourceVersion>
+		<JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">9</JavacTargetVersion>
 
 		<!-- Enable nuget package conflict resolution -->
 		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>

--- a/src/java-runtime/java-runtime.csproj
+++ b/src/java-runtime/java-runtime.csproj
@@ -3,6 +3,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <!-- r8: Invoke-customs are only supported starting with Android O (-min-api 26) -->
+    <JavacSourceVersion>1.8</JavacSourceVersion>
+    <JavacTargetVersion>1.8</JavacTargetVersion>
   </PropertyGroup>
   
   <Import Project="..\..\Configuration.props" />

--- a/src/java-runtime/java-runtime.targets
+++ b/src/java-runtime/java-runtime.targets
@@ -54,7 +54,7 @@
     <_AndroidJar>"$(AndroidSdkDirectory)\platforms\android-$(AndroidJavaRuntimeApiLevel)\android.jar"</_AndroidJar>
   </PropertyGroup>
   <Exec
-      Command="&quot;$(JavaCPath)&quot; $(_Target) -d %(_RuntimeOutput.IntermediateRuntimeOutputPath) -h %(_RuntimeOutput.IntermediateRuntimeOutputPath) -bootclasspath $(_AndroidJar)$(PathSeparator)&quot;%(_RuntimeOutput.OutputJar)&quot; @%(_RuntimeOutput.IntermediateRuntimeClassesTxt)"
+      Command="&quot;$(JavaCPath)&quot; $(_Target) -d %(_RuntimeOutput.IntermediateRuntimeOutputPath) -h %(_RuntimeOutput.IntermediateRuntimeOutputPath) -classpath $(_AndroidJar)$(PathSeparator)&quot;%(_RuntimeOutput.OutputJar)&quot; @%(_RuntimeOutput.IntermediateRuntimeClassesTxt)"
   />
   <Copy
       SourceFiles="$(IntermediateOutputPath)release/mono_android_Runtime.h"


### PR DESCRIPTION
Backport of: https://github.com/dotnet/android/pull/9493
Fixes: https://github.com/dotnet/android/issues/9925
Context: https://stackoverflow.com/a/76043133

Running `javac` with a newer `-source` and `-target` can run additional optimizations that results in *slightly* smaller Java bytecode and runtime performance.

We should do this for all Java code we build as part of the product, as it might improve install size & build times for tools like `manifestmerger.jar` and `r8.jar`.

After this change, I got the error:

    error: option -bootclasspath not allowed with target 17

Which is fixed by using `-classpath` instead.