### PR TITLE
[WIP] move around enough things, to test LLVM Marshal Methods + ReadyToRun

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -198,7 +198,6 @@ _ResolveAssemblies MSBuild target.
       _ResolveSatellitePaths;
       _CreatePackageWorkspace;
       _LinkAssemblies;
-      _AfterILLinkAdditionalSteps;
     </_PrepareAssembliesDependsOnTargets>
   </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -67,8 +67,6 @@ properties that determine build ordering.
       _ResolveSatellitePaths;
       _CreatePackageWorkspace;
       _LinkAssemblies;
-      _AfterILLinkAdditionalSteps;
-      _GenerateJavaStubs;
       _ManifestMerger;
       _ConvertCustomView;
       $(_AfterConvertCustomView);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -925,7 +925,6 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidApkPerAbiFlagFile>$(IntermediateOutputPath)android\bin\apk_per_abi.flag</_AndroidApkPerAbiFlagFile>
 	<_AndroidDebugKeyStoreFlag>$(IntermediateOutputPath)android_debug_keystore.flag</_AndroidDebugKeyStoreFlag>
 	<_RemoveRegisterFlag>$(MonoAndroidIntermediateAssemblyDir)shrunk\shrunk.flag</_RemoveRegisterFlag>
-	<_AdditionalPostLinkerStepsFlag>$(_AndroidStampDirectory)_AdditionalPostLinkerSteps.stamp</_AdditionalPostLinkerStepsFlag>
 	<_AcwMapFile>$(IntermediateOutputPath)acw-map.txt</_AcwMapFile>
 	<_CustomViewMapFile>$(IntermediateOutputPath)customview-map.txt</_CustomViewMapFile>
 	<AndroidResgenNamespace Condition="'$(AndroidResgenNamespace)'==''" >$(RootNamespace)</AndroidResgenNamespace>
@@ -1491,11 +1490,114 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <!-- Runs additional steps after ILLink runs (_LinkAssemblies) -->
-<Target Name="_AfterILLinkAdditionalSteps"
-    DependsOnTargets="_LinkAssembliesNoShrinkInputs"
+<Target Name="_GenerateJavaStubs"
+    AfterTargets="ILLink"
+    BeforeTargets="CreateReadyToRunImages;ComputeIlcCompileInputs"
+    DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest);_LinkAssembliesNoShrinkInputs"
     Condition="'$(PublishTrimmed)' == 'true'"
