### PR TITLE
[release/9.0.1xx] pass `-Xlint:-options` for `javac` -target/source 1.8

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -71,6 +71,10 @@ namespace Xamarin.Android.Tasks
 			} else {
 				cmd.AppendSwitchIfNotNull ("-target ", JavacTargetVersion);
 				cmd.AppendSwitchIfNotNull ("-source ", JavacSourceVersion);
+				// Ignore warning when targeting older Java versions
+				// JAVAC : warning : [options] source value 8 is obsolete and will be removed in a future release
+				// JAVAC : warning : [options] target value 8 is obsolete and will be removed in a future release
+				cmd.AppendSwitchIfNotNull ("-Xlint:", "-options");
 			}
 
 			return cmd.ToString ();


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9925
Partial backport of: https://github.com/dotnet/android/pull/10050

For backporting to .NET 9, we just need to suppress a warning that JDK 21 will show when using `javac -source 1.8 -target 1.8`.