### PR TITLE
[XABT] introduce `$(EnableProfiler)` property

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -398,6 +398,15 @@ final `.apk`.
 
 This property is `False` by default.
 
+## AndroidEnableProfiler
+
+Required for using `dotnet-trace` or `dotnet-gcdump` in Android
+applications. If set to `true`, it includes the Mono diagnostic
+component in the application. This component is the
+`libmono-component-diagnostics_tracing.so` native library.
+
+This property is `False` by default.
+
 ## AndroidEnableObsoleteOverrideInheritance
 
 A boolean property that determines if bound methods automatically inherit `[Obsolete]`
@@ -1547,6 +1556,18 @@ This property is `False` by default.
 
 This property is ignored unless the
 [`$(AotAssemblies)`](#aotassemblies) MSBuild property is `True`.
+
+## EnableProfiler
+
+Synonym for the [`$(AndroidEnableProfiler)`](#androidenableprofiler)
+property.
+
+Required for using `dotnet-trace` or `dotnet-gcdump` in Android
+applications. If set to `true`, it includes the Mono diagnostic
+component in the application. This component is the
+`libmono-component-diagnostics_tracing.so` native library.
+
+This property is `False` by default.
 
 ## EnableProguard
 

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -400,6 +400,8 @@ This property is `False` by default.
 
 ## AndroidEnableProfiler
 
+Synonym for the [`$(EnableProfiler)`](#enableprofiler) property.
+
 Required for using `dotnet-trace` or `dotnet-gcdump` in Android
 applications. If set to `true`, it includes the Mono diagnostic
 component in the application. This component is the

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -52,6 +52,7 @@
     <AndroidEnableRestrictToAttributes Condition=" '$(AndroidEnableRestrictToAttributes)' == '' ">obsolete</AndroidEnableRestrictToAttributes>
 
     <!-- Mono components -->
+    <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == ''">$(EnableProfiler)</AndroidEnableProfiler>
     <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == ''">false</AndroidEnableProfiler>
 
     <!--


### PR DESCRIPTION
Context: https://github.com/dotnet/macios/pull/22685
Context: https://github.com/dotnet/macios/issues/19370

To simplify inclusion of the Mono diagnostics component, the iOS/macOS/etc. workloads are introducing a new `$(EnableProfiler)` property.

To align with Android, we can make `$(EnableProfiler)` available and work the same way as the existing `$(AndroidEnableProfiler)` property.

I documented `$(AndroidEnableProfiler)` (which was missing!), and also added an entry about the new, `$(EnableProfiler)` property.