-    Inputs="$(_AndroidLinkFlag)"
-    Outputs="$(_AdditionalPostLinkerStepsFlag)">
+    Inputs="@(_GenerateJavaStubsInputs);$(_AndroidLinkFlag)"
+    Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
+
+  <PropertyGroup>
+    <_ManifestOutput Condition=" '$(AndroidManifestMerger)' == 'legacy' ">$(_OuterIntermediateOutputPath)android\AndroidManifest.xml</_ManifestOutput>
+    <_ManifestOutput Condition=" '$(AndroidManifestMerger)' != 'legacy' ">$(_OuterIntermediateOutputPath)AndroidManifest.xml</_ManifestOutput>
+    <_LinkingEnabled Condition=" '$(AndroidLinkMode)' != 'None'">True</_LinkingEnabled>
+    <_LinkingEnabled Condition=" '$(AndroidLinkMode)' == 'None'">False</_LinkingEnabled>
+    <_HaveMultipleRIDs Condition=" '$(RuntimeIdentifiers)' != '' ">True</_HaveMultipleRIDs>
+    <_HaveMultipleRIDs Condition=" '$(RuntimeIdentifiers)' == '' ">False</_HaveMultipleRIDs>
+  </PropertyGroup>
+  <ItemGroup>
+    <_MergedManifestDocuments Condition=" '$(AndroidManifestMerger)' == 'legacy' " Include="@(ExtractedManifestDocuments)" />
+  </ItemGroup>
+
+  <GenerateJavaCallableWrappers
+      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
+      OutputDirectory="$(_OuterIntermediateOutputPath)android\src"
+      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
+      SupportedAbis="@(_BuildTargetAbis)">
+    <Output TaskParameter="GeneratedJavaFilesOutput" ItemName="_GeneratedJavaFiles" />
+  </GenerateJavaCallableWrappers>
+
+  <GenerateACWMap
+      AcwMapFile="$(_AcwMapFile)"
+      IntermediateOutputDirectory="$(_OuterIntermediateOutputPath)"
+      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      SupportedAbis="@(_BuildTargetAbis)">
+  </GenerateACWMap>
+
+  <GenerateJavaStubs
+      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
+      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
+      RunCheckedBuild="$(_AndroidJLOCheckedBuild)"
+      GeneratedJavaFiles="@(_GeneratedJavaFiles)"
+      ErrorOnCustomJavaObject="$(AndroidErrorOnCustomJavaObject)"
+      Debug="$(AndroidIncludeDebugSymbols)"
+      AndroidSdkPlatform="$(_AndroidApiLevel)"
+      OutputDirectory="$(_OuterIntermediateOutputPath)android"
+      PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
+      ApplicationJavaClass="$(AndroidApplicationJavaClass)"
+      FrameworkDirectories="$(_XATargetFrameworkDirectories);$(_XATargetFrameworkDirectories)Facades"
+      SupportedAbis="@(_BuildTargetAbis)"
+      EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
+      IntermediateOutputDirectory="$(_OuterIntermediateOutputPath)">
+  </GenerateJavaStubs>
+
+  <RewriteMarshalMethods
+      Condition=" '$(_AndroidUseMarshalMethods)' == 'true' And '$(AndroidIncludeDebugSymbols)' == 'false' "
+      EnableManagedMarshalMethodsLookup="$(_AndroidUseManagedMarshalMethodsLookup)"
+      Environments="@(_EnvironmentFiles)"
+      IntermediateOutputDirectory="$(_OuterIntermediateOutputPath)">
+  </RewriteMarshalMethods>
+
+  <GenerateTypeMappings
+      AndroidRuntime="$(_AndroidRuntime)"
+      Debug="$(AndroidIncludeDebugSymbols)"
+      IntermediateOutputDirectory="$(_OuterIntermediateOutputPath)"
+      SkipJniAddNativeMethodRegistrationAttributeScan="$(_SkipJniAddNativeMethodRegistrationAttributeScan)"
+      TypemapImplementation="$(_AndroidTypeMapImplementation)"
+      TypemapOutputDirectory="$(_NativeAssemblySourceDir)">
+  </GenerateTypeMappings>
+
+  <GenerateACWMap
+      Condition=" '$(_AndroidJLOCheckedBuild)' == 'true' "
+      AcwMapFile="$(_AcwMapFile)"
+      RunCheckedBuild="true"
+      IntermediateOutputDirectory="$(_OuterIntermediateOutputPath)"
+      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      SupportedAbis="@(_BuildTargetAbis)">
+  </GenerateACWMap>
+
+  <GenerateMainAndroidManifest
+      AndroidRuntime="$(_AndroidRuntime)"
+      AndroidSdkDir="$(_AndroidSdkDirectory)"
+      AndroidSdkPlatform="$(_AndroidApiLevel)"
+      ApplicationJavaClass="$(AndroidApplicationJavaClass)"
+      ApplicationLabel="$(_ApplicationLabel)"
+      BundledWearApplicationName="$(BundledWearApplicationPackageName)"
+      CheckedBuild="$(_AndroidCheckedBuild)"
+      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
+      Debug="$(AndroidIncludeDebugSymbols)"
+      EmbedAssemblies="$(EmbedAssembliesIntoApk)"
+      EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
+      IntermediateOutputDirectory="$(_OuterIntermediateOutputPath)"
+      ManifestPlaceholders="$(AndroidManifestPlaceholders)"
+      ManifestTemplate="$(_AndroidManifestAbs)"
+      MergedAndroidManifestOutput="$(_ManifestOutput)"
+      MergedManifestDocuments="@(_MergedManifestDocuments)"
+      MultiDex="$(AndroidEnableMultiDex)"
+      NeedsInternet="$(AndroidNeedsInternetPermission)"
+      OutputDirectory="$(_OuterIntermediateOutputPath)android"
+      PackageName="$(_AndroidPackage)"
+      ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
+      SupportedAbis="@(_BuildTargetAbis)"
+      SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
+      TargetName="$(TargetName)"
+      VersionCode="$(_AndroidVersionCode)"
+      VersionName="$(_AndroidVersionName)">
+  </GenerateMainAndroidManifest>
+
   <AssemblyModifierPipeline
       ApplicationJavaClass="$(AndroidApplicationJavaClass)"
       CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
