### PR TITLE
[Mono.Android] fix "exception unboxing" for `ManagedValueManager`

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -66,19 +66,11 @@ namespace Android.Runtime {
 				return throwable;
 			}
 			JniObjectReference.Dispose (ref reference, options);
-			var unwrapped = UnboxException (peeked!);
+			var unwrapped = JNIEnvInit.ValueManager?.PeekValue (peeked!.PeerReference) as Exception;
 			if (unwrapped != null) {
 				return unwrapped;
 			}
 			return peekedExc;
-		}
-
-		Exception? UnboxException (IJavaPeerable value)
-		{
-			if (JNIEnvInit.ValueManager is AndroidValueManager vm) {
-				return vm.UnboxException (value);
-			}
-			return null;
 		}
 
 		public override void RaisePendingException (Exception pendingException)
@@ -863,15 +855,6 @@ namespace Android.Runtime {
 				return true;
 			}
 			return base.TryUnboxPeerObject (value, out result);
-		}
-
-		internal Exception? UnboxException (IJavaPeerable value)
-		{
-			object? r;
-			if (TryUnboxPeerObject (value, out r) && r is Exception e) {
-				return e;
-			}
-			return null;
 		}
 
 		public override void CollectPeers ()

--- a/src/Mono.Android/Microsoft.Android.Runtime/ManagedValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/ManagedValueManager.cs
@@ -284,4 +284,14 @@ class ManagedValueManager : JniRuntime.JniValueManager
 		}
 		return base.TryConstructPeer (self, ref reference, options, type);
 	}
+
+	protected override bool TryUnboxPeerObject (IJavaPeerable value, [NotNullWhen (true)]out object? result)
+	{
+		var proxy = value as JavaProxyThrowable;
+		if (proxy != null) {
+			result  = proxy.InnerException;
+			return true;
+		}
+		return base.TryUnboxPeerObject (value, out result);
+	}
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10095

After enabling `Java.Interop-Tests.dll` for CoreCLR/NativeAOT, we started seeing `Java.InteropTests.JavaExceptionTests.InnerExceptionIsNotAProxy()` fail with:

    Expected: same as <System.InvalidOperationException: Managed Exception!>
    But was:  <Java.Interop.JavaProxyThrowable: System.InvalidOperationException: Managed Exception!

This is because `AndroidRuntime.cs` was doing:

    if (JNIEnvInit.ValueManager is AndroidValueManager vm) {
        return vm.UnboxException (value);
    }

And in this case `ManagedValueManager` was being used, and so the exception would not be "unboxed".

We can fix this by using `JNIEnvInit.ValueManager?.PeekValue()` instead and the test now passes.

I also noticed that `AndroidValueManager` had code in `TryUnboxPeerObject()` for:

    var proxy = value as Android.Runtime.JavaProxyThrowable;
    if (proxy != null) {
        result  = proxy.InnerException;
        return true;
    }
    return base.TryUnboxPeerObject (value, out result);

While the base class handled `Java.Interop.JavaProxyThrowable`. This was missing for `ManagedValueManager`, so I added it.