### PR TITLE
[xabt] remove `$(AndroidStripILAfterAOT)`

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1245,7 +1245,7 @@ This means that in Release configuration builds -- in which
 This can result in increased app sizes. This behavior can be overridden by explicitly setting
 `$(AndroidEnableProfiledAot)` to `true` within your project file.
 
-Support for this property was added in .NET 8.
+Experimental support for this property was added in .NET 8, removed in .NET 10.
 
 ## AndroidSupportedAbis
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -137,50 +137,14 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
         LLVMPath="$(_LLVMPath)"
         LdName="$(_LdName)"
         LdFlags="$(_LdFlags)"
-        CollectTrimmingEligibleMethods="$(AndroidStripILAfterAOT)"
+        CollectTrimmingEligibleMethods="$(_AndroidCollectTrimmingEligibleMethods)"
         TrimmingEligibleMethodsOutputDirectory="$(IntermediateOutputPath)tokens"
         WorkingDirectory="$(MSBuildProjectDirectory)"
         AotArguments="$(AndroidAotAdditionalArguments)">
       <Output TaskParameter="CompiledAssemblies" ItemName="_MonoAOTCompiledAssemblies" />
       <Output TaskParameter="FileWrites"         ItemName="FileWrites" />
     </MonoAOTCompiler>
-    <ILStrip
-        Condition=" '$(AndroidStripILAfterAOT)' == 'true' "
-        TrimIndividualMethods="true"
-        Assemblies="@(_MonoAOTCompiledAssemblies)"
-        IntermediateOutputPath="$(IntermediateOutputPath)"
-        DisableParallelStripping="$(_DisableParallelAot)">
-      <Output TaskParameter="UpdatedAssemblies" ItemName="_ILStripUpdatedAssemblies" />
-    </ILStrip>
-    <Copy
-        Condition=" '$(AndroidStripILAfterAOT)' == 'true' and '%(_ILStripUpdatedAssemblies.ILStripped)' == 'true' and '%(_ILStripUpdatedAssemblies.UntrimmedAssemblyFilePath)' != '' "
-        SourceFiles="@(_ILStripUpdatedAssemblies)"
-        DestinationFiles="@(_ILStripUpdatedAssemblies->'%(UntrimmedAssemblyFilePath)')"
-    />
-    <ItemGroup>
-      <_UpdateStamp Include="@(_ILStripUpdatedAssemblies)" Condition=" '$(AndroidStripILAfterAOT)' == 'true' and '%(_ILStripUpdatedAssemblies.ILStripped)' == 'true' " />
-    </ItemGroup>
 
-    <!-- We must update the stamp file used by `_GenerateJavaStubs`, but `$(_AndroidStampDirectory)` **here** is inside a per-RID parent
-         directory (e.g. `obj/Release/android-arm64/stamp`) and not the "top level" one (`obj/Release/stamp`).  Since **both** are set
-         in the same place (in `Xamarin.Android.Common.targets`), we don't know where the "top level" one really is.  Hence the hack.
-         If the locations or their relative paths change, then the `EnableAndroidStripILAfterAOTFalse` test will fail.
-
-         However, there should be a better way to do it... Ideally, when marshal methods are enabled **nothing** should modify any
-         assemblies after marshal method classifier and rewriter runs.
-    -->
-    <PropertyGroup>
-      <_StampDir>$(_AndroidStampDirectory)\..\..\stamp</_StampDir>
-    </PropertyGroup>
-    <MakeDir
-        Condition=" '$(AndroidStripILAfterAOT)' == 'true' and '@(_UpdateStamp->Count())' &gt; 0 "
-        Directories="$(_StampDir)"
-    />
-    <Touch
-        Condition=" '$(AndroidStripILAfterAOT)' == 'true' and '@(_UpdateStamp->Count())' &gt; 0 "
-        Files="$(_StampDir)\_GenerateJavaStubs.stamp"
-        AlwaysCreate="True"
-    />
     <WriteLinesToFile
         File="$(_AndroidStampDirectory)_AndroidAot.stamp"
         Lines="@(_MonoAOTCompiledAssemblies->'%(LibraryFile)')"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -106,7 +106,7 @@
     <_AndroidXA1029 Condition=" '$(AotAssemblies)' != '' ">true</_AndroidXA1029>
     <_AndroidXA1030 Condition=" '$(RunAOTCompilation)' == 'true' and '$(PublishTrimmed)' == 'false' ">true</_AndroidXA1030>
     <AotAssemblies>$(RunAOTCompilation)</AotAssemblies>
