### PR TITLE
$(AndroidPackVersionSuffix)=preview.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>36.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.4</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.5</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/10.0.1xx-preview4

We branched for .NET 10 Preview 4 from 5c5745c into `release/10.0.1xx-preview4`; the main branch is now .NET 10 Preview 5.