### PR TITLE
[NativeAOT] Raise `AppDomain.UnhandledException` event

### DIFF
--- a/samples/NativeAOT/MainApplication.cs
+++ b/samples/NativeAOT/MainApplication.cs
@@ -19,5 +19,12 @@ public class MainApplication : Application
         Log.Debug ("NativeAOT", "Application.OnCreate()");
 
         base.OnCreate ();
+
+        AppDomain.CurrentDomain.UnhandledException += (sender, e) => {
+            Console.WriteLine ("AppDomain.UnhandledException!");
+            Console.WriteLine ($"  sender: {sender} [{sender != null} {sender?.GetType ()}]");
+            Console.WriteLine ($"  e.IsTerminating: {e.IsTerminating}");
+            Console.WriteLine ($"  e.ExceptionObject: {e.ExceptionObject}");
+        };
     }
 }

--- a/src/Microsoft.Android.Runtime.NativeAOT/UncaughtExceptionMarshaler.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/UncaughtExceptionMarshaler.cs
@@ -1,3 +1,5 @@
+using System.Runtime.ExceptionServices;
+
 using Java.Interop;
 
 namespace Microsoft.Android.Runtime;
@@ -12,8 +14,7 @@ class UncaughtExceptionMarshaler (Java.Lang.Thread.IUncaughtExceptionHandler? Or
 
 		AndroidLog.Print (AndroidLogLevel.Fatal, "DOTNET", $"FATAL UNHANDLED EXCEPTION: {e}");
 
-		// TODO: https://github.com/dotnet/runtime/issues/102730
-		// ExceptionHandling.RaiseUnhandledExceptionEvent(e);
+		ExceptionHandling.RaiseAppDomainUnhandledExceptionEvent(e);
 
 		OriginalHandler?.UncaughtException (thread, exception);
 	}


### PR DESCRIPTION
Context: 9ad492a42b384519a8b1f1987adae82335536d9c
Context: https://github.com/dotnet/runtime/issues/102730

Commit 9ad492a4 had a TODO:

> TODO: once dotnet/runtime#102730 is fixed, update
> `UncaughtExceptionMarshaler` to do whatever it needs to do to cause
> the `AppDomain.UnhandledException` event to be raised.

dotnet/runtime#102730 *has* been fixed.

Update `UncaughtExceptionMarshaler` to call
`ExceptionHandling.RaiseAppDomainUnhandledExceptionEvent(object)` with the unhandled exception, so that the
`AppDomain.UnhandledException` event is raised.

Update `samples/NativeAOT` to subscribe to the
`AppDomain.UnhandledException` event.

Install the app:

	./dotnet-local.sh build -t:Install samples/NativeAOT/NativeAOT.csproj

and run the sample so that it throws an unhandled exception:

	adb shell am start --ez throw 1 net.dot.hellonativeaot/my.MainActivity

and now `adb logcat` contains:

	I NativeAotFromAndroid: AppDomain.UnhandledException!
	I NativeAotFromAndroid:   sender:  [False ]
	I NativeAotFromAndroid:   e.IsTerminating: True
	I NativeAotFromAndroid:   e.ExceptionObject: System.InvalidOperationException: What happened?
	I NativeAotFromAndroid:    at NativeAOT.MainActivity.OnCreate(Bundle savedInstanceState) + 0x2f4
	I NativeAotFromAndroid:    at Android.App.Activity.n_OnCreate_Landroid_os_Bundle_(IntPtr jnienv, IntPtr native__this, IntPtr native_savedInstanceState) + 0xc8

showing that the `AppDomain.UnhandledException` event was raised.