### PR TITLE
[release/9.0.1xx][Mono.Android] Set API level properties when generating API Docs

### DIFF
--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -145,7 +145,7 @@ extends:
 
         - script: >-
             make update-api-docs CONFIGURATION=$(XA.Build.Configuration)
-            MSBUILD_ARGS='$(DocsApiLevelArg) $(DocsPlatformIdArg) $(DocsFxVersionArg) $(MdocPackageVersionArg) $(AndroidJavadocVerbosity)'
+            MSBUILD_ARGS='$(DocsApiLevelArg) $(DocsPlatformIdArg) $(DocsFxVersionArg) $(MdocPackageVersionArg) $(AndroidJavadocVerbosity) -p:DisableApiCompatibilityCheck=true'
           workingDirectory: $(Build.SourcesDirectory)
           displayName: make update-api-docs
 

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -145,7 +145,7 @@ extends:
 
         - script: >-
             make update-api-docs CONFIGURATION=$(XA.Build.Configuration)
-            MSBUILD_ARGS='$(DocsApiLevelArg) $(DocsPlatformIdArg) $(DocsFxVersionArg) $(MdocPackageVersionArg) $(AndroidJavadocVerbosity) -p:DisableApiCompatibilityCheck=true'
+            MSBUILD_ARGS='$(DocsApiLevelArg) $(DocsPlatformIdArg) $(DocsFxVersionArg) $(MdocPackageVersionArg) $(AndroidJavadocVerbosity)'
           workingDirectory: $(Build.SourcesDirectory)
           displayName: make update-api-docs
 

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -262,7 +262,6 @@
     <RemoveDir Directories="$(BaseIntermediateOutputPath)" />
     <ItemGroup>
       <_BuildProps Include="-p:TargetFramework=$(DotNetTargetFramework)" />
-      <_BuildProps Include="-p:DisableApiCompatibilityCheck=True" />
       <_BuildProps Include="-p:IncludeAndroidJavadoc=True" />
       <_BuildProps Include="-p:AndroidApiLevel=$(DocsApiLevel)" />
       <_BuildProps Include="-p:AndroidPlatformId=$(DocsPlatformId)" />

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -262,6 +262,7 @@
     <RemoveDir Directories="$(BaseIntermediateOutputPath)" />
     <ItemGroup>
       <_BuildProps Include="-p:TargetFramework=$(DotNetTargetFramework)" />
+      <_BuildProps Include="-p:DisableApiCompatibilityCheck=True" />
       <_BuildProps Include="-p:IncludeAndroidJavadoc=True" />
       <_BuildProps Include="-p:AndroidApiLevel=$(DocsApiLevel)" />
       <_BuildProps Include="-p:AndroidPlatformId=$(DocsPlatformId)" />

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -254,7 +254,7 @@
   <!-- Generate documentation using MDoc -->
   <Target Name="UpdateExternalDocumentation">
     <MSBuild Projects="$(MSBuildThisFileDirectory)Mono.Android.csproj"
-        Properties="TargetFramework=$(DotNetTargetFramework);DocsExportOutput=$(BaseIntermediateOutputPath)Mono.Android.temp.xml"
+        Properties="TargetFramework=$(DotNetTargetFramework);AndroidApiLevel=$(DocsApiLevel);AndroidPlatformId=$(DocsPlatformId);DocsExportOutput=$(BaseIntermediateOutputPath)Mono.Android.temp.xml"
         Targets="_UpdateExternalDocumentation;_RunMdoc;_ExportMsxDoc;_GenerateApiDocsDiff"
     />
   </Target>
@@ -277,6 +277,7 @@
   <!-- `mdoc fx-bootstrap` and `mdoc update` require the .NET framework version of mdoc, a mono install will be needed to run the RunMdoc target on macOS/Linux -->
   <Target Name="RunMdoc">
     <MSBuild Projects="$(MSBuildThisFileDirectory)Mono.Android.csproj"
+        Properties="AndroidApiLevel=$(DocsApiLevel);AndroidPlatformId=$(DocsPlatformId)"
         Targets="_RunMdoc"
     />
   </Target>


### PR DESCRIPTION
Commit 3a3beeb6 allows Mono.Android to be built for both API 35 and 36,
while still marking API 36 as "unstable". The API docs update targets
should explicitly pass the API level we want to build for to account for
this and to allow us to generate docs for API level 36.

The docs build also doesn't need to run the ApiCompat targets.