### PR TITLE
[CoreCLR] Remove unused marshal methods code

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGeneratorCoreCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGeneratorCoreCLR.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks;
+
+class MarshalMethodsNativeAssemblyGeneratorCoreCLR : MarshalMethodsNativeAssemblyGenerator
+{
+	/// <summary>
+	/// Constructor to be used ONLY when marshal methods are DISABLED
+	/// </summary>
+	public MarshalMethodsNativeAssemblyGeneratorCoreCLR (TaskLoggingHelper log, AndroidTargetArch targetArch, ICollection<string> uniqueAssemblyNames)
+		: base (log, targetArch, uniqueAssemblyNames)
+	{}
+
+	public MarshalMethodsNativeAssemblyGeneratorCoreCLR (TaskLoggingHelper log, ICollection<string> uniqueAssemblyNames, NativeCodeGenStateObject codeGenState, bool managedMarshalMethodsLookupEnabled)
+		: base (log, uniqueAssemblyNames, codeGenState, managedMarshalMethodsLookupEnabled)
+	{}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGeneratorMonoVM.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGeneratorMonoVM.cs
@@ -25,6 +25,26 @@ class MarshalMethodsNativeAssemblyGeneratorMonoVM : MarshalMethodsNativeAssembly
 		this.numberOfAssembliesInApk = numberOfAssembliesInApk;
 	}
 
