### PR TITLE
[XABT] Enable NRT for some tasks.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,10 +66,10 @@ if (!string.IsNullOrEmpty (NonRequiredProperty)) {
 }
 ```
 
-Convert this to:
+Convert this to use the extension method:
 
 ```csharp
-if (NonRequiredProperty is { Length: > 0 }) {
+if (!NonRequiredProperty.IsNullOrEmpty ()) {
     // Code here
 }
 ```

--- a/src/Xamarin.Android.Build.Tasks/MamJsonToXml.cs
+++ b/src/Xamarin.Android.Build.Tasks/MamJsonToXml.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 
@@ -14,10 +12,10 @@ namespace Xamarin.Android.Tasks
 		public  override    string  TaskPrefix  => "A2C";
 
 		[Required]
-		public  ITaskItem[] MappingFiles        { get; set; }
+		public  ITaskItem[] MappingFiles        { get; set; } = [];
 
 		[Required]
-		public  ITaskItem   XmlMappingOutput    { get; set; }
+		public  ITaskItem   XmlMappingOutput    { get; set; } = null!; // NRT - guarded by [Required]
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -1,6 +1,4 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -23,12 +21,12 @@ namespace Xamarin.Android.Tasks {
 		List<ITaskItem> archives = new List<ITaskItem> ();
 		List<ITaskItem> files = new List<ITaskItem> ();
 
-		public string ExtraArgs { get; set; }
+		public string? ExtraArgs { get; set; }
 
-		public string FlatArchivesDirectory { get; set; }
+		public string? FlatArchivesDirectory { get; set; }
 
-		public string FlatFilesDirectory { get; set; }
-		public ITaskItem [] ResourcesToCompile { get; set; }
+		public string? FlatFilesDirectory { get; set; }
+		public ITaskItem []? ResourcesToCompile { get; set; }
 
 		[Output]
 		public ITaskItem [] CompiledResourceFlatArchives => archives.ToArray ();
@@ -127,7 +125,7 @@ namespace Xamarin.Android.Tasks {
 				cmd.Add (GetFullPath (fileOrDirectory).TrimEnd ('\\'));
 			} else
 				cmd.Add (GetFullPath (fileOrDirectory));
-			if (!string.IsNullOrEmpty (ExtraArgs))
+			if (!ExtraArgs.IsNullOrEmpty ())
 				cmd.Add (ExtraArgs);
 			if (MonoAndroidHelper.LogInternalExceptions)
 				cmd.Add ("-v");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -20,16 +18,16 @@ namespace Xamarin.Android.Tasks {
 		public override string TaskPrefix => "A2LAP";
 
 		[Required]
-		public ITaskItem Manifest { get; set; }
+		public ITaskItem Manifest { get; set; } = null!;  // NRT - guarded by [Required]
 
 		[Required]
-		public ITaskItem[] AssetDirectories { get; set; }
+		public ITaskItem[] AssetDirectories { get; set; } = [];
 
 		[Required]
-		public string PackageName { get; set; }
+		public string PackageName { get; set; } = "";
 
 		[Required]
-		public ITaskItem OutputArchive { get; set; }
+		public ITaskItem OutputArchive { get; set; } = null!;  // NRT - guarded by [Required]
 
 		protected override int GetRequiredDaemonInstances ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AdjustJavacVersionArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AdjustJavacVersionArguments.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
@@ -15,20 +13,20 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "AJV";
 
 		[Required]
-		public string JdkVersion { get; set; }
+		public string JdkVersion { get; set; } = "";
 
 		[Required]
-		public string DefaultJdkVersion { get; set; }
+		public string DefaultJdkVersion { get; set; } = "";
 
 		public bool EnableMultiDex { get; set; }
 
 		public bool SkipJavacVersionCheck { get; set; }
 
 		[Output]
-		public string TargetVersion { get; set; }
+		public string? TargetVersion { get; set; }
 
 		[Output]
-		public string SourceVersion { get; set; }
+		public string? SourceVersion { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidAdb.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidAdb.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -13,9 +11,9 @@ namespace Xamarin.Android.Tasks {
 	{
 		public override string TaskPrefix => "AADB";
 
-		public string AdbTarget { get; set; }
-		public string Command { get; set; }
-		public string Arguments { get; set; }
+		public string? AdbTarget { get; set; }
+		public string? Command { get; set; }
+		public string? Arguments { get; set; }
 
 		public bool IgnoreErrors { get; set; } = false;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -24,8 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#nullable disable
-
 using System;
 using System.Text;
 using Microsoft.Build.Utilities;
@@ -42,36 +40,36 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CRP";
 
 		[Required]
-		public ITaskItem[] ResourceFiles { get; set; }
+		public ITaskItem[] ResourceFiles { get; set; } = [];
 
 		[Required]
-		public string IntermediateDir { get; set; }
+		public string IntermediateDir { get; set; } = "";
 
-		public string AssetPackIntermediateDir { get; set; }
+		public string? AssetPackIntermediateDir { get; set; }
 
-		public string Prefixes { get; set; }
+		public string? Prefixes { get; set; }
 
 		public bool LowercaseFilenames { get; set; }
 
-		public string ProjectDir { get; set; }
+		public string? ProjectDir { get; set; }
 
-		public string AndroidLibraryFlatFilesDirectory { get; set; }
-
-		[Output]
-		public ITaskItem[] IntermediateFiles { get; set; }
+		public string? AndroidLibraryFlatFilesDirectory { get; set; }
 
 		[Output]
-		public ITaskItem [] ResolvedResourceFiles { get; set; }
+		public ITaskItem[]? IntermediateFiles { get; set; }
 
 		[Output]
-		public string FilesHash { get; set; }
+		public ITaskItem []? ResolvedResourceFiles { get; set; }
+
+		[Output]
+		public string? FilesHash { get; set; }
 
 		public override bool RunTask ()
 		{
 			var intermediateFiles = new List<ITaskItem> (ResourceFiles.Length);
 			var resolvedFiles = new List<ITaskItem> (ResourceFiles.Length);
 
-			string[] prefixes = Prefixes != null ? Prefixes.Split (';') : null;
+			string[]? prefixes = Prefixes != null ? Prefixes.Split (';') : null;
 			if (prefixes != null) {
 				for (int i = 0; i < prefixes.Length; i++) {
 					string p = prefixes [i];

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidDotnetToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidDotnetToolTask.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -18,7 +16,7 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// Path to the folder that contains dotnet / dotnet.exe.
 		/// </summary>
-		public string NetCoreRoot { get; set; }
+		public string? NetCoreRoot { get; set; }
 
 		/// <summary>
 		/// If `true`, this task should run `dotnet foo.dll` and `foo.exe` otherwise.
@@ -34,7 +32,7 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// The path to the assembly `foo.dll`. Will be `null` when NeedsDotnet and NeedsMono are `false`.
 		/// </summary>
-		protected string AssemblyPath { get; private set; }
+		protected string? AssemblyPath { get; private set; }
 
 		public override bool Execute ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidError.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidError.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Android.Build.Tasks;
@@ -15,18 +13,18 @@ namespace Xamarin.Android.Tasks
 		/// Error code
 		/// </summary>
 		[Required]
-		public string Code { get; set; }
+		public string Code { get; set; } = "";
 
 		/// <summary>
 		/// The name of the resource from Properties\Resources.resx that contains the message
 		/// </summary>
 		[Required]
-		public string ResourceName { get; set; }
+		public string ResourceName { get; set; } = "";
 
 		/// <summary>
 		/// The string format arguments to use for any numbered format items in the resource provided by ResourceName
 		/// </summary>
-		public string [] FormatArguments { get; set; }
+		public string []? FormatArguments { get; set; }
 
 		public override bool Execute ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidMessage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidMessage.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Android.Build.Tasks;
@@ -15,12 +13,12 @@ namespace Xamarin.Android.Tasks
 		/// The name of the resource from Properties\Resources.resx that contains the message
 		/// </summary>
 		[Required]
-		public string ResourceName { get; set; }
+		public string ResourceName { get; set; } = "";
 
 		/// <summary>
 		/// The string format arguments to use for any numbered format items in the resource provided by ResourceName
 		/// </summary>
-		public string [] FormatArguments { get; set; }
+		public string []? FormatArguments { get; set; }
 
 		public override bool Execute ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -15,17 +13,17 @@ namespace Xamarin.Android.Tasks
 		bool hasWarnings;
 
 		[Required]
-		public string UnsignedApk { get; set; }
+		public string UnsignedApk { get; set; } = "";
 
 		[Required]
-		public string SignedApkDirectory { get; set; }
+		public string SignedApkDirectory { get; set; } = "";
 
 		[Required]
 		[Output]
-		public string KeyStore { get; set; }
+		public string KeyStore { get; set; } = "";
 
 		[Required]
-		public string KeyAlias { get; set; }
+		public string KeyAlias { get; set; } = "";
 
 		/// <summary>
 		/// The Password for the Key.
@@ -37,7 +35,7 @@ namespace Xamarin.Android.Tasks
 		///   file:<PasswordFile>
 		/// </summary>
 		[Required]
-		public string KeyPass { get; set; }
+		public string KeyPass { get; set; } = "";
 
 		/// <summary>
 		/// The Password for the Keystore.
@@ -49,25 +47,25 @@ namespace Xamarin.Android.Tasks
 		///   file:<PasswordFile>
 		/// </summary>
 		[Required]
-		public string StorePass { get; set; }
+		public string StorePass { get; set; } = "";
 
-		public string TimestampAuthorityUrl { get; set; }
+		public string? TimestampAuthorityUrl { get; set; }
 
-		public string TimestampAuthorityCertificateAlias { get; set; }
+		public string? TimestampAuthorityCertificateAlias { get; set; }
 
 		/// <summary>
 		/// -sigalg switch, which is SHA256withRSA by default. Previous versions of XA was md5withRSA.
 		/// </summary>
 		[Required]
-		public string SigningAlgorithm { get; set; }
+		public string SigningAlgorithm { get; set; } = "";
 
 		/// <summary>
 		/// -digestalg switch, which is SHA-256 by default. Previous versions of XA was SHA1.
 		/// </summary>
 		[Required]
-		public string DigestAlgorithm { get; set; }
+		public string DigestAlgorithm { get; set; } = "";
 
-		public string FileSuffix { get; set; }
+		public string? FileSuffix { get; set; }
 
 		protected override string DefaultErrorCode => "ANDJS0000";
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidWarning.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidWarning.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Android.Build.Tasks;
@@ -15,18 +13,18 @@ namespace Xamarin.Android.Tasks
 		/// Warning code
 		/// </summary>
 		[Required]
-		public string Code { get; set; }
+		public string Code { get; set; } = "";
 
 		/// <summary>
 		/// The name of the resource from Properties\Resources.resx that contains the message
 		/// </summary>
 		[Required]
-		public string ResourceName { get; set; }
+		public string ResourceName { get; set; } = "";
 
 		/// <summary>
 		/// The string format arguments to use for any numbered format items in the resource provided by ResourceName
 		/// </summary>
-		public string [] FormatArguments { get; set; }
+		public string []? FormatArguments { get; set; }
 
 		public override bool Execute ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -16,10 +14,10 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "AZA";
 
 		[Required]
-		public ITaskItem Source { get; set; }
+		public ITaskItem Source { get; set; } = null!; // NRT - guarded by [Required]
 
 		[Required]
-		public ITaskItem DestinationDirectory { get; set; }
+		public ITaskItem DestinationDirectory { get; set; } = null!; // NRT - guarded by [Required]
 
 		int alignment = DefaultZipAlignment64Bit;
 		public int Alignment {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AppendCustomMetadataToItemGroup.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AppendCustomMetadataToItemGroup.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -13,13 +11,13 @@ namespace Xamarin.Android.Tasks {
 		public override string TaskPrefix => "ACM";
 
 		[Required]
-		public ITaskItem[] Inputs { get; set; }
+		public ITaskItem[] Inputs { get; set; } = [];
 
 		[Required]
-		public ITaskItem[] MetaDataItems { get; set; }
+		public ITaskItem[] MetaDataItems { get; set; } = [];
 
 		[Output]
-		public ITaskItem[] Output { get; set; }
+		public ITaskItem[]? Output { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApkSet.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
@@ -18,31 +16,31 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "BAS";
 
 		[Required]
-		public string AppBundle { get; set; }
+		public string AppBundle { get; set; } = "";
 
 		[Required]
-		public string Output { get; set; }
+		public string Output { get; set; } = "";
 
 		[Required]
-		public string Aapt2ToolPath { get; set; }
+		public string Aapt2ToolPath { get; set; } = "";
 
-		public string Aapt2ToolExe { get; set; }
+		public string? Aapt2ToolExe { get; set; }
 
 		public string Aapt2ToolName => OS.IsWindows ? "aapt2.exe" : "aapt2";
 
 		[Required]
-		public string KeyStore { get; set; }
+		public string KeyStore { get; set; } = "";
 
 		[Required]
-		public string KeyAlias { get; set; }
+		public string KeyAlias { get; set; } = "";
 
 		[Required]
-		public string KeyPass { get; set; }
+		public string KeyPass { get; set; } = "";
 
 		[Required]
-		public string StorePass { get; set; }
+		public string StorePass { get; set; } = "";
 
-		public string ExtraArgs { get; set; }
+		public string? ExtraArgs { get; set; }
 
 		public bool GenerateUniversalApkSet { get; set; } = false;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Text.Json;
@@ -62,27 +60,27 @@ namespace Xamarin.Android.Tasks
 		};
 
 		[Required]
-		public string BaseZip { get; set; }
+		public string BaseZip { get; set; } = "";
 
-		public string CustomBuildConfigFile { get; set; }
+		public string? CustomBuildConfigFile { get; set; }
 
-		public string [] Modules { get; set; }
+		public string []? Modules { get; set; }
 
-		public ITaskItem [] MetaDataFiles { get; set; }
+		public ITaskItem []? MetaDataFiles { get; set; }
 
 		[Required]
-		public string Output { get; set; }
+		public string Output { get; set; } = "";
 
-		public string UncompressedFileExtensions { get; set; }
+		public string? UncompressedFileExtensions { get; set; }
 
-		string temp;
+		string? temp;
 
 		public override bool RunTask ()
 		{
 			temp = Path.GetTempFileName ();
 			try {
 				var uncompressed = new List<string> (UncompressedByDefault);
-				if (!string.IsNullOrEmpty (UncompressedFileExtensions)) {
+				if (!UncompressedFileExtensions.IsNullOrEmpty ()) {
 					//NOTE: these are file extensions, that need converted to glob syntax
 					var split = UncompressedFileExtensions.Split (new char [] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries);
 					foreach (var extension in split) {
@@ -90,7 +88,7 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-				JsonNode json = JsonNode.Parse ("{}")!;
+				JsonNode? json = JsonNode.Parse ("{}");
 				if (!string.IsNullOrEmpty (CustomBuildConfigFile) && File.Exists (CustomBuildConfigFile)) {
 					using Stream fs = File.OpenRead (CustomBuildConfigFile);
 					using JsonDocument doc = JsonDocument.Parse (fs, new JsonDocumentOptions { AllowTrailingCommas = true });

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BundleTool.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BundleTool.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
@@ -9,7 +7,7 @@ namespace Xamarin.Android.Tasks
 	public abstract class BundleTool : JavaToolTask
 	{
 		[Required]
-		public string JarPath { get; set; }
+		public string JarPath { get; set; } = "";
 
 		protected override string GenerateCommandLineCommands ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BundleToolAdbTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BundleToolAdbTask.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -13,11 +11,11 @@ namespace Xamarin.Android.Tasks
 		/// This is used to detect the attached device and generate an APK set specifically for it
 		/// </summary>
 		[Required]
-		public string AdbToolPath { get; set; }
+		public string AdbToolPath { get; set; } = "";
 
-		public string AdbToolExe { get; set; }
+		public string? AdbToolExe { get; set; }
 
-		public string AdbTarget { get; set; }
+		public string? AdbTarget { get; set; }
 
 		public string AdbToolName => OS.IsWindows ? "adb.exe" : "adb";
 
@@ -27,7 +25,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("--adb ", Path.Combine (AdbToolPath, adb));
 
 			var adbTarget = AdbTarget;
-			if (!string.IsNullOrEmpty (adbTarget)) {
+			if (!adbTarget.IsNullOrEmpty ()) {
 				// Normally of the form "-s emulator-5554"
 				int index = adbTarget.IndexOf (' ');
 				if (index != -1) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateAdditionalResourceCacheDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateAdditionalResourceCacheDirectories.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,13 +14,13 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CAR";
 
 		[Required]
-		public string[] AdditionalAndroidResourcePaths { get; set; }
+		public string[] AdditionalAndroidResourcePaths { get; set; } = [];
 
 		[Required]
-		public string CacheDirectory { get; set; }
+		public string CacheDirectory { get; set; } = "";
 
 		[Output]
-		public ITaskItem[] AdditionalResourceCachePaths { get; set; }
+		public ITaskItem[]? AdditionalResourceCachePaths { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckClientHandlerType.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckClientHandlerType.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,10 +15,10 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CCHT";
 
 		[Required]
-		public string ClientHandlerType { get; set; }
+		public string ClientHandlerType { get; set; } = "";
 
 		[Required]
-		public ITaskItem[] ResolvedAssemblies { get; set; }
+		public ITaskItem[] ResolvedAssemblies { get; set; } = [];
 
 		public override bool RunTask ()
 		{
@@ -32,7 +30,7 @@ namespace Xamarin.Android.Tasks
 				assembly = types[1].Trim ();
 			}
 			// load the assembly.
-			ITaskItem foundAssembly = null;
+			ITaskItem? foundAssembly = null;
 			foreach (var asm in ResolvedAssemblies) {
 				string filename = Path.GetFileNameWithoutExtension (asm.ItemSpec);
 				if (string.CompareOrdinal (assembly, filename) == 0) {
@@ -58,7 +56,7 @@ namespace Xamarin.Android.Tasks
 				}
 
 				var assemblyDefinition = resolver.GetAssembly (Path.GetFullPath (foundAssembly.ItemSpec));
-				TypeDefinition handlerType = null;
+				TypeDefinition? handlerType = null;
 				foreach (var model in assemblyDefinition.Modules) {
 					handlerType = assemblyDefinition.MainModule.GetType (type);
 					if (handlerType != null)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -13,10 +11,10 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "CDJ";
 
-		public ITaskItem [] JavaSourceFiles { get; set; }
-		public ITaskItem[] JavaLibraries { get; set; }
-		public ITaskItem[] LibraryProjectJars { get; set; }
-		public string [] ExcludedFiles { get; set; }
+		public ITaskItem []? JavaSourceFiles { get; set; }
+		public ITaskItem[]? JavaLibraries { get; set; }
+		public ITaskItem[]? LibraryProjectJars { get; set; }
+		public string []? ExcludedFiles { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidDesignerConfig.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidDesignerConfig.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -17,7 +15,7 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "CIRF";
 
-		public ITaskItem[] Assemblies { get; set; }
+		public ITaskItem[]? Assemblies { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -19,7 +17,7 @@ namespace Xamarin.Android.Tasks {
 		public override string TaskPrefix => "CFI";
 
 		[Required]
-		public ITaskItem[] Resources { get; set; }
+		public ITaskItem[] Resources { get; set; } = [];
 
 		Regex fileNameCheck = new Regex ("[^a-zA-Z0-9_.]+", RegexOptions.Compiled);
 		Regex fileNameWithHyphenCheck = new Regex ("[^a-zA-Z0-9_.-]+", RegexOptions.Compiled);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForRemovedItems.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForRemovedItems.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -15,13 +13,13 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CFR";
 
 		[Required]
-		public ITaskItem[] Files { get; set; }
+		public ITaskItem[] Files { get; set; } = [];
 
 		[Required]
-		public string Directory { get; set; }
+		public string Directory { get; set; } = "";
 
 		[Output]
-		public ITaskItem RemovedFilesFlag { get; set; }
+		public ITaskItem? RemovedFilesFlag { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckProjectItems.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckProjectItems.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,10 +13,10 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CPI";
 
 		public bool IsApplication { get; set; }
-		public ITaskItem [] EmbeddedNativeLibraries { get; set; }
-		public ITaskItem [] NativeLibraries { get; set; }
-		public ITaskItem [] JavaLibraries { get; set; }
-		public ITaskItem [] JavaSourceFiles { get; set; }
+		public ITaskItem []? EmbeddedNativeLibraries { get; set; }
+		public ITaskItem []? NativeLibraries { get; set; }
+		public ITaskItem []? JavaLibraries { get; set; }
+		public ITaskItem []? JavaSourceFiles { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -17,16 +15,16 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CIL";
 
 		[Required]
-		public string AndroidAotMode { get; set; }
+		public string AndroidAotMode { get; set; } = "";
 
 		[Required]
-		public string ToolPath { get; set; }
+		public string ToolPath { get; set; } = "";
 
 		[Required]
-		public ITaskItem[] ResolvedAssemblies { get; set; }
+		public ITaskItem[] ResolvedAssemblies { get; set; } = [];
 
 		[Required]
-		public string StampFile { get; set; }
+		public string StampFile { get; set; } = "";
 
 		public CilStrip ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2012 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System.IO;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Framework;
@@ -13,12 +11,12 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CLP";
 
 		[Required]
-		public string OutputFile { get; set; }
+		public string OutputFile { get; set; } = "";
 
 		[Required]
-		public ITaskItem[] SourceJars { get; set; }
+		public ITaskItem[] SourceJars { get; set; } = [];
 
-		public ITaskItem [] DocumentationPaths { get; set; }
+		public ITaskItem []? DocumentationPaths { get; set; }
 
 		protected override string GenerateCommandLineCommands ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectLibraryAssets.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectLibraryAssets.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Linq;
 using Microsoft.Build.Utilities;
@@ -12,8 +10,8 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "CLA";
 
-		public string AssetDirectory { get; set; }
-		public string [] AdditionalAssetDirectories { get; set; }
+		public string? AssetDirectory { get; set; }
+		public string []? AdditionalAssetDirectories { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -19,13 +17,13 @@ namespace Xamarin.Android.Tasks {
 		List<ITaskItem> libraryResourceFiles = new List<ITaskItem> ();
 
 		[Required]
-		public ITaskItem[] Directories { get; set; }
+		public ITaskItem[] Directories { get; set; } = [];
 
 		[Required]
-		public string LibraryProjectIntermediatePath { get; set; }
+		public string LibraryProjectIntermediatePath { get; set; } = "";
 
 		[Required]
-		public string StampDirectory { get; set; }
+		public string StampDirectory { get; set; } = "";
 
 		[Output]
 		public ITaskItem[] Output => output.ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectPdbFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectPdbFiles.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -15,13 +13,13 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CPF";
 
 		[Required]
-		public ITaskItem[] ResolvedAssemblies { get; set; }
+		public ITaskItem[] ResolvedAssemblies { get; set; } = [];
 
 		[Output]
-		public ITaskItem[] PdbFiles { get; set; }
+		public ITaskItem[]? PdbFiles { get; set; }
 
 		[Output]
-		public ITaskItem[] PortablePdbFiles { get; set; }
+		public ITaskItem[]? PortablePdbFiles { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -20,22 +18,22 @@ namespace Xamarin.Android.Tasks
 
 		sealed class Config
 		{
-			public string AssemblerPath;
-			public string AssemblerOptions;
-			public string InputSource;
+			public string? AssemblerPath;
+			public string? AssemblerOptions;
+			public string? InputSource;
 		}
 
 		[Required]
-		public ITaskItem[] Sources { get; set; }
+		public ITaskItem[] Sources { get; set; } = [];
 
 		[Required]
 		public bool DebugBuild { get; set; }
 
 		[Required]
-		public new string WorkingDirectory { get; set; }
+		public new string WorkingDirectory { get; set; } = "";
 
 		[Required]
-		public string AndroidBinUtilsDirectory { get; set; }
+		public string AndroidBinUtilsDirectory { get; set; } = "";
 
 		public override System.Threading.Tasks.Task RunTaskAsync ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ComputeHash.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ComputeHash.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
@@ -13,12 +11,12 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CPT";
 
 		[Required]
-		public ITaskItem [] Source { get; set; }
+		public ITaskItem [] Source { get; set; } = [];
 
 		public bool CopyMetaData { get; set; } = true;
 
 		[Output]
-		public ITaskItem [] Output { get; set; }
+		public ITaskItem []? Output { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.Collections.Generic;
@@ -19,21 +17,21 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CRC";
 
 		[Required]
-		public ITaskItem[] ResourceDirectories { get; set; }
+		public ITaskItem[] ResourceDirectories { get; set; } = [];
 
 		[Required]
-		public string CustomViewMapFile { get; set; }
+		public string CustomViewMapFile { get; set; } = "";
 
-		public string AndroidConversionFlagFile { get; set; }
+		public string? AndroidConversionFlagFile { get; set; }
 
-		Dictionary<string,string> _resource_name_case_map;
-		Dictionary<string, HashSet<string>> customViewMap;
+		Dictionary<string,string>? _resource_name_case_map;
+		Dictionary<string, HashSet<string>>? customViewMap;
 
 		Dictionary<string, string> resource_name_case_map => _resource_name_case_map ??= MonoAndroidHelper.LoadResourceCaseMap (BuildEngine4, ProjectSpecificTaskObjectKey);
 
 		public override bool RunTask ()
 		{
-			if (CustomViewMapFile != null)
+			if (!CustomViewMapFile.IsNullOrEmpty ())
 				customViewMap = Xamarin.Android.Tasks.MonoAndroidHelper.LoadCustomViewMapFile (BuildEngine4, CustomViewMapFile);
 
 			// Look in the resource xml's for capitalized stuff and fix them

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyGeneratedJavaResourceClasses.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyGeneratedJavaResourceClasses.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -15,14 +13,14 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CGJ";
 
 		[Required]
-		public string SourceTopDirectory { get; set; }
-		public string DestinationTopDirectory { get; set; }
+		public string SourceTopDirectory { get; set; } = "";
+		public string? DestinationTopDirectory { get; set; }
 		[Required]
-		public string PrimaryPackageName { get; set; }
+		public string PrimaryPackageName { get; set; } = "";
 
-		public string ExtraPackages { get; set; }
+		public string? ExtraPackages { get; set; }
 		[Output]
-		public string PrimaryJavaResgenFile { get; set; }
+		public string? PrimaryJavaResgenFile { get; set; }
 
 		public override bool RunTask ()
 		{
@@ -54,7 +52,7 @@ namespace Xamarin.Android.Tasks
 		IEnumerable<string> GetPackages ()
 		{
 			yield return PrimaryPackageName.ToLowerInvariant ();
-			if (!string.IsNullOrEmpty (ExtraPackages))
+			if (!ExtraPackages.IsNullOrEmpty ())
 				foreach (var pkg in ExtraPackages.Split (':'))
 					yield return pkg;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -22,15 +20,15 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CIC";
 
 		[Required]
-		public ITaskItem[] SourceFiles { get; set; }
+		public ITaskItem[] SourceFiles { get; set; } = [];
 
 		[Required]
-		public ITaskItem[] DestinationFiles { get; set; }
+		public ITaskItem[] DestinationFiles { get; set; } = [];
 
 		public bool CompareFileLengths { get; set; } = true;
 
 		[Output]
-		public ITaskItem[] ModifiedFiles { get; set; }
+		public ITaskItem[]? ModifiedFiles { get; set; }
 
 		private List<ITaskItem> modifiedFiles = new List<ITaskItem>();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyResource.cs
@@ -1,8 +1,6 @@
 // Author: Jonathan Pobst <jpobst@xamarin.com>
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -18,10 +16,10 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CPR";
 
 		[Required]
-		public string ResourceName { get; set; }
+		public string ResourceName { get; set; } = "";
 
 		[Required]
-		public string OutputPath { get; set; }
+		public string OutputPath { get; set; } = "";
 
 		static readonly Assembly ExecutingAssembly = Assembly.GetExecutingAssembly ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -16,25 +14,25 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "CAAR";
 
-		public ITaskItem [] AndroidAssets { get; set; }
+		public ITaskItem []? AndroidAssets { get; set; }
 
-		public ITaskItem [] AndroidResources { get; set; }
+		public ITaskItem []? AndroidResources { get; set; }
 
-		public ITaskItem [] AndroidEnvironment { get; set; }
+		public ITaskItem []? AndroidEnvironment { get; set; }
 
-		public ITaskItem AndroidManifest { get; set; }
+		public ITaskItem? AndroidManifest { get; set; }
 
-		public ITaskItem [] JarFiles { get; set; }
+		public ITaskItem []? JarFiles { get; set; }
 
-		public ITaskItem [] NativeLibraries { get; set; }
+		public ITaskItem []? NativeLibraries { get; set; }
 
-		public ITaskItem [] ProguardConfigurationFiles { get; set; }
-
-		[Required]
-		public string AssetDirectory { get; set; }
+		public ITaskItem []? ProguardConfigurationFiles { get; set; }
 
 		[Required]
-		public string OutputFile { get; set; }
+		public string AssetDirectory { get; set; } = "";
+
+		[Required]
+		public string OutputFile { get; set; } = "";
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAdditionalLibraryResourceCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAdditionalLibraryResourceCache.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,13 +16,13 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CAL";
 
 		[Required]
-		public ITaskItem[] AdditionalAndroidResourcePaths { get; set; }
+		public ITaskItem[] AdditionalAndroidResourcePaths { get; set; } = [];
 
 		[Required]
-		public ITaskItem[] AdditionalAndroidResourceCachePaths { get; set; }
+		public ITaskItem[] AdditionalAndroidResourceCachePaths { get; set; } = [];
 
 		[Output]
-		public ITaskItem[] CopiedResources { get; set; }
+		public ITaskItem[]? CopiedResources { get; set; }
 
 
 		public override bool RunTask ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -24,25 +22,25 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CDFM";
 
 		[Required]
-		public string FeatureSplitName { get; set; }
+		public string FeatureSplitName { get; set; } = "";
 
 		[Required]
-		public string FeatureDeliveryType { get; set; }
+		public string FeatureDeliveryType { get; set; } = "";
 
 		[Required]
-		public string FeatureType { get; set; }
+		public string FeatureType { get; set; } = "";
 
 		[Required]
-		public string PackageName { get; set; }
+		public string PackageName { get; set; } = "";
 
 		[Required]
-		public ITaskItem OutputFile { get; set; }
+		public ITaskItem OutputFile { get; set; } = null!; // NRT - guarded by [Required]
 
-		public string FeatureTitleResource { get; set; }
+		public string? FeatureTitleResource { get; set; }
 
-		public string MinSdkVersion { get; set; }
+		public string? MinSdkVersion { get; set; }
 
-		public string TargetSdkVersion { get; set; }
+		public string? TargetSdkVersion { get; set; }
 
 		public bool IsFeatureSplit { get; set; } = false;
 		public bool IsInstant { get; set; } = false;
@@ -65,7 +63,7 @@ namespace Xamarin.Android.Tasks
 
 		void GenerateFeatureManifest (XDocument doc)
 		{
-			XAttribute featureTitleResource = null;
+			XAttribute? featureTitleResource = null;
 			if (!string.IsNullOrEmpty (FeatureTitleResource))
 				featureTitleResource = new XAttribute (distNS + "title", FeatureTitleResource);
 			XElement usesSdk = new XElement ("uses-sdk");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMsymManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMsymManifest.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
@@ -14,13 +12,13 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CMM";
 
 		[Required]
-		public string BuildId { get; set; }
+		public string BuildId { get; set; } = "";
 
 		[Required]
-		public string PackageName { get; set; }
+		public string PackageName { get; set; } = "";
 
 		[Required]
-		public string OutputDirectory { get; set; }
+		public string OutputDirectory { get; set; } = "";
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateResgenManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateResgenManifest.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Text;
@@ -19,10 +17,10 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CRM";
 
 		[Required]
-		public string ManifestOutputFile { get; set; }
+		public string ManifestOutputFile { get; set; } = "";
 
 		[Required]
-		public string PackageName { get; set; }
+		public string PackageName { get; set; } = "";
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateTemporaryDirectory.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateTemporaryDirectory.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -15,7 +13,7 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CTD";
 
 		[Output]
-		public string TemporaryDirectory { get; set; }
+		public string? TemporaryDirectory { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateTypeManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateTypeManagerJava.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -15,10 +13,10 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "CTMJ";
 
 		[Required]
-		public string ResourceName { get; set; }
+		public string ResourceName { get; set; } = "";
 
 		[Required]
-		public string OutputFilePath { get; set; }
+		public string OutputFilePath { get; set; } = "";
 
 		static readonly Assembly ExecutingAssembly = Assembly.GetExecutingAssembly ();
 
@@ -26,7 +24,7 @@ namespace Xamarin.Android.Tasks
 		{
 			string? content = ReadResource (ResourceName);
 
-			if (String.IsNullOrEmpty (content)) {
+			if (content.IsNullOrEmpty ()) {
 				return false;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using Microsoft.Build.Utilities;
 using System.Collections.Generic;
@@ -15,23 +13,23 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "DJL";
 
 		[Required]
-		public ITaskItem[] MonoPlatformJarPaths { get; set; }
+		public ITaskItem[]? MonoPlatformJarPaths { get; set; }
 
-		public ITaskItem[] JavaSourceFiles { get; set; }
+		public ITaskItem[]? JavaSourceFiles { get; set; }
 
-		public ITaskItem[] JavaLibraries { get; set; }
+		public ITaskItem[]? JavaLibraries { get; set; }
 
-		public ITaskItem[] ExternalJavaLibraries { get; set; }
+		public ITaskItem[]? ExternalJavaLibraries { get; set; }
 
-		public ITaskItem[] DoNotPackageJavaLibraries { get; set; }
+		public ITaskItem[]? DoNotPackageJavaLibraries { get; set; }
 
-		public ITaskItem[] LibraryProjectJars { get; set; }
-
-		[Output]
-		public ITaskItem[] JavaLibrariesToCompile { get; set; }
+		public ITaskItem[]? LibraryProjectJars { get; set; }
 
 		[Output]
-		public ITaskItem[] ReferenceJavaLibraries { get; set; }
+		public ITaskItem[]? JavaLibrariesToCompile { get; set; }
+
+		[Output]
+		public ITaskItem[]? ReferenceJavaLibraries { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ExtractJarsFromAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ExtractJarsFromAar.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,12 +16,12 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "ELPJ";
 
 		[Required]
-		public string OutputJarsDirectory { get; set; }
+		public string OutputJarsDirectory { get; set; } = "";
 
 		[Required]
-		public string OutputAnnotationsDirectory { get; set; }
+		public string OutputAnnotationsDirectory { get; set; } = "";
 
-		public string [] Libraries { get; set; }
+		public string []? Libraries { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
@@ -24,10 +22,10 @@ namespace Xamarin.Android.Tasks
 
 		const RegisteredTaskObjectLifetime Lifetime = RegisteredTaskObjectLifetime.AppDomain;
 
-		public ITaskItem [] InputAssemblies { get; set; }
+		public ITaskItem []? InputAssemblies { get; set; }
 
 		[Output]
-		public ITaskItem [] OutputAssemblies { get; set; }
+		public ITaskItem []? OutputAssemblies { get; set; }
 
 		public override bool RunTask ()
 		{
@@ -102,11 +100,11 @@ namespace Xamarin.Android.Tasks
 				var name = reader.GetCustomAttributeFullName (attribute, Log);
 				switch (name) {
 					case "System.Runtime.Versioning.TargetFrameworkAttribute":
-						string targetFrameworkIdentifier = null;
+						string? targetFrameworkIdentifier = null;
 						foreach (var p in attribute.GetCustomAttributeArguments ().FixedArguments) {
 							// Of the form "MonoAndroid,Version=v8.1"
 							var value = p.Value?.ToString ();
-							if (!string.IsNullOrEmpty (value)) {
+							if (!value.IsNullOrEmpty ()) {
 								int commaIndex = value.IndexOf (",", StringComparison.Ordinal);
 								if (commaIndex != -1) {
 									targetFrameworkIdentifier = value.Substring (0, commaIndex);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FindLayoutsToBind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FindLayoutsToBind.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -21,15 +19,15 @@ namespace Xamarin.Android.Tasks
 
 		public bool GenerateLayoutBindings { get; set; }
 
-		public string BindingDependenciesCacheFile { get; set; }
+		public string? BindingDependenciesCacheFile { get; set; }
 
-		public ITaskItem[] BoundLayouts { get; set; }
+		public ITaskItem[]? BoundLayouts { get; set; }
 
 		[Required]
-		public ITaskItem[] ResourceFiles { get; set; }
+		public ITaskItem[] ResourceFiles { get; set; } = [];
 
 		[Output]
-		public ITaskItem[] LayoutsToBind { get; set; }
+		public ITaskItem[]? LayoutsToBind { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -15,13 +13,13 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GCANSF";
 
 		[Required]
-		public ITaskItem[] ResolvedAssemblies { get; set; }
+		public ITaskItem[] ResolvedAssemblies { get; set; } = [];
 
 		[Required]
-		public string [] SupportedAbis { get; set; }
+		public string [] SupportedAbis { get; set; } = [];
 
 		[Required]
-		public string EnvironmentOutputDirectory { get; set; }
+		public string EnvironmentOutputDirectory { get; set; } = "";
 
 		[Required]
 		public bool Debug { get; set; }
@@ -30,7 +28,7 @@ namespace Xamarin.Android.Tasks
 		public bool EnableCompression { get; set; }
 
 		[Required]
-		public string ProjectFullPath { get; set; }
+		public string ProjectFullPath { get; set; } = "";
 
 		public override bool RunTask ()
 		{
@@ -92,7 +90,7 @@ namespace Xamarin.Android.Tasks
 			BuildEngine4.RegisterTaskObjectAssemblyLocal (key, archAssemblies, RegisteredTaskObjectLifetime.Build);
 			Generate (archAssemblies);
 
-			void Generate (Dictionary<AndroidTargetArch, Dictionary<string, CompressedAssemblyInfo>> dict)
+			void Generate (Dictionary<AndroidTargetArch, Dictionary<string, CompressedAssemblyInfo>>? dict)
 			{
 				var composer = new CompressedAssembliesNativeAssemblyGenerator (Log, dict);
 				LLVMIR.LlvmIrModule compressedAssemblies = composer.Construct ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.CSharpBindingGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.CSharpBindingGenerator.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -107,7 +105,7 @@ namespace Xamarin.Android.Tasks
 				WriteLineIndent (state, $"{BindingPartialClassBackingFieldName} = new global::{state.BindingClassName} ({parameters});");
 			}
 
-			void WriteMethodStart (State state, string lead, string name, string parameters, string genericConstraint = null, bool startBody = true)
+			void WriteMethodStart (State state, string lead, string name, string parameters, string? genericConstraint = null, bool startBody = true)
 			{
 				string declaration = $"{lead} {name} ({parameters})";
 				if (!String.IsNullOrEmpty (genericConstraint))
@@ -121,7 +119,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			void WriteMethodEnd (State state, string returnExpression = null)
+			void WriteMethodEnd (State state, string? returnExpression = null)
 			{
 				if (!String.IsNullOrWhiteSpace (returnExpression))
 					WriteLineIndent (state, $"return {returnExpression};");
@@ -263,7 +261,7 @@ namespace Xamarin.Android.Tasks
 
 				// There might be several locations, we will write only the first one since we can have
 				// only one and first is as good as any
-				LayoutLocationInfo loc = widget.Locations?.FirstOrDefault ();
+				LayoutLocationInfo? loc = widget.Locations?.FirstOrDefault ();
 				if (loc == null)
 					return;
 
@@ -320,7 +318,7 @@ namespace Xamarin.Android.Tasks
 					id = $"{resourceNamespace}{id}";
 
 				string backingFieldName = GetBindingBackingFieldName (widget);
-				string extraParam;
+				string? extraParam;
 				if (isFragment)
 					extraParam = $" {backingFieldName},";
 				else

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMainAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMainAndroidManifest.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
@@ -1,6 +1,4 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
-#nullable disable
-
 using System;
 using System.CodeDom;
 using System.CodeDom.Compiler;
@@ -21,17 +19,17 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GMA";
 
 		[Required]
-		public ITaskItem[] References { get; set; }
+		public ITaskItem[] References { get; set; } = [];
 
 		[Required]
-		public ITaskItem[] SourceAidlFiles { get; set; }
+		public ITaskItem[] SourceAidlFiles { get; set; } = [];
 		
 		[Required]
-		public string IntermediateOutputDirectory { get; set; }
-		
-		public string OutputNamespace { get; set; }
+		public string IntermediateOutputDirectory { get; set; } = "";
 
-		public string ParcelableHandlingOption { get; set; }
+		public string? OutputNamespace { get; set; }
+
+		public string? ParcelableHandlingOption { get; set; }
 
 		public GenerateManagedAidlProxies ()
 		{
@@ -82,7 +80,7 @@ namespace Xamarin.Android.Tasks
 			return true;
 		}
 		
-		static ParcelableHandling ToParcelableHandling (string option)
+		static ParcelableHandling ToParcelableHandling (string? option)
 		{
 			switch (option) {
 			case "ignore": return ParcelableHandling.Ignore;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeApplicationConfigSources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeApplicationConfigSources.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -27,24 +25,24 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GCA";
 
 		[Required]
-		public ITaskItem[] ResolvedAssemblies { get; set; }
+		public ITaskItem[] ResolvedAssemblies { get; set; } = [];
 
-		public ITaskItem[] NativeLibraries { get; set; }
+		public ITaskItem[]? NativeLibraries { get; set; }
 
-		public ITaskItem[] MonoComponents { get; set; }
+		public ITaskItem[]? MonoComponents { get; set; }
 
-		public ITaskItem[] SatelliteAssemblies { get; set; }
+		public ITaskItem[]? SatelliteAssemblies { get; set; }
 
 		public bool UseAssemblyStore { get; set; }
 
 		[Required]
-		public string EnvironmentOutputDirectory { get; set; }
+		public string EnvironmentOutputDirectory { get; set; } = "";
 
 		[Required]
-		public string [] SupportedAbis { get; set; }
+		public string [] SupportedAbis { get; set; } = [];
 
 		[Required]
-		public string AndroidPackageName { get; set; }
+		public string AndroidPackageName { get; set; } = "";
 
 		[Required]
 		public bool EnablePreloadAssembliesDefault { get; set; }
@@ -54,19 +52,19 @@ namespace Xamarin.Android.Tasks
 
 		public bool EnableMarshalMethods { get; set; }
 		public bool EnableManagedMarshalMethodsLookup { get; set; }
-		public string RuntimeConfigBinFilePath { get; set; }
+		public string? RuntimeConfigBinFilePath { get; set; }
 		public string ProjectRuntimeConfigFilePath { get; set; } = String.Empty;
-		public string BoundExceptionType { get; set; }
+		public string? BoundExceptionType { get; set; }
 
-		public string PackageNamingPolicy { get; set; }
-		public string Debug { get; set; }
-		public ITaskItem[] Environments { get; set; }
-		public string AndroidAotMode { get; set; }
+		public string? PackageNamingPolicy { get; set; }
+		public string? Debug { get; set; }
+		public ITaskItem[]? Environments { get; set; }
+		public string? AndroidAotMode { get; set; }
 		public bool AndroidAotEnableLazyLoad { get; set; }
 		public bool EnableLLVM { get; set; }
-		public string HttpClientHandlerType { get; set; }
-		public string TlsProvider { get; set; }
-		public string AndroidSequencePointsMode { get; set; }
+		public string? HttpClientHandlerType { get; set; }
+		public string? TlsProvider { get; set; }
+		public string? AndroidSequencePointsMode { get; set; }
 		public bool EnableSGenConcurrent { get; set; }
 		public string? CustomBundleConfigFile { get; set; }
 
@@ -94,7 +92,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			AotMode aotMode = AotMode.None;
-			if (!string.IsNullOrEmpty (AndroidAotMode) && Aot.GetAndroidAotMode (AndroidAotMode, out aotMode) && aotMode != AotMode.None) {
+			if (!AndroidAotMode.IsNullOrEmpty () && Aot.GetAndroidAotMode (AndroidAotMode, out aotMode) && aotMode != AotMode.None) {
 				usesMonoAOT = true;
 			}
 
@@ -161,7 +159,7 @@ namespace Xamarin.Android.Tasks
 			};
 
 			int assemblyCount = 0;
-			HashSet<string> archAssemblyNames = null;
+			HashSet<string>? archAssemblyNames = null;
 			HashSet<string> uniqueAssemblyNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
 			Action<ITaskItem> updateAssemblyCount = (ITaskItem assembly) => {
 				string? culture = MonoAndroidHelper.GetAssemblyCulture (assembly);
@@ -330,8 +328,8 @@ namespace Xamarin.Android.Tasks
 
 			void AddEnvironmentVariableLine (string l)
 			{
-				string line = l?.Trim ();
-				if (String.IsNullOrEmpty (line) || line [0] == '#')
+				string? line = l?.Trim ();
+				if (line.IsNullOrEmpty () || line [0] == '#')
 					return;
 
 				string[] nv = line.Split (new char[]{'='}, 2);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs
@@ -1,6 +1,4 @@
 // Copyright (C) 2021 Microsoft, Inc. All rights reserved.
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,20 +16,20 @@ namespace Xamarin.Android.Tasks
 	public class GenerateResourceCaseMap : AndroidTask
 	{
 		public override string TaskPrefix => "GRCM";
-		public ITaskItem[] Resources { get; set; }
+		public ITaskItem[]? Resources { get; set; }
 
 		[Required]
-		public string ResourceDirectory { get; set; }
+		public string ResourceDirectory { get; set; } = "";
 
 		[Required]
-		public string ProjectDir { get; set; }
+		public string ProjectDir { get; set; } = "";
 
-		public ITaskItem[] AdditionalResourceDirectories { get; set; }
+		public ITaskItem[] AdditionalResourceDirectories { get; set; } = [];
 
-		public string[] AarLibraries { get; set; }
+		public string[]? AarLibraries { get; set; }
 
 		[Required]
-		public ITaskItem OutputFile { get; set; }
+		public ITaskItem OutputFile { get; set; } = null!; // NRT - guarded by [Required]
 
 		private Dictionary<string, string> resource_fixup = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateRtxt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateRtxt.cs
@@ -1,6 +1,4 @@
 // Copyright (C) 2022 Microsoft Ltd, Inc. All rights reserved.
-#nullable disable
-
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -13,18 +11,18 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GR";
 
 		[Required]
-		public string RTxtFile { get; set; }
+		public string RTxtFile { get; set; } = "";
 
 		[Required]
-		public string ResourceDirectory { get; set; }
-		public string[] AdditionalResourceDirectories { get; set; }
+		public string ResourceDirectory { get; set; } = "";
+		public string[]? AdditionalResourceDirectories { get; set; }
 
-		public string[] AarLibraries { get; set; }
+		public string[]? AarLibraries { get; set; }
 
-		public string JavaPlatformJarPath { get; set; }
+		public string? JavaPlatformJarPath { get; set; }
 
-		public string ResourceFlagFile { get; set; }
-		public string CaseMapFile { get; set; }
+		public string? ResourceFlagFile { get; set; }
+		public string? CaseMapFile { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2012 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -21,53 +19,53 @@ namespace Xamarin.Android.Tasks
 
 		public bool OnlyRunXmlAdjuster { get; set; }
 
-		public string XmlAdjusterOutput { get; set; }
+		public string? XmlAdjusterOutput { get; set; }
 
 		[Required]
-		public string OutputDirectory { get; set; }
+		public string OutputDirectory { get; set; } = "";
 
-		public string EnumDirectory { get; set; }
+		public string? EnumDirectory { get; set; }
 
-		public string EnumMetadataDirectory { get; set; }
-
-		[Required]
-		public string AndroidApiLevel { get; set; }
+		public string? EnumMetadataDirectory { get; set; }
 
 		[Required]
-		public string ApiXmlInput { get; set; }
+		public string AndroidApiLevel { get; set; } = "";
 
-		public string AssemblyName { get; set; }
+		[Required]
+		public string ApiXmlInput { get; set; } = "";
 
-		public string CodegenTarget { get; set; }
+		public string? AssemblyName { get; set; }
+
+		public string? CodegenTarget { get; set; }
 
 		public bool NoStdlib { get; set; }
 
-		public string TypeMappingReportFile { get; set; }
+		public string? TypeMappingReportFile { get; set; }
 
 		public bool UseShortFileNames { get; set; }
 
 		// apart from ReferencedManagedLibraries we need it to find mscorlib.dll.
 		[Required]
-		public string MonoAndroidFrameworkDirectories { get; set; }
+		public string MonoAndroidFrameworkDirectories { get; set; } = "";
 
-		public string LangVersion { get; set; }
+		public string? LangVersion { get; set; }
 
 		public bool EmitLegacyInterfaceInvokers { get; set; }
 
 		public bool EnableBindingStaticAndDefaultInterfaceMethods { get; set; }
 		public bool EnableBindingNestedInterfaceTypes { get; set; }
 		public bool EnableBindingInterfaceConstants { get; set; }
-		public string EnableRestrictToAttributes { get; set; }
+		public string? EnableRestrictToAttributes { get; set; }
 		public bool EnableObsoleteOverrideInheritance { get; set; }
-		public string Nullable { get; set; }
+		public string? Nullable { get; set; }
 
-		public ITaskItem[] TransformFiles { get; set; }
-		public ITaskItem[] ReferencedManagedLibraries { get; set; }
-		public ITaskItem[] AnnotationsZipFiles { get; set; }
-		public ITaskItem[] NamespaceTransforms { get; set; }
+		public ITaskItem[]? TransformFiles { get; set; }
+		public ITaskItem[]? ReferencedManagedLibraries { get; set; }
+		public ITaskItem[]? AnnotationsZipFiles { get; set; }
+		public ITaskItem[]? NamespaceTransforms { get; set; }
 
-		public ITaskItem[] JavadocXml { get; set; }
-		public string JavadocVerbosity { get; set; }
+		public ITaskItem[]? JavadocXml { get; set; }
+		public string? JavadocVerbosity { get; set; }
 
 		public bool UseJavaLegacyResolver { get; set; }
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidActivityName.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidActivityName.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Xamarin.Android.Tools;
 using Microsoft.Android.Build.Tasks;
@@ -11,10 +9,10 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GAAN";
 
 		[Required]
-		public string ManifestFile { get; set; }
+		public string ManifestFile { get; set; } = "";
 
 		[Output]
-		public string ActivityName { get; set; }
+		public string? ActivityName { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidDefineConstants.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidDefineConstants.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -19,10 +17,10 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public int AndroidApiLevel { get; set; }
 
-		public string ProductVersion         { get; set; }
+		public string? ProductVersion         { get; set; }
 
 		[Output]
-		public  ITaskItem[]     AndroidDefineConstants      { get; set; }
+		public  ITaskItem[]?    AndroidDefineConstants      { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
@@ -23,8 +23,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -39,19 +37,19 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "GAP";
 
-		public string ManifestFile { get; set; }
+		public string? ManifestFile { get; set; }
 
 		[Required]
-		public string AssemblyName { get; set; }
+		public string AssemblyName { get; set; } = "";
 
-		public string [] ManifestPlaceholders { get; set; }
+		public string []? ManifestPlaceholders { get; set; }
 
 		[Output]
-		public string PackageName { get; set; }
+		public string? PackageName { get; set; }
 
 		public override bool RunTask ()
 		{
-			if (!string.IsNullOrEmpty (ManifestFile) && File.Exists (ManifestFile)) {
+			if (!ManifestFile.IsNullOrEmpty () && File.Exists (ManifestFile)) {
 				using var stream = File.OpenRead (ManifestFile);
 				using var reader = XmlReader.Create (stream);
 				if (reader.MoveToContent () == XmlNodeType.Element) {
@@ -62,7 +60,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			if (!string.IsNullOrEmpty (PackageName)) {
+			if (!PackageName.IsNullOrEmpty ()) {
 				// PackageName may be passed in via $(ApplicationId) and missing from AndroidManifest.xml
 				PackageName = AndroidAppManifest.CanonicalizePackageName (PackageName);
 			} else {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -110,7 +110,7 @@ namespace Xamarin.Android.Tasks
 			return false;
 		}
 
-		public static bool TryGetSequencePointsMode (string value, out SequencePointsMode mode)
+		public static bool TryGetSequencePointsMode (string? value, out SequencePointsMode mode)
 		{
 			mode = SequencePointsMode.None;
 			switch ((value ?? string.Empty).ToLowerInvariant ().Trim ()) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAppSettingsDirectory.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAppSettingsDirectory.cs
@@ -1,8 +1,6 @@
 // Author: Jonathan Pobst <jpobst@xamarin.com>
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -16,7 +14,7 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GAS";
 
 		[Output]
-		public string AppSettingsDirectory { get; set; }
+		public string? AppSettingsDirectory { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAssetPacks.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAssetPacks.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -21,15 +19,15 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GAP";
 
 		[Required]
-		public ITaskItem[] Assets { get; set; }
+		public ITaskItem[] Assets { get; set; } = [];
 
 		[Required]
-		public ITaskItem IntermediateDir { get; set; }
+		public ITaskItem IntermediateDir { get; set; } = null!;  // NRT - guarded by [Required]
 
 		public string[] MetadataToCopy { get; set; } = { "DeliveryType" };
 
 		[Output]
-		public ITaskItem[] AssetPacks { get; set; }
+		public ITaskItem[]? AssetPacks { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetConvertedJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetConvertedJavaLibraries.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -14,11 +12,11 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GCJ";
 
 		[Required]
-		public string Extension { get; set; }
-		public string OutputJackDirectory { get; set; }
-		public string [] JarsToConvert { get; set; }
+		public string Extension { get; set; } = "";
+		public string? OutputJackDirectory { get; set; }
+		public string []? JarsToConvert { get; set; }
 		[Output]
-		public string [] ConvertedFilesToBeGenerated { get; set; }
+		public string []? ConvertedFilesToBeGenerated { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetExtraPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetExtraPackages.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -16,13 +14,13 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GEP";
 
 		[Required]
-		public string IntermediateOutputPath { get; set; }
+		public string IntermediateOutputPath { get; set; } = "";
 
 		[Output]
-		public string ExtraPackages { get; set; }
+		public string? ExtraPackages { get; set; }
 
 		[Required]
-		public string LibraryProjectImportsDirectoryName { get; set; }
+		public string LibraryProjectImportsDirectoryName { get; set; } = "";
 
 		public override bool RunTask ()
 		{
@@ -32,7 +30,7 @@ namespace Xamarin.Android.Tasks
 				foreach (var assemblyDir in Directory.GetDirectories (libProjects)) {
 					foreach (var importBaseDir in new string [] { LibraryProjectImportsDirectoryName, "library_project_imports", }) {
 						string importsDir = Path.Combine (assemblyDir, importBaseDir);
-						string libpkg = GetPackageNameForLibrary (importsDir, Path.GetDirectoryName (assemblyDir));
+						string? libpkg = GetPackageNameForLibrary (importsDir, Path.GetDirectoryName (assemblyDir));
 						if (libpkg != null)
 							extraPackages.Add (libpkg);
 					}
@@ -45,7 +43,7 @@ namespace Xamarin.Android.Tasks
 			return true;
 		}
 
-		string GetPackageNameForLibrary (string path, string assemblyName)
+		string? GetPackageNameForLibrary (string path, string assemblyName)
 		{
 			// It looks for:
 			// 1) bin/AndroidManifest.xml

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetFilesThatExist.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetFilesThatExist.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -18,12 +16,12 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GFT";
 
 		[Required]
-		public ITaskItem[] Files { get; set; }
+		public ITaskItem[] Files { get; set; } = [];
 
-		public ITaskItem [] IgnoreFiles { get; set; }
+		public ITaskItem []? IgnoreFiles { get; set; }
 
 		[Output]
-		public ITaskItem[] FilesThatExist { get; set; }
+		public ITaskItem[]? FilesThatExist { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -22,18 +20,18 @@ namespace Xamarin.Android.Tasks
 		};
 
 		[Required]
-		public ITaskItem[] ExtractedDirectories { get; set; }
+		public ITaskItem[] ExtractedDirectories { get; set; } = [];
 
-		public string CacheFile { get; set;} 
-
-		[Output]
-		public ITaskItem [] Jars { get; set; }
+		public string? CacheFile { get; set;} 
 
 		[Output]
-		public ITaskItem [] NativeLibraries { get; set; }
+		public ITaskItem []? Jars { get; set; }
 
 		[Output]
-		public ITaskItem [] ManifestDocuments { get; set; }
+		public ITaskItem []? NativeLibraries { get; set; }
+
+		[Output]
+		public ITaskItem []? ManifestDocuments { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetMonoPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetMonoPlatformJar.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -15,13 +13,13 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GMJ";
 
 		[Required]
-		public string TargetFrameworkDirectory { get; set; }
+		public string TargetFrameworkDirectory { get; set; } = "";
 
 		[Output]
-		public string MonoPlatformJarPath { get; set; }
+		public string? MonoPlatformJarPath { get; set; }
 
 		[Output]
-		public string MonoPlatformDexPath { get; set; }
+		public string? MonoPlatformDexPath { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Collections.Generic;
@@ -22,9 +20,9 @@ namespace Xamarin.Android.Tasks
 		public override string DefaultErrorCode => "BT0000";
 
 		[Required]
-		public string ApkSet { get; set; }
+		public string ApkSet { get; set; } = "";
 
-		public string[] Modules  { get; set; }
+		public string[]? Modules  { get; set; }
 
 		internal override CommandLineBuilder GetCommandLineBuilder ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2012 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.IO;
@@ -18,35 +16,35 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "JTX";
 
 		[Required]
-		public string AndroidSdkDirectory { get; set; }
-		
-		[Required]
-		public string MonoAndroidToolsDirectory { get; set; }
-		
-		[Required]
-		public string JavaSdkDirectory { get; set; }
+		public string AndroidSdkDirectory { get; set; } = "";
 
 		[Required]
-		public string AndroidApiLevel { get; set; }
+		public string MonoAndroidToolsDirectory { get; set; } = "";
 
 		[Required]
-		public string OutputFile { get; set; }
+		public string JavaSdkDirectory { get; set; } = "";
 
 		[Required]
-		public ITaskItem[] SourceJars { get; set; }
+		public string AndroidApiLevel { get; set; } = "";
 
-		public ITaskItem[] ReferenceJars { get; set; }
-		public string DroidDocPaths { get; set; }
-		public string JavaDocPaths { get; set; }
-		public string Java7DocPaths { get; set; }
-		public string Java8DocPaths { get; set; }
-		public ITaskItem[] JavaDocs { get; set; }
+		[Required]
+		public string OutputFile { get; set; } = "";
 
-		public ITaskItem[] LibraryProjectJars { get; set; }
+		[Required]
+		public ITaskItem[] SourceJars { get; set; } = [];
 
-		public string JavaOptions { get; set; }
+		public ITaskItem[]? ReferenceJars { get; set; }
+		public string? DroidDocPaths { get; set; }
+		public string? JavaDocPaths { get; set; }
+		public string? Java7DocPaths { get; set; }
+		public string? Java8DocPaths { get; set; }
+		public ITaskItem[]? JavaDocs { get; set; }
 
-		public string JavaMaximumHeapSize { get; set; }
+		public ITaskItem[]? LibraryProjectJars { get; set; }
+
+		public string? JavaOptions { get; set; }
+
+		public string? JavaMaximumHeapSize { get; set; }
 
 		public override bool RunTask ()
 		{
@@ -143,7 +141,7 @@ namespace Xamarin.Android.Tasks
 			return cmd.ToString ();
 		}
 
-		string GetJavadocOption (string file)
+		string? GetJavadocOption (string file)
 		{
 			string rawHTML = File.ReadAllText (file);
 			if (rawHTML.Length < 500)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
@@ -1,7 +1,5 @@
 // Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.IO;
@@ -17,11 +15,11 @@ namespace Xamarin.Android.Tasks
 
 	public abstract class JavaCompileToolTask : JavaToolTask
 	{
-		public string StubSourceDirectory { get; set; }
+		public string? StubSourceDirectory { get; set; }
 
-		public ITaskItem[] JavaSourceFiles { get; set; }
+		public ITaskItem[]? JavaSourceFiles { get; set; }
 
-		public ITaskItem[] Jars { get; set; }
+		public ITaskItem[]? Jars { get; set; }
 
 		protected override string ToolName {
 			get { return OS.IsWindows ? "javac.exe" : "javac"; }
@@ -34,7 +32,7 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		internal string TemporarySourceListFile;
+		internal string? TemporarySourceListFile;
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/KeyTool.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/KeyTool.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -12,22 +10,22 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "KEY";
 
-		string previousLine;
+		string? previousLine;
 
 		[Required]
-		public string KeyStore { get; set; }
+		public string KeyStore { get; set; } = "";
 
 		[Required]
-		public string KeyAlias { get; set; }
+		public string KeyAlias { get; set; } = "";
 
 		[Required]
-		public string KeyPass { get; set; }
+		public string KeyPass { get; set; } = "";
 
 		[Required]
-		public string StorePass { get; set; }
+		public string StorePass { get; set; } = "";
 
 		[Required]
-		public string Command { get; set; }
+		public string Command { get; set; } = "";
 
 		public bool Verbose { get; set; }
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LayoutLocationInfo.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LayoutLocationInfo.cs
@@ -1,10 +1,8 @@
-#nullable disable
-
 namespace Xamarin.Android.Tasks
 {
 	sealed class LayoutLocationInfo
 	{
-		public string FilePath;
+		public string? FilePath;
 		public int Line;
 		public int Column;
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LayoutTypeFixup.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LayoutTypeFixup.cs
@@ -1,10 +1,8 @@
-#nullable disable
-
 namespace Xamarin.Android.Tasks
 {
 	sealed class LayoutTypeFixup
 	{
-		public string OldType;
-		public LayoutLocationInfo Location;
+		public string? OldType;
+		public LayoutLocationInfo? Location;
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LayoutWidget.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LayoutWidget.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 
@@ -7,13 +5,13 @@ namespace Xamarin.Android.Tasks
 {
 	sealed class LayoutWidget
 	{
-		public string Id;
-		public string Type;
-		public string Name;
-		public string PartialClasses;
-		public List<LayoutWidgetType> AllTypes;
-		public List<LayoutLocationInfo> Locations;
-		public List<LayoutTypeFixup> TypeFixups;
+		public string? Id;
+		public string? Type;
+		public string? Name;
+		public string? PartialClasses;
+		public List<LayoutWidgetType>? AllTypes;
+		public List<LayoutLocationInfo>? Locations;
+		public List<LayoutTypeFixup>? TypeFixups;
 		public LayoutWidgetType WidgetType = LayoutWidgetType.Unknown;
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LogErrorsForFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LogErrorsForFiles.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
@@ -12,17 +10,17 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "LEF";
 
 		[Required]
-		public ITaskItem[] Files { get; set; }
+		public ITaskItem[] Files { get; set; } = [];
 
 		[Required]
-		public string Code { get; set; }
+		public string Code { get; set; } = "";
 
 		[Required]
-		public string Text { get; set; }
+		public string Text { get; set; } = "";
 
-		public string SubCategory { get; set; }
+		public string? SubCategory { get; set; }
 
-		public string HelpKeyword { get; set; }
+		public string? HelpKeyword { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LogWarningsForFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LogWarningsForFiles.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
@@ -12,17 +10,17 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "LWF";
 
 		[Required]
-		public ITaskItem[] Files { get; set; }
+		public ITaskItem[] Files { get; set; } = [];
 
 		[Required]
-		public string Code { get; set; }
+		public string Code { get; set; } = "";
 
 		[Required]
-		public string Text { get; set; }
+		public string Text { get; set; } = "";
 
-		public string SubCategory { get; set; }
+		public string? SubCategory { get; set; }
 
-		public string HelpKeyword { get; set; }
+		public string? HelpKeyword { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MDoc.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MDoc.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,13 +13,13 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "MDC";
 
-		public string [] References { get; set; }
+		public string []? References { get; set; }
 		
 		[Required]
-		public string TargetAssembly { get; set; }
+		public string TargetAssembly { get; set; } = "";
 
 		[Required]
-		public string OutputDocDirectory { get; set; }
+		public string OutputDocDirectory { get; set; } = "";
 
 		public bool RunExport { get; set; }
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -25,32 +23,32 @@ namespace Xamarin.Android.Tasks
 
 		const string BundleSharedLibraryName = "libmonodroid_bundle_app.so";
 
-		public string AndroidNdkDirectory { get; set; }
+		public string? AndroidNdkDirectory { get; set; }
 
 		[Required]
-		public ITaskItem[] Assemblies { get; set; }
+		public ITaskItem[] Assemblies { get; set; } = [];
 
 		// Which ABIs to include native libs for
 		[Required]
-		public string [] SupportedAbis { get; set; }
+		public string [] SupportedAbis { get; set; } = [];
 
 		[Required]
-		public string TempOutputPath { get; set; }
+		public string TempOutputPath { get; set; } = "";
 
-		public string IncludePath { get; set; }
+		public string? IncludePath { get; set; }
 
 		[Required]
-		public string ToolPath { get; set; }
+		public string ToolPath { get; set; } = "";
 
 		public bool AutoDeps { get; set; }
 		public bool EmbedDebugSymbols { get; set; }
 		public bool KeepTemp { get; set; }
 
 		[Required]
-		public string BundleApiPath { get; set; }
+		public string BundleApiPath { get; set; } = "";
 
 		[Output]
-		public ITaskItem [] OutputNativeLibraries { get; set; }
+		public ITaskItem []? OutputNativeLibraries { get; set; }
 
 		public MakeBundleNativeCodeExternal ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ManifestMerger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ManifestMerger.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -18,20 +16,20 @@ namespace Xamarin.Android.Tasks
 		public override string DefaultErrorCode => $"{TaskPrefix}0000";
 
 		[Required]
-		public string ManifestMergerJarPath { get; set; }
+		public string ManifestMergerJarPath { get; set; } = "";
 
 		[Required]
-		public string AndroidManifest { get; set; }
+		public string AndroidManifest { get; set; } = "";
 
 		[Required]
-		public string OutputManifestFile { get; set; }
+		public string OutputManifestFile { get; set; } = "";
 
-		public string [] ManifestOverlayFiles { get; set; }
-		public string [] LibraryManifestFiles { get; set; }
+		public string []? ManifestOverlayFiles { get; set; }
+		public string []? LibraryManifestFiles { get; set; }
 
-		public string [] ManifestPlaceholders { get; set; }
+		public string []? ManifestPlaceholders { get; set; }
 
-		public string ExtraArgs { get; set; }
+		public string? ExtraArgs { get; set; }
 
 		/*
 		 * obj\Debug\AndroidManifest.xml:12:5-16:15 Error:
@@ -39,8 +37,8 @@ namespace Xamarin.Android.Tasks
 		 */
 		static readonly Regex manifestErrorRegEx = new Regex (@"(?<file>.+AndroidManifest\.xml):(?<line>\d+:\d+).+Error:(?<error>.+)?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-		string tempFile;
-		string responseFile;
+		string? tempFile;
+		string? responseFile;
 
 		protected override Regex CodeErrorRegEx => manifestErrorRegEx;
 
@@ -132,7 +130,7 @@ namespace Xamarin.Android.Tasks
 						Log.LogCodedWarning ("XA1010", string.Format (Properties.Resources.XA1010, string.Join (";", ManifestPlaceholders)));
 				}
 			}
-			if (!string.IsNullOrEmpty (ExtraArgs)) {
+			if (!ExtraArgs.IsNullOrEmpty ()) {
 				foreach (var entry in ExtraArgs.Split (new char[] { ' ' })) {
 					sb.AppendLine (entry);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MonoSymbolicate.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MonoSymbolicate.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
@@ -16,10 +14,10 @@ namespace Xamarin.Android.Tasks
 		protected override string ToolName => OS.IsWindows ? "mono-symbolicate.exe" : "mono-symbolicate";
 
 		[Required]
-		public string InputDirectory { get; set; }
+		public string InputDirectory { get; set; } = "";
 
 		[Required]
-		public string OutputDirectory { get; set; }
+		public string OutputDirectory { get; set; } = "";
 
 		protected override string GenerateFullPathToTool ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareAbiItems.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareAbiItems.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using System.Collections.Generic;
@@ -22,22 +20,22 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "PAI";
 
 		[Required]
-		public string [] BuildTargetAbis { get; set; }
+		public string [] BuildTargetAbis { get; set; } = [];
 
 		[Required]
-		public string NativeSourcesDir { get; set; }
+		public string NativeSourcesDir { get; set; } = "";
 
 		[Required]
-		public string Mode { get; set; }
+		public string Mode { get; set; } = "";
 
 		[Required]
 		public bool Debug { get; set; }
 
 		[Output]
-		public ITaskItem[] AssemblySources { get; set; }
+		public ITaskItem[]? AssemblySources { get; set; }
 
 		[Output]
-		public ITaskItem[] AssemblyIncludes { get; set; }
+		public ITaskItem[]? AssemblyIncludes { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareSatelliteAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareSatelliteAssemblies.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,7 +23,7 @@ public class PrepareSatelliteAssemblies : AndroidTask
 	public ITaskItem[] IntermediateSatelliteAssemblies { get; set; } = Array.Empty<ITaskItem> ();
 
 	[Output]
-	public ITaskItem[] ProcessedSatelliteAssemblies { get; set; }
+	public ITaskItem[]? ProcessedSatelliteAssemblies { get; set; }
 
 	public override bool RunTask ()
 	{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessNativeLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessNativeLibraries.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -27,14 +25,14 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// Assumed to be .so files only
 		/// </summary>
-		public ITaskItem [] InputLibraries { get; set; }
-		public ITaskItem [] Components { get; set; }
-		public string [] ExcludedLibraries { get; set; }
+		public ITaskItem []? InputLibraries { get; set; }
+		public ITaskItem []? Components { get; set; }
+		public string []? ExcludedLibraries { get; set; }
 
 		public bool IncludeDebugSymbols { get; set; }
 
 		[Output]
-		public ITaskItem [] OutputLibraries { get; set; }
+		public ITaskItem []? OutputLibraries { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Collections.Generic;
@@ -17,13 +15,13 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "RAM";
 
 		[Required]
-		public string ManifestFile { get; set; }
+		public string ManifestFile { get; set; } = "";
 
 		[Required]
-		public string AndroidSdkDirectory { get; set; }
+		public string AndroidSdkDirectory { get; set; } = "";
 
 		[Required]
-		public string AndroidApiLevel { get; set; }
+		public string AndroidApiLevel { get; set; } = "";
 
 		/// <summary>
 		/// True if //manifest/application/[@android:extractNativeLibs='false']. False otherwise.
@@ -32,7 +30,7 @@ namespace Xamarin.Android.Tasks
 		public bool EmbeddedDSOsEnabled { get; set; }
 
 		[Output]
-		public ITaskItem [] UsesLibraries { get; set; }
+		public ITaskItem []? UsesLibraries { get; set; }
 
 		[Output]
 		public bool UseEmbeddedDex { get; set; } = false;
@@ -47,7 +45,7 @@ namespace Xamarin.Android.Tasks
 			var app = manifest.Document.Element ("manifest")?.Element ("application");
 
 			if (app != null) {
-				string text = app.Attribute (androidNs + "extractNativeLibs")?.Value;
+				string? text = app.Attribute (androidNs + "extractNativeLibs")?.Value;
 				if (bool.TryParse (text, out bool value)) {
 					EmbeddedDSOsEnabled = !value;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadImportedLibrariesCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadImportedLibrariesCache.cs
@@ -23,8 +23,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -41,16 +39,16 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "RIL";
 
 		[Required]
-		public string CacheFile { get; set;} 
+		public string CacheFile { get; set; } = "";
 
 		[Output]
-		public ITaskItem [] Jars { get; set; }
+		public ITaskItem []? Jars { get; set; }
 
 		[Output]
-		public ITaskItem [] NativeLibraries { get; set; }
+		public ITaskItem []? NativeLibraries { get; set; }
 
 		[Output]
-		public ITaskItem [] ManifestDocuments { get; set; }
+		public ITaskItem []? ManifestDocuments { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadLibraryProjectImportsCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadLibraryProjectImportsCache.cs
@@ -23,8 +23,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -40,28 +38,28 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "RLC";
 
 		[Required]
-		public string CacheFile { get; set;}
+		public string CacheFile { get; set;} = "";
 
 		[Output]
-		public ITaskItem [] Jars { get; set; }
+		public ITaskItem []? Jars { get; set; }
 
 		[Output]
-		public ITaskItem [] ResolvedAssetDirectories { get; set; }
+		public ITaskItem []? ResolvedAssetDirectories { get; set; }
 
 		[Output]
-		public ITaskItem [] ResolvedResourceDirectories { get; set; }
+		public ITaskItem []? ResolvedResourceDirectories { get; set; }
 
 		[Output]
-		public ITaskItem [] ResolvedEnvironmentFiles { get; set; }
+		public ITaskItem []? ResolvedEnvironmentFiles { get; set; }
 
 		[Output]
-		public ITaskItem [] ResolvedResourceDirectoryStamps { get; set; }
+		public ITaskItem []? ResolvedResourceDirectoryStamps { get; set; }
 
 		[Output]
-		public ITaskItem [] ProguardConfigFiles { get; set; }
+		public ITaskItem []? ProguardConfigFiles { get; set; }
 
 		[Output]
-		public ITaskItem [] ExtractedDirectories { get; set; }
+		public ITaskItem []? ExtractedDirectories { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -25,8 +25,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -103,9 +101,9 @@ namespace Xamarin.Android.Tasks
 		}
 
 		[Required]
-		public ITaskItem [] Directories { get; set; }
+		public ITaskItem [] Directories { get; set; } = [];
 
 		[Output]
-		public ITaskItem [] RemovedDirectories { get; set; }
+		public ITaskItem []? RemovedDirectories { get; set; }
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright (C) 2011, Xamarin Inc.
 // Copyright (C) 2010, Novell Inc.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -21,7 +19,7 @@ namespace Xamarin.Android.Tasks
 		const string RegisterAttribute = "Android.Runtime.RegisterAttribute";
 
 		[Required]
-		public ITaskItem[] ShrunkFrameworkAssemblies { get; set; }
+		public ITaskItem[] ShrunkFrameworkAssemblies { get; set; } = [];
 
 		public override bool RunTask ()
 		{
@@ -32,6 +30,11 @@ namespace Xamarin.Android.Tasks
 			resolver.SearchDirectories.Add (path);
 			
 			using (var assembly = resolver.Load (mono_android)) {
+				if (assembly is null) {
+					Log.LogError ($"Unable to load assembly '{mono_android}'");
+					return false;
+				}
+
 				// Strip out [Register] attributes
 				foreach (TypeDefinition type in assembly.MainModule.Types)
 					ProcessType (type);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveUnknownFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveUnknownFiles.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Text;
 using Microsoft.Build.Utilities;
@@ -18,20 +16,20 @@ namespace Xamarin.Android.Tasks
 		static bool IsWindows = Path.DirectorySeparatorChar == '\\';
 
 		[Required]
-		public ITaskItem[] Files { get; set; }
+		public ITaskItem[] Files { get; set; } = [];
 		
 		[Required]
-		public string[] Directories { get; set; }
+		public string[] Directories { get; set; } = [];
 		
 		public bool RemoveDirectories { get; set; }
 
 		public string FileType { get; set; } = "AndroidResource";
 
 		[Output]
-		public ITaskItem[] RemovedFiles { get; set; }
+		public ITaskItem[]? RemovedFiles { get; set; }
 
 		[Output]
-		public ITaskItem [] RemovedDirectories { get; set; }
+		public ITaskItem []? RemovedDirectories { get; set; }
 		
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveJdkJvmPath.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveJdkJvmPath.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
@@ -17,16 +15,16 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "RJJ";
 
-		public string JavaSdkPath { get; set; }
+		public string? JavaSdkPath { get; set; }
 
 		[Output]
-		public string JdkJvmPath { get; set; }
+		public string? JdkJvmPath { get; set; }
 
 		[Required]
-		public string MinimumSupportedJavaVersion   { get; set; }
+		public string MinimumSupportedJavaVersion   { get; set; } = "";
 
 		[Required]
-		public string LatestSupportedJavaVersion    { get; set; }
+		public string LatestSupportedJavaVersion    { get; set; } = "";
 
 		public override bool RunTask ()
 		{
@@ -50,11 +48,11 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		string GetJvmPath ()
+		string? GetJvmPath ()
 		{
 			// NOTE: this doesn't need to use GetRegisteredTaskObjectAssemblyLocal()
 			// because JavaSdkPath is the key and the value is a string.
-			var key = new Tuple<string, string> (nameof (ResolveJdkJvmPath), JavaSdkPath);
+			var key = new Tuple<string, string?> (nameof (ResolveJdkJvmPath), JavaSdkPath);
 			var cached = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.AppDomain) as string;
 			if (cached != null) {
 				Log.LogDebugMessage ($"Using cached value for {nameof (JdkJvmPath)}: {cached}");
@@ -65,7 +63,7 @@ namespace Xamarin.Android.Tasks
 			var minVersion  = Version.Parse (MinimumSupportedJavaVersion);
 			var maxVersion  = Version.Parse (LatestSupportedJavaVersion);
 
-			JdkInfo info    = MonoAndroidHelper.GetJdkInfo (this.CreateTaskLogger (), JavaSdkPath, minVersion, maxVersion);
+			JdkInfo? info    = MonoAndroidHelper.GetJdkInfo (this.CreateTaskLogger (), JavaSdkPath, minVersion, maxVersion);
 
 			if (info == null)
 				return null;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -22,26 +20,26 @@ namespace Xamarin.Android.Tasks
 		internal const string AndroidSkipResourceExtraction = "AndroidSkipResourceExtraction";
 
 		[Required]
-		public string ImportsDirectory { get; set; }
+		public string ImportsDirectory { get; set; } = "";
 
 		[Required]
-		public string NativeImportsDirectory { get; set; }
+		public string NativeImportsDirectory { get; set; } = "";
 
 		[Required]
-		public string OutputDirectory { get; set; }
+		public string OutputDirectory { get; set; } = "";
 
 		[Required]
-		public string OutputImportDirectory { get; set; }
+		public string OutputImportDirectory { get; set; } = "";
 
 		[Required]
-		public ITaskItem[] Assemblies { get; set; }
+		public ITaskItem[] Assemblies { get; set; } = [];
 
-		public ITaskItem [] AarLibraries { get; set; }
+		public ITaskItem []? AarLibraries { get; set; }
 
 		[Required]
-		public string AssemblyIdentityMapFile { get; set; }
+		public string AssemblyIdentityMapFile { get; set; } = "";
 
-		public string CacheFile { get; set; }
+		public string? CacheFile { get; set; }
 
 		[Required]
 		public bool DesignTimeBuild { get; set; }
@@ -49,25 +47,25 @@ namespace Xamarin.Android.Tasks
 		public bool AndroidApplication { get; set; }
 
 		[Output]
-		public ITaskItem [] Jars { get; set; }
+		public ITaskItem []? Jars { get; set; }
 
 		[Output]
-		public ITaskItem [] ResolvedAssetDirectories { get; set; }
+		public ITaskItem []? ResolvedAssetDirectories { get; set; }
 
 		[Output]
-		public ITaskItem [] ResolvedResourceDirectories { get; set; }
+		public ITaskItem []? ResolvedResourceDirectories { get; set; }
 
 		[Output]
-		public ITaskItem [] ResolvedEnvironmentFiles { get; set; }
+		public ITaskItem []? ResolvedEnvironmentFiles { get; set; }
 
 		[Output]
-		public ITaskItem [] ResolvedResourceDirectoryStamps { get; set; }
+		public ITaskItem []? ResolvedResourceDirectoryStamps { get; set; }
 
 		[Output]
-		public ITaskItem [] ProguardConfigFiles { get; set; }
+		public ITaskItem []? ProguardConfigFiles { get; set; }
 
 		[Output]
-		public ITaskItem [] ExtractedDirectories { get; set; }
+		public ITaskItem []? ExtractedDirectories { get; set; }
 
 		internal const string OriginalFile = "OriginalFile";
 		internal const string AndroidSkipResourceProcessing = "AndroidSkipResourceProcessing";
@@ -219,7 +217,7 @@ namespace Xamarin.Android.Tasks
 				bool updated = false;
 				string assemblyHash = Files.HashFile (assemblyPath);
 				string stamp = Path.Combine (outdir, assemblyIdentName + ".stamp");
-				string stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
+				string? stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
 				if (assemblyHash == stampHash) {
 					Log.LogDebugMessage ("Skipped resource lookup for {0}: extracted files are up to date", assemblyPath);
 					if (Directory.Exists (importsDir)) {
@@ -401,7 +399,7 @@ namespace Xamarin.Android.Tasks
 				bool updated = false;
 				string aarHash = Files.HashFile (aarFile.ItemSpec);
 				string stamp = Path.Combine (outdir, aarIdentityName + ".stamp");
-				string stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
+				string? stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
 				var aarFullPath = Path.GetFullPath (aarFile.ItemSpec);
 				if (aarHash == stampHash) {
 					Log.LogDebugMessage ("Skipped {0}: extracted files are up to date", aarFile.ItemSpec);
@@ -514,16 +512,16 @@ namespace Xamarin.Android.Tasks
 			});
 		}
 
-		static void AddJar (IDictionary<string, ITaskItem> jars, string destination, string path, string originalFile = null, string nuGetPackageId = null, string nuGetPackageVersion = null)
+		static void AddJar (IDictionary<string, ITaskItem> jars, string destination, string path, string? originalFile = null, string? nuGetPackageId = null, string? nuGetPackageVersion = null)
 		{
 			var fullPath = Path.GetFullPath (Path.Combine (destination, path));
 			AddJar (jars, fullPath, originalFile: originalFile, nuGetPackageId: nuGetPackageId, nuGetPackageVersion: nuGetPackageVersion);
 		}
 
-		static void AddJar (IDictionary<string, ITaskItem> jars, string fullPath, string originalFile = null, string nuGetPackageId = null, string nuGetPackageVersion = null)
+		static void AddJar (IDictionary<string, ITaskItem> jars, string fullPath, string? originalFile = null, string? nuGetPackageId = null, string? nuGetPackageVersion = null)
 		{
 			if (!jars.ContainsKey (fullPath)) {
-				jars.Add (fullPath, new TaskItem (fullPath, new Dictionary<string, string> {
+				jars.Add (fullPath, new TaskItem (fullPath, new Dictionary<string, string?> {
 					[OriginalFile] = originalFile,
 					[NuGetPackageId] = nuGetPackageId,
 					[NuGetPackageVersion] = nuGetPackageVersion,

--- a/src/Xamarin.Android.Build.Tasks/Tasks/SplitProperty.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/SplitProperty.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
@@ -18,10 +16,10 @@ namespace Xamarin.Android.Tasks
 
 		static readonly char [] Delimiters = { ',', ';' };
 
-		public string Value { get; set; }
+		public string? Value { get; set; }
 
 		[Output]
-		public string [] Output { get; set; }
+		public string []? Output { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/UnzipToFolder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/UnzipToFolder.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -14,9 +12,9 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "UNZ";
 
-		public ITaskItem [] Sources { get; set; }
-		public ITaskItem [] DestinationDirectories { get; set; }
-		public ITaskItem [] Files { get; set; }
+		public ITaskItem []? Sources { get; set; }
+		public ITaskItem []? DestinationDirectories { get; set; }
+		public ITaskItem []? Files { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -16,7 +14,7 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "WLF";
 
 		[Required]
-		public string LockFile { get; set; }
+		public string LockFile { get; set; } = "";
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ConvertResourcesCasesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ConvertResourcesCasesTests.cs
@@ -39,7 +39,8 @@ namespace Xamarin.Android.Build.Tests
 			var errors = new List<BuildErrorEventArgs> ();
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
 			var task = new ConvertResourcesCases {
-				BuildEngine = engine
+				BuildEngine = engine,
+				CustomViewMapFile = "",
 			};
 			task.ResourceDirectories = new ITaskItem [] {
 				new TaskItem (resPath),

--- a/src/Xamarin.Android.Build.Tasks/Utilities/EnvironmentFilesParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/EnvironmentFilesParser.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Tasks
 			return false;
 		}
 
-		public void Parse (ITaskItem[] environments, SequencePointsMode sequencePointsMode, TaskLoggingHelper log)
+		public void Parse (ITaskItem[]? environments, SequencePointsMode sequencePointsMode, TaskLoggingHelper log)
 		{
 			foreach (ITaskItem env in environments ?? Array.Empty<ITaskItem> ()) {
 				foreach (string line in File.ReadLines (env.ItemSpec)) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NullableExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NullableExtensions.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Xamarin.Android.Tasks;
+
+static class NullableExtensions
+{
+	// The static methods in System.String are not NRT annotated in netstandard2.0,
+	// so we need to add our own extension methods to make them nullable aware.
+	public static bool IsNullOrEmpty ([NotNullWhen (false)] this string? str)
+	{
+		return string.IsNullOrEmpty (str);
+	}
+
+	public static bool IsNullOrWhiteSpace ([NotNullWhen (false)] this string? str)
+	{
+		return string.IsNullOrWhiteSpace (str);
+	}
+}

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -314,9 +314,10 @@ namespace Xamarin.Android.Build.Tests
 			var task = new BuildAppBundle {
 				BaseZip = "base.zip",
 				Output = "foo.aab",
+				JarPath = "bundletool.jar",
 			};
 			string cmd = task.GetCommandLineBuilder ().ToString ();
-			Assert.AreEqual ($"build-bundle --modules base.zip --output foo.aab", cmd);
+			Assert.AreEqual ($"-jar bundletool.jar build-bundle --modules base.zip --output foo.aab", cmd);
 		}
 
 		[Test]
@@ -333,12 +334,13 @@ namespace Xamarin.Android.Build.Tests
 				Aapt2ToolExe = "aapt2",
 				AdbToolPath = Path.Combine ("adb", "with spaces"),
 				AdbToolExe = "adb",
-				AdbTarget = "-s emulator-5554"
+				AdbTarget = "-s emulator-5554",
+				JarPath = "bundletool.jar",
 			};
 			string aapt2 = Path.Combine (task.Aapt2ToolPath, task.Aapt2ToolExe);
 			string adb = Path.Combine (task.AdbToolPath, task.AdbToolExe);
 			string cmd = task.GetCommandLineBuilder ().ToString ();
-			Assert.AreEqual ($"build-apks --connected-device --mode default --adb \"{adb}\" --device-id emulator-5554 --bundle foo.aab --output foo.apks --aapt2 \"{aapt2}\" --ks foo.keystore --ks-key-alias alias --key-pass pass:keypass --ks-pass pass:storepass", cmd);
+			Assert.AreEqual ($"-jar bundletool.jar build-apks --connected-device --mode default --adb \"{adb}\" --device-id emulator-5554 --bundle foo.aab --output foo.apks --aapt2 \"{aapt2}\" --ks foo.keystore --ks-key-alias alias --key-pass pass:keypass --ks-pass pass:storepass", cmd);
 		}
 
 		[Test]
@@ -348,11 +350,12 @@ namespace Xamarin.Android.Build.Tests
 				ApkSet = "foo.apks",
 				AdbToolPath = Path.Combine ("path", "with spaces"),
 				AdbToolExe = "adb",
-				AdbTarget = "-s emulator-5554"
+				AdbTarget = "-s emulator-5554",
+				JarPath = "bundletool.jar",
 			};
 			string adb = Path.Combine (task.AdbToolPath, task.AdbToolExe);
 			string cmd = task.GetCommandLineBuilder ().ToString ();
-			Assert.AreEqual ($"install-apks --apks foo.apks --adb \"{adb}\" --device-id emulator-5554 --allow-downgrade --modules _ALL_", cmd);
+			Assert.AreEqual ($"-jar bundletool.jar install-apks --apks foo.apks --adb \"{adb}\" --device-id emulator-5554 --allow-downgrade --modules _ALL_", cmd);
 		}
 	}
 }


### PR DESCRIPTION
Enable NRT for tasks in `Xamarin.Android.Build.Tasks` that only needed trivial changes.

The following conventions were used:

When the task property is guarded by `[Register]`, MSBuild will ensure the property is not `null`, thus we set these values to a non-allocating default:

```csharp
[Required]
public ITaskItem Manifest { get; set; } = null!;  // NRT - guarded by [Required]

[Required]
public ITaskItem[] AssetDirectories { get; set; } = [];

[Required]
public string PackageName { get; set; } = "";
```

For non-`[Required]` properties and fields, set the type to nullable.

```csharp
public ITaskItem? Manifest { get; set; }

public ITaskItem[]? AssetDirectories { get; set; }

public string? PackageName { get; set; }
```

Additionally, `string.IsNullOrEmpty (string)` and friends are not properly annotated for NRT in `netstandard2.0`.  Create `string` extension methods like `foo.IsNullOrEmpty ()` that are properly annotated and use them where needed.

A few of our unit tests were not filling in `[Required]` task properties and thus failing due to getting different results.  Update the tests to pass the `[Required]` properties.