### PR TITLE
[CoreCLR] Cache JNI to Managed type mappings

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -260,7 +260,9 @@ namespace Java.Interop {
 
 		private static Type? GetJavaToManagedTypeCore (string class_name)
 		{
-			if (TypeManagerMapDictionaries.JniToManaged.TryGetValue (class_name, out Type? type)) {
+			Type? type = null;
+
+			if (TypeManagerMapDictionaries.JniToManaged.TryGetValue (class_name, out type)) {
 				return type;
 			}
 

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -258,11 +258,9 @@ namespace Java.Interop {
 			}
 		}
 
-		private static Type? GetJavaToManagedTypeCore (string class_name)
+		static Type? GetJavaToManagedTypeCore (string class_name)
 		{
-			Type? type = null;
-
-			if (TypeManagerMapDictionaries.JniToManaged.TryGetValue (class_name, out type)) {
+			if (TypeManagerMapDictionaries.JniToManaged.TryGetValue (class_name, out Type? type)) {
 				return type;
 			}
 

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -253,14 +253,27 @@ namespace Java.Interop {
 
 		internal static Type? GetJavaToManagedType (string class_name)
 		{
-			Type? type = JNIEnvInit.RuntimeType switch {
+			lock (TypeManagerMapDictionaries.AccessLock) {
+				return GetJavaToManagedTypeCore (class_name);
+			}
+		}
+
+		private static Type? GetJavaToManagedTypeCore (string class_name)
+		{
+			if (TypeManagerMapDictionaries.JniToManaged.TryGetValue (class_name, out Type? type)) {
+				return type;
+			}
+
+			type = JNIEnvInit.RuntimeType switch {
 				DotNetRuntimeType.MonoVM  => monovm_typemap_java_to_managed (class_name),
 				DotNetRuntimeType.CoreCLR => clr_typemap_java_to_managed (class_name),
 				_                         => throw new NotSupportedException ($"Internal error: runtime type {JNIEnvInit.RuntimeType} not supported")
 			};
 
-			if (type != null)
+			if (type != null) {
+				TypeManagerMapDictionaries.JniToManaged.Add (class_name, type);
 				return type;
+			}
 
 			if (!JNIEnvInit.IsRunningOnDesktop) {
 				// Miss message is logged in the native runtime
@@ -285,11 +298,9 @@ namespace Java.Interop {
 			IntPtr class_ptr = JNIEnv.GetObjectClass (handle);
 			string? class_name = GetClassName (class_ptr);
 			lock (TypeManagerMapDictionaries.AccessLock) {
-				while (class_ptr != IntPtr.Zero && !TypeManagerMapDictionaries.JniToManaged.TryGetValue (class_name, out type)) {
-
-					type = GetJavaToManagedType (class_name);
+				while (class_ptr != IntPtr.Zero) {
+					type = GetJavaToManagedTypeCore (class_name);
 					if (type != null) {
-						TypeManagerMapDictionaries.JniToManaged.Add (class_name, type);
 						break;
 					}
 


### PR DESCRIPTION
I noticed there were _thousands_ of log messages such as `I monodroid: Loaded type: Java.Lang.Object` printed in logcat while running unit tests. It turns out we aren't caching the resolved type mappings when the `GetJavaToManagedType` method is called from `AndroidRuntime.GetTypesForSimpleReference`. This hurts performance because the call to `clr_typemap_java_to_managed` is fairly expensive.

This PR makes sure we're using the `TypeManagerMapDictionaries.JniToManaged` cache in this codepath.