### PR TITLE
[xaprepare] Fix warnings produced by building and running.

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Android.Prepare
 			Log.StatusLine ("Downloading dotnet-install script...");
 
 			if (useCachedInstallScript && File.Exists (dotnetScriptPath)) {
-				Log.WarningLine ($"Using cached installation script found in '{dotnetScriptPath}'");
+				Log.StatusLine ($"Using cached installation script found in '{dotnetScriptPath}'");
 				return true;
 			}
 			Utilities.DeleteFile (dotnetScriptPath);
@@ -102,7 +102,7 @@ namespace Xamarin.Android.Prepare
 
 			if (File.Exists (dotnetScriptPath)) {
 				Log.WarningLine ($"Download of dotnet-install from '{dotnetScriptUrl}' failed");
-				Log.WarningLine ($"Using cached installation script found in '{dotnetScriptPath}'");
+				Log.StatusLine ($"Using cached installation script found in '{dotnetScriptPath}'");
 				return true;
 			} else {
 				Log.ErrorLine ($"Download of dotnet-install from '{dotnetScriptUrl}' failed");

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -48,10 +48,7 @@
     <PackageReference Include="Kajabity.Tools.Java" Version="0.2.6862.30334" />
     <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
 
   <Import Project="xaprepare.targets" Condition=" $(MSBuildToolsPath.IndexOf('omnisharp')) &lt; 0 " />


### PR DESCRIPTION
Fix warnings produced by building and running `xaprepare`:

```
warning NU1510: PackageReference System.Net.Http will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
warning NU1510: PackageReference System.Private.Uri will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
warning NU1510: PackageReference System.Text.Encoding.CodePages will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.

EXEC : warning : Using cached installation script found in 'C:\Users\user\android-archives\dotnet-install.ps1'
```

- Remove referenced packages, these were likely required when `xaprepare` was multi-targeting with `net472`
- Convert cached script warning to a debug message, as this is expected behavior