### PR TITLE
[xabt] rename `$(EnableProfiler)` to `$(EnableDiagnostics)`

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -400,7 +400,7 @@ This property is `False` by default.
 
 ## AndroidEnableProfiler
 
-Synonym for the [`$(EnableProfiler)`](#enableprofiler) property.
+Synonym for the [`$(EnableDiagnostics)`](#enablediagnostics) property.
 
 Required for using `dotnet-trace` or `dotnet-gcdump` in Android
 applications. If set to `true`, it includes the Mono diagnostic
@@ -1545,6 +1545,18 @@ MSBuild property also controls what
 will be embedded into the `.apk`, which can impact deployment and
 rebuild times.
 
+## EnableDiagnostics
+
+Synonym for the [`$(AndroidEnableProfiler)`](#androidenableprofiler)
+property.
+
+Required for using `dotnet-trace` or `dotnet-gcdump` in Android
+applications. If set to `true`, it includes the Mono diagnostic
+component in the application. This component is the
+`libmono-component-diagnostics_tracing.so` native library.
+
+This property is `False` by default.
+
 ## EnableLLVM
 
 A boolean property that determines whether
@@ -1558,18 +1570,6 @@ This property is `False` by default.
 
 This property is ignored unless the
 [`$(AotAssemblies)`](#aotassemblies) MSBuild property is `True`.
-
-## EnableProfiler
-
-Synonym for the [`$(AndroidEnableProfiler)`](#androidenableprofiler)
-property.
-
-Required for using `dotnet-trace` or `dotnet-gcdump` in Android
-applications. If set to `true`, it includes the Mono diagnostic
-component in the application. This component is the
-`libmono-component-diagnostics_tracing.so` native library.
-
-This property is `False` by default.
 
 ## EnableProguard
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -52,7 +52,7 @@
     <AndroidEnableRestrictToAttributes Condition=" '$(AndroidEnableRestrictToAttributes)' == '' ">obsolete</AndroidEnableRestrictToAttributes>
 
     <!-- Mono components -->
-    <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == ''">$(EnableProfiler)</AndroidEnableProfiler>
+    <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == ''">$(EnableDiagnostics)</AndroidEnableProfiler>
     <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == ''">false</AndroidEnableProfiler>
 
     <!--


### PR DESCRIPTION
Context: https://github.com/dotnet/macios/pull/22982
Context: https://github.com/dotnet/runtime/issues/115473#issuecomment-2933946678

We are aligning WASM, iOS, Android to all use the same property name for this.