### PR TITLE
[CoreCLR] support for debug build typemaps

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FindTypeMapObjectsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FindTypeMapObjectsStep.cs
@@ -37,13 +37,14 @@ public class FindTypeMapObjectsStep : BaseStep, IAssemblyModifierPipelineStep
 
 		var xml = new TypeMapObjectsXmlFile {
 			AssemblyName = assembly.Name.Name,
+			AssemblyMvid = assembly.MainModule.Mvid,
 		};
 
 		if (Debug) {
-			var (javaToManaged, managedToJava, foundJniNativeRegistration) = TypeMapCecilAdapter.GetDebugNativeEntries (types, Context);
+			var (typeMapDebugSets, foundJniNativeRegistration) = TypeMapCecilAdapter.GetDebugNativeEntries (types, Context, needUniqueAssemblies: false);
 
-			xml.JavaToManagedDebugEntries.AddRange (javaToManaged);
-			xml.ManagedToJavaDebugEntries.AddRange (managedToJava);
+			xml.JavaToManagedDebugEntries.AddRange (typeMapDebugSets.JavaToManaged);
+			xml.ManagedToJavaDebugEntries.AddRange (typeMapDebugSets.ManagedToJava);
 			xml.FoundJniNativeRegistration = foundJniNativeRegistration;
 		} else {
 			var genState = TypeMapCecilAdapter.GetReleaseGenerationState (types, Context, out var foundJniNativeRegistration);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("SmokeTests")]
 		[TestCase (false, AndroidRuntime.MonoVM)]
 		[TestCase (true, AndroidRuntime.MonoVM)]
+		[TestCase (false, AndroidRuntime.CoreCLR)]
 		[TestCase (true, AndroidRuntime.CoreCLR)]
 		[TestCase (true, AndroidRuntime.NativeAOT)]
 		public void BuildApplicationWithAssetPackThatHasInvalidName (bool isRelease, AndroidRuntime runtime)
@@ -67,6 +68,7 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("SmokeTests")]
 		[TestCase (false, AndroidRuntime.MonoVM)]
 		[TestCase (true, AndroidRuntime.MonoVM)]
+		[TestCase (false, AndroidRuntime.CoreCLR)]
 		[TestCase (true, AndroidRuntime.CoreCLR)]
 		[TestCase (true, AndroidRuntime.NativeAOT)]
 		public void BuildApplicationWithAssetPackOutsideProjectDirectory (bool isRelease, AndroidRuntime runtime)
@@ -117,6 +119,7 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("SmokeTests")]
 		[TestCase (false, AndroidRuntime.MonoVM)]
 		[TestCase (true, AndroidRuntime.MonoVM)]
+		[TestCase (false, AndroidRuntime.CoreCLR)]
 		[TestCase (true, AndroidRuntime.CoreCLR)]
 		[TestCase (true, AndroidRuntime.NativeAOT)]
 		public void BuildApplicationWithAssetPackOverrides (bool isRelease, AndroidRuntime runtime)
@@ -160,6 +163,7 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("SmokeTests")]
 		[TestCase (false, AndroidRuntime.MonoVM)]
 		[TestCase (true, AndroidRuntime.MonoVM)]
+		[TestCase (false, AndroidRuntime.CoreCLR)]
 		[TestCase (true, AndroidRuntime.CoreCLR)]
 		[TestCase (true, AndroidRuntime.NativeAOT)]
 		public void BuildApplicationWithAssetPack (bool isRelease, AndroidRuntime runtime)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.TestCaseSource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.TestCaseSource.cs
