### PR TITLE
[NativeAOT] Provide the Android ClassLoader

### DIFF
--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
@@ -31,7 +31,7 @@ static partial class JavaInteropRuntime
 
 	// symbol name from `$(IntermediateOutputPath)obj/Release/osx-arm64/h-classes/net_dot_jni_hello_JavaInteropRuntime.h`
 	[UnmanagedCallersOnly (EntryPoint="Java_net_dot_jni_nativeaot_JavaInteropRuntime_init")]
-	static void init (IntPtr jnienv, IntPtr klass)
+	static void init (IntPtr jnienv, IntPtr klass, IntPtr classLoader)
 	{
 		JniTransition   transition  = default;
 		try {
@@ -41,6 +41,7 @@ static partial class JavaInteropRuntime
 			var typeManager = new ManagedTypeManager ();
 			var options = new NativeAotRuntimeOptions {
 				EnvironmentPointer          = jnienv,
+				ClassLoader                 = new JniObjectReference (classLoader),
 				TypeManager                 = typeManager,
 				ValueManager                = new ManagedValueManager (),
 				UseMarshalMemberBuilder     = false,

--- a/src/Xamarin.Android.Build.Tasks/Resources/JavaInteropRuntime.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/JavaInteropRuntime.java
@@ -11,5 +11,5 @@ public class JavaInteropRuntime {
     private JavaInteropRuntime() {
     }
 
-    public static native void init();
+    public static native void init(ClassLoader classLoader);
 }

--- a/src/Xamarin.Android.Build.Tasks/Resources/NativeAotRuntimeProvider.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/NativeAotRuntimeProvider.java
@@ -37,8 +37,10 @@ public class NativeAotRuntimeProvider
             Log.e(TAG, "Failed to set environment variables", e);
         }
 
+        ClassLoader loader  = context.getClassLoader ();
+
         // Initialize .NET runtime
-        JavaInteropRuntime.init();
+        JavaInteropRuntime.init(loader);
         // NOTE: only required for custom applications
         ApplicationRegistration.registerApplications();
         super.attachInfo (context, info);

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -44,7 +44,7 @@ namespace Java.InteropTests
 		public void RegisterTypeOnNewNativeThread ()
 		{
 			Java.Lang.JavaSystem.LoadLibrary ("reuse-threads");
-			int ret = rt_register_type_on_new_thread ("from.NewThreadOne", Application.Context.ClassLoader.Handle);
+			int ret = rt_register_type_on_new_thread ("from.NewNativeThreadOne", Application.Context.ClassLoader.Handle);
 			Assert.AreEqual (0, ret, $"Java type registration on a new thread failed with code {ret}");
 		}
 
@@ -55,6 +55,23 @@ namespace Java.InteropTests
 			thread.Start ();
 			thread.Join (5000);
 			Assert.AreNotEqual (null, thread.Instance, "Failed to register instance of a class on new thread");
+		}
+
+		[Test]
+		public void RegisterTypeOnNewManagedThread ()
+		{
+			Exception? ex = null;
+			var thread = new System.Threading.Thread (() => {
+				try {
+					using var instance = new RegisterMeOnNewManagedThreadOne ();
+				}
+				catch (Exception e) {
+					ex = e;
+				}
+			});
+			thread.Start ();
+			thread.Join (5000);
+			Assert.IsNull (ex, $"Failed to register instance of a class on new thread: {ex}");
 		}
 
 		[Test]
@@ -459,8 +476,12 @@ namespace Java.InteropTests
 		}
 	}
 
-	[Register ("from/NewThreadOne")]
-	class RegisterMeOnNewThreadOne : Java.Lang.Object
+	[Register ("from/NewNativeThreadOne")]
+	class RegisterMeOnNewNativeThreadOne : Java.Lang.Object
+	{}
+
+	[Register ("from/NewManagedThreadOne")]
+	class RegisterMeOnNewManagedThreadOne : Java.Lang.Object
 	{}
 
 	[Register ("from/NewThreadTwo")]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/10081
Fixes: https://github.com/dotnet/android/issues/10118

Context: 18ca52896f36bd756f6b9df801758ab4fe3dc31a
Context: https://github.com/dotnet/java-interop/commit/5852e6e398a6c96d42fff3ed4b8a5d4b5a0abf97

dotnet/java-interop@5852e6e3 updated `JniEnviroment.Types.FindClass()` to begin using [`Class.forName(String, bool, ClassLoader)`][0] to load Java types instead of `ClassLoader.loadClass()`.

This broke type registration on non-Java threads under NativeAOT; attempting to load a non-Android Java type from a managed thread:

	var t = new System.Threading.Thread(() => {
	    using var c = new ClassFromThisAssembly();
	});
	t.Start();
	t.Join();

would fail with a `ClassNotFoundException`:

	E NUnit   : Java.Lang.ClassNotFoundException: Didn't find class "from.NewManagedThreadOne" on path: DexPathList[[directory "."],nativeLibraryDirectories=[/system/lib64, /system_ext/lib64, /system/lib64, /system_ext/lib64]]
	E NUnit   :    at Java.Interop.JniEnvironment.Types.TryFindClass(String, Boolean) + 0x3f4
	E NUnit   :    at Java.Interop.JniPeerMembers.JniInstanceMethods..ctor(Type) + 0x130
	E NUnit   :    at Java.Interop.JniPeerMembers.JniInstanceMethods.GetConstructorsForType(Type) + 0x94
	E NUnit   :    at Java.Interop.JniPeerMembers.JniInstanceMethods.StartCreateInstance(String, Type, JniArgumentValue*) + 0x1c
	E NUnit   :    at Java.Lang.Object..ctor() + 0x108
	E NUnit   :    at Java.InteropTests.JnienvTest.<>c__DisplayClass6_0.<RegisterTypeOnNewManagedThread>b__0() + 0x24
	E NUnit   :   --- End of managed Java.Lang.ClassNotFoundException stack trace ---
	E NUnit   : java.lang.ClassNotFoundException: Didn't find class "from.NewManagedThreadOne" on path: DexPathList[[directory "."],nativeLibraryDirectories=[/system/lib64, /system_ext/lib64, /system/lib64, /system_ext/lib64]]
	E NUnit   : 	at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:259)
	E NUnit   : 	at java.lang.ClassLoader.loadClass(ClassLoader.java:637)
	E NUnit   : 	at java.lang.ClassLoader.loadClass(ClassLoader.java:573)

Fix this by setting `NativeAotRuntimeOptions.ClassLoader` to the `context.getClassLoader()` value within
`NativeAotRuntimeProvider.attachInfo()`.  This ensures that we use a `ClassLoader` that knows about the app's `classes.dex`.

[0]: https://developer.android.com/reference/java/lang/Class#forName(java.lang.String,%20boolean,%20java.lang.ClassLoader)