### PR TITLE
[ci] Use Sequoia images for all shared mac jobs

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -186,7 +186,7 @@ stages:
     pool:
       name: $(SharedMacPool)
       demands:
-      - macOS.Name -equals Sequoia
+      - macOS.Name -equals $(SharedMacName)
       - macOS.Architecture -equals x64
     timeoutInMinutes: 120
     workspace:
@@ -239,7 +239,7 @@ stages:
     pool:
       name: $(SharedMacPool)
       demands:
-      - macOS.Name -equals Sequoia
+      - macOS.Name -equals $(SharedMacName)
       - macOS.Architecture -equals x64
     timeoutInMinutes: 150
     workspace:

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -40,7 +40,7 @@ variables:
 - name: SharedMacPool
   value: VSEng-VSMac-Xamarin-Shared
 - name: SharedMacName
-  value: Sonoma
+  value: Sequoia
 - name: SharedMacArch
   value: arm64
 - name: HostedWinImage


### PR DESCRIPTION
Jobs running on the shared macOS pool will now use the latest Sequoia
images which should hopefully bring better performance and reliability.