### PR TITLE
[build] update to API 35, 36 revision 2

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -72,8 +72,8 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-32_r01",   apiLevel: "32", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-33-ext3_r03",   apiLevel: "33", pkgRevision: "3"),
 				new AndroidPlatformComponent ("platform-34-ext7_r02",   apiLevel: "34", pkgRevision: "2"),
-				new AndroidPlatformComponent ("platform-35_r01",   apiLevel: "35", pkgRevision: "1"),
-				new AndroidPlatformComponent ("platform-36_r01",   apiLevel: "36", pkgRevision: "1", isLatestStable: true),
+				new AndroidPlatformComponent ("platform-35_r02",   apiLevel: "35", pkgRevision: "2"),
+				new AndroidPlatformComponent ("platform-36_r02",   apiLevel: "36", pkgRevision: "2", isLatestStable: true),
 
 				new AndroidToolchainComponent ("source-36_r01",
 					destDir: Path.Combine ("sources", "android-36"),


### PR DESCRIPTION
Reviewing our manifests for the SDK manager, I noticed that both API 35 & 36 have a "revision 2". Let's build against them.