### PR TITLE
[build] install .NET 10.x for BAR manifest

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -347,9 +347,9 @@ extends:
           submodules: recursive
 
         - task: UseDotNet@2
-          displayName: Install .NET 9.x
+          displayName: Install .NET 10.x
           inputs:
-            version: 9.x
+            version: 10.x
             includePreviewVersions: true
 
         # Download symbols to be published to the symbols artifact drop declared above


### PR DESCRIPTION
The `Publish symbols and Push to Maestro` job and `generate and publish BAR manifest` step fail with:

    C:\hostedtoolcache\windows\dotnet\sdk\9.0.203\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(166,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 10.0.  Either target .NET 9.0 or lower, or use a version of the .NET SDK that supports .NET 10.0. Download the .NET SDK from https://aka.ms/dotnet/download [D:\a\_work\1\s\build-tools\create-packs\Microsoft.Android.Sdk.proj]
        0 Warning(s)
        1 Error(s)

It looks like we were using .NET 9 previews in the past:

```yaml
- task: UseDotNet@2
  displayName: Install .NET 9.x
  inputs:
    version: 9.x
    includePreviewVersions: true
```

So, we can use .NET 10 previews for this during .NET 10 development.