### PR TITLE
[ci] run MSBuild "SmokeTests" category on all runtimes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -90,7 +90,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
     </PropertyGroup>
     <ItemGroup>
       <!-- Android needs a proper soname property or it will refuse to load the library -->
-      <LinkerArg Include="-Wl,-soname,lib$(TargetName)$(NativeBinaryExt)" />
+      <LinkerArg Include="&quot;-Wl,-soname,lib$(TargetName)$(NativeBinaryExt)&quot;" />
       <!-- Required for [UnmanagedCallersOnly] to work inside this assembly -->
       <UnmanagedEntryPointsAssembly Include="Microsoft.Android.Runtime.NativeAOT" />
       <!-- Give ILLink's output to ILC -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
@@ -2,6 +2,7 @@ using System;
 using NUnit.Framework;
 using System.IO;
 using System.Text;
+using Xamarin.Android.Tasks;
 using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
@@ -35,7 +36,11 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Category ("SmokeTests")]
-		public void BuildApplicationWithAssetPackThatHasInvalidName ([Values (true, false)] bool isRelease)
+		[TestCase (false, AndroidRuntime.MonoVM)]
+		[TestCase (true, AndroidRuntime.MonoVM)]
+		[TestCase (true, AndroidRuntime.CoreCLR)]
+		[TestCase (true, AndroidRuntime.NativeAOT)]
+		public void BuildApplicationWithAssetPackThatHasInvalidName (bool isRelease, AndroidRuntime runtime)
 		{
 			var path = Path.Combine ("temp", TestName);
 			var app = new XamarinAndroidApplicationProject {
@@ -48,6 +53,7 @@ namespace Xamarin.Android.Build.Tests
 					},
 				}
 			};
+			app.SetRuntime (runtime);
 			app.SetProperty ("AndroidPackageFormat", "aab");
 			using (var builder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
 				builder.ThrowOnBuildFailure = false;
@@ -59,7 +65,11 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Category ("SmokeTests")]
-		public void BuildApplicationWithAssetPackOutsideProjectDirectory ([Values (true, false)] bool isRelease)
+		[TestCase (false, AndroidRuntime.MonoVM)]
+		[TestCase (true, AndroidRuntime.MonoVM)]
+		[TestCase (true, AndroidRuntime.CoreCLR)]
+		[TestCase (true, AndroidRuntime.NativeAOT)]
+		public void BuildApplicationWithAssetPackOutsideProjectDirectory (bool isRelease, AndroidRuntime runtime)
 		{
 			var path = Path.Combine ("temp", TestName);
 			var app = new XamarinAndroidApplicationProject {
@@ -83,6 +93,7 @@ namespace Xamarin.Android.Build.Tests
 					},
 				}
 			};
+			app.SetRuntime (runtime);
 			app.SetProperty ("AndroidPackageFormat", "aab");
 			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
 				Assert.IsTrue (appBuilder.Build (app), $"{app.ProjectName} should succeed");
@@ -104,7 +115,11 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Category ("SmokeTests")]
-		public void BuildApplicationWithAssetPackOverrides ([Values (true, false)] bool isRelease)
+		[TestCase (false, AndroidRuntime.MonoVM)]
+		[TestCase (true, AndroidRuntime.MonoVM)]
+		[TestCase (true, AndroidRuntime.CoreCLR)]
+		[TestCase (true, AndroidRuntime.NativeAOT)]
+		public void BuildApplicationWithAssetPackOverrides (bool isRelease, AndroidRuntime runtime)
 		{
 			var path = Path.Combine ("temp", TestName);
 			var app = new XamarinAndroidApplicationProject {
@@ -123,6 +138,7 @@ namespace Xamarin.Android.Build.Tests
 					},
 				}
 			};
+			app.SetRuntime (runtime);
 			app.SetProperty ("AndroidPackageFormat", "aab");
 			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
 				Assert.IsTrue (appBuilder.Build (app), $"{app.ProjectName} should succeed");
