### PR TITLE
[release/9.0.1xx] fix `Microsoft.NET.Sdk.Android.Manifest-9.0.100` version band

### DIFF
--- a/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
+++ b/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
@@ -10,7 +10,7 @@ about the various Microsoft.Android workloads.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <PackageId>Microsoft.NET.Sdk.Android.Manifest-$(DotNetSdkManifestsFolder)</PackageId>
+    <PackageId>Microsoft.NET.Sdk.Android.Manifest-$(DotNetAndroidManifestVersionBand)</PackageId>
     <Description>Microsoft.NET.Sdk.Android workload manifest. Please do not reference directly.</Description>
   </PropertyGroup>
 

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -58,7 +58,7 @@
   <Target Name="UpdateMauiWorkloadsProj">
     <XmlPoke
       XmlInputPath="$(MauiSourcePath)\src\DotNet\Dependencies\Workloads.csproj"
-      Value="Microsoft.NET.Sdk.Android.Manifest-$(DotNetSdkManifestsFolder)"
+      Value="Microsoft.NET.Sdk.Android.Manifest-$(DotNetAndroidManifestVersionBand)"
       Query="/Project/ItemGroup/PackageDownload[contains(@Include,'Microsoft.NET.Sdk.Android.Manifest-')]/@Include" />
     <XmlPeek
         XmlInputPath="$(_Root)NuGet.config"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,8 +21,8 @@
     <VersionBand Condition=" '$(VersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</VersionBand>
     <VersionSuffixRegex>\-(preview|rc|alpha).\d+</VersionSuffixRegex>
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$(VersionBand)$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), $(VersionSuffixRegex)))</DotNetPreviewVersionBand>
-    <DotNetSdkManifestsFolder>$(DotNetPreviewVersionBand)</DotNetSdkManifestsFolder>
     <!-- NOTE: sometimes we hardcode these when transitioning to new version bands -->
+    <DotNetSdkManifestsFolder>9.0.100</DotNetSdkManifestsFolder>
     <DotNetMonoManifestVersionBand>9.0.100</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>9.0.100</DotNetEmscriptenManifestVersionBand>
     <DotNetAndroidManifestVersionBand>9.0.100</DotNetAndroidManifestVersionBand>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,8 +21,8 @@
     <VersionBand Condition=" '$(VersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</VersionBand>
     <VersionSuffixRegex>\-(preview|rc|alpha).\d+</VersionSuffixRegex>
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$(VersionBand)$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), $(VersionSuffixRegex)))</DotNetPreviewVersionBand>
+    <DotNetSdkManifestsFolder>$(DotNetPreviewVersionBand)</DotNetSdkManifestsFolder>
     <!-- NOTE: sometimes we hardcode these when transitioning to new version bands -->
-    <DotNetSdkManifestsFolder>9.0.100</DotNetSdkManifestsFolder>
     <DotNetMonoManifestVersionBand>9.0.100</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>9.0.100</DotNetEmscriptenManifestVersionBand>
     <DotNetAndroidManifestVersionBand>9.0.100</DotNetAndroidManifestVersionBand>


### PR DESCRIPTION
In fc72bb40, we migrated to a 9.0.300 .NET SDK, which unfortunately resulted in an Android workload manifest with a 9.0.300 version band:

    Microsoft.NET.Sdk.Android.Manifest-9.0.300.35.0.73.nupkg

To stay on 9.0.100, we need to also set `$(DotNetSdkManifestsFolder)` in `eng/Versions.props` in addition to the other properties we set in fc72bb40.