### PR TITLE
[workload] Fix symbols paths in Microsoft.Android.Sdk

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -47,18 +47,23 @@ core workload SDK packs imported by WorkloadManifest.targets.
         Files="@(AndroidSdkBuildTools)"
     />
 
+    <!-- For symbols use a relative path one directory up to circumvent the inclusion of a root 'runtimes' folder in the target path due to:
+      https://github.com/dotnet/arcade/blob/2b1931c05dd6ceb89120131a8b39eaa81735179a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets#L569
+    -->
     <ItemGroup>
-      <FilesToPackage Include="@(AndroidSdkBuildTools)" TargetPath="%(AndroidSdkBuildTools.TargetPath)" />
+      <FilesToPackage Include="@(AndroidSdkBuildTools)" Condition=" '%(Extension)' != '.pdb' " TargetPath="%(AndroidSdkBuildTools.TargetPath)" />
+      <FilesToPackage Include="@(AndroidSdkBuildTools)" Condition=" '%(Extension)' == '.pdb' " TargetPath="..\%(AndroidSdkBuildTools.TargetPath)" IsSymbolFile="true" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Sdk.ILLink.dll" TargetPath="tools" />
-      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Sdk.ILLink.pdb" TargetPath="tools" />
+      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Sdk.ILLink.pdb" TargetPath="..\tools" IsSymbolFile="true"/>
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)%(_LocalizationLanguages.Identity)\Microsoft.Android.Sdk.ILLink.resources.dll" TargetPath="tools\%(_LocalizationLanguages.Identity)" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)%(_LocalizationLanguages.Identity)\Java.Interop.Localization.resources.dll" TargetPath="tools\%(_LocalizationLanguages.Identity)" />
-      <FilesToPackage Include="@(JIUtilityFile->'$(MicrosoftAndroidSdkOutDir)%(Identity)')"  TargetPath="tools" />
+      <FilesToPackage Include="@(JIUtilityFile->'$(MicrosoftAndroidSdkOutDir)%(Identity)')" Condition=" '%(Extension)' != '.pdb' " TargetPath="tools" />
+      <FilesToPackage Include="@(JIUtilityFile->'$(MicrosoftAndroidSdkOutDir)%(Identity)')" Condition=" '%(Extension)' == '.pdb' " TargetPath="..\tools" IsSymbolFile="true" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)class-parse.dll" TargetPath="tools" />
-      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)class-parse.pdb" TargetPath="tools" />
+      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)class-parse.pdb" TargetPath="..\tools" IsSymbolFile="true" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)class-parse.runtimeconfig.json" TargetPath="tools" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)generator.dll" TargetPath="tools" />
-      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)generator.pdb" TargetPath="tools" />
+      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)generator.pdb" TargetPath="..\tools" IsSymbolFile="true" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)generator.runtimeconfig.json" TargetPath="tools" />
       <FilesToPackage Include="@(VersionFiles)" TargetPath="tools" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\Sdk\**" TargetPath="Sdk" />


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/dc089720b658de788990f1c3426d19c673ccfa20

Removes the extra `runtimes` folder that was inadvertently included in the symbols target path in the new symbols.nupkg files.

Before:

    53652  01-24-2021 16:24   runtimes/tools/HtmlAgilityPack.pdb
    42736  04-24-2025 21:55   runtimes/tools/Java.Interop.Tools.Maven.pdb
    42940  06-06-2024 15:33   runtimes/tools/libZipSharp.pdb
    ....

After:

    53652  01-24-2021 16:24   tools/HtmlAgilityPack.pdb
    42736  04-24-2025 21:55   tools/Java.Interop.Tools.Maven.pdb
    42940  06-06-2024 15:33   tools/libZipSharp.pdb
    ....