@@ -142,7 +158,12 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Category ("SmokeTests")]
-		public void BuildApplicationWithAssetPack ([Values (true, false)] bool isRelease) {
+		[TestCase (false, AndroidRuntime.MonoVM)]
+		[TestCase (true, AndroidRuntime.MonoVM)]
+		[TestCase (true, AndroidRuntime.CoreCLR)]
+		[TestCase (true, AndroidRuntime.NativeAOT)]
+		public void BuildApplicationWithAssetPack (bool isRelease, AndroidRuntime runtime)
+		{
 			var path = Path.Combine ("temp", TestName);
 			var asset3 = new AndroidItem.AndroidAsset ("Assets\\asset3.txt") {
 				TextContent = () => "Asset3",
@@ -175,6 +196,7 @@ namespace Xamarin.Android.Build.Tests
 					},
 				}
 			};
+			app.SetRuntime (runtime);
 			app.SetProperty ("AndroidPackageFormat", "aab");
 			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
 				Assert.IsTrue (appBuilder.Build (app), $"{app.ProjectName} should succeed");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.TestCaseSource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.TestCaseSource.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using NUnit.Framework;
+using Xamarin.Android.Tasks;
 using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
@@ -17,96 +18,126 @@ namespace Xamarin.Android.Build.Tests
 				/* isRelease */          false,
 				/* aot */                false,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm",
 				/* isRelease */          false,
 				/* aot */                false,
 				/* usesAssemblyStore */  true,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm64",
 				/* isRelease */          false,
 				/* aot */                false,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-x86",
 				/* isRelease */          false,
 				/* aot */                false,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-x64",
 				/* isRelease */          false,
 				/* aot */                false,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm",
 				/* isRelease */          true,
 				/* aot */                false,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm",
 				/* isRelease */          true,
 				/* aot */                false,
 				/* usesAssemblyStore */  true,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm",
 				/* isRelease */          true,
 				/* aot */                true,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm",
 				/* isRelease */          true,
 				/* aot */                true,
 				/* usesAssemblyStore */  true,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm64",
 				/* isRelease */          true,
 				/* aot */                false,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86;android-x64",
 				/* isRelease */          false,
 				/* aot */                false,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86;android-x64",
 				/* isRelease */          false,
 				/* aot */                false,
 				/* usesAssemblyStore */  true,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86",
 				/* isRelease */          true,
 				/* aot */                false,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86;android-x64",
 				/* isRelease */          true,
 				/* aot */                false,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86;android-x64",
 				/* isRelease */          true,
 				/* aot */                false,
 				/* usesAssemblyStore */  true,
+				/* runtime */            AndroidRuntime.MonoVM,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86;android-x64",
 				/* isRelease */          true,
 				/* aot */                true,
 				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.MonoVM,
+			},
+			new object [] {
+				/* runtimeIdentifiers */ "android-arm64",
+				/* isRelease */          true,
+				/* aot */                false,
+				/* usesAssemblyStore */  true,
+				/* runtime */            AndroidRuntime.CoreCLR,
+			},
+			new object [] {
+				/* runtimeIdentifiers */ "android-arm64",
+				/* isRelease */          true,
+				/* aot */                false,
+				/* usesAssemblyStore */  false,
+				/* runtime */            AndroidRuntime.NativeAOT,
 			},
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
-				ProjectName = runtime == AndroidRuntime.NativeAOT ? "Test_Me" : "Test Me", // TODO: https://github.com/dotnet/runtime/issues/115165
+				ProjectName = "Test Me",
 				RootNamespace = "Test.Me",
 				EnableDefaultItems = true,
 				ExtraNuGetConfigSources = {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -101,10 +101,6 @@ namespace Xamarin.Android.Build.Tests
 			} else {
 				proj.SetProperty (KnownProperties.RuntimeIdentifiers, runtimeIdentifiers);
 			}
-			// NOTE: Ignore warning XA1040: The CoreCLR/NativeAOT runtime on Android is an experimental feature and not yet suitable for production use.
-			if (runtime == AndroidRuntime.CoreCLR || runtime == AndroidRuntime.NativeAOT) {
-				proj.SetProperty ("EnablePreviewFeatures", "true");
-			}
 
 			var builder = CreateApkBuilder ();
 			builder.Verbosity = LoggerVerbosity.Detailed;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -134,6 +134,10 @@ namespace Xamarin.Android.Build.Tests
 				$"{proj.ProjectName}.runtimeconfig.json",
 				$"{proj.ProjectName}.xml",
 			};
