### PR TITLE
[build] default `$(JavacSource/TargetVersion)` to 1.8 for Android code

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -132,6 +132,7 @@
     <TestsFlavor>$(_TestsProfiledAotName)$(_TestsAotName)</TestsFlavor>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Default to Java 17 for desktop, projects targeting Android should use 1.8 -->
     <JavacSourceVersion>17</JavacSourceVersion>
     <JavacTargetVersion>17</JavacTargetVersion>
   </PropertyGroup>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -162,10 +162,6 @@
       <DefineConstants>$(DefineConstants);$([System.String]::Copy('$(_GeneratedDefineConstants)').Replace ('%24(DefineConstants);', ''))</DefineConstants>
     </PropertyGroup>
   </Target>
-  <PropertyGroup>
-    <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' And '$(AndroidApiLevel)' != '' And $(AndroidApiLevel) &gt; 23 ">1.8</JavacSourceVersion>
-    <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">1.6</JavacSourceVersion>
-  </PropertyGroup>
   <ItemGroup>
     <JavaCallableWrapperSource Include="java\**\*.java" />
   </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -70,6 +70,10 @@ namespace Xamarin.Android.Tasks
 			} else {
 				cmd.AppendSwitchIfNotNull ("-target ", JavacTargetVersion);
 				cmd.AppendSwitchIfNotNull ("-source ", JavacSourceVersion);
+				// Ignore warning when targeting older Java versions
+				// JAVAC : warning : [options] source value 8 is obsolete and will be removed in a future release
+				// JAVAC : warning : [options] target value 8 is obsolete and will be removed in a future release
+				cmd.AppendSwitchIfNotNull ("-Xlint:", "-options");
 			}
 
 			return cmd.ToString ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1604,7 +1604,7 @@ public class ToolbarEx {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed.");
 				var ext = b.IsUnix ? "" : ".exe";
-				var text = $"TestMe.java(1,8): javac{ext} error JAVAC0000:  error: class, interface, enum, or record expected";
+				var text = $"TestMe.java(1,8): javac{ext} error JAVAC0000:  error: class, interface, or enum expected";
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, text), "TestMe.java(1,8) expected");
 				text = $"TestMe2.java(1,41): javac{ext} error JAVAC0000:  error: ';' expected";
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, text), "TestMe2.java(1,41) expected");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -26,8 +26,10 @@
 		<BundleToolVersion Condition="'$(BundleToolVersion)' == ''">@BUNDLETOOL_VERSION@</BundleToolVersion>
 		<_XamarinAndroidMSBuildDirectory>$(MSBuildThisFileDirectory)</_XamarinAndroidMSBuildDirectory>
 
-		<JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">17</JavacSourceVersion>
-		<JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">17</JavacTargetVersion>
+		<!-- NOTE: Compile Java code for Android against 1.8 -->
+		<!-- Invoke-customs are only supported starting with Android O (-min-api 26) -->
+		<JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">1.8</JavacSourceVersion>
+		<JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">1.8</JavacTargetVersion>
 
 		<!-- Enable nuget package conflict resolution -->
 		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>

--- a/src/java-runtime/java-runtime.csproj
+++ b/src/java-runtime/java-runtime.csproj
@@ -3,6 +3,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <!-- NOTE: Compile Java code for Android against 1.8 -->
+    <!-- Invoke-customs are only supported starting with Android O (-min-api 26) -->
+    <JavacSourceVersion>1.8</JavacSourceVersion>
+    <JavacTargetVersion>1.8</JavacTargetVersion>
   </PropertyGroup>
   
   <Import Project="..\..\Configuration.props" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9922
Fixes: https://github.com/dotnet/android/issues/9925

In 165cef7d, we started compiling with Java 17 by default. This causes warnings in #9922 such as:

    "/Users/builder/android-toolchain/jdk-21/bin/java" -classpath "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/r8.jar" com.android.tools.r8.D8 --release --no-desugaring --output "obj/Release/release" "/Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime.jar"
    Warning in /Users/builder/azdo/_work/11/s/xamarin-android/bin/Release/lib/packs/Microsoft.Android.Sdk.Darwin/35.99.0/tools/java_runtime.jar:mono/MonoPackageManager.class at Lmono/MonoPackageManager;LoadApplication(Landroid/content/Context;)V:
    Invoke-customs are only supported starting with Android O (--min-api 26)

This also happens if we go back to Java 9.

We can get rid of the warning by desugaring the code to API 21:

* https://github.com/dotnet/android/pull/10039

However, we think desugaring in itself could break something (especially for servicing).

For now, we think the safest option is:

* Target 1.8 for Java code targeting Android.

* Desktop Java projects can still target 17.

With these changes, tests like `BuildHasNoWarnings()` fail due to build warnings.

Next:

* When using the `-source` and `-target` switches in the `<Javac/>` MSBuild task, we can pass `-Xlint:-options` to `javac` to prevent warnings about these switches being deprecated.

This change is suitable for servicing in .NET 9 and the `BuildHasNoWarnings()` test now passes.