### PR TITLE
Fix NRT warnings in `assembly-store-reader-mk2` and `decompress-assemblies` tools.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,8 +64,6 @@
       
       This can be opted into locally with $(_AndroidTreatWarningsAsErrors) = true.
     -->
-    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'assembly-store-reader.csproj' ">true</_AllowProjectWarnings>
-    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'decompress-assemblies.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'jnienv-gen.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Microsoft.Android.Sdk.ILLink.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Microsoft.Android.Templates.csproj' ">true</_AllowProjectWarnings>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNativeFilesForArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNativeFilesForArchive.cs
@@ -219,7 +219,7 @@ public class CollectNativeFilesForArchive : AndroidTask
 		}
 
 		foreach (string abi in supportedAbis) {
-			string clangAbi = MonoAndroidHelper.MapAndroidAbiToClang (abi);
+			string? clangAbi = MonoAndroidHelper.MapAndroidAbiToClang (abi);
 			if (string.IsNullOrEmpty (clangAbi)) {
 				LogSanitizerError ($"Unable to map Android ABI {abi} to clang ABI");
 				return;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Basic.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Basic.cs
@@ -95,7 +95,7 @@ partial class MonoAndroidHelper
 
 	public static string AbiToRid (string abi)
 	{
-		if (!AbiToRidMap.TryGetValue (abi, out string rid)) {
+		if (!AbiToRidMap.TryGetValue (abi, out string? rid)) {
 			throw new NotSupportedException ($"Internal error: unsupported ABI '{abi}'");
 		};
 
@@ -104,7 +104,7 @@ partial class MonoAndroidHelper
 
 	public static string RidToAbi (string rid)
 	{
-		if (!RidToAbiMap.TryGetValue (rid, out string abi)) {
+		if (!RidToAbiMap.TryGetValue (rid, out string? abi)) {
 			throw new NotSupportedException ($"Internal error: unsupported Runtime Identifier '{rid}'");
 		};
 
@@ -132,7 +132,7 @@ partial class MonoAndroidHelper
 
 	public static string ArchToRid (AndroidTargetArch arch)
 	{
-		if (!ArchToRidMap.TryGetValue (arch, out string rid)) {
+		if (!ArchToRidMap.TryGetValue (arch, out string? rid)) {
 			throw new InvalidOperationException ($"Internal error: unsupported architecture '{arch}'");
 		};
 
@@ -141,7 +141,7 @@ partial class MonoAndroidHelper
 
 	public static string ArchToAbi (AndroidTargetArch arch)
 	{
-		if (!ArchToAbiMap.TryGetValue (arch, out string abi)) {
+		if (!ArchToAbiMap.TryGetValue (arch, out string? abi)) {
 			throw new InvalidOperationException ($"Internal error: unsupported architecture '{arch}'");
 		};
 
@@ -160,9 +160,9 @@ partial class MonoAndroidHelper
 		return Convert.ToString (obj, CultureInfo.InvariantCulture);
 	}
 
-	public static string MapAndroidAbiToClang (string androidAbi)
+	public static string? MapAndroidAbiToClang (string androidAbi)
 	{
-		if (ClangAbiMap.TryGetValue (androidAbi, out string clangAbi)) {
+		if (ClangAbiMap.TryGetValue (androidAbi, out string? clangAbi)) {
 			return clangAbi;
 		}
 		return null;

--- a/tools/assembly-store-reader-mk2/AssemblyStore/AssemblyStoreExplorer.cs
+++ b/tools/assembly-store-reader-mk2/AssemblyStore/AssemblyStoreExplorer.cs
@@ -36,7 +36,7 @@ class AssemblyStoreExplorer
 		Is64Bit = reader.Is64Bit;
 
 		var dict = new Dictionary<string, AssemblyStoreItem> (StringComparer.Ordinal);
-		foreach (AssemblyStoreItem item in Assemblies) {
+		foreach (AssemblyStoreItem item in Assemblies ?? []) {
 			dict.Add (item.Name, item);
 		}
 		AssembliesByName = dict.AsReadOnly ();

--- a/tools/decompress-assemblies/main.cs
+++ b/tools/decompress-assemblies/main.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Android.Tools.DecompressAssemblies
 						Console.Error.WriteLine ($"  Failed to decompress LZ4 data of {fileName} (decoded: {decoded})");
 						retVal = false;
 					} else {
-						string outputDir = Path.GetDirectoryName (outputFile);
+						string? outputDir = Path.GetDirectoryName (outputFile);
 						if (!String.IsNullOrEmpty (outputDir)) {
 							Directory.CreateDirectory (outputDir);
 						}


### PR DESCRIPTION
Fix all NRT warnings in `assembly-store-reader-mk2` and `decompress-assemblies` tools and removes them from the "allow warnings" allow-list in the `Directory.Build.props` file.