-    <AndroidEnableProfiledAot Condition=" '$(AndroidEnableProfiledAot)' == '' and '$(RunAOTCompilation)' == 'true' and '$(AndroidStripILAfterAOT)' != 'true' ">true</AndroidEnableProfiledAot>
+    <AndroidEnableProfiledAot Condition=" '$(AndroidEnableProfiledAot)' == '' and '$(RunAOTCompilation)' == 'true' ">true</AndroidEnableProfiledAot>
 
     <!--
       Runtime libraries feature switches defaults

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2108,7 +2108,7 @@ because xbuild doesn't support framework reference assemblies.
 
   <!-- Shrink Mono.Android.dll by removing attribute only needed for GenerateJavaStubs -->
   <RemoveRegisterAttribute
-    Condition="'$(AndroidLinkMode)' != 'None' and '$(AndroidIncludeDebugSymbols)' != 'true' and '$(AndroidStripILAfterAOT)' != 'true' and '$(_AndroidRuntime)' != 'NativeAOT' and '$(PublishReadyToRun)' != 'true' "
+    Condition="'$(AndroidLinkMode)' != 'None' and '$(AndroidIncludeDebugSymbols)' != 'true' and '$(_AndroidRuntime)' != 'NativeAOT' and '$(PublishReadyToRun)' != 'true' "
     ShrunkFrameworkAssemblies="@(_ShrunkAssemblies)" />
 
   <MakeDir Directories="$(MonoAndroidIntermediateAssemblyDir)shrunk" />

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1088,44 +1088,6 @@ Bar34=Foo55",
 		}
 
 		[Test]
-		public void EnableAndroidStripILAfterAOT ([Values (false, true)] bool profiledAOT)
-		{
-			var proj = new XamarinAndroidApplicationProject {
-				ProjectName = nameof (EnableAndroidStripILAfterAOT),
-				RootNamespace = nameof (EnableAndroidStripILAfterAOT),
-				IsRelease = true,
-				EnableDefaultItems = true,
-			};
-			proj.SetProperty("AndroidStripILAfterAOT", "true");
-			proj.SetProperty("AndroidEnableProfiledAot", profiledAOT.ToString ());
-			// So we can use Mono.Cecil to open assemblies directly
-			proj.SetProperty ("AndroidEnableAssemblyCompression", "false");
-
-			var builder = CreateApkBuilder ();
-			Assert.IsTrue (builder.Build (proj), "`dotnet build` should succeed");
-
-			var apk = Path.Combine (Root, builder.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk");
-			FileAssert.Exists (apk);
-			var helper = new ArchiveAssemblyHelper (apk);
-			Assert.IsTrue (helper.Exists ($"assemblies/{proj.ProjectName}.dll"), $"{proj.ProjectName}.dll should exist in apk!");
-			using (var stream = helper.ReadEntry ($"assemblies/{proj.ProjectName}.dll")) {
-				stream.Position = 0;
-				using var assembly = AssemblyDefinition.ReadAssembly (stream);
-				var type = assembly.MainModule.GetType ($"{proj.RootNamespace}.MainActivity");
-				var method = type.Methods.FirstOrDefault (p => p.Name == "OnCreate");
-				Assert.IsNotNull (method, $"{proj.RootNamespace}.MainActivity.OnCreate should exist!");
-				Assert.IsTrue (!method.HasBody || method.Body.Instructions.Count == 0, $"{proj.RootNamespace}.MainActivity.OnCreate should have no body!");
-			}
-
-			RunProjectAndAssert (proj, builder);
-
-			WaitForPermissionActivity (Path.Combine (Root, builder.ProjectDirectory, "permission-logcat.log"));
-			bool didLaunch = WaitForActivityToStart (proj.PackageName, "MainActivity",
-				Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), 30);
-			Assert.IsTrue(didLaunch, "Activity should have started.");
-		}
-
-		[Test]
 		public void FixLegacyResourceDesignerStep ([Values (true, false)] bool isRelease)
 		{
 			string previousTargetFramework = "net9.0-android";


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/9577

Partially reverts 82a40927.

We introduced an "experimental" property `$(AndroidStripILAfterAOT)` in .NET 8, which has a few flaws as mentioned in #9577. I've seen this come up on a couple customer issues, and the solution was to stop using the feature...

Since, this feature is only available for Mono (not CoreCLR or NativeAOT), it feels like we should remove it from the codebase for now. We could bring it back in the future, if we also solved #9577.