@@ -1512,7 +1614,14 @@ because xbuild doesn't support framework reference assemblies.
       TargetName="$(TargetName)">
   </AssemblyModifierPipeline>
 
-  <Touch Files="$(_AdditionalPostLinkerStepsFlag)" AlwaysCreate="true" />
+  <ItemGroup>
+    <FileWrites Include="@(_TypeMapAssemblySource)" />
+    <FileWrites Include="@(_TypeMapAssemblyInclude)" />
+    <FileWrites Include="@(_AndroidTypeMapping)" Condition=" '@(_AndroidTypeMapping->Count())' == '0' " />
+    <FileWrites Include="$(_ManifestOutput)" />
+  </ItemGroup>
+
+  <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp" AlwaysCreate="true" />
 </Target>
 
 <!-- _PrepareAssemblies lives in Microsoft.Android.Sdk.AssemblyResolution.targets -->
@@ -1548,121 +1657,6 @@ because xbuild doesn't support framework reference assemblies.
     <_GenerateJavaStubsInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
     <_EnvironmentFiles Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
   </ItemGroup>
-</Target>
-
-<Target Name="_GenerateJavaStubs"
-    DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest)"
-    Inputs="@(_GenerateJavaStubsInputs)"
-    Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
-
-  <PropertyGroup>
-    <_ManifestOutput Condition=" '$(AndroidManifestMerger)' == 'legacy' ">$(IntermediateOutputPath)android\AndroidManifest.xml</_ManifestOutput>
-    <_ManifestOutput Condition=" '$(AndroidManifestMerger)' != 'legacy' ">$(IntermediateOutputPath)AndroidManifest.xml</_ManifestOutput>
-    <_LinkingEnabled Condition=" '$(AndroidLinkMode)' != 'None'">True</_LinkingEnabled>
-    <_LinkingEnabled Condition=" '$(AndroidLinkMode)' == 'None'">False</_LinkingEnabled>
-    <_HaveMultipleRIDs Condition=" '$(RuntimeIdentifiers)' != '' ">True</_HaveMultipleRIDs>
-    <_HaveMultipleRIDs Condition=" '$(RuntimeIdentifiers)' == '' ">False</_HaveMultipleRIDs>
-  </PropertyGroup>
-  <ItemGroup>
-    <_MergedManifestDocuments Condition=" '$(AndroidManifestMerger)' == 'legacy' " Include="@(ExtractedManifestDocuments)" />
-  </ItemGroup>
-
-  <GenerateJavaCallableWrappers
-      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
-      OutputDirectory="$(IntermediateOutputPath)android\src"
-      ResolvedAssemblies="@(_ResolvedAssemblies)"
-      PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
-      SupportedAbis="@(_BuildTargetAbis)">
-    <Output TaskParameter="GeneratedJavaFilesOutput" ItemName="_GeneratedJavaFiles" />
-  </GenerateJavaCallableWrappers>
-
-  <GenerateACWMap
-      AcwMapFile="$(_AcwMapFile)"
-      IntermediateOutputDirectory="$(IntermediateOutputPath)"
-      ResolvedAssemblies="@(_ResolvedAssemblies)"
-      SupportedAbis="@(_BuildTargetAbis)">
-  </GenerateACWMap>
-
-  <GenerateJavaStubs
-      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
-      ResolvedAssemblies="@(_ResolvedAssemblies)"
-      ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
-      RunCheckedBuild="$(_AndroidJLOCheckedBuild)"
-      GeneratedJavaFiles="@(_GeneratedJavaFiles)"
-      ErrorOnCustomJavaObject="$(AndroidErrorOnCustomJavaObject)"
-      Debug="$(AndroidIncludeDebugSymbols)"
-      AndroidSdkPlatform="$(_AndroidApiLevel)"
-      OutputDirectory="$(IntermediateOutputPath)android"
-      PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
-      ApplicationJavaClass="$(AndroidApplicationJavaClass)"
-      FrameworkDirectories="$(_XATargetFrameworkDirectories);$(_XATargetFrameworkDirectories)Facades"
-      SupportedAbis="@(_BuildTargetAbis)"
-      EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
-      IntermediateOutputDirectory="$(IntermediateOutputPath)">
-  </GenerateJavaStubs>
-
-  <RewriteMarshalMethods
-      Condition=" '$(_AndroidUseMarshalMethods)' == 'true' And '$(AndroidIncludeDebugSymbols)' == 'false' "
-      EnableManagedMarshalMethodsLookup="$(_AndroidUseManagedMarshalMethodsLookup)"
-      Environments="@(_EnvironmentFiles)"
-      IntermediateOutputDirectory="$(IntermediateOutputPath)">
-  </RewriteMarshalMethods>
-
-  <GenerateTypeMappings
-      AndroidRuntime="$(_AndroidRuntime)"
-      Debug="$(AndroidIncludeDebugSymbols)"
-      IntermediateOutputDirectory="$(IntermediateOutputPath)"
-      SkipJniAddNativeMethodRegistrationAttributeScan="$(_SkipJniAddNativeMethodRegistrationAttributeScan)"
-      TypemapImplementation="$(_AndroidTypeMapImplementation)"
-      TypemapOutputDirectory="$(_NativeAssemblySourceDir)">
-  </GenerateTypeMappings>
-
-  <GenerateACWMap
-      Condition=" '$(_AndroidJLOCheckedBuild)' == 'true' "
-      AcwMapFile="$(_AcwMapFile)"
-      RunCheckedBuild="true"
-      IntermediateOutputDirectory="$(IntermediateOutputPath)"
-      ResolvedAssemblies="@(_ResolvedAssemblies)"
-      SupportedAbis="@(_BuildTargetAbis)">
-  </GenerateACWMap>
-
-  <GenerateMainAndroidManifest
-      AndroidRuntime="$(_AndroidRuntime)"
-      AndroidSdkDir="$(_AndroidSdkDirectory)"
-      AndroidSdkPlatform="$(_AndroidApiLevel)"
-      ApplicationJavaClass="$(AndroidApplicationJavaClass)"
-      ApplicationLabel="$(_ApplicationLabel)"
-      BundledWearApplicationName="$(BundledWearApplicationPackageName)"
-      CheckedBuild="$(_AndroidCheckedBuild)"
-      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
-      Debug="$(AndroidIncludeDebugSymbols)"
-      EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-      EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
-      IntermediateOutputDirectory="$(IntermediateOutputPath)"
-      ManifestPlaceholders="$(AndroidManifestPlaceholders)"
-      ManifestTemplate="$(_AndroidManifestAbs)"
-      MergedAndroidManifestOutput="$(_ManifestOutput)"
-      MergedManifestDocuments="@(_MergedManifestDocuments)"
-      MultiDex="$(AndroidEnableMultiDex)"
-      NeedsInternet="$(AndroidNeedsInternetPermission)"
-      OutputDirectory="$(IntermediateOutputPath)android"
-      PackageName="$(_AndroidPackage)"
-      ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
-      SupportedAbis="@(_BuildTargetAbis)"
-      SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
-      TargetName="$(TargetName)"
-      VersionCode="$(_AndroidVersionCode)"
-      VersionName="$(_AndroidVersionName)">
-  </GenerateMainAndroidManifest>
-
-  <ItemGroup>
-    <FileWrites Include="@(_TypeMapAssemblySource)" />
-    <FileWrites Include="@(_TypeMapAssemblyInclude)" />
-    <FileWrites Include="@(_AndroidTypeMapping)" Condition=" '@(_AndroidTypeMapping->Count())' == '0' " />
-    <FileWrites Include="$(_ManifestOutput)" />
-  </ItemGroup>
-
-  <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp" AlwaysCreate="True" />
 </Target>
 
 <Target Name="_ManifestMerger"
