### PR TITLE
[java-runtime] fix `Invoke-customs` warning

### DIFF
--- a/src/java-runtime/java-runtime.targets
+++ b/src/java-runtime/java-runtime.targets
@@ -88,12 +88,12 @@
       Command="&quot;$(JarPath)&quot; cf &quot;%(_RuntimeOutput.OutputJar)&quot; -C &quot;%(_RuntimeOutput.IntermediateRuntimeOutputPath)&quot; ."
   />
 </Target>
-<Target Name="_GenerateRuntimeDex16"
+<Target Name="_GenerateRuntimeDex"
     AfterTargets="Build"
-    Inputs="@(_RuntimeOutput->'%(Identity)')"
+    Inputs="@(_RuntimeOutput->'%(Identity)');$(MSBuildThisFileFullPath)"
     Outputs="@(_RuntimeOutput->'%(OutputDex)')">
   <Exec
-      Command="&quot;$(JavaPath)&quot; -classpath &quot;$(OutputPath)r8.jar&quot; com.android.tools.r8.D8 --release --no-desugaring --output &quot;%(_RuntimeOutput.IntermediateRuntimeOutputPath)&quot; &quot;%(_RuntimeOutput.OutputJar)&quot;"
+      Command="&quot;$(JavaPath)&quot; -classpath &quot;$(OutputPath)r8.jar&quot; com.android.tools.r8.D8 --release --min-api $(AndroidMinimumDotNetApiLevel) --lib &quot;$(_AndroidJar)&quot; --output &quot;%(_RuntimeOutput.IntermediateRuntimeOutputPath)&quot; &quot;%(_RuntimeOutput.OutputJar)&quot;"
       EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
   />
   <Move


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9922

