### PR TITLE
[XABT] Move additional provider source code generation out of `<GenerateMainAndroidManifest>` task.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateAdditionalProviderSources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateAdditionalProviderSources.cs
@@ -12,7 +12,7 @@ public class GenerateAdditionalProviderSources : AndroidTask
 	public override string TaskPrefix => "GPS";
 
 	[Required]
-	public ITaskItem [] AdditionalProviderSources { get; set; } = [];
+	public string [] AdditionalProviderSources { get; set; } = [];
 
 	[Required]
 	public string AndroidRuntime { get; set; } = "";
@@ -51,8 +51,6 @@ public class GenerateAdditionalProviderSources : AndroidTask
 
 	void Generate (NativeCodeGenStateObject codeGenState)
 	{
-		var additionalProviders = AdditionalProviderSources.Select (p => p.ItemSpec).ToList ();
-
 		// Create additional runtime provider java sources.
 		bool isMonoVM = androidRuntime switch {
 			Xamarin.Android.Tasks.AndroidRuntime.MonoVM => true,
@@ -64,7 +62,7 @@ public class GenerateAdditionalProviderSources : AndroidTask
 			"NativeAotRuntimeProvider.java";
 		string providerTemplate = GetResource (providerTemplateFile);
 
-		foreach (var provider in additionalProviders) {
+		foreach (var provider in AdditionalProviderSources) {
 			var contents = providerTemplate.Replace (isMonoVM ? "MonoRuntimeProvider" : "NativeAotRuntimeProvider", provider);
 			var real_provider = isMonoVM ?
 				Path.Combine (OutputDirectory, "src", "mono", provider + ".java") :
@@ -86,7 +84,7 @@ public class GenerateAdditionalProviderSources : AndroidTask
 		StringWriter regCallsWriter = new StringWriter ();
 		regCallsWriter.WriteLine ("// Application and Instrumentation ACWs must be registered first.");
 
-		foreach ((string jniName, string assemblyQualifiedName) in codeGenState.ApplicationsAndInstrumentationsToReigster) {
+		foreach ((string jniName, string assemblyQualifiedName) in codeGenState.ApplicationsAndInstrumentationsToRegister) {
 			regCallsWriter.WriteLine (
 				codeGenerationTarget == JavaPeerStyle.XAJavaInterop1 ?
 					"\t\tmono.android.Runtime.register (\"{0}\", {1}.class, {1}.__md_methods);" :

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateAdditionalProviderSources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateAdditionalProviderSources.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Linq;
+using Java.Interop.Tools.JavaCallableWrappers;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.Tasks;
+
+public class GenerateAdditionalProviderSources : AndroidTask
+{
+	public override string TaskPrefix => "GPS";
+
+	[Required]
+	public ITaskItem [] AdditionalProviderSources { get; set; } = [];
+
+	[Required]
+	public string AndroidRuntime { get; set; } = "";
+
+	public string CodeGenerationTarget { get; set; } = "";
+
+	[Required]
+	public string IntermediateOutputDirectory { get; set; } = "";
+
+	public string? OutputDirectory { get; set; }
+
+	[Required]
+	public string TargetName { get; set; } = "";
+
+	AndroidRuntime androidRuntime;
+	JavaPeerStyle codeGenerationTarget;
+
+	public override bool RunTask ()
+	{
+		androidRuntime = MonoAndroidHelper.ParseAndroidRuntime (AndroidRuntime);
+		codeGenerationTarget = MonoAndroidHelper.ParseCodeGenerationTarget (CodeGenerationTarget);
+
+		// Retrieve the stored NativeCodeGenStateObject
+		var nativeCodeGenStates = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<NativeCodeGenStateCollection> (
+			MonoAndroidHelper.GetProjectBuildSpecificTaskObjectKey (GenerateJavaStubs.NativeCodeGenStateObjectRegisterTaskKey, WorkingDirectory, IntermediateOutputDirectory),
+			RegisteredTaskObjectLifetime.Build
+		);
+
+		// We only need the first architecture, since this task is architecture-agnostic
+		var templateCodeGenState = nativeCodeGenStates.States.First ().Value;
+
+		Generate (templateCodeGenState);
+
+		return !Log.HasLoggedErrors;
+	}
+
+	void Generate (NativeCodeGenStateObject codeGenState)
+	{
+		var additionalProviders = AdditionalProviderSources.Select (p => p.ItemSpec).ToList ();
+
+		// Create additional runtime provider java sources.
+		bool isMonoVM = androidRuntime switch {
+			Xamarin.Android.Tasks.AndroidRuntime.MonoVM => true,
+			Xamarin.Android.Tasks.AndroidRuntime.CoreCLR => true,
+			_ => false,
+		};
+		string providerTemplateFile = isMonoVM ?
+			"MonoRuntimeProvider.Bundled.java" :
+			"NativeAotRuntimeProvider.java";
+		string providerTemplate = GetResource (providerTemplateFile);
+
+		foreach (var provider in additionalProviders) {
+			var contents = providerTemplate.Replace (isMonoVM ? "MonoRuntimeProvider" : "NativeAotRuntimeProvider", provider);
+			var real_provider = isMonoVM ?
+				Path.Combine (OutputDirectory, "src", "mono", provider + ".java") :
+				Path.Combine (OutputDirectory, "src", "net", "dot", "jni", "nativeaot", provider + ".java");
+			Files.CopyIfStringChanged (contents, real_provider);
+		}
+
+		// For NativeAOT, generate JavaInteropRuntime.java
+		if (androidRuntime == Xamarin.Android.Tasks.AndroidRuntime.NativeAOT) {
+			const string fileName = "JavaInteropRuntime.java";
+			string template = GetResource (fileName);
+			var contents = template.Replace ("@MAIN_ASSEMBLY_NAME@", TargetName);
+			var path = Path.Combine (OutputDirectory, "src", "net", "dot", "jni", "nativeaot", fileName);
+			Log.LogDebugMessage ($"Writing: {path}");
+			Files.CopyIfStringChanged (contents, path);
+		}
+
+		// Create additional application java sources.
+		StringWriter regCallsWriter = new StringWriter ();
+		regCallsWriter.WriteLine ("// Application and Instrumentation ACWs must be registered first.");
+
+		foreach ((string jniName, string assemblyQualifiedName) in codeGenState.ApplicationsAndInstrumentationsToReigster) {
+			regCallsWriter.WriteLine (
+				codeGenerationTarget == JavaPeerStyle.XAJavaInterop1 ?
+					"\t\tmono.android.Runtime.register (\"{0}\", {1}.class, {1}.__md_methods);" :
+					"\t\tnet.dot.jni.ManagedPeer.registerNativeMembers ({1}.class, {1}.__md_methods);",
+				assemblyQualifiedName,
+				jniName
+			);
+		}
+
+		regCallsWriter.Close ();
+
+		var real_app_dir = Path.Combine (OutputDirectory, "src", "net", "dot", "android");
+		string applicationTemplateFile = "ApplicationRegistration.java";
+		SaveResource (
+			applicationTemplateFile,
+			applicationTemplateFile,
+			real_app_dir,
+			template => template.Replace ("// REGISTER_APPLICATION_AND_INSTRUMENTATION_CLASSES_HERE", regCallsWriter.ToString ())
+		);
+	}
+
+	string GetResource (string resource)
+	{
+		using (var stream = GetType ().Assembly.GetManifestResourceStream (resource))
+		using (var reader = new StreamReader (stream))
+			return reader.ReadToEnd ();
+	}
+
+	void SaveResource (string resource, string filename, string destDir, Func<string, string> applyTemplate)
+	{
+		string template = GetResource (resource);
+		template = applyTemplate (template);
+		Files.CopyIfStringChanged (template, Path.Combine (destDir, filename));
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMainAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMainAndroidManifest.cs
@@ -14,7 +14,7 @@ public class GenerateMainAndroidManifest : AndroidTask
 	public override string TaskPrefix => "GMM";
 
 	[Output]
-	public ITaskItem []? AdditionalProviderSources { get; set; }
+	public string []? AdditionalProviderSources { get; set; }
 	[Required]
 	public string AndroidRuntime { get; set; } = "";
 	public string? AndroidSdkDir { get; set; }
@@ -62,7 +62,7 @@ public class GenerateMainAndroidManifest : AndroidTask
 		// Generate the merged manifest
 		var additionalProviders = MergeManifest (templateCodeGenState, GenerateJavaStubs.MaybeGetArchAssemblies (userAssembliesPerArch, templateCodeGenState.TargetArch));
 
-		AdditionalProviderSources = additionalProviders.Select (p => new TaskItem (p)).ToArray ();
+		AdditionalProviderSources = additionalProviders.ToArray ();
 
 		// We still need the NativeCodeGenState for later tasks, but we're going to transfer
 		// it to a new object that doesn't require holding open Cecil AssemblyDefinitions.

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodCecilAdapter.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodCecilAdapter.cs
@@ -47,7 +47,7 @@ class MarshalMethodCecilAdapter
 				var jniName = JavaNativeTypeManager.ToJniName (type, state.TypeCache).Replace ('/', '.');
 				var assemblyQualifiedName = type.GetAssemblyQualifiedName (state.TypeCache);
 
-				obj.ApplicationsAndInstrumentationsToReigster.Add ((jniName, assemblyQualifiedName));
+				obj.ApplicationsAndInstrumentationsToRegister.Add ((jniName, assemblyQualifiedName));
 			}
 		}
 
@@ -156,7 +156,7 @@ class NativeCodeGenStateCollection
 class NativeCodeGenStateObject
 {
 	public Dictionary<string, IList<MarshalMethodEntryObject>> MarshalMethods { get; } = [];
-	public List<(string JniName, string AssemblyQualifiedName)> ApplicationsAndInstrumentationsToReigster { get; } = [];
+	public List<(string JniName, string AssemblyQualifiedName)> ApplicationsAndInstrumentationsToRegister { get; } = [];
 }
 
 class MarshalMethodEntryObject

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodCecilAdapter.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodCecilAdapter.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Java.Interop.Tools.Cecil;
+using Java.Interop.Tools.JavaCallableWrappers;
+using Java.Interop.Tools.TypeNameMappings;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Mono.Cecil;
@@ -34,6 +37,19 @@ class MarshalMethodCecilAdapter
 	static NativeCodeGenStateObject CreateNativeCodeGenState (AndroidTargetArch arch, NativeCodeGenState state)
 	{
 		var obj = new NativeCodeGenStateObject ();
+
+		foreach (var type in state.JavaTypesForJCW) {
+			if (JavaNativeTypeManager.IsApplication (type, state.TypeCache) || JavaNativeTypeManager.IsInstrumentation (type, state.TypeCache)) {
+				if (state.Classifier != null && !state.Classifier.TypeHasDynamicallyRegisteredMethods (type)) {
+					continue;
+				}
+
+				var jniName = JavaNativeTypeManager.ToJniName (type, state.TypeCache).Replace ('/', '.');
+				var assemblyQualifiedName = type.GetAssemblyQualifiedName (state.TypeCache);
+
+				obj.ApplicationsAndInstrumentationsToReigster.Add ((jniName, assemblyQualifiedName));
+			}
+		}
 
 		if (state.Classifier is null)
 			return obj;
@@ -140,6 +156,7 @@ class NativeCodeGenStateCollection
 class NativeCodeGenStateObject
 {
 	public Dictionary<string, IList<MarshalMethodEntryObject>> MarshalMethods { get; } = [];
+	public List<(string JniName, string AssemblyQualifiedName)> ApplicationsAndInstrumentationsToReigster { get; } = [];
 }
 
 class MarshalMethodEntryObject

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -64,6 +64,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.FilterAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.FindLayoutsToBind" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateACWMap" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.GenerateAdditionalProviderSources" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateLayoutBindings" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateLibraryResources" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateManagedAidlProxies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -1641,10 +1642,8 @@ because xbuild doesn't support framework reference assemblies.
       ApplicationLabel="$(_ApplicationLabel)"
       BundledWearApplicationName="$(BundledWearApplicationPackageName)"
       CheckedBuild="$(_AndroidCheckedBuild)"
-      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
       Debug="$(AndroidIncludeDebugSymbols)"
       EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-      EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
       IntermediateOutputDirectory="$(IntermediateOutputPath)"
       ManifestPlaceholders="$(AndroidManifestPlaceholders)"
       ManifestTemplate="$(_AndroidManifestAbs)"
@@ -1652,15 +1651,23 @@ because xbuild doesn't support framework reference assemblies.
       MergedManifestDocuments="@(_MergedManifestDocuments)"
       MultiDex="$(AndroidEnableMultiDex)"
       NeedsInternet="$(AndroidNeedsInternetPermission)"
-      OutputDirectory="$(IntermediateOutputPath)android"
       PackageName="$(_AndroidPackage)"
       ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
       SupportedAbis="@(_BuildTargetAbis)"
       SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
-      TargetName="$(TargetName)"
       VersionCode="$(_AndroidVersionCode)"
       VersionName="$(_AndroidVersionName)">
+    <Output TaskParameter="AdditionalProviderSources" ItemName="_AdditionalProviderSources" />
   </GenerateMainAndroidManifest>
+
+  <GenerateAdditionalProviderSources
+      AdditionalProviderSources="@(_AdditionalProviderSources)"
+      AndroidRuntime="$(_AndroidRuntime)"
+      CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
+      IntermediateOutputDirectory="$(IntermediateOutputPath)"
+      OutputDirectory="$(IntermediateOutputPath)android"
+      TargetName="$(TargetName)">
+  </GenerateAdditionalProviderSources>
 
   <ItemGroup>
     <FileWrites Include="@(_TypeMapAssemblySource)" />


### PR DESCRIPTION
Move the process of generating additional provider source code out of the `<GenerateMainAndroidManifest>` task into a new `<GenerateAdditionalProviderSources>` task.

Additionally, move the Cecil data needed for this task into the Cecil-less `NativeCodeGenStateObject` class to help facilitate a future where we aren't using Cecil in the `_GenerateJavaStubs` target.