@@ -1824,7 +1818,6 @@ because xbuild doesn't support framework reference assemblies.
 
 <PropertyGroup>
   <_GeneratePackageManagerJavaDependsOn>
-    _GenerateJavaStubs;
     _RunAotForAllRIDs;
     _ManifestMerger;
     _ConvertCustomView;
@@ -1932,7 +1925,6 @@ because xbuild doesn't support framework reference assemblies.
 
 <PropertyGroup>
 	<_CreateBaseApkDependsOnTargets>
-		_GenerateJavaStubs;
 		_ManifestMerger;
 		_ConvertCustomView;
 		$(_AfterConvertCustomView);
@@ -1976,7 +1968,7 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
-<Target Name="_FindJavaStubFiles" DependsOnTargets="_GenerateJavaStubs;_ManifestMerger;_ConvertCustomView;$(_AfterConvertCustomView);_GenerateEnvironmentFiles;">
+<Target Name="_FindJavaStubFiles" DependsOnTargets="_ManifestMerger;_ConvertCustomView;$(_AfterConvertCustomView);_GenerateEnvironmentFiles;">
   <ItemGroup>
     <_JavaStubFiles Include="$(_AndroidIntermediateJavaSourceDirectory)**\*.java" />
     <FileWrites Include="@(_JavaStubFiles)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1499,7 +1499,8 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GetGenerateJavaStubsInputs" DependsOnTargets="_GenerateEnvironmentFiles">
   <ItemGroup>