The `r8.jar` command in the `_GenerateRuntimeDex16` MSBuild target (`java-runtime.targets`) produces warnings such as:

    "/Users/builder/android-toolchain/jdk-21/bin/java" -classpath "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/r8.jar" com.android.tools.r8.D8 --release --no-desugaring --output "obj/Release/release" "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime.jar"
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime.jar:mono/MonoPackageManager.class at Lmono/MonoPackageManager;LoadApplication(Landroid/content/Context;)V:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev.jar:mono/android/incrementaldeployment/IncrementalClassLoader.class at Lmono/android/incrementaldeployment/IncrementalClassLoader;createDelegateClassLoader(Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/ClassLoader;)Lmono/android/incrementaldeployment/IncrementalClassLoader$DelegateClassLoader;:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    "/Users/builder/android-toolchain/jdk-21/bin/java" -classpath "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/r8.jar" com.android.tools.r8.D8 --release --no-desugaring --output "obj/Release/release-net6" "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_net6.jar"
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_net6.jar:mono/MonoPackageManager.class at Lmono/MonoPackageManager;LoadApplication(Landroid/content/Context;)V:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_net6.jar:mono/MonoPackageManager.class at Lmono/MonoPackageManager;getNativeLibraryPath(Landroid/content/pm/ApplicationInfo;)Ljava/lang/String;:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_net6.jar:mono/android/incrementaldeployment/IncrementalClassLoader.class at Lmono/android/incrementaldeployment/IncrementalClassLoader;createDelegateClassLoader(Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/ClassLoader;)Lmono/android/incrementaldeployment/IncrementalClassLoader$DelegateClassLoader;:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    "/Users/builder/android-toolchain/jdk-21/bin/java" -classpath "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/r8.jar" com.android.tools.r8.D8 --release --no-desugaring --output "obj/Release/fastdev-net6" "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_net6.jar"
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_net6.jar:mono/android/MultiDexLoader.class at Lmono/android/MultiDexLoader;getDexList(Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_net6.jar:mono/MonoPackageManager.class at Lmono/MonoPackageManager;LoadApplication(Landroid/content/Context;)V:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_net6.jar:mono/android/MultiDexLoader.class at Lmono/android/MultiDexLoader;attachInfo(Landroid/content/Context;Landroid/content/pm/ProviderInfo;)V:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_net6.jar:mono/MonoPackageManager.class at Lmono/MonoPackageManager;getNativeLibraryPath(Landroid/content/pm/ApplicationInfo;)Ljava/lang/String;:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_net6.jar:mono/android/incrementaldeployment/IncrementalClassLoader.class at Lmono/android/incrementaldeployment/IncrementalClassLoader;createDelegateClassLoader(Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/ClassLoader;)Lmono/android/incrementaldeployment/IncrementalClassLoader$DelegateClassLoader;:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    "/Users/builder/android-toolchain/jdk-21/bin/java" -classpath "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/r8.jar" com.android.tools.r8.D8 --release --no-desugaring --output "obj/Release/release-clr" "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_clr.jar"
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_clr.jar:mono/MonoPackageManager.class at Lmono/MonoPackageManager;LoadApplication(Landroid/content/Context;)V:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_clr.jar:mono/android/incrementaldeployment/IncrementalClassLoader.class at Lmono/android/incrementaldeployment/IncrementalClassLoader;createDelegateClassLoader(Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/ClassLoader;)Lmono/android/incrementaldeployment/IncrementalClassLoader$DelegateClassLoader;:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    "/Users/builder/android-toolchain/jdk-21/bin/java" -classpath "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/r8.jar" com.android.tools.r8.D8 --release --no-desugaring --output "obj/Release/fastdev-clr" "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_clr.jar"
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_clr.jar:mono/android/MultiDexLoader.class at Lmono/android/MultiDexLoader;getDexList(Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_clr.jar:mono/MonoPackageManager.class at Lmono/MonoPackageManager;LoadApplication(Landroid/content/Context;)V:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_clr.jar:mono/android/MultiDexLoader.class at Lmono/android/MultiDexLoader;attachInfo(Landroid/content/Context;Landroid/content/pm/ProviderInfo;)V:
    Invoke-customs are only supported starting with Android O (--min-api 26)
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime_fastdev_clr.jar:mono/android/incrementaldeployment/IncrementalClassLoader.class at Lmono/android/incrementaldeployment/IncrementalClassLoader;createDelegateClassLoader(Ljava/io/File;Ljava/lang/String;Ljava/util/List;Ljava/lang/ClassLoader;)Lmono/android/incrementaldeployment/IncrementalClassLoader$DelegateClassLoader;:
    Invoke-customs are only supported starting with Android O (--min-api 26)

Reviewing the command, I see the following issues:

* `--min-api` is omitted, so it would default to API 1
* We are passing `--no-desugaring`, which leaves all Java features as-is.
* We don't pass the path to `android.jar`.

After fixing all of these, I see now warnings from `r8.jar` anymore and no log messages are shown:

    Exec
        Assembly = D:\src\xamarin-android\bin\Release\dotnet\sdk\10.0.100-preview.4.25180.3\Microsoft.Build.Tasks.Core.dll
        Parameters
            EnvironmentVariables = JAVA_HOME=D:\android-toolchain\jdk-21
            Command = "D:\android-toolchain\jdk-21\bin\java.exe" -classpath "D:\src\xamarin-android\bin\Debug\lib\packs\Microsoft.Android.Sdk.Windows\36.0.0\tools\r8.jar" com.android.tools.r8.D8 --release --min-api 21 --lib ""D:\android-toolchain\sdk\platforms\android-36\android.jar"" --output "obj\Debug\release" "D:\src\xamarin-android\bin\Debug\lib\packs\Microsoft.Android.Sdk.Windows\36.0.0\tools\java_runtime.jar"
        Environment Variables passed to tool:
        JAVA_HOME=D:\android-toolchain\jdk-21
        CommandLineArguments = "D:\android-toolchain\jdk-21\bin\java.exe" -classpath "D:\src\xamarin-android\bin\Debug\lib\packs\Microsoft.Android.Sdk.Windows\36.0.0\tools\r8.jar" com.android.tools.r8.D8 --release --min-api 21 --lib ""D:\android-toolchain\sdk\platforms\android-36\android.jar"" --output "obj\Debug\release" "D:\src\xamarin-android\bin\Debug\lib\packs\Microsoft.Android.Sdk.Windows\36.0.0\tools\java_runtime.jar"

I didn't see why `--no-desugaring` was initially passed:

* https://github.com/dotnet/android/commit/4742d50d61000997b29512a63a37a91d90d16726

I also removed the `16` in the target name, as it likely refers to API-16, which is not a number we should be tracking any longer. API-21 is our minimum.