### PR TITLE
[xabt] fall back to libZipSharp on .NET framework

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildArchive.cs
@@ -216,39 +216,16 @@ public class BuildArchive : AndroidTask
 			return true;
 		}
 
+		// Always fallback on .NET Framework
+		var frameworkDescription = RuntimeInformation.FrameworkDescription;
+		Log.LogDebugMessage ($"RuntimeInformation.FrameworkDescription: {frameworkDescription}");
+		if (frameworkDescription != ".NET") {
+			Log.LogDebugMessage ("Falling back to LibZipSharp because we are *not* running on .NET 6+.");
+			return true;
+		}
+
 		// .NET 6+ handles uncompressed files correctly, so we don't need to fallback.
-		if (RuntimeInformation.FrameworkDescription == ".NET") {
-			Log.LogDebugMessage ("Using System.IO.Compression because we're running on .NET 6+.");
-			return false;
-		}
-
-		// Nothing is going to get written uncompressed, so we don't need to fallback.
-		if (uncompressedMethod != CompressionMethod.Store) {
-			Log.LogDebugMessage ("Using System.IO.Compression because uncompressedMethod isn't 'Store'.");
-			return false;
-		}
-
-		// No uncompressed file extensions were specified, so we don't need to fallback.
-		if (UncompressedFileExtensionsSet.Count == 0) {
-			Log.LogDebugMessage ("Using System.IO.Compression because no uncompressed file extensions were specified.");
-			return false;
-		}
-
-		// See if any of the files to be added need to be uncompressed.
-		foreach (var file in FilesToAddToArchive) {
-			var file_path = file.ItemSpec;
-
-			// Handle files from inside a .jar/.aar
-			if (file.GetMetadataOrDefault ("JavaArchiveEntry", (string?)null) is string jar_entry_name)
-				file_path = jar_entry_name;
-
-			if (UncompressedFileExtensionsSet.Contains (Path.GetExtension (file_path))) {
-				Log.LogDebugMessage ($"Falling back to LibZipSharp because '{file_path}' needs to be stored uncompressed.");
-				return true;
-			}
-		}
-
-		Log.LogDebugMessage ("Using System.IO.Compression because no files need to be stored uncompressed.");
+		Log.LogDebugMessage ("Using System.IO.Compression because we're running on .NET 6+.");
 		return false;
 	}
 


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2510554

In testing .NET 10, we found the issue:

    ADB0010: Mono.AndroidTools.InstallFailedException: Unexpected install
    output: Failure [-124: Failed parse during installPackageLI: Targeting
    R+ (version 30 and above) requires the resources.arsc of installed
    APKs to be stored uncompressed and aligned on a 4-byte boundary] ...

1. Create a new .NET MAUI/MAUI Blazor app.
2. Change the value for the Color attribute to #FF0000 or any color.
```xml
<!-- Splash Screen -->
<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#FF0000" BaseSize="128,128" />
```
3. Deploy to android.
4. The splash screen color should change according to the chosen color.
5. Stop Debugging and change the splash screen color again.
6. If you do it enough times, you would encounter the error.

Manually, adding `$(_AndroidUseLibZipSharp)` to the `.csproj` file solves the issue:

    <_AndroidUseLibZipSharp>true</_AndroidUseLibZipSharp>

Reviewing, a `.binlog` created by setting `%MSBUILDDEBUGENGINE%=1` and launching Visual Studio, we see the message:

    Task BuildArchive
    ...
    Using System.IO.Compression because no uncompressed file extensions were specified.

So, we are relying on .NET Framework's `System.IO.Compression` to handle `.apk` creation in some cases. `libZipSharp` *was created* because of bugs in .NET Framework's & Mono's implementation of `System.IO.Compression` that caused issues with Android packaging.

To fix this, we will always use `libZipSharp` for .NET Framework, regardless if files are compressed or not.