-    <_AndroidILLinkAssemblies Include="@(ManagedAssemblyToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" Condition="Exists('$(IntermediateLinkDir)%(Filename)%(Extension)')" Abi="$(RuntimeIdentifier)" />
+    <!-- HACK: %(Abi) is just hardcoded to get things to work at all -->
+    <_AndroidILLinkAssemblies Include="@(ManagedAssemblyToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" Condition="Exists('$(IntermediateLinkDir)%(Filename)%(Extension)')" Abi="arm64-v8a" />
     <_GenerateJavaStubsInputs Include="@(_AndroidMSBuildAllProjects)" />
     <_GenerateJavaStubsInputs Include="$(_AndroidILLinkAssemblies)" />
     <_GenerateJavaStubsInputs Include="$(_AndroidManifestAbs)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -342,9 +342,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <AndroidUseAssemblyStore Condition=" '$(AndroidUseAssemblyStore)' == '' ">true</AndroidUseAssemblyStore>
   <AndroidAotEnableLazyLoad Condition=" '$(AndroidAotEnableLazyLoad)' == '' And '$(AotAssemblies)' == 'true' And '$(AndroidIncludeDebugSymbols)' != 'true' ">True</AndroidAotEnableLazyLoad>
   <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and ('$(UsingMicrosoftNETSdkRazor)' == 'true') ">False</AndroidEnableMarshalMethods>
-  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' and '$(PublishReadyToRun)' != 'true' ">True</AndroidEnableMarshalMethods>
+  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' ">True</AndroidEnableMarshalMethods>
   <!-- NOTE: temporarily disable for NativeAOT for now, to get build passing -->
-  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and ('$(_AndroidRuntime)' == 'NativeAOT' or '$(PublishReadyToRun)' == 'true') ">False</AndroidEnableMarshalMethods>
+  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and '$(_AndroidRuntime)' == 'NativeAOT' ">False</AndroidEnableMarshalMethods>
 
   <_AndroidUseMarshalMethods Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' ">False</_AndroidUseMarshalMethods>
   <_AndroidUseMarshalMethods Condition=" '$(AndroidIncludeDebugSymbols)' != 'True' ">$(AndroidEnableMarshalMethods)</_AndroidUseMarshalMethods>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1500,8 +1500,13 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GetGenerateJavaStubsInputs" DependsOnTargets="_GenerateEnvironmentFiles">
   <ItemGroup>
-    <!-- HACK: %(Abi) is just hardcoded to get things to work at all -->
-    <_AndroidILLinkAssemblies Include="@(ManagedAssemblyToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" Condition="Exists('$(IntermediateLinkDir)%(Filename)%(Extension)')" Abi="arm64-v8a" />
+    <!-- HACK: %(Abi) and %(HasMonoAndroidReference) are hardcoded to get things to work at all -->
+    <_AndroidILLinkAssemblies
+        Include="@(ManagedAssemblyToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')"
+        Condition="Exists('$(IntermediateLinkDir)%(Filename)%(Extension)')"
+        Abi="arm64-v8a"
+        HasMonoAndroidReference="true"
+    />
     <_GenerateJavaStubsInputs Include="@(_AndroidMSBuildAllProjects)" />
     <_GenerateJavaStubsInputs Include="$(_AndroidILLinkAssemblies)" />
     <_GenerateJavaStubsInputs Include="$(_AndroidManifestAbs)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1519,6 +1519,22 @@ because xbuild doesn't support framework reference assemblies.
     Inputs="@(_GenerateJavaStubsInputs);$(_AndroidLinkFlag)"
     Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
 
