### PR TITLE
[native] Generate less relocations in libxamarin-app.so

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -855,7 +855,11 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					WriteByteTypeAndValue (b);
 				}
 
-				WriteCommaWithStride (counter);
+				if (bytes.Length > 0) {
+					WriteCommaWithStride (counter);
+				} else {
+					context.Output.Write (context.CurrentIndent);
+				}
 				WriteByteTypeAndValue (0); // Terminating NUL is counted for each string, but not included in its bytes
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrStringBlob.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrStringBlob.cs
@@ -26,6 +26,11 @@ class LlvmIrStringBlob
 
 	public long Size => size;
 
+	/// <summary>
+	/// Add string <paramref name="s"/> to the blob, returning its offset in the blob
+	/// and its size (which is the string length after conversion from UTF8 to a byte array plus
+	/// 1 for the terminating NUL character)
+	/// </summary>
 	public (int offset, int length) Add (string s)
 	{
 		if (cache.TryGetValue (s, out StringInfo info)) {

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -35,10 +35,10 @@ auto AssemblyStore::get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData co
 			internal_timing.start_event (TimingEventKind::AssemblyDecompression);
 		}
 
-		if (compressed_assemblies.descriptors == nullptr) [[unlikely]] {
+		if (compressed_assembly_count == 0) [[unlikely]] {
 			Helpers::abort_application (LOG_ASSEMBLY, "Compressed assembly found but no descriptor defined"sv);
 		}
-		if (header->descriptor_index >= compressed_assemblies.count) [[unlikely]] {
+		if (header->descriptor_index >= compressed_assembly_count) [[unlikely]] {
 			Helpers::abort_application (
 				LOG_ASSEMBLY,
 				std::format (
@@ -48,13 +48,42 @@ auto AssemblyStore::get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData co
 			);
 		}
 
-		CompressedAssemblyDescriptor &cad = compressed_assemblies.descriptors[header->descriptor_index];
+		CompressedAssemblyDescriptor &cad = compressed_assembly_descriptors[header->descriptor_index];
 		assembly_data_size = e.descriptor->data_size - sizeof(CompressedAssemblyHeader);
+
+		if (cad.buffer_offset >= uncompressed_assemblies_data_size) [[unlikely]] {
+			Helpers::abort_application (
+				LOG_ASSEMBLY,
+				std::format (
+					"Invalid compressed assembly buffer offset {}. Must be smaller than {}",
+					cad.buffer_offset,
+					uncompressed_assemblies_data_size
+				)
+			);
+		}
+
+		// This is not a perfect check, since we might be still within the buffer size and yet
+		// have the tail end of this assembly's data overwritten by the next assembly's data, but
+		// that will cause the app to crash when one or the the other assembly is loaded, so it's
+		// OK to accept that risk. The whole situation is very, very unlikely.
+		if (cad.uncompressed_file_size > uncompressed_assemblies_data_size - cad.buffer_offset) [[unlikely]] {
+			Helpers::abort_application (
+				LOG_ASSEMBLY,
+				std::format (
+					"Invalid compressed assembly buffer size {} at offset {}. Must not exceed {}",
+					cad.uncompressed_file_size,
+					cad.buffer_offset,
+					uncompressed_assemblies_data_size - cad.buffer_offset
+				)
+			);
+		}
+
+		uint8_t *data_buffer = uncompressed_assemblies_data_buffer + cad.buffer_offset;
 		if (!cad.loaded) {
 			StartupAwareLock decompress_lock (assembly_decompress_mutex);
 
 			if (cad.loaded) {
-				set_assembly_data_and_size (reinterpret_cast<uint8_t*>(cad.data), cad.uncompressed_file_size, assembly_data, assembly_data_size);
+				set_assembly_data_and_size (data_buffer, cad.uncompressed_file_size, assembly_data, assembly_data_size);
 
 				if (FastTiming::enabled ()) [[unlikely]] {
 					internal_timing.end_event (true /* uses_more_info */);
@@ -65,16 +94,6 @@ auto AssemblyStore::get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData co
 					internal_timing.add_more_info (msg);
 				}
 				return {assembly_data, assembly_data_size};
-			}
-
-			if (cad.data == nullptr) [[unlikely]] {
-				Helpers::abort_application (
-					LOG_ASSEMBLY,
-					std::format (
-						"Invalid compressed assembly descriptor at {}: no data"sv,
-						header->descriptor_index
-					)
-				);
 			}
 
 			if (header->uncompressed_length != cad.uncompressed_file_size) {
@@ -95,7 +114,7 @@ auto AssemblyStore::get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData co
 			}
 
 			const char *data_start = pointer_add<const char*>(e.image_data, sizeof(CompressedAssemblyHeader));
-			int ret = LZ4_decompress_safe (data_start, reinterpret_cast<char*>(cad.data), static_cast<int>(assembly_data_size), static_cast<int>(cad.uncompressed_file_size));
+			int ret = LZ4_decompress_safe (data_start, reinterpret_cast<char*>(data_buffer), static_cast<int>(assembly_data_size), static_cast<int>(cad.uncompressed_file_size));
 
 			if (ret < 0) {
 				Helpers::abort_application (
@@ -126,7 +145,7 @@ auto AssemblyStore::get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData co
 			}
 		}
 
-		set_assembly_data_and_size (reinterpret_cast<uint8_t*>(cad.data), cad.uncompressed_file_size, assembly_data, assembly_data_size);
+		set_assembly_data_and_size (reinterpret_cast<uint8_t*>(data_buffer), cad.uncompressed_file_size, assembly_data, assembly_data_size);
 	} else
 #endif // def HAVE_LZ4 && def RELEASE
 	{

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -145,7 +145,7 @@ auto AssemblyStore::get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData co
 			}
 		}
 
-		set_assembly_data_and_size (reinterpret_cast<uint8_t*>(data_buffer), cad.uncompressed_file_size, assembly_data, assembly_data_size);
+		set_assembly_data_and_size (data_buffer, cad.uncompressed_file_size, assembly_data, assembly_data_size);
 	} else
 #endif // def HAVE_LZ4 && def RELEASE
 	{

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -76,7 +76,7 @@ size_t Host::clr_get_runtime_property (const char *key, char *value_buffer, size
 		);
 	}
 
-	strncpy (value_buffer, prop.value, value_buffer_size);
+	strncpy (value_buffer, &runtime_properties_data[prop.value_index], value_buffer_size);
 	return std::min (static_cast<size_t>(prop.value_size - 1), value_buffer_size - 1);
 }
 

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -131,13 +131,7 @@ struct CompressedAssemblyDescriptor
 {
 	uint32_t   uncompressed_file_size;
 	bool       loaded;
-	uint8_t   *data;
-};
-
-struct CompressedAssemblies
-{
-	uint32_t                      count;
-	CompressedAssemblyDescriptor *descriptors;
+	uint32_t   buffer_offset;
 };
 
 struct XamarinAndroidBundledAssembly
@@ -354,7 +348,10 @@ extern "C" {
 	[[gnu::visibility("default")]] extern const xamarin::android::hash_t java_to_managed_hashes[];
 #endif
 
-	[[gnu::visibility("default")]] extern CompressedAssemblies compressed_assemblies;
+	[[gnu::visibility("default")]] extern uint32_t compressed_assembly_count;
+	[[gnu::visibility("default")]] extern CompressedAssemblyDescriptor compressed_assembly_descriptors[];
+	[[gnu::visibility("default")]] extern uint32_t uncompressed_assemblies_data_size;
+	[[gnu::visibility("default")]] extern uint8_t uncompressed_assemblies_data_buffer[];
 	[[gnu::visibility("default")]] extern const ApplicationConfig application_config;
 	[[gnu::visibility("default")]] extern const char* const app_environment_variables[];
 	[[gnu::visibility("default")]] extern const char* const app_system_properties[];

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -280,11 +280,11 @@ struct DSOApkEntry
 
 struct DSOCacheEntry
 {
-	uint64_t       hash;
-	uint64_t       real_name_hash;
-	bool           ignore;
-	const char    *name;
-	void          *handle;
+	const uint64_t  hash;
+	const uint64_t  real_name_hash;
+	const bool      ignore;
+	const uint32_t  name_index;
+	void           *handle;
 };
 
 struct JniRemappingString
@@ -371,6 +371,7 @@ extern "C" {
 
 	[[gnu::visibility("default")]] extern DSOCacheEntry dso_cache[];
 	[[gnu::visibility("default")]] extern DSOCacheEntry aot_dso_cache[];
+	[[gnu::visibility("default")]] extern const char dso_names_data[];
 	[[gnu::visibility("default")]] extern DSOApkEntry dso_apk_entries[];
 
 	[[gnu::visibility("default")]] extern const RuntimeProperty runtime_properties[];

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -260,9 +260,9 @@ struct ApplicationConfig
 
 struct RuntimeProperty
 {
-	const char *key;
-	const char *value;
-	uint32_t value_size; // including the terminating NUL
+	const uint32_t key_index;
+	const uint32_t value_index;
+	const uint32_t value_size; // including the terminating NUL
 };
 
 struct RuntimePropertyIndexEntry
@@ -374,6 +374,7 @@ extern "C" {
 	[[gnu::visibility("default")]] extern DSOApkEntry dso_apk_entries[];
 
 	[[gnu::visibility("default")]] extern const RuntimeProperty runtime_properties[];
+	[[gnu::visibility("default")]] extern const char runtime_properties_data[];
 	[[gnu::visibility("default")]] extern const RuntimePropertyIndexEntry runtime_property_index[];
 
 	[[gnu::visibility("default")]] extern const char *init_runtime_property_names[];

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -322,6 +322,12 @@ struct JniRemappingTypeReplacementEntry
 	const char      *replacement;
 };
 
+struct AppEnvironmentVariable
+{
+	const uint32_t name_index;
+	const uint32_t value_index;
+};
+
 extern "C" {
 	[[gnu::visibility("default")]] extern const JniRemappingIndexTypeEntry jni_remapping_method_replacement_index[];
 	[[gnu::visibility("default")]] extern const JniRemappingTypeReplacementEntry jni_remapping_type_replacements[];
@@ -353,7 +359,8 @@ extern "C" {
 	[[gnu::visibility("default")]] extern uint32_t uncompressed_assemblies_data_size;
 	[[gnu::visibility("default")]] extern uint8_t uncompressed_assemblies_data_buffer[];
 	[[gnu::visibility("default")]] extern const ApplicationConfig application_config;
-	[[gnu::visibility("default")]] extern const char* const app_environment_variables[];
+	[[gnu::visibility("default")]] extern const AppEnvironmentVariable app_environment_variables[];
+	[[gnu::visibility("default")]] extern const char app_environment_variable_contents[];
 	[[gnu::visibility("default")]] extern const char* const app_system_properties[];
 
 	[[gnu::visibility("default")]] extern const char* const mono_aot_mode_name;

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -230,16 +230,10 @@ AndroidSystem::setup_environment () noexcept
 
 	const char *var_name;
 	const char *var_value;
-	for (size_t i = 0uz; i < application_config.environment_variable_count; i += 2) {
-		var_name = app_environment_variables [i];
-		if (var_name == nullptr || *var_name == '\0') {
-			continue;
-		}
-
-		var_value = app_environment_variables [i + 1uz];
-		if (var_value == nullptr) {
-			var_value = "";
-		}
+	for (size_t i = 0uz; i < application_config.environment_variable_count; i++) {
+		AppEnvironmentVariable const& env_var = app_environment_variables [i];
+		var_name = &app_environment_variable_contents[env_var.name_index];
+		var_value = &app_environment_variable_contents[env_var.value_index];
 
 		if constexpr (Constants::is_debug_build) {
 			log_info (LOG_DEFAULT, "Setting environment variable '{}' to '{}'", var_name, var_value);

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -38,10 +38,10 @@ const TypeMapJava java_to_managed_map[] = {};
 const xamarin::android::hash_t java_to_managed_hashes[] = {};
 #endif
 
-CompressedAssemblies compressed_assemblies = {
-	.count = 0,
-	.descriptors = nullptr,
-};
+uint32_t compressed_assembly_count = 0;
+CompressedAssemblyDescriptor compressed_assembly_descriptors[] = {};
+uint32_t uncompressed_assemblies_data_size = 0;
+uint8_t uncompressed_assemblies_data_buffer[] = {};
 
 //
 // Config settings below **must** be valid for Desktop builds as the default `libxamarin-app.{dll,dylib,so}` is used by

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -259,23 +259,26 @@ constexpr char prop_test_boolean_key[] = "test_boolean";
 
 const RuntimeProperty runtime_properties[] = {
 	{
-		.key = prop_test_string_key,
-		.value = "test",
-		.value_size = sizeof("test"),
+		.key_index = 0,
+		.value_index = 10,
+		.value_size = 10,
 	},
 
 	{
-		.key = prop_test_integer_key,
-		.value = "42",
-		.value_size = sizeof("42"),
+		.key_index = 20,
+		.value_index = 25,
+		.value_size = 5,
 	},
 
 	{
-		.key = prop_test_boolean_key,
-		.value = "true",
-		.value_size = sizeof("true"),
+		.key_index = 30,
+		.value_index = 33,
+		.value_size = 7,
 	},
 };
+
+
+const char runtime_properties_data[] = {};
 
 const RuntimePropertyIndexEntry runtime_property_index[] = {
 	{

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -72,7 +72,8 @@ const ApplicationConfig application_config = {
 };
 
 // TODO: migrate to std::string_view for these two
-const char* const app_environment_variables[] = {};
+const AppEnvironmentVariable app_environment_variables[] = {};
+const char app_environment_variable_contents[] = {};
 const char* const app_system_properties[] = {};
 
 static constexpr size_t AssemblyNameWidth = 128uz;

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -134,7 +134,7 @@ DSOCacheEntry dso_cache[] = {
 		.hash = xamarin::android::xxhash::hash (fake_dso_name, sizeof(fake_dso_name) - 1),
 		.real_name_hash = xamarin::android::xxhash::hash (fake_dso_name, sizeof(fake_dso_name) - 1),
 		.ignore = true,
-		.name = fake_dso_name,
+		.name_index = 1,
 		.handle = nullptr,
 	},
 
@@ -142,7 +142,7 @@ DSOCacheEntry dso_cache[] = {
 		.hash = xamarin::android::xxhash::hash (fake_dso_name2, sizeof(fake_dso_name2) - 1),
 		.real_name_hash = xamarin::android::xxhash::hash (fake_dso_name2, sizeof(fake_dso_name2) - 1),
 		.ignore = true,
-		.name = fake_dso_name2,
+		.name_index = 2,
 		.handle = nullptr,
 	},
 };
@@ -152,7 +152,7 @@ DSOCacheEntry aot_dso_cache[] = {
 		.hash = xamarin::android::xxhash::hash (fake_dso_name, sizeof(fake_dso_name) - 1),
 		.real_name_hash = xamarin::android::xxhash::hash (fake_dso_name, sizeof(fake_dso_name) - 1),
 		.ignore = true,
-		.name = fake_dso_name,
+		.name_index = 3,
 		.handle = nullptr,
 	},
 
@@ -160,10 +160,12 @@ DSOCacheEntry aot_dso_cache[] = {
 		.hash = xamarin::android::xxhash::hash (fake_dso_name2, sizeof(fake_dso_name2) - 1),
 		.real_name_hash = xamarin::android::xxhash::hash (fake_dso_name2, sizeof(fake_dso_name2) - 1),
 		.ignore = true,
-		.name = fake_dso_name2,
+		.name_index = 4,
 		.handle = nullptr,
 	},
 };
+
+const char dso_names_data[] = {};
 
 DSOApkEntry dso_apk_entries[2] {};
 

--- a/src/native/mono/monodroid/embedded-assemblies.cc
+++ b/src/native/mono/monodroid/embedded-assemblies.cc
@@ -85,10 +85,11 @@ EmbeddedAssemblies::get_assembly_data (uint8_t *data, uint32_t data_size, [[mayb
 #if defined (HAVE_LZ4) && defined (RELEASE)
 	auto header = reinterpret_cast<const CompressedAssemblyHeader*>(data);
 	if (header->magic == COMPRESSED_DATA_MAGIC) {
-		if (compressed_assemblies.descriptors == nullptr) [[unlikely]] {
+		if (compressed_assembly_count == 0) [[unlikely]] {
 			Helpers::abort_application (LOG_ASSEMBLY, "Compressed assembly found but no descriptor defined"sv);
 		}
-		if (header->descriptor_index >= compressed_assemblies.count) [[unlikely]] {
+
+		if (header->descriptor_index >= compressed_assembly_count) [[unlikely]] {
 			Helpers::abort_application (
 				LOG_ASSEMBLY,
 				std::format (
@@ -98,24 +99,43 @@ EmbeddedAssemblies::get_assembly_data (uint8_t *data, uint32_t data_size, [[mayb
 			);
 		}
 
-		CompressedAssemblyDescriptor &cad = compressed_assemblies.descriptors[header->descriptor_index];
+		CompressedAssemblyDescriptor &cad = compressed_assembly_descriptors[header->descriptor_index];
 		assembly_data_size = data_size - sizeof(CompressedAssemblyHeader);
+
+		if (cad.buffer_offset >= uncompressed_assemblies_data_size) [[unlikely]] {
+			Helpers::abort_application (
+				LOG_ASSEMBLY,
+				std::format (
+					"Invalid compressed assembly buffer offset {}. Must be smaller than {}",
+					cad.buffer_offset,
+					uncompressed_assemblies_data_size
+				)
+			);
+		}
+
+		// This is not a perfect check, since we might be still within the buffer size and yet
+		// have the tail end of this assembly's data overwritten by the next assembly's data, but
+		// that will cause the app to crash when one or the the other assembly is loaded, so it's
+		// OK to accept that risk. The whole situation is very, very unlikely.
+		if (cad.uncompressed_file_size > uncompressed_assemblies_data_size - cad.buffer_offset) [[unlikely]] {
+			Helpers::abort_application (
+				LOG_ASSEMBLY,
+				std::format (
+					"Invalid compressed assembly buffer size {} at offset {}. Must not exceed {}",
+					cad.uncompressed_file_size,
+					cad.buffer_offset,
+					uncompressed_assemblies_data_size - cad.buffer_offset
+				)
+			);
+		}
+
+		uint8_t *data_buffer = uncompressed_assemblies_data_buffer + cad.buffer_offset;
 		if (!cad.loaded) {
 			StartupAwareLock decompress_lock (assembly_decompress_mutex);
 
 			if (cad.loaded) {
-				set_assembly_data_and_size (reinterpret_cast<uint8_t*>(cad.data), cad.uncompressed_file_size, assembly_data, assembly_data_size);
+				set_assembly_data_and_size (data_buffer, cad.uncompressed_file_size, assembly_data, assembly_data_size);
 				return;
-			}
-
-			if (cad.data == nullptr) [[unlikely]] {
-				Helpers::abort_application (
-					LOG_ASSEMBLY,
-					std::format (
-						"Invalid compressed assembly descriptor at {}: no data",
-						header->descriptor_index
-					)
-				);
 			}
 
 			if (header->uncompressed_length != cad.uncompressed_file_size) {
@@ -136,7 +156,7 @@ EmbeddedAssemblies::get_assembly_data (uint8_t *data, uint32_t data_size, [[mayb
 			}
 
 			const char *data_start = pointer_add<const char*>(data, sizeof(CompressedAssemblyHeader));
-			int ret = LZ4_decompress_safe (data_start, reinterpret_cast<char*>(cad.data), static_cast<int>(assembly_data_size), static_cast<int>(cad.uncompressed_file_size));
+			int ret = LZ4_decompress_safe (data_start, reinterpret_cast<char*>(data_buffer), static_cast<int>(assembly_data_size), static_cast<int>(cad.uncompressed_file_size));
 
 			if (ret < 0) {
 				Helpers::abort_application (
@@ -163,7 +183,7 @@ EmbeddedAssemblies::get_assembly_data (uint8_t *data, uint32_t data_size, [[mayb
 			cad.loaded = true;
 		}
 
-		set_assembly_data_and_size (reinterpret_cast<uint8_t*>(cad.data), cad.uncompressed_file_size, assembly_data, assembly_data_size);
+		set_assembly_data_and_size (data_buffer, cad.uncompressed_file_size, assembly_data, assembly_data_size);
 	} else
 #endif // def HAVE_LZ4 && def RELEASE
 	{

--- a/src/native/mono/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/mono/xamarin-app-stub/application_dso_stub.cc
@@ -31,10 +31,10 @@ const TypeMapJava map_java[] = {};
 const xamarin::android::hash_t map_java_hashes[] = {};
 #endif
 
-CompressedAssemblies compressed_assemblies = {
-	.count = 0,
-	.descriptors = nullptr,
-};
+uint32_t compressed_assembly_count = 0;
+CompressedAssemblyDescriptor compressed_assembly_descriptors[] = {};
+uint32_t uncompressed_assemblies_data_size = 0;
+uint8_t uncompressed_assemblies_data_buffer[] = {};
 
 //
 // Config settings below **must** be valid for Desktop builds as the default `libxamarin-app.{dll,dylib,so}` is used by

--- a/src/native/mono/xamarin-app-stub/xamarin-app.hh
+++ b/src/native/mono/xamarin-app-stub/xamarin-app.hh
@@ -113,6 +113,7 @@ struct CompressedAssemblyDescriptor
 {
 	uint32_t   uncompressed_file_size;
 	bool       loaded;
+	uint32_t   buffer_offset;
 	uint8_t   *data;
 };
 

--- a/src/native/mono/xamarin-app-stub/xamarin-app.hh
+++ b/src/native/mono/xamarin-app-stub/xamarin-app.hh
@@ -111,16 +111,9 @@ struct CompressedAssemblyHeader
 
 struct CompressedAssemblyDescriptor
 {
-	uint32_t   uncompressed_file_size;
-	bool       loaded;
-	uint32_t   buffer_offset;
-	uint8_t   *data;
-};
-
-struct CompressedAssemblies
-{
-	uint32_t                      count;
-	CompressedAssemblyDescriptor *descriptors;
+    uint32_t   uncompressed_file_size;
+    bool       loaded;
+    uint32_t   buffer_offset;
 };
 
 struct XamarinAndroidBundledAssembly
@@ -329,7 +322,11 @@ MONO_API MONO_API_EXPORT const TypeMapJava map_java[];
 MONO_API MONO_API_EXPORT const xamarin::android::hash_t map_java_hashes[];
 #endif
 
-MONO_API MONO_API_EXPORT CompressedAssemblies compressed_assemblies;
+MONO_API MONO_API_EXPORT uint32_t compressed_assembly_count;
+MONO_API MONO_API_EXPORT CompressedAssemblyDescriptor compressed_assembly_descriptors[];
+MONO_API MONO_API_EXPORT uint32_t uncompressed_assemblies_data_size;
+MONO_API MONO_API_EXPORT uint8_t uncompressed_assemblies_data_buffer[];
+
 MONO_API MONO_API_EXPORT const ApplicationConfig application_config;
 MONO_API MONO_API_EXPORT const char* const app_environment_variables[];
 MONO_API MONO_API_EXPORT const char* const app_system_properties[];


### PR DESCRIPTION
Another in series of PRs which reduces the number of relocations in
`libxamarin-app.so`.

This PR changes the way compressed assemblies (CoreCLR and MonoVM),
environment variables (CoreCLR) and runtime properties (CoreCLR)
are stored.

Compressed assemblies no longer use one target buffer per assembly,
but instead allocate a single big buffer for all the decompressed
assemblies, addressing the data using indexes into the buffer instead
of pointers.

Environment variables and runtime properties now use string blobs
instead of string pointers.

For the `dotnet new maui -sc` sample, this PR reduces the number of 
relocations in `libxamarin-app.so` from 394 (in the `main` branch)
to 136 entries.

Size of `libxamarin-app.so` is slightly reduced:

  * arm64: from 370936 to 365800 bytes (1.4%)
  * x64: from 362520 to 357328 bytes (1.4%)

Modest improvements in startup time, the sample app starts faster by
0.71% on Pixel 9 with Android 16.