### PR TITLE
[NativeAOT] "Fix" AndroidRuntimeInternal.WaitForBridgeProcessing()

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -118,7 +118,7 @@ namespace Android.Runtime {
 
 		public static void WaitForBridgeProcessing ()
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 		}
 
 		public static IntPtr AllocObject (string jniClassName)

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
@@ -17,7 +17,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PP_V (this _JniMarshal_PP_V callback, IntPtr jnienv, IntPtr klazz)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -28,7 +28,7 @@ namespace Android.Runtime
 
 		internal static int Wrap_JniMarshal_PP_I (this _JniMarshal_PP_I callback, IntPtr jnienv, IntPtr klazz)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -39,7 +39,7 @@ namespace Android.Runtime
 
 		internal static bool Wrap_JniMarshal_PP_Z (this _JniMarshal_PP_Z callback, IntPtr jnienv, IntPtr klazz)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -50,7 +50,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPI_V (this _JniMarshal_PPI_V callback, IntPtr jnienv, IntPtr klazz, int p0)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -61,7 +61,7 @@ namespace Android.Runtime
 
 		internal static IntPtr Wrap_JniMarshal_PPI_L (this _JniMarshal_PPI_L callback, IntPtr jnienv, IntPtr klazz, int p0)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -72,7 +72,7 @@ namespace Android.Runtime
 
 		internal static int Wrap_JniMarshal_PPI_I (this _JniMarshal_PPI_I callback, IntPtr jnienv, IntPtr klazz, int p0)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -83,7 +83,7 @@ namespace Android.Runtime
 
 		internal static long Wrap_JniMarshal_PPI_J (this _JniMarshal_PPI_J callback, IntPtr jnienv, IntPtr klazz, int p0)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -94,7 +94,7 @@ namespace Android.Runtime
 
 		internal static int Wrap_JniMarshal_PPL_I (this _JniMarshal_PPL_I callback, IntPtr jnienv, IntPtr klazz, IntPtr p0)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -105,7 +105,7 @@ namespace Android.Runtime
 
 		internal static IntPtr Wrap_JniMarshal_PPL_L (this _JniMarshal_PPL_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -116,7 +116,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPL_V (this _JniMarshal_PPL_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -127,7 +127,7 @@ namespace Android.Runtime
 
 		internal static bool Wrap_JniMarshal_PPL_Z (this _JniMarshal_PPL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -138,7 +138,7 @@ namespace Android.Runtime
 
 		internal static bool Wrap_JniMarshal_PPJ_Z (this _JniMarshal_PPJ_Z callback, IntPtr jnienv, IntPtr klazz, long p0)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -149,7 +149,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPII_V (this _JniMarshal_PPII_V callback, IntPtr jnienv, IntPtr klazz, int p0, int p1)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -160,7 +160,7 @@ namespace Android.Runtime
 
 		internal static IntPtr Wrap_JniMarshal_PPII_L (this _JniMarshal_PPII_L callback, IntPtr jnienv, IntPtr klazz, int p0, int p1)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -171,7 +171,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPLI_V (this _JniMarshal_PPLI_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -182,7 +182,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPLZ_V (this _JniMarshal_PPLZ_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, bool p1)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -193,7 +193,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPLL_V (this _JniMarshal_PPLL_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -204,7 +204,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPLF_V (this _JniMarshal_PPLF_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, float p1)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -215,7 +215,7 @@ namespace Android.Runtime
 
 		internal static IntPtr Wrap_JniMarshal_PPLI_L (this _JniMarshal_PPLI_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -226,7 +226,7 @@ namespace Android.Runtime
 
 		internal static IntPtr Wrap_JniMarshal_PPLL_L (this _JniMarshal_PPLL_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -237,7 +237,7 @@ namespace Android.Runtime
 
 		internal static bool Wrap_JniMarshal_PPLL_Z (this _JniMarshal_PPLL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -248,7 +248,7 @@ namespace Android.Runtime
 
 		internal static bool Wrap_JniMarshal_PPIL_Z (this _JniMarshal_PPIL_Z callback, IntPtr jnienv, IntPtr klazz, int p0, IntPtr p1)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -259,7 +259,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPIIL_V (this _JniMarshal_PPIIL_V callback, IntPtr jnienv, IntPtr klazz, int p0, int p1, IntPtr p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -270,7 +270,7 @@ namespace Android.Runtime
 
 		internal static int Wrap_JniMarshal_PPLII_I (this _JniMarshal_PPLII_I callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -281,7 +281,7 @@ namespace Android.Runtime
 
 		internal static bool Wrap_JniMarshal_PPLII_Z (this _JniMarshal_PPLII_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -292,7 +292,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPLII_V (this _JniMarshal_PPLII_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -303,7 +303,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPIII_V (this _JniMarshal_PPIII_V callback, IntPtr jnienv, IntPtr klazz, int p0, int p1, int p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -314,7 +314,7 @@ namespace Android.Runtime
 
 		internal static bool Wrap_JniMarshal_PPLLJ_Z (this _JniMarshal_PPLLJ_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, long p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -325,7 +325,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPILL_V (this _JniMarshal_PPILL_V callback, IntPtr jnienv, IntPtr klazz, int p0, IntPtr p1, IntPtr p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -336,7 +336,7 @@ namespace Android.Runtime
 
 		internal static bool Wrap_JniMarshal_PPLIL_Z (this _JniMarshal_PPLIL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, IntPtr p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -347,7 +347,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPLLL_V (this _JniMarshal_PPLLL_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -358,7 +358,7 @@ namespace Android.Runtime
 
 		internal static IntPtr Wrap_JniMarshal_PPLLL_L (this _JniMarshal_PPLLL_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -369,7 +369,7 @@ namespace Android.Runtime
 
 		internal static bool Wrap_JniMarshal_PPLLL_Z (this _JniMarshal_PPLLL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -380,7 +380,7 @@ namespace Android.Runtime
 
 		internal static IntPtr Wrap_JniMarshal_PPIZI_L (this _JniMarshal_PPIZI_L callback, IntPtr jnienv, IntPtr klazz, int p0, bool p1, int p2)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1, p2);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -391,7 +391,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPIIII_V (this _JniMarshal_PPIIII_V callback, IntPtr jnienv, IntPtr klazz, int p0, int p1, int p2, int p3)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1, p2, p3);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -402,7 +402,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPLLLL_V (this _JniMarshal_PPLLLL_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2, IntPtr p3)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1, p2, p3);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -413,7 +413,7 @@ namespace Android.Runtime
 
 		internal static bool Wrap_JniMarshal_PPLZZL_Z (this _JniMarshal_PPLZZL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, bool p1, bool p2, IntPtr p3)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				return callback (jnienv, klazz, p0, p1, p2, p3);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -424,7 +424,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPLIIII_V (this _JniMarshal_PPLIIII_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2, int p3, int p4)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1, p2, p3, p4);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -435,7 +435,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPZIIII_V (this _JniMarshal_PPZIIII_V callback, IntPtr jnienv, IntPtr klazz, bool p0, int p1, int p2, int p3, int p4)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1, p2, p3, p4);
 			} catch (Exception e) when (_unhandled_exception (e)) {
@@ -446,7 +446,7 @@ namespace Android.Runtime
 
 		internal static void Wrap_JniMarshal_PPLIIIIIIII_V (this _JniMarshal_PPLIIIIIIII_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				callback (jnienv, klazz, p0, p1, p2, p3, p4, p5, p6, p7, p8);
 			} catch (Exception e) when (_unhandled_exception (e)) {

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
@@ -268,7 +268,7 @@ foreach (var info in delegateTypes) {
 #>
 		internal static <#= info.Return #> Wrap<#= info.Type #> (this <#= info.Type #> callback, <#= info.Signature #>)
 		{
-			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			JNIEnvInit.ValueManager?.WaitForGCBridgeProcessing ();
 			try {
 				<#= info.Return != "void" ? "return " : "" #>callback (<#= info.Invoke #>);
 			} catch (Exception e) when (_unhandled_exception (e)) {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/10126

Context: 4b158cee17f01abc792383169ba6eb026c99bbd4
Context: https://github.com/dotnet/java-interop/commit/356485ee41fb61570e84c11ba120d6f8cf81ae09
Context: 32cff4383232d5de156bd6c5d10292fcffa66d50

NativeAOT currently requires new binding assemblies, bindings which do not use `JNINativeWrapper.CreateDelegate()`, as one of the code paths within `JNINativeWrapper.CreateDelegate()` uses `System.Reflection.Emit`, which does not exist in NativeAOT. dotnet/java-interop@356485ee contains the `generator` changes needed to avoid `JNINativeWrapper.CreateDelegate()`.

However, there is one situation in which that "requirement" is (kinda) *conditional*: commit 32cff438 added "builtin" JNI wrapper methods, avoiding the need for System.Reflection.Emit when overriding Java methods that match a builtin signature.

This means existing binding assemblies can work, right?

Kinda, yeah!  So long as you *only* override methods which match a builtin signature.  Which was enough to get MAUI going atop NativeAOT *without* rebuilding all of dotnet/android-libraries…

However, for not-entirely-understood reasons, sometimes using a builtin JNI wrapper method would cause the app to crash:

	digest=============com.avalonia.safeareademo /apex/com.android.runtime/lib/bionic/libc.so (abort+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (SystemNative_Abort+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (S_P_CoreLib_Interop_Sys__Abort+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (S_P_CoreLib_System_RuntimeExceptionHelpers__FailFast+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (RuntimeFailFast+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (S_P_CoreLib_System_Runtime_EH__UnhandledExceptionFailFastViaClasslib+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (S_P_CoreLib_System_Runtime_EH__DispatchEx+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (RhThrowEx+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (RhpThrowEx+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (S_P_CoreLib_System_Runtime_CompilerServices_ClassConstructorRunner__EnsureClassConstructorRun+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (RhpCallCatchFunclet+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (S_P_CoreLib_System_Runtime_CompilerServices_ClassConstructorRunner__CheckStaticClassConstructionReturnNonGCStaticBase+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (Mono_Android_Runtime_Android_Runtime_AndroidRuntimeInternal__WaitForBridgeProcessing+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (Mono_Android_Android_Runtime_JNINativeWrapper__Wrap_JniMarshal_PPLL_L+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (Mono_Android__JniMarshal_PPLL_L__InvokeClosedStaticThunk+) ()
	XXlib/arm/libSafeAreaDemo.Android.so (Internal_CompilerGenerated__Module___<ReverseDelegateStub>Mono_Android__JniMarshal_PPLL_L+) ()
	/apex/com.android.art/lib/libart.so (art_quick_generic_jni_trampoline+) ()

The cause of this crash is that
`JNIINativeWrapper.Wrap_JniMarshal_PPLL_L()` called `AndroidRuntimeInternal.WaitForBridgeProcessing()`, which in turn triggers the `AndroidRuntimeInternal` static constructor, which *throws* unless on MonoVM or CoreCLR, of which NativeAOT is neither.

Fix this by updating `JNINativeWrapper.g.tt` to call `JNIEnv.ValueManager?.WaitForGCBridgeProcessing()` instead of `AndroidRuntimeInternal.WaitForBridgeProcessing()`.  This allows NativeAOT to control what actually happens.

Aside: this project includes [T4 Text Templates][0].  To regenerate the output files *without involving Visual Studio*, you can install the [`dotnet-t4`][1] tool:

	$ dotnet tool install --global dotnet-t4

then run it separately for each `.tt` file:

	$HOME/.dotnet/tools/t4 -o src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs \
	  src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt

[0]: https://learn.microsoft.com/visualstudio/modeling/code-generation-and-t4-text-templates?view=vs-2022
[1]: https://www.nuget.org/packages/dotnet-t4/