@@ -134,6 +134,13 @@ namespace Xamarin.Android.Build.Tests
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm64",
+				/* isRelease */          false,
+				/* aot */                false,
+				/* usesAssemblyStore */  true,
+				/* runtime */            AndroidRuntime.CoreCLR,
+			},
+			new object [] {
+				/* runtimeIdentifiers */ "android-arm64",
 				/* isRelease */          true,
 				/* aot */                false,
 				/* usesAssemblyStore */  false,

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapCecilAdapter.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapCecilAdapter.cs
@@ -17,14 +17,14 @@ class TypeMapCecilAdapter
 {
 	public static TypeMapDebugDataSets GetDebugNativeEntries (NativeCodeGenState state, bool needUniqueAssemblies)
 	{
-		var (TypeMapDebugDataSets dataSets, foundJniNativeRegistration) = GetDebugNativeEntries (state.AllJavaTypes, state.TypeCache);
+		var (dataSets, foundJniNativeRegistration) = GetDebugNativeEntries (state.AllJavaTypes, state.TypeCache, needUniqueAssemblies);
 
 		state.JniAddNativeMethodRegistrationAttributePresent = foundJniNativeRegistration;
 
 		return dataSets;
 	}
 
-	public static (TypeMapDebugDataSets dataSets, bool foundJniNativeRegistration) GetDebugNativeEntries (List<TypeDefinition> types, TypeDefinitionCache cache)
+	public static (TypeMapDebugDataSets dataSets, bool foundJniNativeRegistration) GetDebugNativeEntries (List<TypeDefinition> types, TypeDefinitionCache cache, bool needUniqueAssemblies)
 	{
 		var javaDuplicates = new Dictionary<string, List<TypeMapDebugEntry>> (StringComparer.Ordinal);
 		var uniqueAssemblies = needUniqueAssemblies ? new Dictionary<string, TypeMapDebugAssembly> (StringComparer.OrdinalIgnoreCase) : null;
@@ -227,7 +227,7 @@ class TypeMapCecilAdapter
 		if (alreadyFound || !javaType.HasCustomAttributes) {
 			return alreadyFound;
 		}
-		
+
 		foreach (CustomAttribute ca in javaType.CustomAttributes) {
 			if (string.Equals ("JniAddNativeMethodRegistrationAttribute", ca.AttributeType.Name, StringComparison.Ordinal)) {
 				return true;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
@@ -283,8 +283,18 @@ namespace Xamarin.Android.Tasks
 		{
 			var javaToManaged = new List<TypeMapDebugEntry> ();
 			var managedToJava = new List<TypeMapDebugEntry> ();
+			var uniqueAssemblies = new Dictionary<string, TypeMapDebugAssembly> (StringComparer.OrdinalIgnoreCase);
 
 			foreach (var xml in XmlFiles) {
+				if (!uniqueAssemblies.ContainsKey (xml.AssemblyName)) {
+					var assm = new TypeMapDebugAssembly {
+						MVID = xml.AssemblyMvid,
+						MVIDBytes = xml.AssemblyMvid.ToByteArray (),
+						Name = xml.AssemblyName,
+					};
+					uniqueAssemblies.Add (xml.AssemblyName, assm);
+				}
+
 				javaToManaged.AddRange (xml.JavaToManagedDebugEntries);
 				managedToJava.AddRange (xml.ManagedToJavaDebugEntries);
 			}
@@ -296,8 +306,8 @@ namespace Xamarin.Android.Tasks
 			return new TypeMapDebugDataSets {
 				JavaToManaged = javaToManaged,
 				ManagedToJava = managedToJava,
-				UniqueAssemblies = null,
-			}
+				UniqueAssemblies = uniqueAssemblies.Values.ToList (),
+			};
 		}
 
 		void GroupDuplicateDebugEntries (List<TypeMapDebugEntry> debugEntries)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
@@ -153,7 +153,7 @@ namespace Xamarin.Android.Tasks
 
 		void GenerateDebugNativeAssembly (string outputDirectory)
 		{
-			TypeMapDebugDataSets dataSets = TypeMapCecilAdapter.GetDebugNativeEntries (state, needUniqueAssemblies: runtime == AndroidRuntime.CoreCLR);
+			TypeMapDebugDataSets dataSets = state.GetDebugNativeEntries (needUniqueAssemblies: runtime == AndroidRuntime.CoreCLR);
 
 			var data = new ModuleDebugData {
 				EntryCount = (uint)dataSets.JavaToManaged.Count,
@@ -236,7 +236,7 @@ namespace Xamarin.Android.Tasks
 	{
 		AndroidTargetArch TargetArch { get; }
 		bool JniAddNativeMethodRegistrationAttributePresent { get; set; }
-		(List<TypeMapDebugEntry> javaToManaged, List<TypeMapDebugEntry> managedToJava) GetDebugNativeEntries ();
+		TypeMapDebugDataSets GetDebugNativeEntries (bool needUniqueAssemblies);
 		ReleaseGenerationState GetReleaseGenerationState ();
 	}
 
@@ -256,9 +256,9 @@ namespace Xamarin.Android.Tasks
 			set => state.JniAddNativeMethodRegistrationAttributePresent = value;
 		}
 
-		public (List<TypeMapDebugEntry> javaToManaged, List<TypeMapDebugEntry> managedToJava) GetDebugNativeEntries ()
+		public TypeMapDebugDataSets GetDebugNativeEntries (bool needUniqueAssemblies)
 		{
-			return TypeMapCecilAdapter.GetDebugNativeEntries (state);
+			return TypeMapCecilAdapter.GetDebugNativeEntries (state, needUniqueAssemblies);
 		}
 
 		public ReleaseGenerationState GetReleaseGenerationState ()
@@ -279,7 +279,7 @@ namespace Xamarin.Android.Tasks
 
 		public bool JniAddNativeMethodRegistrationAttributePresent { get; set; }
 
-		public (List<TypeMapDebugEntry> javaToManaged, List<TypeMapDebugEntry> managedToJava) GetDebugNativeEntries ()
+		public TypeMapDebugDataSets GetDebugNativeEntries (bool needUniqueAssemblies)
 		{
 			var javaToManaged = new List<TypeMapDebugEntry> ();
 			var managedToJava = new List<TypeMapDebugEntry> ();
@@ -293,7 +293,11 @@ namespace Xamarin.Android.Tasks
 			GroupDuplicateDebugEntries (javaToManaged);
 			GroupDuplicateDebugEntries (managedToJava);
 
-			return (javaToManaged, managedToJava);
+			return new TypeMapDebugDataSets {
+				JavaToManaged = javaToManaged,
+				ManagedToJava = managedToJava,
+				UniqueAssemblies = null,
+			}
 		}
 
 		void GroupDuplicateDebugEntries (List<TypeMapDebugEntry> debugEntries)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
@@ -25,6 +25,7 @@ class TypeMapObjectsXmlFile
 	static readonly TypeMapObjectsXmlFile unscanned = new TypeMapObjectsXmlFile { WasScanned = false };
 
 	public string? AssemblyName { get; set; }
+	public Guid AssemblyMvid { get; set; } = Guid.Empty;
 	public bool FoundJniNativeRegistration { get; set; }
 	public List<TypeMapDebugEntry> JavaToManagedDebugEntries { get; } = [];
 	public List<TypeMapDebugEntry> ManagedToJavaDebugEntries { get; } = [];
@@ -58,6 +59,10 @@ class TypeMapObjectsXmlFile
 		xml.WriteStartElement ("api");
 		xml.WriteAttributeString ("type", HasDebugEntries ? "debug" : "release");
 		xml.WriteAttributeStringIfNotDefault ("assembly-name", AssemblyName);
+
+		if (AssemblyMvid != Guid.Empty) {
+			xml.WriteAttributeString ("mvid", AssemblyMvid.ToString ("N"));
+		}
 		xml.WriteAttributeStringIfNotDefault ("found-jni-native-registration", FoundJniNativeRegistration);
 
 		if (HasDebugEntries)
@@ -173,11 +178,13 @@ class TypeMapObjectsXmlFile
 
 		var type = root.GetRequiredAttribute ("type");
 		var assemblyName = root.GetAttributeOrDefault ("assembly-name", (string?)null);
+		var mvid = Guid.Parse (root.GetAttributeOrDefault ("mvid", Guid.Empty.ToString ()));
 		var foundJniNativeRegistration = root.GetAttributeOrDefault ("found-jni-native-registration", false);
 
 		var file = new TypeMapObjectsXmlFile {
 			WasScanned = true,
 			AssemblyName = assemblyName,
+			AssemblyMvid = mvid,
 			FoundJniNativeRegistration = foundJniNativeRegistration,
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Tasks
 	{
 		const string JavaToManagedSymbol = "map_java_to_managed";
 		const string ManagedToJavaSymbol = "map_managed_to_java";
-		const string TypeMapSymbol = "type_map"; // MUST match src/monodroid/xamarin-app.hh
+		const string TypeMapSymbol = "type_map"; // MUST match src/native/mono/xamarin-app-stub/xamarin-app.hh
 
 		sealed class TypeMapContextDataProvider : NativeAssemblerStructContextDataProvider
 		{
@@ -66,11 +66,11 @@ namespace Xamarin.Android.Tasks
 				var entry = EnsureType<TypeMapEntry> (data);
 
 				if (String.Compare ("from", fieldName, StringComparison.Ordinal) == 0) {
-					return $"from: entry.from";
+					return $"from: {entry.from}";
 				}
 
 				if (String.Compare ("to", fieldName, StringComparison.Ordinal) == 0) {
-					return $"to: entry.to";
+					return $"to: {entry.to}";
 				}
 
 				return String.Empty;
@@ -78,7 +78,7 @@ namespace Xamarin.Android.Tasks
 		}
 
 		// Order of fields and their type must correspond *exactly* to that in
-		// src/monodroid/jni/xamarin-app.hh TypeMapEntry structure
+		// src/native/mono/xamarin-app-stub/xamarin-app.hh TypeMapEntry structure
 		[NativeAssemblerStructContextDataProvider (typeof (TypeMapEntryContextDataProvider))]
 		sealed class TypeMapEntry
 		{
@@ -87,7 +87,7 @@ namespace Xamarin.Android.Tasks
 		};
 
 		// Order of fields and their type must correspond *exactly* to that in
-		// src/monodroid/jni/xamarin-app.hh TypeMap structure
+		// src/native/mono/xamarin-app-stub/xamarin-app.hh TypeMap structure
 		[NativeAssemblerStructContextDataProvider (typeof (TypeMapContextDataProvider))]
 		sealed class TypeMap
 		{

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
@@ -22,12 +22,11 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 		public override ulong GetBufferSize (object data, string fieldName)
 		{
 			var map_module = EnsureType<TypeMap> (data);
-			if (String.Compare ("java_to_managed", fieldName, StringComparison.Ordinal) == 0 ||
-			    String.Compare ("managed_to_java", fieldName, StringComparison.Ordinal) == 0) {
-				    return map_module.entry_count;
-			    }
-
-			return 0;
+			return fieldName switch {
+				"java_to_managed" => map_module.entry_count,
+				"managed_to_java" => map_module.entry_count,
+				_ => 0
+			};
 		}
 
 		public override string? GetPointedToSymbolName (object data, string fieldName)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Build.Utilities;
+
+using Xamarin.Android.Tasks.LLVMIR;
+
+namespace Xamarin.Android.Tasks;
+
+class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
+{
+	const string JavaToManagedSymbol = "map_java_to_managed";
+	const string ManagedToJavaSymbol = "map_managed_to_java";
+
+	// These names MUST match src/native/clr/include/xamarin-app.hh
+	const string TypeMapSymbol = "type_map";
+	const string UniqueAssembliesSymbol = "type_map_unique_assemblies";
+	const string AssemblyNamesBlobSymbol = "type_map_assembly_names_blob";
+
+	sealed class TypeMapContextDataProvider : NativeAssemblerStructContextDataProvider
+	{
+		public override ulong GetBufferSize (object data, string fieldName)
+		{
+			var map_module = EnsureType<TypeMap> (data);
+			if (String.Compare ("java_to_managed", fieldName, StringComparison.Ordinal) == 0 ||
+			    String.Compare ("managed_to_java", fieldName, StringComparison.Ordinal) == 0) {
+				    return map_module.entry_count;
+			    }
+
+			return 0;
+		}
+
+		public override string GetPointedToSymbolName (object data, string fieldName)
+		{
+			var map_module = EnsureType<TypeMap> (data);
+
+			if (String.Compare ("java_to_managed", fieldName, StringComparison.Ordinal) == 0) {
+				return map_module.JavaToManagedCount == 0 ? null : JavaToManagedSymbol;
+			}
+
+			if (String.Compare ("managed_to_java", fieldName, StringComparison.Ordinal) == 0) {
+				return map_module.ManagedToJavaCount == 0 ? null : ManagedToJavaSymbol;
+			}
+
+			return base.GetPointedToSymbolName (data, fieldName);
+		}
+	}
+
+	sealed class TypeMapEntryContextDataProvider : NativeAssemblerStructContextDataProvider
+	{
+		public override string GetComment (object data, string fieldName)
+		{
+			var entry = EnsureType<TypeMapEntry> (data);
+
+			if (String.Compare ("from", fieldName, StringComparison.Ordinal) == 0) {
+				return $"from: {entry.from}";
+			}
+
+			if (String.Compare ("to", fieldName, StringComparison.Ordinal) == 0) {
+				return $"to: {entry.to}";
+			}
+
+			return String.Empty;
+		}
+	}
+
+	sealed class TypeMapAssemblyContextDataProvider : NativeAssemblerStructContextDataProvider
+	{
+		public override string GetComment (object data, string fieldName)
+		{
+			var entry = EnsureType<TypeMapAssembly> (data);
+
+			if (String.Compare ("mvid_hash", fieldName, StringComparison.Ordinal) == 0) {
+				return $" MVID: {entry.MVID}";
+			}
+
+			if (String.Compare ("name_offset", fieldName, StringComparison.Ordinal) == 0) {
+				return $" {entry.Name}";
+			}
+
+			return String.Empty;
+		}
+	}
+
+	// Order of fields and their type must correspond *exactly* to that in
+	// src/native/clr/include/xamarin-app.hh TypeMapEntry structure
+	[NativeAssemblerStructContextDataProvider (typeof (TypeMapEntryContextDataProvider))]
+	sealed class TypeMapEntry
+	{
+		[NativeAssembler (UsesDataProvider = true)]
+		public string from;
+
+		[NativeAssembler (UsesDataProvider = true)]
+		public string to;
+	};
+
+	// Order of fields and their type must correspond *exactly* to that in
+	// src/native/clr/include/xamarin-app.hh TypeMap structure
+	[NativeAssemblerStructContextDataProvider (typeof (TypeMapContextDataProvider))]
+	sealed class TypeMap
+	{
+		[NativeAssembler (Ignore = true)]
+		public int    JavaToManagedCount;
+
+		[NativeAssembler (Ignore = true)]
+		public int    ManagedToJavaCount;
+
+		public uint   entry_count;
+		public ulong  unique_assemblies_count;
+		public ulong  assembly_names_blob_size;
+
+		[NativeAssembler (UsesDataProvider = true), NativePointer (PointsToSymbol = "")]
+		public TypeMapEntry? java_to_managed = null;
+
+		[NativeAssembler (UsesDataProvider = true), NativePointer (PointsToSymbol = "")]
+		public TypeMapEntry? managed_to_java = null;
+	};
+
+	// Order of fields and their type must correspond *exactly* to that in
+	// src/native/clr/include/xamarin-app.hh TypeMapAssembly structure
+	[NativeAssemblerStructContextDataProvider (typeof (TypeMapAssemblyContextDataProvider))]
+	sealed class TypeMapAssembly
+	{
+		[NativeAssembler (Ignore = true)]
+		public string Name;
+
+		[NativeAssembler (Ignore = true)]
+		public Guid MVID;
+
+		[NativeAssembler (UsesDataProvider = true, NumberFormat = LlvmIrVariableNumberFormat.Hexadecimal)]
+		public ulong mvid_hash;
+		public ulong name_length;
+
+		[NativeAssembler (UsesDataProvider = true)]
+		public ulong name_offset;
+	}
+
+	readonly TypeMapGenerator.ModuleDebugData data;
+	StructureInfo typeMapEntryStructureInfo;
+	StructureInfo typeMapStructureInfo;
+	StructureInfo typeMapAssemblyStructureInfo;
+	List<StructureInstance<TypeMapEntry>> javaToManagedMap;
+	List<StructureInstance<TypeMapEntry>> managedToJavaMap;
+	List<StructureInstance<TypeMapAssembly>> uniqueAssemblies;
+	StructureInstance<TypeMap> type_map;
+
+	public TypeMappingDebugNativeAssemblyGeneratorCLR (TaskLoggingHelper log, TypeMapGenerator.ModuleDebugData data)
+		: base (log)
+	{
+		if (data.UniqueAssemblies == null || data.UniqueAssemblies.Count == 0) {
+			throw new InvalidOperationException ("Internal error: set of unique assemblies must be provided.");
+		}
+
+		this.data = data;
+
+		javaToManagedMap = new ();
+		managedToJavaMap = new ();
+		uniqueAssemblies = new ();
+	}
+
+	protected override void Construct (LlvmIrModule module)
+	{
+		module.DefaultStringGroup = "tmd";
+
+		MapStructures (module);
+
+		if (data.ManagedToJavaMap != null && data.ManagedToJavaMap.Count > 0) {
+			foreach (TypeMapGenerator.TypeMapDebugEntry entry in data.ManagedToJavaMap) {
+				var m2j = new TypeMapEntry {
+					from = entry.ManagedName,
+					to = entry.JavaName,
+				};
+				managedToJavaMap.Add (new StructureInstance<TypeMapEntry> (typeMapEntryStructureInfo, m2j));
+			}
+		}
+
+		if (data.JavaToManagedMap != null && data.JavaToManagedMap.Count > 0) {
+			foreach (TypeMapGenerator.TypeMapDebugEntry entry in data.JavaToManagedMap) {
+				TypeMapGenerator.TypeMapDebugEntry managedEntry = entry.DuplicateForJavaToManaged != null ? entry.DuplicateForJavaToManaged : entry;
+
+				var j2m = new TypeMapEntry {
+					from = entry.JavaName,
+					to = managedEntry.SkipInJavaToManaged ? null : managedEntry.ManagedName,
+				};
+				javaToManagedMap.Add (new StructureInstance<TypeMapEntry> (typeMapEntryStructureInfo, j2m));
+			}
+		}
+
+		// CoreCLR supports only 64-bit targets, so we can make things simpler by hashing the MVIDs here instead of
+		// in a callback during code generation
+		var assemblyNamesBlob = new List<byte> ();
+		foreach (TypeMapGenerator.TypeMapDebugAssembly asm in data.UniqueAssemblies) {
+			byte[] nameBytes = MonoAndroidHelper.Utf8StringToBytes (asm.Name);
+			var entry = new TypeMapAssembly {
+				Name = asm.Name,
+				MVID = asm.MVID,
+
+				mvid_hash = MonoAndroidHelper.GetXxHash (asm.MVIDBytes, is64Bit: true),
+				name_length = (ulong)nameBytes.Length, // without the trailing NUL
+				name_offset = (ulong)assemblyNamesBlob.Count,
+			};
+			uniqueAssemblies.Add (new StructureInstance<TypeMapAssembly> (typeMapAssemblyStructureInfo, entry));
+			assemblyNamesBlob.AddRange (nameBytes);
+			assemblyNamesBlob.Add (0);
+		}
+		uniqueAssemblies.Sort ((StructureInstance<TypeMapAssembly> a, StructureInstance<TypeMapAssembly> b) => a.Instance.mvid_hash.CompareTo (b.Instance.mvid_hash));
+
+		var map = new TypeMap {
+			JavaToManagedCount = data.JavaToManagedMap == null ? 0 : data.JavaToManagedMap.Count,
+			ManagedToJavaCount = data.ManagedToJavaMap == null ? 0 : data.ManagedToJavaMap.Count,
+
+			entry_count = data.EntryCount,
+			unique_assemblies_count = (ulong)data.UniqueAssemblies.Count,
+			assembly_names_blob_size = (ulong)assemblyNamesBlob.Count,
+		};
+		type_map = new StructureInstance<TypeMap> (typeMapStructureInfo, map);
+		module.AddGlobalVariable (TypeMapSymbol, type_map, LlvmIrVariableOptions.GlobalConstant);
+
+		if (managedToJavaMap.Count > 0) {
+			module.AddGlobalVariable (ManagedToJavaSymbol, managedToJavaMap, LlvmIrVariableOptions.LocalConstant);
+		}
+
+		if (javaToManagedMap.Count > 0) {
+			module.AddGlobalVariable (JavaToManagedSymbol, javaToManagedMap, LlvmIrVariableOptions.LocalConstant);
+		}
+
+		module.AddGlobalVariable (UniqueAssembliesSymbol, uniqueAssemblies, LlvmIrVariableOptions.GlobalConstant);
+		module.AddGlobalVariable (AssemblyNamesBlobSymbol, assemblyNamesBlob, LlvmIrVariableOptions.GlobalConstant);
+	}
+
+	void MapStructures (LlvmIrModule module)
+	{
+		typeMapAssemblyStructureInfo = module.MapStructure<TypeMapAssembly> ();
+		typeMapEntryStructureInfo = module.MapStructure<TypeMapEntry> ();
+		typeMapStructureInfo = module.MapStructure<TypeMap> ();
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1873,39 +1873,9 @@ because xbuild doesn't support framework reference assemblies.
   
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
-    ResolvedAssemblies="@(_ResolvedAssemblies)"
-    ResolvedUserAssemblies="@(_ResolvedUserAssemblies)"
-    SatelliteAssemblies="@(_AndroidResolvedSatellitePaths)"
-    IntermediateOutputDirectory="$(IntermediateOutputPath)"
-    NativeLibraries="@(AndroidNativeLibrary);@(EmbeddedNativeLibrary);@(FrameworkNativeLibrary)"
-    MonoComponents="@(_MonoComponent)"
-    MainAssembly="$(TargetPath)"
-    OutputDirectory="$(_AndroidIntermediateJavaSourceDirectory)mono"
-    EnvironmentOutputDirectory="$(IntermediateOutputPath)android"
-    TargetFrameworkVersion="$(TargetFrameworkVersion)"
-    Manifest="$(IntermediateOutputPath)android\AndroidManifest.xml"
-    Environments="@(_EnvironmentFiles)"
-    AndroidAotMode="$(AndroidAotMode)"
-    AndroidAotEnableLazyLoad="$(AndroidAotEnableLazyLoad)"
-    EnableLLVM="$(EnableLLVM)"
-    HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
-    TlsProvider="$(AndroidTlsProvider)"
-    Debug="$(AndroidIncludeDebugSymbols)"
-    AndroidSequencePointsMode="$(_SequencePointsMode)"
-    EnableSGenConcurrent="$(AndroidEnableSGenConcurrent)"
-    SupportedAbis="@(_BuildTargetAbis)"
-    AndroidPackageName="$(_AndroidPackage)"
-    EnablePreloadAssembliesDefault="$(_AndroidEnablePreloadAssembliesDefault)"
-    PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
-    BoundExceptionType="$(AndroidBoundExceptionType)"
-    RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
-    UseAssemblyStore="$(_AndroidUseAssemblyStore)"
-    EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
-    EnableManagedMarshalMethodsLookup="$(_AndroidUseManagedMarshalMethodsLookup)"
-    CustomBundleConfigFile="$(AndroidBundleConfigurationFile)"
-    TargetsCLR="$(_AndroidUseCLR)"
-    ProjectRuntimeConfigFilePath="$(ProjectRuntimeConfigFilePath)"
-  >
+      MainAssembly="$(TargetPath)"
+      OutputDirectory="$(_AndroidIntermediateJavaSourceDirectory)mono"
+      ResolvedUserAssemblies="@(_ResolvedUserAssemblies)">
   </GeneratePackageManagerJava>
 
   <GenerateNativeApplicationConfigSources
@@ -1929,7 +1899,7 @@ because xbuild doesn't support framework reference assemblies.
       PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
       BoundExceptionType="$(AndroidBoundExceptionType)"
       RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
-      UseAssemblyStore="$(AndroidUseAssemblyStore)"
+      UseAssemblyStore="$(_AndroidUseAssemblyStore)"
       EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
       EnableManagedMarshalMethodsLookup="$(_AndroidUseManagedMarshalMethodsLookup)"
       CustomBundleConfigFile="$(AndroidBundleConfigurationFile)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -338,10 +338,21 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</Otherwise>
 </Choose>
 
-<PropertyGroup>
-  <_AndroidAotStripLibraries Condition=" '$(_AndroidAotStripLibraries)' == '' And '$(AndroidIncludeDebugSymbols)' != 'true' ">True</_AndroidAotStripLibraries>
+<PropertyGroup Condition=" '$(_AndroidRuntime)' != 'CoreCLR' ">
   <AndroidUseAssemblyStore Condition=" '$(AndroidUseAssemblyStore)' == '' and ('$(EmbedAssembliesIntoApk)' != 'true' or '$(AndroidIncludeDebugSymbols)' == 'true') ">false</AndroidUseAssemblyStore>
   <AndroidUseAssemblyStore Condition=" '$(AndroidUseAssemblyStore)' == '' ">true</AndroidUseAssemblyStore>
+  <_AndroidUseAssemblyStore>$(AndroidUseAssemblyStore)</_AndroidUseAssemblyStore>
+</PropertyGroup>
+
+<!-- For CoreCLR assembly stores are always on, individual assembly entries in the APK aren't supported.
+     The store, however, will NOT be built for Fastdev! -->
+<PropertyGroup Condition=" '$(_AndroidRuntime)' == 'CoreCLR' ">
+  <_AndroidUseAssemblyStore Condition="'$(EmbedAssembliesIntoApk)' == 'true' ">true</_AndroidUseAssemblyStore>
+  <_AndroidUseAssemblyStore Condition="'$(EmbedAssembliesIntoApk)' != 'true' ">false</_AndroidUseAssemblyStore>
+</PropertyGroup>
+
+<PropertyGroup>
+  <_AndroidAotStripLibraries Condition=" '$(_AndroidAotStripLibraries)' == '' And '$(AndroidIncludeDebugSymbols)' != 'true' ">True</_AndroidAotStripLibraries>
   <AndroidAotEnableLazyLoad Condition=" '$(AndroidAotEnableLazyLoad)' == '' And '$(AotAssemblies)' == 'true' And '$(AndroidIncludeDebugSymbols)' != 'true' ">True</AndroidAotEnableLazyLoad>
   <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and ('$(UsingMicrosoftNETSdkRazor)' == 'true') ">False</AndroidEnableMarshalMethods>
   <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' and '$(PublishReadyToRun)' != 'true' ">True</AndroidEnableMarshalMethods>
@@ -1728,7 +1739,7 @@ because xbuild doesn't support framework reference assemblies.
   <PropertyGroup>
     <AndroidStoreUncompressedFileExtensions Condition=" '$(_EmbeddedDSOsEnabled)' == 'True' ">.so;$(AndroidStoreUncompressedFileExtensions)</AndroidStoreUncompressedFileExtensions>
     <AndroidStoreUncompressedFileExtensions Condition=" '$(_UseEmbeddedDex)' == 'True' ">.dex;$(AndroidStoreUncompressedFileExtensions)</AndroidStoreUncompressedFileExtensions>
-    <AndroidStoreUncompressedFileExtensions Condition=" '$(AndroidUseAssemblyStore)' == 'True' ">.blob;$(AndroidStoreUncompressedFileExtensions)</AndroidStoreUncompressedFileExtensions>
+    <AndroidStoreUncompressedFileExtensions Condition=" '$(_AndroidUseAssemblyStore)' == 'True' ">.blob;$(AndroidStoreUncompressedFileExtensions)</AndroidStoreUncompressedFileExtensions>
   </PropertyGroup>
 </Target>
 
@@ -1862,9 +1873,39 @@ because xbuild doesn't support framework reference assemblies.
   
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
-      MainAssembly="$(TargetPath)"
-      OutputDirectory="$(_AndroidIntermediateJavaSourceDirectory)mono"
-      ResolvedUserAssemblies="@(_ResolvedUserAssemblies)">
+    ResolvedAssemblies="@(_ResolvedAssemblies)"
+    ResolvedUserAssemblies="@(_ResolvedUserAssemblies)"
+    SatelliteAssemblies="@(_AndroidResolvedSatellitePaths)"
+    IntermediateOutputDirectory="$(IntermediateOutputPath)"
+    NativeLibraries="@(AndroidNativeLibrary);@(EmbeddedNativeLibrary);@(FrameworkNativeLibrary)"
+    MonoComponents="@(_MonoComponent)"
+    MainAssembly="$(TargetPath)"
+    OutputDirectory="$(_AndroidIntermediateJavaSourceDirectory)mono"
+    EnvironmentOutputDirectory="$(IntermediateOutputPath)android"
+    TargetFrameworkVersion="$(TargetFrameworkVersion)"
+    Manifest="$(IntermediateOutputPath)android\AndroidManifest.xml"
+    Environments="@(_EnvironmentFiles)"
+    AndroidAotMode="$(AndroidAotMode)"
+    AndroidAotEnableLazyLoad="$(AndroidAotEnableLazyLoad)"
+    EnableLLVM="$(EnableLLVM)"
+    HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
+    TlsProvider="$(AndroidTlsProvider)"
+    Debug="$(AndroidIncludeDebugSymbols)"
+    AndroidSequencePointsMode="$(_SequencePointsMode)"
+    EnableSGenConcurrent="$(AndroidEnableSGenConcurrent)"
+    SupportedAbis="@(_BuildTargetAbis)"
+    AndroidPackageName="$(_AndroidPackage)"
+    EnablePreloadAssembliesDefault="$(_AndroidEnablePreloadAssembliesDefault)"
+    PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
+    BoundExceptionType="$(AndroidBoundExceptionType)"
+    RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
+    UseAssemblyStore="$(_AndroidUseAssemblyStore)"
+    EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
+    EnableManagedMarshalMethodsLookup="$(_AndroidUseManagedMarshalMethodsLookup)"
+    CustomBundleConfigFile="$(AndroidBundleConfigurationFile)"
+    TargetsCLR="$(_AndroidUseCLR)"
+    ProjectRuntimeConfigFilePath="$(ProjectRuntimeConfigFilePath)"
+  >
   </GeneratePackageManagerJava>
 
   <GenerateNativeApplicationConfigSources
@@ -2302,7 +2343,7 @@ because xbuild doesn't support framework reference assemblies.
       ResolvedFrameworkAssemblies="@(_BuildApkResolvedFrameworkAssemblies)"
       ResolvedUserAssemblies="@(_BuildApkResolvedUserAssemblies)"
       SupportedAbis="@(_BuildTargetAbis)"
-      UseAssemblyStore="$(AndroidUseAssemblyStore)">
+      UseAssemblyStore="$(_AndroidUseAssemblyStore)">
     <Output TaskParameter="AssembliesToAddToArchive" ItemName="_BuildApkAssembliesToAddToArchive" />
   </CreateAssemblyStore>
 
@@ -2313,7 +2354,7 @@ because xbuild doesn't support framework reference assemblies.
       IntermediateOutputPath="$(IntermediateOutputPath)"
       ResolvedAssemblies="@(_BuildApkAssembliesToAddToArchive)"
       SupportedAbis="@(_BuildTargetAbis)"
-      UseAssemblyStore="$(AndroidUseAssemblyStore)"
+      UseAssemblyStore="$(_AndroidUseAssemblyStore)"
       RuntimePackLibraryDirectories="@(_RuntimePackLibraryDirectory)">
     <Output TaskParameter="WrappedAssemblies" ItemName="FilesToAddToArchive" />
   </WrapAssembliesAsSharedLibraries>

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -176,7 +176,17 @@ auto AssemblyStore::find_assembly_store_entry (hash_t hash, const AssemblyStoreI
 auto AssemblyStore::open_assembly (std::string_view const& name, int64_t &size) noexcept -> void*
 {
 	hash_t name_hash = xxhash::hash (name.data (), name.length ());
-	log_debug (LOG_ASSEMBLY, "assembly_store_open_from_bundles: looking for bundled name: '{}' (hash {:x})", optional_string (name.data ()), name_hash);
+	log_debug (LOG_ASSEMBLY, "AssemblyStore::open_assembly: looking for bundled name: '{}' (hash {:x})", optional_string (name.data ()), name_hash);
+
+	if constexpr (Constants::is_debug_build) {
+		// TODO: implement filesystem lookup here
+
+		// In fastdev mode we might not have any assembly store.
+		if (assembly_store_hashes == nullptr) {
+			log_warn (LOG_ASSEMBLY, "Assembly store not registered. Unable to look up assembly '{}'", name);
+			return nullptr;
+		}
+	}
 
 	const AssemblyStoreIndexEntry *hash_entry = find_assembly_store_entry (name_hash, assembly_store_hashes, assembly_store.index_entry_count);
 	if (hash_entry == nullptr) {

--- a/src/native/clr/host/internal-pinvokes.cc
+++ b/src/native/clr/host/internal-pinvokes.cc
@@ -28,13 +28,11 @@ void _monodroid_gref_log_delete (jobject handle, char type, const char *threadNa
 
 const char* clr_typemap_managed_to_java (const char *typeName, const uint8_t *mvid) noexcept
 {
-	log_debug (LOG_DEFAULT, __PRETTY_FUNCTION__);
 	return TypeMapper::typemap_managed_to_java (typeName, mvid);
 }
 
 bool clr_typemap_java_to_managed (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept
 {
-	log_debug (LOG_DEFAULT, __PRETTY_FUNCTION__);
 	return TypeMapper::typemap_java_to_managed (java_type_name, assembly_name, managed_type_token_id);
 }
 

--- a/src/native/clr/host/internal-pinvokes.cc
+++ b/src/native/clr/host/internal-pinvokes.cc
@@ -28,11 +28,13 @@ void _monodroid_gref_log_delete (jobject handle, char type, const char *threadNa
 
 const char* clr_typemap_managed_to_java (const char *typeName, const uint8_t *mvid) noexcept
 {
+	log_debug (LOG_DEFAULT, __PRETTY_FUNCTION__);
 	return TypeMapper::typemap_managed_to_java (typeName, mvid);
 }
 
 bool clr_typemap_java_to_managed (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept
 {
+	log_debug (LOG_DEFAULT, __PRETTY_FUNCTION__);
 	return TypeMapper::typemap_java_to_managed (java_type_name, assembly_name, managed_type_token_id);
 }
 

--- a/src/native/clr/host/typemap.cc
+++ b/src/native/clr/host/typemap.cc
@@ -313,10 +313,6 @@ auto TypeMapper::find_java_to_managed_entry (hash_t name_hash) noexcept -> const
 [[gnu::flatten]]
 auto TypeMapper::typemap_java_to_managed_release (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept -> bool
 {
-	if (FastTiming::enabled ()) [[unlikely]] {
-		internal_timing.start_event (TimingEventKind::JavaToManaged);
-	}
-
 	if (java_type_name == nullptr || assembly_name == nullptr || managed_type_token_id == nullptr) [[unlikely]] {
 		if (java_type_name == nullptr) {
 			log_warn (
@@ -373,10 +369,6 @@ auto TypeMapper::typemap_java_to_managed_release (const char *java_type_name, ch
 		*managed_type_token_id,
 		optional_string (*assembly_name)
 	);
-
-	if (FastTiming::enabled ()) [[unlikely]] {
-		internal_timing.end_event ();
-	}
 
 	return true;
 }

--- a/src/native/clr/host/typemap.cc
+++ b/src/native/clr/host/typemap.cc
@@ -67,6 +67,7 @@ namespace {
 [[gnu::always_inline]]
 auto TypeMapper::typemap_type_to_type_debug (const char *typeName, const TypeMapEntry *map, std::string_view const& from_name, std::string_view const& to_name) noexcept -> const char*
 {
+	log_debug (LOG_ASSEMBLY, "Looking up {} type '{}'", from_name, optional_string (typeName));
 	auto equal = [](TypeMapEntry const& entry, const char *key) -> bool {
 		if (entry.from == nullptr) {
 			return 1;
@@ -100,7 +101,7 @@ auto TypeMapper::typemap_type_to_type_debug (const char *typeName, const TypeMap
 }
 
 [[gnu::always_inline]]
-auto TypeMapper::typemap_managed_to_java_debug (const char *typeName) noexcept -> const char*
+auto TypeMapper::typemap_managed_to_java_debug (const char *typeName, const uint8_t *mvid) noexcept -> const char*
 {
 	return typemap_type_to_type_debug (typeName, type_map.managed_to_java, MANAGED, JAVA);
 }
@@ -243,7 +244,7 @@ auto TypeMapper::typemap_managed_to_java_release (const char *typeName, const ui
 #endif // def RELEASE
 
 [[gnu::flatten]]
-auto TypeMapper::typemap_managed_to_java (const char *typeName, [[maybe_unused]] const uint8_t *mvid) noexcept -> const char*
+auto TypeMapper::typemap_managed_to_java (const char *typeName, const uint8_t *mvid) noexcept -> const char*
 {
 	log_debug (LOG_ASSEMBLY, "typemap_managed_to_java: looking up type '{}'", optional_string (typeName));
 	if (FastTiming::enabled ()) [[unlikely]] {
@@ -259,7 +260,7 @@ auto TypeMapper::typemap_managed_to_java (const char *typeName, [[maybe_unused]]
 #if defined(RELEASE)
 	ret = typemap_managed_to_java_release (typeName, mvid);
 #else
-	ret = typemap_managed_to_java_debug (typeName);
+	ret = typemap_managed_to_java_debug (typeName, mvid);
 #endif
 
 	if (FastTiming::enabled ()) [[unlikely]] {

--- a/src/native/clr/host/typemap.cc
+++ b/src/native/clr/host/typemap.cc
@@ -73,7 +73,7 @@ auto TypeMapper::typemap_type_to_type_debug (const char *typeName, const TypeMap
 			return 1;
 		}
 
-		return strcmp (key, entry.from) == 0;
+		return strcmp (entry.from, key) == 0;
 	};
 
 	auto less_than = [](TypeMapEntry const& entry, const char *key) -> bool {
@@ -81,7 +81,7 @@ auto TypeMapper::typemap_type_to_type_debug (const char *typeName, const TypeMap
 			return 1;
 		}
 
-		return strcmp (key, entry.from);
+		return strcmp (entry.from, key) < 0;
 	};
 
 	ssize_t idx = Search::binary_search<TypeMapEntry, const char*, equal, less_than> (typeName, map, type_map.entry_count);
@@ -103,7 +103,25 @@ auto TypeMapper::typemap_type_to_type_debug (const char *typeName, const TypeMap
 [[gnu::always_inline]]
 auto TypeMapper::typemap_managed_to_java_debug (const char *typeName, const uint8_t *mvid) noexcept -> const char*
 {
-	return typemap_type_to_type_debug (typeName, type_map.managed_to_java, MANAGED, JAVA);
+	dynamic_local_path_string full_type_name;
+	full_type_name.append (typeName);
+
+	hash_t mvid_hash = xxhash::hash (mvid, 16z); // we must hope managed land called us with valid data
+
+	auto equal = [](TypeMapAssembly const& entry, hash_t key) -> bool { return entry.mvid_hash == key; };
+	auto less_than = [](TypeMapAssembly const& entry, hash_t key) -> bool { return entry.mvid_hash < key; };
+	ssize_t idx = Search::binary_search<TypeMapAssembly, hash_t, equal, less_than> (mvid_hash, type_map_unique_assemblies, type_map.unique_assemblies_count);
+
+	if (idx >= 0) [[likely]] {
+		TypeMapAssembly const& assm = type_map_unique_assemblies[idx];
+		full_type_name.append (", "sv);
+		full_type_name.append (&type_map_assembly_names_blob[assm.name_offset], assm.name_length);
+		log_debug (LOG_ASSEMBLY, "Fixed-up type name: '{}'", full_type_name.get ());
+	} else {
+		log_warn (LOG_ASSEMBLY, "Unable to look up assembly name for type '{}', trying without it.", typeName);
+	}
+
+	return typemap_type_to_type_debug (full_type_name.get (), type_map.managed_to_java, MANAGED, JAVA);
 }
 #endif // def DEBUG
 

--- a/src/native/clr/include/host/typemap.hh
+++ b/src/native/clr/include/host/typemap.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 
 #include "../runtime-base/logger.hh"
 #include <shared/xxhash.hh>
@@ -9,9 +10,12 @@
 namespace xamarin::android {
 	class TypeMapper
 	{
+		static constexpr std::string_view MANAGED { "Managed" };
+		static constexpr std::string_view JAVA { "Java" };
+
 	public:
 		static auto typemap_managed_to_java (const char *typeName, const uint8_t *mvid) noexcept -> const char*;
-		static auto typemap_java_to_managed (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_doken_id) noexcept -> bool;
+		static auto typemap_java_to_managed (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept -> bool;
 
 	private:
 #if defined(RELEASE)
@@ -19,10 +23,13 @@ namespace xamarin::android {
 		static auto find_module_entry (const uint8_t *mvid, const TypeMapModule *entries, size_t entry_count) noexcept -> const TypeMapModule*;
 		static auto find_managed_to_java_map_entry (hash_t name_hash, const TypeMapModuleEntry *map, size_t entry_count) noexcept -> const TypeMapModuleEntry*;
 		static auto typemap_managed_to_java_release (const char *typeName, const uint8_t *mvid) noexcept -> const char*;
+		static auto typemap_java_to_managed_release (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept -> bool;
 
 		static auto find_java_to_managed_entry (hash_t name_hash) noexcept -> const TypeMapJava*;
 #else
-		static auto typemap_managed_to_java_debug (const char *typeName, const uint8_t *mvid) noexcept -> const char*;
+		static auto typemap_type_to_type_debug (const char *typeName, const TypeMapEntry *map, std::string_view const& from_name, std::string_view const& to_name) noexcept -> const char*;
+		static auto typemap_managed_to_java_debug (const char *typeName) noexcept -> const char*;
+		static auto typemap_java_to_managed_debug (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept -> bool;
 #endif
 	};
 }

--- a/src/native/clr/include/host/typemap.hh
+++ b/src/native/clr/include/host/typemap.hh
@@ -28,7 +28,7 @@ namespace xamarin::android {
 		static auto find_java_to_managed_entry (hash_t name_hash) noexcept -> const TypeMapJava*;
 #else
 		static auto typemap_type_to_type_debug (const char *typeName, const TypeMapEntry *map, std::string_view const& from_name, std::string_view const& to_name) noexcept -> const char*;
-		static auto typemap_managed_to_java_debug (const char *typeName) noexcept -> const char*;
+		static auto typemap_managed_to_java_debug (const char *typeName, const uint8_t *mvid) noexcept -> const char*;
 		static auto typemap_java_to_managed_debug (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept -> bool;
 #endif
 	};

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -62,14 +62,21 @@ struct TypeMapEntry
 	const char *to;
 };
 
-// MUST match src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
+// MUST match src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
 struct TypeMap
 {
 	uint32_t             entry_count;
-	char                *assembly_name;
-	uint8_t             *data;
+	uint64_t             unique_assemblies_count;
+	uint64_t             assembly_names_blob_size;
 	const TypeMapEntry  *java_to_managed;
 	const TypeMapEntry  *managed_to_java;
+};
+
+struct TypeMapAssembly
+{
+	xamarin::android::hash_t mvid_hash;
+	uint64_t name_length;
+	uint64_t name_offset; // into the assembly names blob
 };
 #else
 struct TypeMapModuleEntry
@@ -312,7 +319,9 @@ extern "C" {
 	[[gnu::visibility("default")]] extern const uint64_t format_tag;
 
 #if defined (DEBUG)
-	[[gnu::visibility("default")]] extern const TypeMap type_map; // MUST match src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
+	[[gnu::visibility("default")]] extern const TypeMap type_map; // MUST match src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
+	[[gnu::visibility("default")]] extern const TypeMapAssembly type_map_unique_assemblies;
+	[[gnu::visibility("default")]] extern const char type_map_assembly_names_blob[];
 #else
 	[[gnu::visibility("default")]] extern const uint32_t managed_to_java_map_module_count;
 	[[gnu::visibility("default")]] extern const uint32_t java_type_count;

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -320,7 +320,7 @@ extern "C" {
 
 #if defined (DEBUG)
 	[[gnu::visibility("default")]] extern const TypeMap type_map; // MUST match src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
-	[[gnu::visibility("default")]] extern const TypeMapAssembly type_map_unique_assemblies;
+	[[gnu::visibility("default")]] extern const TypeMapAssembly type_map_unique_assemblies[];
 	[[gnu::visibility("default")]] extern const char type_map_assembly_names_blob[];
 #else
 	[[gnu::visibility("default")]] extern const uint32_t managed_to_java_map_module_count;

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -15,11 +15,11 @@ static TypeMapEntry managed_to_java[] = {};
 
 // MUST match src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
 const TypeMap type_map = {
-	0,
-	nullptr,
-	nullptr,
-	java_to_managed,
-	managed_to_java
+	.entry_count = 0,
+	.unique_assemblies_count = 0,
+	.assembly_names_blob_size = 0,
+	.java_to_managed = java_to_managed,
+	.managed_to_java = managed_to_java,
 };
 #else
 const uint32_t managed_to_java_map_module_count = 0;

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -21,6 +21,9 @@ const TypeMap type_map = {
 	.java_to_managed = java_to_managed,
 	.managed_to_java = managed_to_java,
 };
+
+const TypeMapAssembly type_map_unique_assemblies[] = {};
+const char type_map_assembly_names_blob[] = {};
 #else
 const uint32_t managed_to_java_map_module_count = 0;
 const uint32_t java_type_count = 0;

--- a/src/native/common/include/shared/xxhash.hh
+++ b/src/native/common/include/shared/xxhash.hh
@@ -163,8 +163,8 @@ namespace xamarin::android
 	class xxhash64 final
 	{
 	public:
-		[[gnu::always_inline]]
-		static auto hash (const char *p, size_t len) noexcept -> XXH64_hash_t
+		template<typename T> [[gnu::always_inline]]
+		static auto hash (const T *p, size_t len) noexcept -> XXH64_hash_t
 		{
 			return XXH3_64bits (static_cast<const void*>(p), len);
 		}

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -26,13 +26,15 @@ void FastTiming::really_initialize (bool log_immediately) noexcept
 	open_sequences.push (0);
 	open_sequences.pop ();
 
+	// Options in `debug.mono.timing` are relevant only when immediate logging is disabled
+	if (immediate_logging) {
+		log_warn (LOG_DEFAULT, " immediate mode, returning");
+		return;
+	}
+
 	dynamic_local_property_string value;
 	if (AndroidSystem::monodroid_get_system_property (Constants::DEBUG_MONO_TIMING, value) != 0) {
 		internal_timing.parse_options (value);
-	}
-
-	if (immediate_logging) {
-		return;
 	}
 
 	log_write (

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -28,7 +28,6 @@ void FastTiming::really_initialize (bool log_immediately) noexcept
 
 	// Options in `debug.mono.timing` are relevant only when immediate logging is disabled
 	if (immediate_logging) {
-		log_warn (LOG_DEFAULT, " immediate mode, returning");
 		return;
 	}
 

--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -38,6 +38,7 @@
       <_ConfigureRuntimesInputs  Include="common\libstub\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="common\libunwind\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="common\lz4\CMakeLists.txt" />
+      <_ConfigureRuntimesInputs  Include="common\runtime-base\CMakeLists.txt" />
 
       <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(FlavorIntermediateOutputPath)\%(AndroidRID)-Debug\CMakeCache.txt')" />
       <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(FlavorIntermediateOutputPath)\%(AndroidRID)-Release\CMakeCache.txt')" />
@@ -171,6 +172,7 @@
       <_RuntimeSources Include="common\archive-dso-stub\*.cc" />
       <_RuntimeSources Include="common\include\**\*.hh" />
       <_RuntimeSources Include="common\libstub\*.cc;common\libstub\*.hh" />
+      <_RuntimeSources Include="common\runtime-base\*.cc" />
       <_RuntimeSources Include="$(LZ4SourceFullPath)\lib\lz4.c;$(LZ4SourceFullPath)\lib\lz4.h" />
     </ItemGroup>
 


### PR DESCRIPTION
Implements support for Debug configuration typemaps in CoreCLR apps.

This PR is limited to the managed-to-java lookup, as the java-to-managed one isn't
currently used in CoreCLR apps (that lookup is done in managed code, I will open a
new PR to experiment in this area). 

This PR also doesn't implement support for fastdev, it will be addressed in a separate PR.

CoreCLR doesn't provide us with a way to translate a `System.Type` instance to a type name in
native code, and therefore the managed code calls into the native runtime to perform the lookup using the type name and the assembly MVID.  However, the managed-to-java lookup tables use the assembly-qualified managed type name, so this PR introduces a step to "fix up" the 
passed managed type name by appending the assembly name, which is obtained by searching for
MVID match in the MVID-to-name lookup table.