### PR TITLE
[tests] run `InnerExceptionIsSet` on CoreCLR

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System/ExceptionTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System/ExceptionTest.cs
@@ -29,7 +29,6 @@ namespace Xamarin.Android.RuntimeTests {
 		}
 
 		[Test]
-		[Category ("CoreCLRIgnore")] //TODO: https://github.com/dotnet/android/issues/10069
 		[Category ("NativeAOTIgnore")] // NativeAOT has very limited stack traces
 		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void InnerExceptionIsSet ()


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/10069
Context: https://github.com/dotnet/android/pull/10100

I believe `ExceptionTest.InnerExceptionIsSet()` was fixed in dc078009 for CoreCLR.