+	protected override void AddClassNames (LlvmIrModule module)
+	{
+		// Marshal methods class names
+		var mm_class_names = new List<string> ();
+		foreach (StructureInstance<MarshalMethodsManagedClass> klass in classes) {
+			if (klass.Instance == null) {
+				throw new InvalidOperationException ("Internal error: null class instance found");
+			}
+
+			mm_class_names.Add (klass.Instance.ClassName);
+		}
+		module.AddGlobalVariable ("mm_class_names", mm_class_names, LlvmIrVariableOptions.GlobalConstant, comment: " Names of classes in which marshal methods reside");
+	}
+
+	protected override void AddClassCache (LlvmIrModule module)
+	{
+		module.AddGlobalVariable ("marshal_methods_number_of_classes", (uint)classes.Count, LlvmIrVariableOptions.GlobalConstant);
+		module.AddGlobalVariable ("marshal_methods_class_cache", classes, LlvmIrVariableOptions.GlobalWritable);
+	}
+
 	protected override void AddAssemblyImageCache (LlvmIrModule module, AssemblyCacheState acs)
 	{
 		var assembly_image_cache = new LlvmIrGlobalVariable (typeof(List<IntPtr>), "assembly_image_cache", LlvmIrVariableOptions.GlobalWritable) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGeneratorMonoVM.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGeneratorMonoVM.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tasks.LLVMIR;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks;
+
+class MarshalMethodsNativeAssemblyGeneratorMonoVM : MarshalMethodsNativeAssemblyGenerator
+{
+	readonly int numberOfAssembliesInApk;
+
+	/// <summary>
+	/// Constructor to be used ONLY when marshal methods are DISABLED
+	/// </summary>
+	public MarshalMethodsNativeAssemblyGeneratorMonoVM (TaskLoggingHelper log, AndroidTargetArch targetArch, int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames)
+		: base (log, targetArch, uniqueAssemblyNames)
+	{
+		this.numberOfAssembliesInApk = numberOfAssembliesInApk;
+	}
+
+	public MarshalMethodsNativeAssemblyGeneratorMonoVM (TaskLoggingHelper log, int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames, NativeCodeGenStateObject codeGenState, bool managedMarshalMethodsLookupEnabled)
+		: base (log, uniqueAssemblyNames, codeGenState, managedMarshalMethodsLookupEnabled)
+	{
+		this.numberOfAssembliesInApk = numberOfAssembliesInApk;
+	}
+
+	protected override void AddAssemblyImageCache (LlvmIrModule module, AssemblyCacheState acs)
+	{
+		var assembly_image_cache = new LlvmIrGlobalVariable (typeof(List<IntPtr>), "assembly_image_cache", LlvmIrVariableOptions.GlobalWritable) {
+			ZeroInitializeArray = true,
+			ArrayItemCount = (ulong)numberOfAssembliesInApk,
+		};
+		module.Add (assembly_image_cache);
+
+		var assembly_image_cache_hashes = new LlvmIrGlobalVariable (typeof(List<ulong>), "assembly_image_cache_hashes", LlvmIrVariableOptions.GlobalConstant) {
+			Comment = " Each entry maps hash of an assembly name to an index into the `assembly_image_cache` array",
+			BeforeWriteCallback = UpdateAssemblyImageCacheHashes,
+			BeforeWriteCallbackCallerState = acs,
+			GetArrayItemCommentCallback = GetAssemblyImageCacheItemComment,
+			GetArrayItemCommentCallbackCallerState = acs,
+			NumberFormat = LlvmIrVariableNumberFormat.Hexadecimal,
+		};
+		module.Add (assembly_image_cache_hashes);
+
+		var assembly_image_cache_indices = new LlvmIrGlobalVariable (typeof(List<uint>), "assembly_image_cache_indices", LlvmIrVariableOptions.GlobalConstant) {
+			WriteOptions = LlvmIrVariableWriteOptions.ArrayWriteIndexComments | LlvmIrVariableWriteOptions.ArrayFormatInRows,
+			BeforeWriteCallback = UpdateAssemblyImageCacheIndices,
+			BeforeWriteCallbackCallerState = acs,
+		};
+		module.Add (assembly_image_cache_indices);
+	}
+
+	void UpdateAssemblyImageCacheHashes (LlvmIrVariable variable, LlvmIrModuleTarget target, object? callerState)
+	{
+		AssemblyCacheState acs = EnsureAssemblyCacheState (callerState);
+		object value;
+		Type type;
+
+		if (target.Is64Bit) {
+			value = acs.Keys64;
+			type = typeof(List<ulong>);
+		} else {
+			value = acs.Keys32;
+			type = typeof(List<uint>);
+		}
+
+		LlvmIrGlobalVariable gv = EnsureGlobalVariable (variable);
+		gv.OverrideTypeAndValue (type, value);
+	}
+
+	string? GetAssemblyImageCacheItemComment (LlvmIrVariable v, LlvmIrModuleTarget target, ulong index, object? value, object? callerState)
+	{
+		AssemblyCacheState acs = EnsureAssemblyCacheState (callerState);
+
+		string name;
+		uint i;
+		if (target.Is64Bit) {
+			var v64 = (ulong)value!;
+			name = acs.Hashes64[v64].name;
+			i = acs.Hashes64[v64].index;
+		} else {
+			var v32 = (uint)value!;
+			name = acs.Hashes32[v32].name;
+			i = acs.Hashes32[v32].index;
+		}
+
+		return $" {index}: {name} => {i}";
+	}
+
+	void UpdateAssemblyImageCacheIndices (LlvmIrVariable variable, LlvmIrModuleTarget target, object? callerState)
+	{
+		AssemblyCacheState acs = EnsureAssemblyCacheState (callerState);
+		object value;
+
+		if (target.Is64Bit) {
+			value = acs.Indices64;
+		} else {
+			value = acs.Indices32;
+		}
+
+		LlvmIrGlobalVariable gv = EnsureGlobalVariable (variable);
+		gv.OverrideTypeAndValue (variable.Type, value);
+	}
+
+	AssemblyCacheState EnsureAssemblyCacheState (object? callerState)
+	{
+		var acs = callerState as AssemblyCacheState;
+		if (acs == null) {
+			throw new InvalidOperationException ("Internal error: construction state expected but not found");
+		}
+
+		return acs;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1877,7 +1877,7 @@ because xbuild doesn't support framework reference assemblies.
   DependsOnTargets="$(_GeneratePackageManagerJavaDependsOn)"
   Inputs="@(_GeneratePackageManagerJavaInputs)"
   Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp">
-  
+
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
       MainAssembly="$(TargetPath)"
@@ -1915,6 +1915,7 @@ because xbuild doesn't support framework reference assemblies.
   </GenerateNativeApplicationConfigSources>
 
   <GenerateNativeMarshalMethodSources
+      AndroidRuntime="$(_AndroidRuntime)"
       EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
       EnableManagedMarshalMethodsLookup="$(_AndroidUseManagedMarshalMethodsLookup)"
       EnvironmentOutputDirectory="$(IntermediateOutputPath)android"
@@ -1923,7 +1924,7 @@ because xbuild doesn't support framework reference assemblies.
       SatelliteAssemblies="@(_AndroidResolvedSatellitePaths)"
       SupportedAbis="@(_BuildTargetAbis)">
   </GenerateNativeMarshalMethodSources>
-      
+
   <Touch Files="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp" AlwaysCreate="True" />
   <ItemGroup>
     <FileWrites Include="@(_EnvironmentAssemblySource)" />

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -386,10 +386,6 @@ struct MarshalMethodsManagedClass
 	void            *klass;
 };
 
-// Number of unique classes which contain native callbacks we bind
-[[gnu::visibility("default")]] extern uint32_t marshal_methods_number_of_classes;
-[[gnu::visibility("default")]] extern MarshalMethodsManagedClass marshal_methods_class_cache[];
-
 //
 // These tables store names of classes and managed callback methods used in the generated marshal methods
 // code. They are used just for error reporting.

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -376,34 +376,5 @@ extern "C" {
 	[[gnu::visibility("default")]] extern char *init_runtime_property_values[];
 }
 
-//
-// Support for marshal methods
-//
-#if defined (RELEASE)
-struct MarshalMethodsManagedClass
-{
-	const uint32_t   token;
-	void            *klass;
-};
-
-//
-// These tables store names of classes and managed callback methods used in the generated marshal methods
-// code. They are used just for error reporting.
-//
-// Class names are found at the same indexes as their corresponding entries in the `marshal_methods_class_cache` array
-// above. Method names are stored as token:name pairs and the array must end with an "invalid" terminator entry (token
-// == 0; name == nullptr)
-//
-struct MarshalMethodName
-{
-	// combination of assembly index (high 32 bits) and method token (low 32 bits)
-	const uint64_t  id;
-	const char     *name;
-};
-
-[[gnu::visibility("default")]] extern const char* const mm_class_names[];
-[[gnu::visibility("default")]] extern const MarshalMethodName mm_method_names[];
-#endif // def RELEASE
-
 using get_function_pointer_fn = void(*)(uint32_t mono_image_index, uint32_t class_index, uint32_t method_token, void*& target_ptr);
 extern "C" [[gnu::visibility("default")]] void xamarin_app_init (JNIEnv *env, get_function_pointer_fn fn) noexcept;

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -386,23 +386,6 @@ struct MarshalMethodsManagedClass
 	void            *klass;
 };
 
-// Number of assembly name forms for which we generate hashes (essentially file name mutations. For instance
-// `HelloWorld.dll`, `HelloWorld`, `en-US/HelloWorld` etc). This is multiplied by the number of assemblies in the apk to
-// obtain number of entries in the `assembly_image_cache_hashes` and `assembly_image_cache_indices` entries
-constexpr uint32_t number_of_assembly_name_forms_in_image_cache = 3;
-
-// These 3 arrays constitute the cache used to store pointers to loaded managed assemblies.
-// Three arrays are used so that we can have multiple hashes pointing to the same MonoImage*.
-//
-// This is done by the `assembly_image_cache_hashes` containing hashes for all mutations of some
-// assembly's name (e.g. with culture prefix, without extension etc) and position of that hash in
-// `assembly_image_cache_hashes` is an index into `assembly_image_cache_indices` which, in turn,
-// stores final index into the `assembly_image_cache` array.
-//
-[[gnu::visibility("default")]] extern void* assembly_image_cache[];
-[[gnu::visibility("default")]] extern const uint32_t assembly_image_cache_indices[];
-[[gnu::visibility("default")]] extern const xamarin::android::hash_t assembly_image_cache_hashes[];
-
 // Number of unique classes which contain native callbacks we bind
 [[gnu::visibility("default")]] extern uint32_t marshal_methods_number_of_classes;
 [[gnu::visibility("default")]] extern MarshalMethodsManagedClass marshal_methods_class_cache[];

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -169,27 +169,6 @@ DSOApkEntry dso_apk_entries[2] {};
 //
 // Support for marshal methods
 //
-#if defined (RELEASE)
-
-const char* const mm_class_names[2] = {
-	"one",
-	"two",
-};
-
-const MarshalMethodName mm_method_names[] = {
-	{
-		.id = 1,
-		.name = "one",
-	},
-
-	{
-		.id = 2,
-		.name = "two",
-	},
-};
-
-#endif // def RELEASE
-
 void xamarin_app_init ([[maybe_unused]] JNIEnv *env, [[maybe_unused]] get_function_pointer_fn fn) noexcept
 {
 	// Dummy

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -171,19 +171,6 @@ DSOApkEntry dso_apk_entries[2] {};
 //
 #if defined (RELEASE)
 
-uint32_t marshal_methods_number_of_classes = 2;
-MarshalMethodsManagedClass marshal_methods_class_cache[] = {
-	{
-		.token = 0,
-		.klass = nullptr,
-	},
-
-	{
-		.token = 0,
-		.klass = nullptr,
-	},
-};
-
 const char* const mm_class_names[2] = {
 	"one",
 	"two",

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -170,27 +170,6 @@ DSOApkEntry dso_apk_entries[2] {};
 // Support for marshal methods
 //
 #if defined (RELEASE)
-void* assembly_image_cache[] = {
-	nullptr,
-	nullptr,
-
-};
-
-// Each element contains an index into `assembly_image_cache`
-const uint32_t assembly_image_cache_indices[] = {
-	0,
-	1,
-	1,
-	1,
-};
-
-// hashes point to indices in `assembly_image_cache_indices`
-const xamarin::android::hash_t assembly_image_cache_hashes[] = {
-	0,
-	1,
-	2,
-	3,
-};
 
 uint32_t marshal_methods_number_of_classes = 2;
 MarshalMethodsManagedClass marshal_methods_class_cache[] = {

--- a/src/native/common/include/runtime-base/timing-internal.hh
+++ b/src/native/common/include/runtime-base/timing-internal.hh
@@ -207,7 +207,7 @@ namespace xamarin::android {
 			}
 
 			auto interval = event.end - event.start; // nanoseconds
-			message.append ("; elapsed exp: "sv);
+			message.append ("; elapsed: "sv);
 			message.append (static_cast<uint64_t>((chrono::duration_cast<chrono::seconds>(interval).count ())));
 			message.append (":"sv);
 			message.append (static_cast<uint64_t>((chrono::duration_cast<chrono::milliseconds>(interval)).count ()));


### PR DESCRIPTION
Our build process targetting CoreCLR generated marshal methods code that is
only used by our MonoVM runtime. The native code included marshal methods and 
class names, as well as assembly image cache which is not supported on CoreCLR.

All of the above data were stored as pointers in the resulting `libxamarin-app.so`,
each pointer being a relocation that has to be fixed up by the system dynamic linker
at application load time. The more relocations exist across the `.so` file, the more
of it the linker has to actually read into memory (instead of just mmapping it and 
lazily loading whenever/if the code/data in that section is used).

This PR removes all of that code from the CoreCLR version of `libxamarin-app.so`,
together with a number of native structs supporting the data.

Testing the changes on a `dotnet new maui -sc` application, we can see the following
savings:

  * Number of relocations in `libxamarin-app.so` drops from 903 to 394 entries
  * `libxamarin-app.so` size drops from:
    * arm64: 443648 to 368832 bytes (16.9%)
    * x64: 438856 to 360464 bytes (17.9%)

Testing the above MAUI app performance on Pixel 8, we can also see a tiny startup
time decrease by 0.71%. On slower devices and with bigger applications the startup
performance improvement will be bigger (the slower the device's storage, the bigger
time savings)