### PR TITLE
[tests] enable Java.Interop-Tests for CoreCLR

### DIFF
--- a/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.NET.csproj
+++ b/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.NET.csproj
@@ -14,6 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);NO_MARSHAL_MEMBER_BUILDER_SUPPORT</DefineConstants>
+    <DefineConstants Condition=" '$(UseMonoRuntime)' == 'false' or '$(PublishAot)' == 'true' ">$(DefineConstants);NO_GC_BRIDGE_SUPPORT</DefineConstants>
     <JavaInteropTestDirectory>$(JavaInteropSourceDirectory)\tests\Java.Interop-Tests\</JavaInteropTestDirectory>
   </PropertyGroup>
 

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Android.RuntimeTests
         protected override IList<TestAssemblyInfo> GetTestAssemblies()
         {
             Assembly asm = Assembly.GetExecutingAssembly();
-            #if !NATIVEAOT && !CORECLR // TODO: Java.Interop-Tests not passing yet
+            #if !NATIVEAOT // TODO: Java.Interop-Tests not passing yet
             Assembly ji  = typeof (Java.InteropTests.JavaInterop_Tests_Reference).Assembly;
             #endif
 
@@ -38,7 +38,7 @@ namespace Xamarin.Android.RuntimeTests
             return new List<TestAssemblyInfo>()
             {
                 new TestAssemblyInfo (asm, asm.Location ?? String.Empty),
-                #if !NATIVEAOT && !CORECLR
+                #if !NATIVEAOT
                 new TestAssemblyInfo (ji, ji.Location ?? String.Empty),
                 #endif
             };


### PR DESCRIPTION
Until a "GC Bridge" exists, for `Java.Interop-Tests` to work on the new runtimes, we need to set:

```xml
<DefineConstants Condition=" '$(UseMonoRuntime)' == 'false' or '$(PublishAot)' == 'true' ">$(DefineConstants);NO_GC_BRIDGE_SUPPORT</DefineConstants>
```