### PR TITLE
[main] fix `Microsoft.NET.Sdk.Android.Manifest-*` version band

### DIFF
--- a/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
+++ b/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
@@ -10,7 +10,7 @@ about the various Microsoft.Android workloads.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <PackageId>Microsoft.NET.Sdk.Android.Manifest-$(DotNetSdkManifestsFolder)</PackageId>
+    <PackageId>Microsoft.NET.Sdk.Android.Manifest-$(DotNetAndroidManifestVersionBand)</PackageId>
     <Description>Microsoft.NET.Sdk.Android workload manifest. Please do not reference directly.</Description>
   </PropertyGroup>
 

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -58,7 +58,7 @@
   <Target Name="UpdateMauiWorkloadsProj">
     <XmlPoke
       XmlInputPath="$(MauiSourcePath)\src\DotNet\Dependencies\Workloads.csproj"
-      Value="Microsoft.NET.Sdk.Android.Manifest-$(DotNetSdkManifestsFolder)"
+      Value="Microsoft.NET.Sdk.Android.Manifest-$(DotNetAndroidManifestVersionBand)"
       Query="/Project/ItemGroup/PackageDownload[contains(@Include,'Microsoft.NET.Sdk.Android.Manifest-')]/@Include" />
     <XmlPeek
         XmlInputPath="$(_Root)NuGet.config"


### PR DESCRIPTION
"Forward port" of: https://github.com/dotnet/android/pull/10112

Bringing this to `main`, so we won't have the same problem with a .NET 10.0.200/300 SDK.

In fc72bb40, we migrated to a 9.0.300 .NET SDK, which unfortunately resulted in an Android workload manifest with a 9.0.300 version band:

    Microsoft.NET.Sdk.Android.Manifest-9.0.300.35.0.73.nupkg

To stay on 9.0.100, we need should use `$(DotNetAndroidManifestVersionBand)` for the manifest version band instead of `$(DotNetSdkManifestsFolder)`.

I also had to make a similar change in `DotNet.targets`.