### PR TITLE
[darc] stop tracking `Microsoft.DotNet.ApiCompat` from dotnet/arcade

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,10 +27,6 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22103.1">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>70831f0d126fe88b81d7dc8de11358e17a5ce364</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25251.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>3b83017bbef1dd0918f7c2f894cfd07f56bcd689</Sha>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/10074
Context: https://github.com/dotnet/sdk/issues/39892

`Microsoft.DotNet.ApiCompat` was moved to dotnet/sdk in later versions than 7.x, so we really can't track it with darc/maestro unless we move to the new version.

Let's remove the entry from `eng/Version.Details.xml` to prevent confusion.

The version number remains in `eng/Versions.props`, so this should not affect our build to remove this.