+			// NOTE: a native subdirectory exists for NativeAOT
+			if (runtime == AndroidRuntime.NativeAOT) {
+				expectedFiles.Add ("native");
+			}
 			if (isRelease) {
 				expectedFiles.Add ($"{proj.PackageName}.aab");
 				expectedFiles.Add ($"{proj.PackageName}-Signed.aab");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -177,11 +177,13 @@ namespace Xamarin.Android.Build.Tests
 			var apkPath = Path.Combine (outputPath, $"{proj.PackageName}-Signed.apk");
 			FileAssert.Exists (apkPath);
 			var helper = new ArchiveAssemblyHelper (apkPath, usesAssemblyStore, rids);
-			helper.AssertContainsEntry ($"assemblies/{proj.ProjectName}.dll", shouldContainEntry: expectEmbeddedAssembies);
-			helper.AssertContainsEntry ($"assemblies/{proj.ProjectName}.pdb", shouldContainEntry: !TestEnvironment.CommercialBuildAvailable && !isRelease);
-			helper.AssertContainsEntry ($"assemblies/Mono.Android.dll",        shouldContainEntry: expectEmbeddedAssembies);
-			helper.AssertContainsEntry ($"assemblies/es/{proj.ProjectName}.resources.dll", shouldContainEntry: expectEmbeddedAssembies);
-			helper.AssertContainsEntry ($"assemblies/de-DE/{proj.ProjectName}.resources.dll", shouldContainEntry: expectEmbeddedAssembies);
+			if (runtime != AndroidRuntime.NativeAOT) {
+				helper.AssertContainsEntry ($"assemblies/{proj.ProjectName}.dll", shouldContainEntry: expectEmbeddedAssembies);
+				helper.AssertContainsEntry ($"assemblies/{proj.ProjectName}.pdb", shouldContainEntry: !TestEnvironment.CommercialBuildAvailable && !isRelease);
+				helper.AssertContainsEntry ($"assemblies/Mono.Android.dll",        shouldContainEntry: expectEmbeddedAssembies);
+				helper.AssertContainsEntry ($"assemblies/es/{proj.ProjectName}.resources.dll", shouldContainEntry: expectEmbeddedAssembies);
+				helper.AssertContainsEntry ($"assemblies/de-DE/{proj.ProjectName}.resources.dll", shouldContainEntry: expectEmbeddedAssembies);
+			}
 			foreach (var abi in rids.Select (AndroidRidAbiHelper.RuntimeIdentifierToAbi)) {
 				helper.AssertContainsEntry ($"lib/{abi}/libmonodroid.so");
 				if (runtime == AndroidRuntime.MonoVM) {
@@ -190,6 +192,7 @@ namespace Xamarin.Android.Build.Tests
 					helper.AssertContainsEntry ($"lib/{abi}/libcoreclr.so");
 				} else if (runtime == AndroidRuntime.NativeAOT) {
 					helper.AssertContainsEntry ($"lib/{abi}/lib{proj.ProjectName}.so");
+					continue; // NOTE: NativeAOT does not have following files
 				}
 				if (rids.Length > 1) {
 					helper.AssertContainsEntry ($"assemblies/{abi}/System.Private.CoreLib.dll",        shouldContainEntry: expectEmbeddedAssembies);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -185,15 +185,15 @@ namespace Xamarin.Android.Build.Tests
 				helper.AssertContainsEntry ($"assemblies/de-DE/{proj.ProjectName}.resources.dll", shouldContainEntry: expectEmbeddedAssembies);
 			}
 			foreach (var abi in rids.Select (AndroidRidAbiHelper.RuntimeIdentifierToAbi)) {
-				helper.AssertContainsEntry ($"lib/{abi}/libmonodroid.so");
 				if (runtime == AndroidRuntime.MonoVM) {
 					helper.AssertContainsEntry ($"lib/{abi}/libmonosgen-2.0.so");
 				} else if (runtime == AndroidRuntime.CoreCLR) {
 					helper.AssertContainsEntry ($"lib/{abi}/libcoreclr.so");
 				} else if (runtime == AndroidRuntime.NativeAOT) {
 					helper.AssertContainsEntry ($"lib/{abi}/lib{proj.ProjectName}.so");
-					continue; // NOTE: NativeAOT does not have following files
+					continue; // NOTE: NativeAOT will not include the other files below
 				}
+				helper.AssertContainsEntry ($"lib/{abi}/libmonodroid.so");
 				if (rids.Length > 1) {
 					helper.AssertContainsEntry ($"assemblies/{abi}/System.Private.CoreLib.dll",        shouldContainEntry: expectEmbeddedAssembies);
 				} else {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -105,7 +105,10 @@ namespace Xamarin.Android.Build.Tests
 			var builder = CreateApkBuilder ();
 			builder.Verbosity = LoggerVerbosity.Detailed;
 			Assert.IsTrue (builder.Build (proj), "`dotnet build` should succeed");
-			builder.AssertHasNoWarnings ();
+			// TODO: NativeAOT has trimmer warnings: https://github.com/dotnet/android/issues/9784
+			if (runtime != AndroidRuntime.NativeAOT) {
+				builder.AssertHasNoWarnings ();
+			}
 
 			var outputPath = Path.Combine (Root, builder.ProjectDirectory, proj.OutputPath);
 			var intermediateOutputPath = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -180,7 +180,13 @@ namespace Xamarin.Android.Build.Tests
 			helper.AssertContainsEntry ($"assemblies/de-DE/{proj.ProjectName}.resources.dll", shouldContainEntry: expectEmbeddedAssembies);
 			foreach (var abi in rids.Select (AndroidRidAbiHelper.RuntimeIdentifierToAbi)) {
 				helper.AssertContainsEntry ($"lib/{abi}/libmonodroid.so");
-				helper.AssertContainsEntry ($"lib/{abi}/libmonosgen-2.0.so");
+				if (runtime == AndroidRuntime.MonoVM) {
+					helper.AssertContainsEntry ($"lib/{abi}/libmonosgen-2.0.so");
+				} else if (runtime == AndroidRuntime.CoreCLR) {
+					helper.AssertContainsEntry ($"lib/{abi}/libcoreclr.so");
+				} else if (runtime == AndroidRuntime.NativeAOT) {
+					helper.AssertContainsEntry ($"lib/{abi}/lib{proj.ProjectName}.so");
+				}
 				if (rids.Length > 1) {
 					helper.AssertContainsEntry ($"assemblies/{abi}/System.Private.CoreLib.dll",        shouldContainEntry: expectEmbeddedAssembies);
 				} else {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
-				ProjectName = "Test Me",
+				ProjectName = runtime == AndroidRuntime.NativeAOT ? "Test_Me" : "Test Me", // TODO: https://github.com/dotnet/runtime/issues/115165
 				RootNamespace = "Test.Me",
 				EnableDefaultItems = true,
 				ExtraNuGetConfigSources = {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("SmokeTests")]
 		[TestCaseSource (nameof (DotNetBuildSource))]
 		[NonParallelizable] // On MacOS, parallel /restore causes issues
-		public void DotNetBuild (string runtimeIdentifiers, bool isRelease, bool aot, bool usesAssemblyStore)
+		public void DotNetBuild (string runtimeIdentifiers, bool isRelease, bool aot, bool usesAssemblyStore, AndroidRuntime runtime)
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
@@ -65,6 +65,7 @@ namespace Xamarin.Android.Build.Tests
 					},
 				}
 			};
+			proj.SetRuntime (runtime);
 			proj.MainActivity = proj.DefaultMainActivity.Replace (": Activity", ": AndroidX.AppCompat.App.AppCompatActivity")
 				.Replace ("//${AFTER_ONCREATE}", @"button.Text = Resource.CancelButton;");
 			proj.SetProperty ("AndroidUseAssemblyStore", usesAssemblyStore.ToString ());
@@ -762,11 +763,17 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 
 		[Test]
 		[Category ("SmokeTests")]
-		public void BuildInDesignTimeMode ([Values(false, true)] bool useManagedParser)
+		public void BuildInDesignTimeMode (
+				[Values (false, true)]
+				bool useManagedParser,
+				[Values (AndroidRuntime.MonoVM, AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)]
+				AndroidRuntime runtime
+			)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
+			proj.SetRuntime (runtime);
 			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", useManagedParser.ToString ());
 			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "UpdateAndroidResources";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -101,6 +101,10 @@ namespace Xamarin.Android.Build.Tests
 			} else {
 				proj.SetProperty (KnownProperties.RuntimeIdentifiers, runtimeIdentifiers);
 			}
+			// NOTE: Ignore warning XA1040: The CoreCLR/NativeAOT runtime on Android is an experimental feature and not yet suitable for production use.
+			if (runtime == AndroidRuntime.CoreCLR || runtime == AndroidRuntime.NativeAOT) {
+				proj.SetProperty ("EnablePreviewFeatures", "true");
+			}
 
 			var builder = CreateApkBuilder ();
 			builder.Verbosity = LoggerVerbosity.Detailed;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -153,19 +153,21 @@ Console.WriteLine ($""{DateTime.UtcNow.AddHours(-30).Humanize(culture:c)}"");
 		[Category ("SmokeTests")]
 		[TestCase ("Test Me")]
 		// testing characters as per https://www.compart.com/en/unicode/category/Zs
-		[TestCase ("TestUnicodeSpace0020\u0020Me")]
-		// TODO these break with AOT error on windows
-		[TestCase ("TestUnicodeSpace2000\u2000Me")]
-		[TestCase ("TestUnicodeSpace2009\u2009Me")]
-		[TestCase ("TestUnicodeSpace2002\u2002Me")]
-		[TestCase ("TestUnicodeSpace2007\u2007Me")]
-		public void CheckProjectWithSpaceInNameWorks (string projectName)
+		[TestCase ("TestUnicodeSpace0020\u0020Me", AndroidRuntime.MonoVM)]
+		[TestCase ("TestUnicodeSpace2000\u2000Me", AndroidRuntime.MonoVM)]
+		[TestCase ("TestUnicodeSpace2009\u2009Me", AndroidRuntime.MonoVM)]
+		[TestCase ("TestUnicodeSpace2002\u2002Me", AndroidRuntime.MonoVM)]
+		[TestCase ("TestUnicodeSpace2007\u2007Me", AndroidRuntime.MonoVM)]
+		[TestCase ("TestUnicodeSpace0020\u0020Me", AndroidRuntime.CoreCLR)]
+		[TestCase ("TestUnicodeSpace0020\u0020Me", AndroidRuntime.NativeAOT)]
+		public void CheckProjectWithSpaceInNameWorks (string projectName, AndroidRuntime runtime)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 				ProjectName = projectName,
 				RootNamespace = "Test.Me",
 			};
+			proj.SetRuntime (runtime);
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "build failed");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -159,8 +159,7 @@ Console.WriteLine ($""{DateTime.UtcNow.AddHours(-30).Humanize(culture:c)}"");
 		[TestCase ("TestUnicodeSpace2002\u2002Me", AndroidRuntime.MonoVM)]
 		[TestCase ("TestUnicodeSpace2007\u2007Me", AndroidRuntime.MonoVM)]
 		[TestCase ("TestUnicodeSpace0020\u0020Me", AndroidRuntime.CoreCLR)]
