### PR TITLE
[XABT] GeneratePackageManagerJava - Convert `NativeCodeGenState` to Cecil-less DTOs.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Android.Tasks
 	public class GenerateJavaStubs : AndroidTask
 	{
 		public const string NativeCodeGenStateRegisterTaskKey = ".:!MarshalMethods!:.";
+		public const string NativeCodeGenStateObjectRegisterTaskKey = ".:!MarshalMethodsObject!:.";
 
 		public override string TaskPrefix => "GJS";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMainAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMainAndroidManifest.cs
@@ -56,8 +56,8 @@ public class GenerateMainAndroidManifest : AndroidTask
 
 	public override bool RunTask ()
 	{
-		// Retrieve the stored NativeCodeGenState
-		var nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>> (
+		// Retrieve the stored NativeCodeGenState (and remove it from the cache)
+		var nativeCodeGenStates = BuildEngine4.UnregisterTaskObjectAssemblyLocal<ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>> (
 			MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory),
 			RegisteredTaskObjectLifetime.Build
 		);
@@ -74,14 +74,21 @@ public class GenerateMainAndroidManifest : AndroidTask
 		var additionalProviders = MergeManifest (templateCodeGenState, GenerateJavaStubs.MaybeGetArchAssemblies (userAssembliesPerArch, templateCodeGenState.TargetArch));
 		GenerateAdditionalProviderSources (templateCodeGenState, additionalProviders);
 
-		// Marshal methods needs this data in the <GeneratePackageManagerJava/> later,
-		// but if we're not using marshal methods we need to dispose of the resolver.
-		if (!UseMarshalMethods) {
-			Log.LogDebugMessage ($"Disposing all {nameof (NativeCodeGenState)}.{nameof (NativeCodeGenState.Resolver)}");
 
-			foreach (var state in nativeCodeGenStates.Values) {
-				state.Resolver.Dispose ();
-			}
+		// If we still need the NativeCodeGenState in <GeneratePackageManagerJava/> because we're using marshal methods,
+		// we're going to transfer it to a new object that doesn't require holding open Cecil AssemblyDefinitions.
+		if (UseMarshalMethods) {
+			var nativeCodeGenStateObject = MarshalMethodCecilAdapter.GetNativeCodeGenStateCollection (Log, nativeCodeGenStates);
+
+			Log.LogDebugMessage ($"Saving {nameof (NativeCodeGenStateObject)} to {nameof (GenerateJavaStubs.NativeCodeGenStateObjectRegisterTaskKey)}");
+			BuildEngine4.RegisterTaskObjectAssemblyLocal (MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateObjectRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory), nativeCodeGenStateObject, RegisteredTaskObjectLifetime.Build);
+		}
+
+		// Dispose the Cecil resolvers so the assemblies are closed.
+		Log.LogDebugMessage ($"Disposing all {nameof (NativeCodeGenState)}.{nameof (NativeCodeGenState.Resolver)}");
+
+		foreach (var state in nativeCodeGenStates.Values) {
+			state.Resolver.Dispose ();
 		}
 
 		if (Log.HasLoggedErrors) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -314,10 +314,11 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>? nativeCodeGenStates = null;
+			NativeCodeGenStateCollection? nativeCodeGenStates = null;
+
 			if (enableMarshalMethods) {
-				nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>> (
-					MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory),
+				nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<NativeCodeGenStateCollection> (
+					MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateObjectRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory),
 					RegisteredTaskObjectLifetime.Build
 				);
 			}
@@ -423,17 +424,9 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			if (nativeCodeGenStates is not null) {
-				// Dispose all XAAssemblyResolvers
-				Log.LogDebugMessage ($"Disposing all {nameof (NativeCodeGenState)}.{nameof (NativeCodeGenState.Resolver)}");
-				foreach	(var state in nativeCodeGenStates.Values) {
-					state.Resolver.Dispose ();
-				}
-			}
-
-			NativeCodeGenState EnsureCodeGenState (AndroidTargetArch targetArch)
+			NativeCodeGenStateObject EnsureCodeGenState (AndroidTargetArch targetArch)
 			{
-				if (nativeCodeGenStates == null || !nativeCodeGenStates.TryGetValue (targetArch, out NativeCodeGenState? state)) {
+				if (nativeCodeGenStates == null || !nativeCodeGenStates.States.TryGetValue (targetArch, out NativeCodeGenStateObject? state)) {
 					throw new InvalidOperationException ($"Internal error: missing native code generation state for architecture '{targetArch}'");
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodCecilAdapter.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodCecilAdapter.cs
@@ -40,7 +40,7 @@ class MarshalMethodCecilAdapter
 			return obj;
 
 		foreach (var group in state.Classifier.MarshalMethods) {
-			var methods = new List<MarshalMethodEntryObject> ();
+			var methods = new List<MarshalMethodEntryObject> (group.Value.Count);
 
 			foreach (var method in group.Value) {
 				var entry = CreateEntry (method, state.ManagedMarshalMethodsLookupInfo);
@@ -105,7 +105,7 @@ class MarshalMethodCecilAdapter
 		if (method is null)
 			return null;
 
-		var parameters = new List<MarshalMethodEntryMethodParameterObject> ();
+		var parameters = new List<MarshalMethodEntryMethodParameterObject> (method.Parameters.Count);
 
 		foreach (var parameter in method.Parameters) {
 			parameters.Add (new MarshalMethodEntryMethodParameterObject (

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodCecilAdapter.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodCecilAdapter.cs
@@ -1,0 +1,253 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Utilities;
+using Mono.Cecil;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks;
+
+class MarshalMethodCecilAdapter
+{
+	public static NativeCodeGenStateCollection? GetNativeCodeGenStateCollection (TaskLoggingHelper log, ConcurrentDictionary<AndroidTargetArch, NativeCodeGenState>? nativeCodeGenStates)
+	{
+		if (nativeCodeGenStates is null) {
+			log.LogDebugMessage ($"No {nameof (NativeCodeGenState)} found");
+			return null;
+		}
+
+		var collection = new NativeCodeGenStateCollection ();
+
+		// Convert each architecture
+		foreach (var kvp in nativeCodeGenStates) {
+			var arch = kvp.Key;
+			var state = kvp.Value;
+			var obj = CreateNativeCodeGenState (arch, state);
+			collection.States.Add (arch, obj);
+		}
+
+		return collection;
+	}
+
+	static NativeCodeGenStateObject CreateNativeCodeGenState (AndroidTargetArch arch, NativeCodeGenState state)
+	{
+		var obj = new NativeCodeGenStateObject ();
+
+		if (state.Classifier is null)
+			return obj;
+
+		foreach (var group in state.Classifier.MarshalMethods) {
+			var methods = new List<MarshalMethodEntryObject> ();
+
+			foreach (var method in group.Value) {
+				var entry = CreateEntry (method, state.ManagedMarshalMethodsLookupInfo);
+				methods.Add (entry);
+			}
+
+			obj.MarshalMethods.Add (group.Key, methods);
+		}
+
+		return obj;
+	}
+
+	static MarshalMethodEntryObject CreateEntry (MarshalMethodEntry entry, ManagedMarshalMethodsLookupInfo? info)
+	{
+		var obj = new MarshalMethodEntryObject (
+			declaringType: CreateDeclaringType (entry.DeclaringType),
+			implementedMethod: CreateMethod (entry.ImplementedMethod),
+			isSpecial: entry.IsSpecial,
+			jniTypeName: entry.JniTypeName,
+			jniMethodName: entry.JniMethodName,
+			jniMethodSignature: entry.JniMethodSignature,
+			nativeCallback: CreateMethod (entry.NativeCallback),
+			registeredMethod: CreateMethodBase (entry.RegisteredMethod)
+		);
+
+		if (info is not null) {
+			(uint assemblyIndex, uint classIndex, uint methodIndex) = info.GetIndex (entry.NativeCallback);
+
+			obj.NativeCallback.AssemblyIndex = assemblyIndex;
+			obj.NativeCallback.ClassIndex = classIndex;
+			obj.NativeCallback.MethodIndex = methodIndex;
+		}
+
+		return obj;
+	}
+
+	static MarshalMethodEntryTypeObject CreateDeclaringType (TypeDefinition type)
+	{
+		var cecilModule = type.Module;
+		var cecilAssembly = cecilModule.Assembly;
+
+		var assembly = new MarshalMethodEntryAssemblyObject (
+			fullName: cecilAssembly.FullName,
+			nameFullName: cecilAssembly.Name.FullName,
+			mainModuleFileName: cecilAssembly.MainModule.FileName,
+			nameName: cecilAssembly.Name.Name
+		);
+
+		var module = new MarshalMethodEntryModuleObject (
+			assembly: assembly
+		);
+
+		return new MarshalMethodEntryTypeObject (
+			fullName: type.FullName,
+			metadataToken: type.MetadataToken.ToUInt32 (),
+			module: module);
+	}
+
+	[return:NotNullIfNotNull (nameof (method))]
+	static MarshalMethodEntryMethodObject? CreateMethod (MethodDefinition? method)
+	{
+		if (method is null)
+			return null;
+
+		var parameters = new List<MarshalMethodEntryMethodParameterObject> ();
+
+		foreach (var parameter in method.Parameters) {
+			parameters.Add (new MarshalMethodEntryMethodParameterObject (
+				name: parameter.Name,
+				parameterTypeName: parameter.ParameterType.Name
+			));
+		}
+
+		return new MarshalMethodEntryMethodObject (
+			name: method.Name,
+			fullName: method.FullName,
+			declaringType: CreateDeclaringType (method.DeclaringType),
+			metadataToken: method.MetadataToken.ToUInt32 (),
+			parameters: parameters
+		);
+	}
+
+	static MarshalMethodEntryMethodBaseObject? CreateMethodBase (MethodDefinition? method)
+	{
+		if (method is null)
+			return null;
+		return new MarshalMethodEntryMethodBaseObject (
+			fullName: method.FullName
+		);
+	}
+}
+
+class NativeCodeGenStateCollection
+{
+	public Dictionary<AndroidTargetArch, NativeCodeGenStateObject> States { get; } = [];
+}
+
+class NativeCodeGenStateObject
+{
+	public Dictionary<string, IList<MarshalMethodEntryObject>> MarshalMethods { get; } = [];
+}
+
+class MarshalMethodEntryObject
+{
+	public MarshalMethodEntryTypeObject DeclaringType { get; }
+	public MarshalMethodEntryMethodObject? ImplementedMethod { get; }
+	public bool IsSpecial { get; }
+	public string JniTypeName { get; }
+	public string JniMethodName { get; }
+	public string JniMethodSignature { get; }
+	public MarshalMethodEntryMethodObject NativeCallback { get; }
+	public MarshalMethodEntryMethodBaseObject? RegisteredMethod { get; }
+
+	public MarshalMethodEntryObject (MarshalMethodEntryTypeObject declaringType, MarshalMethodEntryMethodObject? implementedMethod, bool isSpecial, string jniTypeName, string jniMethodName, string jniMethodSignature, MarshalMethodEntryMethodObject nativeCallback, MarshalMethodEntryMethodBaseObject? registeredMethod)
+	{
+		DeclaringType = declaringType;
+		ImplementedMethod = implementedMethod;
+		IsSpecial = isSpecial;
+		JniTypeName = jniTypeName;
+		JniMethodName = jniMethodName;
+		JniMethodSignature = jniMethodSignature;
+		NativeCallback = nativeCallback;
+		RegisteredMethod = registeredMethod;
+	}
+}
+
+class MarshalMethodEntryAssemblyObject
+{
+	public string FullName { get; }
+	public string NameFullName { get; }  // Cecil's Assembly.Name.FullName
+	public string MainModuleFileName { get; }  // Cecil's Assembly.MainModule.FileName
+	public string NameName { get; } // Cecil's Module.Name.Name
+
+	public MarshalMethodEntryAssemblyObject (string fullName, string nameFullName, string mainModuleFileName, string nameName)
+	{
+		FullName = fullName;
+		NameFullName = nameFullName;
+		MainModuleFileName = mainModuleFileName;
+		NameName = nameName;
+	}
+}
+
+class MarshalMethodEntryModuleObject
+{
+	public MarshalMethodEntryAssemblyObject Assembly { get; }
+
+	public MarshalMethodEntryModuleObject (MarshalMethodEntryAssemblyObject assembly)
+	{
+		Assembly = assembly;
+	}
+}
+
+class MarshalMethodEntryTypeObject
+{
+	public string FullName { get; }
+	public uint MetadataToken { get; }
+	public MarshalMethodEntryModuleObject Module { get; }
+
+	public MarshalMethodEntryTypeObject (string fullName, uint metadataToken, MarshalMethodEntryModuleObject module)
+	{
+		FullName = fullName;
+		MetadataToken = metadataToken;
+		Module = module;
+	}
+}
+
+class MarshalMethodEntryMethodBaseObject
+{
+	public string FullName { get; }
+
+	public MarshalMethodEntryMethodBaseObject (string fullName)
+	{
+		FullName = fullName;
+	}
+}
+
+class MarshalMethodEntryMethodObject : MarshalMethodEntryMethodBaseObject
+{
+	public string Name { get; }
+	public MarshalMethodEntryTypeObject DeclaringType { get; }
+	public uint MetadataToken { get; }
+	public List<MarshalMethodEntryMethodParameterObject> Parameters { get; }
+
+	public uint? AssemblyIndex { get; set; }
+	public uint? ClassIndex { get; set; }
+	public uint? MethodIndex { get; set; }
+
+	public bool HasParameters => Parameters.Count > 0;
+
+	public MarshalMethodEntryMethodObject (string name, string fullName, MarshalMethodEntryTypeObject declaringType, uint metadataToken, List<MarshalMethodEntryMethodParameterObject> parameters)
+		: base (fullName)
+	{
+		Name = name;
+		DeclaringType = declaringType;
+		MetadataToken = metadataToken;
+		Parameters = parameters;
+	}
+}
+
+class MarshalMethodEntryMethodParameterObject
+{
+	public string Name { get; }
+	public string ParameterTypeName { get; }  // Cecil's ParameterDefinition.ParameterType.Name
+
+	public MarshalMethodEntryMethodParameterObject (string name, string parameterTypeName)
+	{
+		Name = name;
+		ParameterTypeName = parameterTypeName;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Android.Tasks
 
 		sealed class MarshalMethodInfo
 		{
-			public MarshalMethodEntry Method                { get; }
+			public MarshalMethodEntryObject Method          { get; }
 			public string NativeSymbolName                  { get; set; }
 			public List<LlvmIrFunctionParameter> Parameters { get; }
 			public Type ReturnType                          { get; }
@@ -86,7 +86,7 @@ namespace Xamarin.Android.Tasks
 			// the outside.
 			public uint AssemblyCacheIndex                  { get; set; }
 
-			public MarshalMethodInfo (MarshalMethodEntry method, Type returnType, string nativeSymbolName, int classCacheIndex)
+			public MarshalMethodInfo (MarshalMethodEntryObject method, Type returnType, string nativeSymbolName, int classCacheIndex)
 			{
 				Method = method ?? throw new ArgumentNullException (nameof (method));
 				ReturnType = returnType ?? throw new ArgumentNullException (nameof (returnType));
@@ -194,7 +194,7 @@ namespace Xamarin.Android.Tasks
 			public override object? GetValue (LlvmIrModuleTarget target)
 			{
 				// What a monstrosity...
-				string asmName = mmi.Method.NativeCallback.DeclaringType.Module.Assembly.Name.Name;
+				string asmName = mmi.Method.NativeCallback.DeclaringType.Module.Assembly.NameName;
 				Dictionary<string, uint> asmNameToIndex = target.Is64Bit ? acs.AsmNameToIndexData64 : acs.AsmNameToIndexData32;
 				if (!asmNameToIndex.TryGetValue (asmName, out uint asmIndex)) {
 					throw new InvalidOperationException ($"Unable to translate assembly name '{asmName}' to its index");
@@ -239,7 +239,7 @@ namespace Xamarin.Android.Tasks
 		readonly bool generateEmptyCode;
 		readonly bool managedMarshalMethodsLookupEnabled;
 		readonly AndroidTargetArch targetArch;
-		readonly NativeCodeGenState? codeGenState;
+		readonly NativeCodeGenStateObject? codeGenState;
 
 		/// <summary>
 		/// Constructor to be used ONLY when marshal methods are DISABLED
@@ -257,7 +257,7 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// Constructor to be used ONLY when marshal methods are ENABLED
 		/// </summary>
-		public MarshalMethodsNativeAssemblyGenerator (TaskLoggingHelper log, int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames, NativeCodeGenState codeGenState, bool managedMarshalMethodsLookupEnabled)
+		public MarshalMethodsNativeAssemblyGenerator (TaskLoggingHelper log, int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames, NativeCodeGenStateObject codeGenState, bool managedMarshalMethodsLookupEnabled)
 			: base (log)
 		{
 			this.numberOfAssembliesInApk = numberOfAssembliesInApk;
@@ -271,13 +271,13 @@ namespace Xamarin.Android.Tasks
 
 		void Init ()
 		{
-			if (generateEmptyCode || codeGenState.Classifier == null || codeGenState.Classifier.MarshalMethods.Count == 0) {
+			if (generateEmptyCode || codeGenState.MarshalMethods.Count == 0) {
 				return;
 			}
 
 			var seenClasses = new Dictionary<string, int> (StringComparer.Ordinal);
 			var allMethods = new List<MarshalMethodInfo> ();
-			IDictionary<string, IList<MarshalMethodEntry>> marshalMethods = codeGenState.Classifier.MarshalMethods;
+			IDictionary<string, IList<MarshalMethodEntryObject>> marshalMethods = codeGenState.MarshalMethods;
 
 			// It's possible that several otherwise different methods (from different classes, but with the same
 			// names and similar signatures) will actually share the same **short** native symbol name. In this case we must
@@ -307,9 +307,9 @@ namespace Xamarin.Android.Tasks
 			//   new native symbol name: Java_crc64e1fb321c08285b90_CellAdapter_n_1onPrepareActionMode__Landroidx_appcompat_view_ActionMode_2Landroid_view_Menu_2
 			//
 			var overloadedNativeSymbolNames = new Dictionary<string, List<MarshalMethodInfo>> (StringComparer.Ordinal);
-			foreach (IList<MarshalMethodEntry> entryList in marshalMethods.Values) {
+			foreach (IList<MarshalMethodEntryObject> entryList in marshalMethods.Values) {
 				bool useFullNativeSignature = entryList.Count > 1;
-				foreach (MarshalMethodEntry entry in entryList) {
+				foreach (MarshalMethodEntryObject entry in entryList) {
 					Log.LogDebugMessage ($"MM: processing {entry.DeclaringType.FullName} {entry.NativeCallback.FullName}");
 					ProcessAndAddMethod (allMethods, entry, useFullNativeSignature, seenClasses, overloadedNativeSymbolNames);
 				}
@@ -349,7 +349,7 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		string MakeNativeSymbolName (MarshalMethodEntry entry, bool useFullNativeSignature)
+		string MakeNativeSymbolName (MarshalMethodEntryObject entry, bool useFullNativeSignature)
 		{
 			var sb = new StringBuilder ("Java_");
 			sb.Append (MangleForJni (entry.JniTypeName));
@@ -386,18 +386,18 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		void ProcessAndAddMethod (List<MarshalMethodInfo> allMethods, MarshalMethodEntry entry, bool useFullNativeSignature, Dictionary<string, int> seenClasses, Dictionary<string, List<MarshalMethodInfo>> overloadedNativeSymbolNames)
+		void ProcessAndAddMethod (List<MarshalMethodInfo> allMethods, MarshalMethodEntryObject entry, bool useFullNativeSignature, Dictionary<string, int> seenClasses, Dictionary<string, List<MarshalMethodInfo>> overloadedNativeSymbolNames)
 		{
-			CecilMethodDefinition nativeCallback = entry.NativeCallback;
+			MarshalMethodEntryMethodObject nativeCallback = entry.NativeCallback;
 			string nativeSymbolName = MakeNativeSymbolName (entry, useFullNativeSignature);
-			string klass = $"{nativeCallback.DeclaringType.FullName}, {nativeCallback.Module.Assembly.FullName}";
+			string klass = $"{nativeCallback.DeclaringType.FullName}, {nativeCallback.DeclaringType.Module.Assembly.FullName}";
 
 			if (!seenClasses.TryGetValue (klass, out int classIndex)) {
 				classIndex = classes.Count;
 				seenClasses.Add (klass, classIndex);
 
 				var mc = new MarshalMethodsManagedClass {
-					token = nativeCallback.DeclaringType.MetadataToken.ToUInt32 (),
+					token = nativeCallback.DeclaringType.MetadataToken,
 					ClassName = klass,
 				};
 
@@ -458,7 +458,7 @@ namespace Xamarin.Android.Tasks
 			return sb.ToString ();
 		}
 
-		(Type returnType, List<LlvmIrFunctionParameter>? functionParams) ParseJniSignature (string signature, Mono.Cecil.MethodDefinition implementedMethod)
+		(Type returnType, List<LlvmIrFunctionParameter>? functionParams) ParseJniSignature (string signature, MarshalMethodEntryMethodObject implementedMethod)
 		{
 			Type returnType = null;
 			List<LlvmIrFunctionParameter>? parameters = null;
@@ -646,8 +646,8 @@ namespace Xamarin.Android.Tasks
 				GetFunctionPtrFunction = getFunctionPtrFunction,
 			};
 			foreach (MarshalMethodInfo mmi in methods) {
-				CecilMethodDefinition nativeCallback = mmi.Method.NativeCallback;
-				string asmName = nativeCallback.DeclaringType.Module.Assembly.Name.Name;
+				MarshalMethodEntryMethodObject nativeCallback = mmi.Method.NativeCallback;
+				string asmName = nativeCallback.DeclaringType.Module.Assembly.NameName;
 
 				if (!writeState.UniqueAssemblyId.TryGetValue (asmName, out ulong asmId)) {
 					asmId = (ulong)writeState.UniqueAssemblyId.Count;
@@ -663,8 +663,8 @@ namespace Xamarin.Android.Tasks
 		void AddMarshalMethod (LlvmIrModule module, MarshalMethodInfo method, ulong asmId, MarshalMethodsWriteState writeState)
 		{
 			Log.LogDebugMessage ($"MM: generating code for {method.Method.DeclaringType.FullName} {method.Method.NativeCallback.FullName}");
-			CecilMethodDefinition nativeCallback = method.Method.NativeCallback;
-			string backingFieldName = $"native_cb_{method.Method.JniMethodName}_{asmId}_{method.ClassCacheIndex}_{nativeCallback.MetadataToken.ToUInt32():x}";
+			MarshalMethodEntryMethodObject nativeCallback = method.Method.NativeCallback;
+			string backingFieldName = $"native_cb_{method.Method.JniMethodName}_{asmId}_{method.ClassCacheIndex}_{nativeCallback.MetadataToken:x}";
 
 			if (!writeState.UsedBackingFields.TryGetValue (backingFieldName, out LlvmIrVariable backingField)) {
 				backingField = module.AddGlobalVariable (typeof(IntPtr), backingFieldName, null, LlvmIrVariableOptions.LocalWritableInsignificantAddr);
@@ -674,7 +674,7 @@ namespace Xamarin.Android.Tasks
 			var funcComment = new StringBuilder (" Method: ");
 			funcComment.AppendLine (nativeCallback.FullName);
 			funcComment.Append (" Assembly: ");
-			funcComment.AppendLine (nativeCallback.Module.Assembly.Name.FullName);
+			funcComment.AppendLine (nativeCallback.DeclaringType.Module.Assembly.NameFullName);
 			funcComment.Append (" Registered: ");
 			funcComment.AppendLine (method.Method.RegisteredMethod?.FullName ?? "none");
 			funcComment.Append (" Implemented: ");
@@ -707,11 +707,11 @@ namespace Xamarin.Android.Tasks
 
 				List<object?> getFunctionPointerArguments;
 				if (managedMarshalMethodsLookupEnabled) {
-					(uint assemblyIndex, uint classIndex, uint methodIndex) = codeGenState.ManagedMarshalMethodsLookupInfo.GetIndex (nativeCallback);
+					(uint assemblyIndex, uint classIndex, uint methodIndex) = GetManagedMarshalMethodsLookupIndexes (nativeCallback);
 					getFunctionPointerArguments = new List<object?> { assemblyIndex, classIndex, methodIndex, backingField };
 				} else {
 					var placeholder = new MarshalMethodAssemblyIndexValuePlaceholder (method, writeState.AssemblyCacheState);
-					getFunctionPointerArguments = new List<object?> { placeholder, method.ClassCacheIndex, nativeCallback.MetadataToken.ToUInt32 (), backingField };
+					getFunctionPointerArguments = new List<object?> { placeholder, method.ClassCacheIndex, nativeCallback.MetadataToken, backingField };
 				}
 
 				LlvmIrInstructions.Call call = body.Call (writeState.GetFunctionPtrFunction, arguments: getFunctionPointerArguments, funcPointer: getFuncPtrResult);
@@ -739,6 +739,15 @@ namespace Xamarin.Android.Tasks
 				call.CallMarker = LlvmIrCallMarker.Tail;
 
 				body.Ret (nativeFunc.Signature.ReturnType, result);
+			}
+
+			(uint assemblyIndex, uint classIndex, uint methodIndex) GetManagedMarshalMethodsLookupIndexes (MarshalMethodEntryMethodObject nativeCallback)
+			{
+				var assemblyIndex = nativeCallback.AssemblyIndex ?? throw new InvalidOperationException ("ManagedMarshalMethodsLookupInfo missing");
+				var classIndex = nativeCallback.ClassIndex ?? throw new InvalidOperationException ("ManagedMarshalMethodsLookupInfo missing");
+				var methodIndex = nativeCallback.MethodIndex ?? throw new InvalidOperationException ("ManagedMarshalMethodsLookupInfo missing");
+
+				return (assemblyIndex, classIndex, methodIndex);
 			}
 		}
 
@@ -881,7 +890,7 @@ namespace Xamarin.Android.Tasks
 
 			if (!generateEmptyCode && methods != null) {
 				foreach (MarshalMethodInfo mmi in methods) {
-					string asmName = Path.GetFileName (mmi.Method.NativeCallback.Module.Assembly.MainModule.FileName);
+					string asmName = Path.GetFileName (mmi.Method.NativeCallback.DeclaringType.Module.Assembly.MainModuleFileName);
 
 					if (!acs.AsmNameToIndexData32.TryGetValue (asmName, out uint idx32)) {
 						throw new InvalidOperationException ($"Internal error: failed to match assembly name '{asmName}' to 32-bit cache array index");
@@ -891,7 +900,7 @@ namespace Xamarin.Android.Tasks
 						throw new InvalidOperationException ($"Internal error: failed to match assembly name '{asmName}' to 64-bit cache array index");
 					}
 
-					ulong methodToken = (ulong)mmi.Method.NativeCallback.MetadataToken.ToUInt32 ();
+					ulong methodToken = (ulong)mmi.Method.NativeCallback.MetadataToken;
 					ulong id32 = ((ulong)idx32 << 32) | methodToken;
 					if (uniqueMethods.ContainsKey (id32)) {
 						continue;
@@ -937,7 +946,7 @@ namespace Xamarin.Android.Tasks
 			};
 			module.Add (mm_method_names_variable);
 
-			void RenderMethodNameWithParams (CecilMethodDefinition md, StringBuilder buffer)
+			void RenderMethodNameWithParams (MarshalMethodEntryMethodObject md, StringBuilder buffer)
 			{
 				buffer.Clear ();
 				buffer.Append (md.Name);
@@ -945,14 +954,14 @@ namespace Xamarin.Android.Tasks
 
 				if (md.HasParameters) {
 					bool first = true;
-					foreach (CecilParameterDefinition pd in md.Parameters) {
+					foreach (MarshalMethodEntryMethodParameterObject pd in md.Parameters) {
 						if (!first) {
 							buffer.Append (',');
 						} else {
 							first = false;
 						}
 
-						buffer.Append (pd.ParameterType.Name);
+						buffer.Append (pd.ParameterTypeName);
 					}
 				}
 


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/10062

_One_ issue with our desire to move around LLVM Marshal Method build code so that it can work with Ready2Run is that our current implementation relies on holding Cecil `AssemblyDefinition` objects open in global state across multiple targets.  While these objects are open, no other process can access our assemblies, making it harder to reorder targets and tasks.

As a first step towards refactoring this process, let's move the data into a DTO that does not require Cecil.  Additionally, this makes it clear _what_ data is actually consumed by `<GeneratePackageManagerJava>` rather than "entire assemblies" so we can focus on how to properly obtain and persist the data.

This still relies on `BuildEngine4.RegisterTaskObject` to store the data, but a likely future step would be to persist it to a file instead.