### PR TITLE
Update TSA Area Path to DevDiv\.NET MAUI\Android

### DIFF
--- a/.gdn/tsaoptions-v2.json
+++ b/.gdn/tsaoptions-v2.json
@@ -5,7 +5,7 @@
   ],
   "instanceUrl": "https://devdiv.visualstudio.com/",
   "projectName": "DevDiv",
-  "areaPath": "DevDiv\\VS Client - Runtime SDKs\\Android",
+  "areaPath": "DevDiv\\.NET MAUI\\Android",
   "iterationPath": "DevDiv",
   "allTools": true
 }

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -435,6 +435,7 @@ extends:
         windowsImageOverride: $(WindowsPoolImage1ESPT)
         stageDependsOn: []
         tsaConfigFile: $(Build.SourcesDirectory)\.gdn\tsaoptions-v2.json
+        tsaUploadEnabled: true
         policheckLocScanEnabled: true
         policheckExclusionFilesFolder: $(Build.SourcesDirectory)\.gdn\policheck
         policheckGdnSuppressionFilesFolder: $(Build.SourcesDirectory)\.gdn\policheck


### PR DESCRIPTION
by changing the area path in AzDO, I accidentally broke the integration with TSA. This PR fixes the area path to point to the correct location. 