### PR TITLE
[build] pin to System.IO.Hashing 9.0.4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>9.0.201</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.25125.1</MicrosoftDotNetCecilPackageVersion>
-    <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
+    <SystemIOHashingPackageVersion>9.0.4</SystemIOHashingPackageVersion>
     <!-- Previous .NET Android version -->
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.61</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/10042

.NET 10's `System.IO.Hashing.dll` fails to load on .NET framework MSBuild with:

    System.IO.FileNotFoundException: Could not load file or assembly 'System.Memory, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified.
    File name: 'System.Memory, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'
    at Xamarin.Android.Tasks.MonoAndroidHelper.GetXxHash(Byte[] stringBytes, Boolean is64Bit)
    at Xamarin.Android.Tasks.ApplicationConfigNativeAssemblyGenerator.HashAndSortDSOCache(LlvmIrVariable variable, LlvmIrModuleTarget target, Object state) in /Users/runner/work/1/s/android/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs:line 339
    at Xamarin.Android.Tasks.LLVMIR.LlvmIrGenerator.WriteGlobalVariables(GeneratorWriteContext context) in /Users/runner/work/1/s/android/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs:line 255
    at Xamarin.Android.Tasks.LLVMIR.LlvmIrGenerator.Generate(TextWriter writer, LlvmIrModule module) in /Users/runner/work/1/s/android/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs:line 176
    at Xamarin.Android.Tasks.LLVMIR.LlvmIrComposer.Generate(LlvmIrModule module, AndroidTargetArch arch, StreamWriter output, String fileName) in /Users/runner/work/1/s/android/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs:line 42
    at Xamarin.Android.Tasks.GeneratePackageManagerJava.AddEnvironment() in /Users/runner/work/1/s/android/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs:line 390
    at Xamarin.Android.Tasks.GeneratePackageManagerJava.RunTask() in /Users/runner/work/1/s/android/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs:line 136
    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 25
    WRN: Assembly binding logging is turned OFF.
    To enable assembly bind failure logging, set the registry value [HKLM\Software\Microsoft\Fusion!EnableLog] (DWORD) to 1.
    Note: There is some performance penalty associated with assembly bind failure logging.
    To turn this feature off, remove the registry value [HKLM\Software\Microsoft\Fusion!EnableLog].

The `MSBuild.exe.config` file in VS 17.14 Preview 2 has:

    <dependentAssembly>
      <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
      <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
    </dependentAssembly>

If we use the stable `System.IO.Hashing.dll`:

https://www.nuget.org/packages/System.IO.Hashing/9.0.4

It depends on:

https://www.nuget.org/packages/System.Memory/4.5.5

Which has a version of:

    // D:\Downloads\system.memory.4.5.5\lib\net461\System.Memory.dll
    // System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51