-		// TODO: https://github.com/dotnet/runtime/issues/115165
-		// [TestCase ("TestUnicodeSpace0020\u0020Me", AndroidRuntime.NativeAOT)]
+		[TestCase ("TestUnicodeSpace0020\u0020Me", AndroidRuntime.NativeAOT)]
 		public void CheckProjectWithSpaceInNameWorks (string projectName, AndroidRuntime runtime)
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -151,7 +151,7 @@ Console.WriteLine ($""{DateTime.UtcNow.AddHours(-30).Humanize(culture:c)}"");
 
 		[Test]
 		[Category ("SmokeTests")]
-		[TestCase ("Test Me")]
+		[TestCase ("Test Me", AndroidRuntime.MonoVM)]
 		// testing characters as per https://www.compart.com/en/unicode/category/Zs
 		[TestCase ("TestUnicodeSpace0020\u0020Me", AndroidRuntime.MonoVM)]
 		[TestCase ("TestUnicodeSpace2000\u2000Me", AndroidRuntime.MonoVM)]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -159,7 +159,8 @@ Console.WriteLine ($""{DateTime.UtcNow.AddHours(-30).Humanize(culture:c)}"");
 		[TestCase ("TestUnicodeSpace2002\u2002Me", AndroidRuntime.MonoVM)]
 		[TestCase ("TestUnicodeSpace2007\u2007Me", AndroidRuntime.MonoVM)]
 		[TestCase ("TestUnicodeSpace0020\u0020Me", AndroidRuntime.CoreCLR)]
