### PR TITLE
Bump android-platform-support submodule

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@8b8d0a556383eb32afb6429f965fe5b25cc92056
+DevDiv/android-platform-support:main@ba980b15c8d61f10d902602ad4e614423f39b43a

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			// Set to true when we are marking a new Android API level as stable, but it has not
 			// been added to the Xamarin manifest yet.
-			var xamarin_manifest_needs_updating = true;
+			var xamarin_manifest_needs_updating = false;
 
 			AssertCommercialBuild ();
 			var oldSdkPath = Environment.GetEnvironmentVariable ("TEST_ANDROID_SDK_PATH");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/10167

FastDev binary utilities are rebuilt with 16k page alignment for arm64, 
which causes them not to segfault on devices or emulators which enabled 
16k page support.

At the same time, the 16k-aligned binaries work fine on 4k-page devices/emulators.
Tested both on Android 16.