### PR TITLE
[XABT] Fix build errors caused by enabling nullable checks in the tasks

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -49,7 +49,8 @@ namespace Xamarin.Android.Tasks
 
 		public string? Prefixes { get; set; }
 
-		public string PrefixProperty { get; set; }
+		[Required]
+		public string PrefixProperty { get; set; } = "";
 
 		public bool LowercaseFilenames { get; set; }
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
@@ -34,7 +34,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string OutputFile { get; set; } = "";
 
-		public string PrefixProperty { get; set; }
+		[Required]
+		public string PrefixProperty { get; set; } = "";
 
 		public override bool RunTask ()
 		{


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10099
Context: https://github.com/dotnet/android/pull/9918

#10099 enabled NRT checks for a number of XABT Tasks and was merged because all the tests passed.  However, #10099 was not rebased on the tip of `main` which, in the meantime, contained code from the recently merged #9918 PR. #9918 introduced a couple of `string` properties to the `AndroidComputeResPaths` and `CreateAar` tasks, which were not nullable annotated.

This resulted in the following build errors once #10099 was merged:

```
src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs(52,17): error CS8618: Non-nullable property 'PrefixProperty' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.

src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs(37,17): error CS8618: Non-nullable property 'PrefixProperty' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
```

This PR makes the `PrefixProperty` properties `[Required]` (because of the way they are used in the tasks) and assigns default values to them, as per convention introduced in #10099