-		[TestCase ("TestUnicodeSpace0020\u0020Me", AndroidRuntime.NativeAOT)]
+		// TODO: https://github.com/dotnet/runtime/issues/115165
+		// [TestCase ("TestUnicodeSpace0020\u0020Me", AndroidRuntime.NativeAOT)]
 		public void CheckProjectWithSpaceInNameWorks (string projectName, AndroidRuntime runtime)
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ProjectExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ProjectExtensions.cs
@@ -7,15 +7,18 @@ public static class ProjectExtensions
 {
 	/// <summary>
 	/// Sets the appropriate MSBuild property to use a specific .NET runtime.
+	/// NOTE: $(EnablePreviewFeatures) ignores warning XA1040: The CoreCLR/NativeAOT runtime on Android is an experimental feature and not yet suitable for production use.
 	/// </summary>
 	public static void SetRuntime (this XamarinProject project, AndroidRuntime runtime)
 	{
 		switch (runtime) {
 			case AndroidRuntime.CoreCLR:
 				project.SetProperty ("UseMonoRuntime", "false");
+				project.SetProperty ("EnablePreviewFeatures", "true");
 				break;
 			case AndroidRuntime.NativeAOT:
 				project.SetProperty ("PublishAot", "true");
+				project.SetProperty ("EnablePreviewFeatures", "true");
 				break;
 			default:
 				// MonoVM or default can just use default settings

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ProjectExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ProjectExtensions.cs
@@ -1,0 +1,25 @@
+using Xamarin.Android.Tasks;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests;
+
+public static class ProjectExtensions
+{
+	/// <summary>
+	/// Sets the appropriate MSBuild property to use a specific .NET runtime.
+	/// </summary>
+	public static void SetRuntime (this XamarinProject project, AndroidRuntime runtime)
+	{
+		switch (runtime) {
+			case AndroidRuntime.CoreCLR:
+				project.SetProperty ("UseMonoRuntime", "false");
+				break;
+			case AndroidRuntime.NativeAOT:
+				project.SetProperty ("PublishAot", "true");
+				break;
+			default:
+				// MonoVM or default can just use default settings
+				break;
+		}
+	}
+}


### PR DESCRIPTION
For each "smoke test" that build an Android application project (libraries not really relevant), we run the test on all runtimes.

For each test, I generally added two more test cases for NativeAOT and CoreCLR.

This is a first step to ensure that we don't break CoreCLR or NativeAOT support at build time.

This also discovered a bug on NativeAOT, in a project with spaces:

    clang no such file or directory: 'Me.so'
    C:\Users\cloudtest\.nuget\packages\microsoft.dotnet.ilcompiler\10.0.0-preview.5.25227.101\build\Microsoft.NETCore.Native.targets(391,5): error MSB3073: The command ""clang" "obj\Release\android-arm64\native\Test Me.o" -o "bin\Release\android-arm64\native\Test Me.so" -Wl,--version-script="obj\Release\android-arm64\native\Test Me.exports" -Wl,--export-dynamic -gz=zlib -fuse-ld=lld C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libSystem.Native.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libSystem.Globalization.Native.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libSystem.IO.Compression.Native.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libSystem.Security.Cryptography.Native.OpenSsl.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libbootstrapperdll.o C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libRuntime.WorkstationGC.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libeventpipe-disabled.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libstandalonegc-disabled.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libaotminipal.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libstdc++compat.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libbrotlienc.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libbrotlidec.a C:\Users\cloudtest\.nuget\packages\microsoft.netcore.app.runtime.nativeaot.linux-bionic-arm64\10.0.0-preview.5.25227.101/runtimes/linux-bionic-arm64/\native\libbrotlicommon.a --target=aarch64-linux-android21 -g -Wl,-rpath,"$ORIGIN" -Wl,--build-id=sha1 -Wl,--as-needed -Wl,-e,0x0 -pthread -ldl -lz -llog -lm -shared -Wl,-z,relro -Wl,-z,now -Wl,--eh-frame-hdr -Wl,-z,max-page-size=16384 -Wl,-soname,libTest Me.so -Wl,--discard-all -Wl,--gc-sections -Wl,-T,"obj\Release\android-arm64\native\sections.ld"" exited with code 1.

The fix was to quote `@(LinkerArg)`:

    <LinkerArg Include="&quot;-Wl,-soname,lib$(TargetName)$(NativeBinaryExt)&quot;" />