+  <AssemblyModifierPipeline
+      ApplicationJavaClass="$(AndroidApplicationJavaClass)"
+      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
+      Debug="$(AndroidIncludeDebugSymbols)"
+      DestinationFiles="@(_AndroidILLinkAssemblies)"
+      Deterministic="$(Deterministic)"
+      EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
+      ErrorOnCustomJavaObject="$(AndroidErrorOnCustomJavaObject)"
+      PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
+      ReadSymbols="$(_AndroidLinkAssembliesReadSymbols)"
+      ResolvedAssemblies="@(_AndroidILLinkAssemblies)"
+      ResolvedUserAssemblies="@(_AndroidILLinkAssemblies)"
+      SourceFiles="@(_AndroidILLinkAssemblies)"
+      TargetName="$(TargetName)">
+  </AssemblyModifierPipeline>
+
   <PropertyGroup>
     <_ManifestOutput Condition=" '$(AndroidManifestMerger)' == 'legacy' ">$(_OuterIntermediateOutputPath)android\AndroidManifest.xml</_ManifestOutput>
     <_ManifestOutput Condition=" '$(AndroidManifestMerger)' != 'legacy' ">$(_OuterIntermediateOutputPath)AndroidManifest.xml</_ManifestOutput>
@@ -1618,22 +1634,6 @@ because xbuild doesn't support framework reference assemblies.
       VersionCode="$(_AndroidVersionCode)"
       VersionName="$(_AndroidVersionName)">
   </GenerateMainAndroidManifest>
-
-  <AssemblyModifierPipeline
-      ApplicationJavaClass="$(AndroidApplicationJavaClass)"
-      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
-      Debug="$(AndroidIncludeDebugSymbols)"
-      DestinationFiles="@(ResolvedAssemblies)"
-      Deterministic="$(Deterministic)"
-      EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
-      ErrorOnCustomJavaObject="$(AndroidErrorOnCustomJavaObject)"
-      PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
-      ReadSymbols="$(_AndroidLinkAssembliesReadSymbols)"
-      ResolvedAssemblies="@(_AllResolvedAssemblies)"
-      ResolvedUserAssemblies="@(ResolvedUserAssemblies)"
-      SourceFiles="@(ResolvedAssemblies)"
-      TargetName="$(TargetName)">
-  </AssemblyModifierPipeline>
 
   <ItemGroup>
     <FileWrites Include="@(_TypeMapAssemblySource)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1836,7 +1836,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GetGeneratePackageManagerJavaInputs">
   <ItemGroup>
-    <_GeneratePackageManagerJavaInputs Include="@(_GenerateJavaStubsInputs)" />
+    <_GeneratePackageManagerJavaInputs Include="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp" />
   </ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1492,6 +1492,7 @@ because xbuild doesn't support framework reference assemblies.
 <PropertyGroup>
   <_GenerateJavaStubsDependsOnTargets>
     _SetLatestTargetFrameworkVersion;
+    _GetAndroidPackageName;
     _PrepareNativeAssemblySources;
     _GetGenerateJavaStubsInputs;
   </_GenerateJavaStubsDependsOnTargets>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1489,6 +1489,26 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
+<PropertyGroup>
+  <_GenerateJavaStubsDependsOnTargets>
+    _SetLatestTargetFrameworkVersion;
+    _PrepareNativeAssemblySources;
+    _GetGenerateJavaStubsInputs;
+  </_GenerateJavaStubsDependsOnTargets>
+</PropertyGroup>
+
+<Target Name="_GetGenerateJavaStubsInputs" DependsOnTargets="_GenerateEnvironmentFiles">
+  <ItemGroup>
+    <_AndroidILLinkAssemblies Include="@(ManagedAssemblyToLink->'$(IntermediateLinkDir)%(Filename)%(Extension)')" Condition="Exists('$(IntermediateLinkDir)%(Filename)%(Extension)')" Abi="$(RuntimeIdentifier)" />
+    <_GenerateJavaStubsInputs Include="@(_AndroidMSBuildAllProjects)" />
+    <_GenerateJavaStubsInputs Include="$(_AndroidILLinkAssemblies)" />
+    <_GenerateJavaStubsInputs Include="$(_AndroidManifestAbs)" />
+    <_GenerateJavaStubsInputs Include="$(_AndroidBuildPropertiesCache)" />
+    <_GenerateJavaStubsInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
+    <_EnvironmentFiles Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
+  </ItemGroup>
+</Target>
+
 <!-- Runs additional steps after ILLink runs (_LinkAssemblies) -->
 <Target Name="_GenerateJavaStubs"
     AfterTargets="ILLink"
