### PR TITLE
[dependabot] allow mono/debugger-libs to update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "external/constexpr-xxh3"
-      - dependency-name: "external/debugger-libs"
       - dependency-name: "external/lz4"
       - dependency-name: "external/robin-map"
       - dependency-name: "external/xxHash"


### PR DESCRIPTION
Our build has the `NU1510` warnings like:

    external\debugger-libs\Mono.Debugging\Mono.Debugging.csproj warning NU1510: PackageReference System.Buffers will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    external\debugger-libs\Mono.Debugging\Mono.Debugging.csproj warning NU1510: PackageReference System.Collections.Immutable will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    external\debugger-libs\Mono.Debugger.Soft\Mono.Debugger.Soft.csproj warning NU1510: PackageReference System.Runtime will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    external\debugger-libs\Mono.Debugger.Soft\Mono.Debugger.Soft.csproj warning NU1510: PackageReference System.Reflection.Metadata will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.

This is fixed in:

* https://github.com/mono/debugger-libs/commit/c0353072de4a6cd4813964a0536c48df3e9ceb4e

Let's allow dependabot to update debugger-libs, so we can get fixes like this in the future.