### PR TITLE
[build] set `%(Kind)` for `PushManifestToBuildAssetRegistry`

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -153,9 +153,9 @@
     <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
 
     <ItemGroup>
-      <ItemsToPush Include="$(OutputPath)*.nupkg" />
+      <ItemsToPush Include="$(OutputPath)*.nupkg" Kind="Package" />
       <WorkloadArtifacts Include="$(OutputPath)*.zip" />
-      <ItemsToPush Include="@(WorkloadArtifacts)" PublishFlatContainer="true" RelativeBlobPath="android/$(AndroidPackVersionLong)/%(Filename)%(Extension)" />
+      <ItemsToPush Include="@(WorkloadArtifacts)" PublishFlatContainer="true" RelativeBlobPath="android/$(AndroidPackVersionLong)/%(Filename)%(Extension)" Kind="Blob" />
     </ItemGroup>
 
     <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />


### PR DESCRIPTION
Context: https://github.com/dotnet/arcade/blob/79ecdf3ef50e5e8e9d2b02e7113ec37c4219eeb5/src/Microsoft.DotNet.Build.Manifest/BuildModelFactory.cs#L95

Builds on main/release branches fail with:

    build-tools\create-packs\Directory.Build.targets(175,5): error : Missing 'Kind' property on artifact D:\a\_work\1\a\nuget-signed\Microsoft.Android.Ref.36.36.0.0-ci.main.72.nupkg.
    Possible values are 'Blob', 'PDB', 'Package'.

Set `%(Kind)=Package` for `.nupkg` files and `%(Kind)=Blob` for everything else.