@@ -1513,7 +1533,7 @@ because xbuild doesn't support framework reference assemblies.
   <GenerateJavaCallableWrappers
       CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
       OutputDirectory="$(_OuterIntermediateOutputPath)android\src"
-      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      ResolvedAssemblies="@(_AndroidILLinkAssemblies)"
       PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
       SupportedAbis="@(_BuildTargetAbis)">
     <Output TaskParameter="GeneratedJavaFilesOutput" ItemName="_GeneratedJavaFiles" />
@@ -1522,14 +1542,14 @@ because xbuild doesn't support framework reference assemblies.
   <GenerateACWMap
       AcwMapFile="$(_AcwMapFile)"
       IntermediateOutputDirectory="$(_OuterIntermediateOutputPath)"
-      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      ResolvedAssemblies="@(_AndroidILLinkAssemblies)"
       SupportedAbis="@(_BuildTargetAbis)">
   </GenerateACWMap>
 
   <GenerateJavaStubs
       CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
-      ResolvedAssemblies="@(_ResolvedAssemblies)"
-      ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
+      ResolvedAssemblies="@(_AndroidILLinkAssemblies)"
+      ResolvedUserAssemblies="@(_AndroidILLinkAssemblies)"
       RunCheckedBuild="$(_AndroidJLOCheckedBuild)"
       GeneratedJavaFiles="@(_GeneratedJavaFiles)"
       ErrorOnCustomJavaObject="$(AndroidErrorOnCustomJavaObject)"
@@ -1565,7 +1585,7 @@ because xbuild doesn't support framework reference assemblies.
       AcwMapFile="$(_AcwMapFile)"
       RunCheckedBuild="true"
       IntermediateOutputDirectory="$(_OuterIntermediateOutputPath)"
-      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      ResolvedAssemblies="@(_AndroidILLinkAssemblies)"
       SupportedAbis="@(_BuildTargetAbis)">
   </GenerateACWMap>
 
@@ -1590,7 +1610,7 @@ because xbuild doesn't support framework reference assemblies.
       NeedsInternet="$(AndroidNeedsInternetPermission)"
       OutputDirectory="$(_OuterIntermediateOutputPath)android"
       PackageName="$(_AndroidPackage)"
-      ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
+      ResolvedUserAssemblies="@(_AndroidILLinkAssemblies)"
       SupportedAbis="@(_BuildTargetAbis)"
       SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
       TargetName="$(TargetName)"
@@ -1635,26 +1655,6 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="AssemblySources" ItemName="_TypeMapAssemblySource" />
     <Output TaskParameter="AssemblyIncludes" ItemName="_TypeMapAssemblyInclude" />
   </PrepareAbiItems>
-</Target>
-
-<PropertyGroup>
-  <_GenerateJavaStubsDependsOnTargets>
-    _SetLatestTargetFrameworkVersion;
-    _PrepareNativeAssemblySources;
-    _GetGenerateJavaStubsInputs;
-  </_GenerateJavaStubsDependsOnTargets>
-</PropertyGroup>
-
-<Target Name="_GetGenerateJavaStubsInputs" DependsOnTargets="_GenerateEnvironmentFiles">
-  <ItemGroup>
-    <_GenerateJavaStubsInputs Include="@(_AndroidMSBuildAllProjects)" />
-    <_GenerateJavaStubsInputs Include="$(_ResolvedUserAssembliesHashFile)" />
-    <_GenerateJavaStubsInputs Include="@(_ResolvedUserMonoAndroidAssemblies)" />
-    <_GenerateJavaStubsInputs Include="$(_AndroidManifestAbs)" />
-    <_GenerateJavaStubsInputs Include="$(_AndroidBuildPropertiesCache)" />
-    <_GenerateJavaStubsInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
-    <_EnvironmentFiles Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
-  </ItemGroup>
 </Target>
 
 <Target Name="_ManifestMerger"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1640,9 +1640,7 @@ because xbuild doesn't support framework reference assemblies.
 <PropertyGroup>
   <_GenerateJavaStubsDependsOnTargets>
     _SetLatestTargetFrameworkVersion;
-    _PrepareAssemblies;
     _PrepareNativeAssemblySources;
-    $(_AfterPrepareAssemblies);
     _GetGenerateJavaStubsInputs;
   </_GenerateJavaStubsDependsOnTargets>
 </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2125,7 +2125,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CompileNativeAssemblySources"
-    DependsOnTargets="_PrepareNativeAssemblyItems;_GenerateCompressedAssembliesNativeSourceFiles"
+    DependsOnTargets="_PrepareNativeAssemblySources;_PrepareNativeAssemblyItems;_GenerateCompressedAssembliesNativeSourceFiles"
     Inputs="@(_TypeMapAssemblySource);@(_TypeMapAssemblyInclude);@(_EnvironmentAssemblySource);@(_CompressedAssembliesAssemblySource);@(_MarshalMethodsAssemblySource);@(_AndroidRemapAssemblySource)"
     Outputs="@(_NativeAssemblyTarget)">
   <CompileNativeAssembly

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1511,7 +1511,7 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
-<!-- Runs additional steps after ILLink runs (_LinkAssemblies) -->
+<!-- Additional steps after ILLink -->
 <Target Name="_GenerateJavaStubs"
     AfterTargets="ILLink"
     BeforeTargets="CreateReadyToRunImages;ComputeIlcCompileInputs"
@@ -1702,7 +1702,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_ReadAndroidManifest"
-    DependsOnTargets="_GenerateJavaStubs;_ManifestMerger">
+    DependsOnTargets="_ManifestMerger">
   <ReadAndroidManifest
       ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
       AndroidSdkDirectory="$(_AndroidSdkDirectory)"
@@ -2087,7 +2087,7 @@ because xbuild doesn't support framework reference assemblies.
    <Touch Files="$(_AndroidApkPerAbiFlagFile)" Condition="'$(AndroidCreatePackagePerAbi)' == 'true'" AlwaysCreate="True" />
 </Target>
 
-<Target Name="_PrepareNativeAssemblyItems" DependsOnTargets="_GenerateJavaStubs">
+<Target Name="_PrepareNativeAssemblyItems">
   <ItemGroup>
     <_NativeAssemblyTarget Include="@(_TypeMapAssemblySource->'$([System.IO.Path]::ChangeExtension('%(Identity)', '.o'))')">
       <abi>%(_TypeMapAssemblySource.abi)</abi>


### PR DESCRIPTION
This is WIP, I don't really intend for this to be merged. We need to be able to test the perf of LLVM Marshal Methods w/ ReadyToRun.

I'm only building such as:
```
.\dotnet-local.cmd build -c Release -p:UseMonoRuntime=false -p:PublishReadyToRun=true -p:_IsPublishing=true -r android-arm64 -p:AndroidPackageFormat=apk -bl
```

This is currently working.

Results of the comparision [available here](https://microsoft.sharepoint.com/:fl:/s/c4ebe80e-841c-45ca-af40-97adcecf6c5b/Eb1dNnTZSBtOqEsDUFC6QyYBp4M579HtZhSlKF9jjXRDZw?e=M92YM8&nav=cz0lMkZzaXRlcyUyRmM0ZWJlODBlLTg0MWMtNDVjYS1hZjQwLTk3YWRjZWNmNmM1YiZkPWIlMjFJRGUycjdacTFreW4tME42VVFZQnUybklYWkM3VmJwRmk5SUF3dlNxZHY4Wlhhem5LNVc5U0k3dnNXc3VKZGhWJmY9MDFMTkJBMk9GNUxVM0hKV0tJRE5IS1FTWURLQklMVVFaRyZjPSUyRiZhPUxvb3BBcHAmcD0lNDBmbHVpZHglMkZsb29wLXBhZ2UtY29udGFpbmVyJng9JTdCJTIydyUyMiUzQSUyMlQwUlRVSHh0YVdOeWIzTnZablF1YzJoaGNtVndiMmx1ZEM1amIyMThZaUZKUkdVeWNqZGFjVEZyZVc0dE1FNDJWVkZaUW5VeWJrbFlXa00zVm1Kd1JtazVTVUYzZGxOeFpIWTRXbGhoZW01TE5WYzVVMGszZG5OWGMzVktaR2hXZkRBeFRFNUNRVEpQU0ZJeU4wWlNSMGxHTkRZMVIxbFdVa3MxUzBKTFRrZFRTMEklM0QlMjIlMkMlMjJpJTIyJTNBJTIyMWY5NTI4MDgtYTAwNy00ZDE4LThkNmItYTllNGNhZmQ5M2JiJTIyJTdE).