### PR TITLE
[CoreCLR] Remove unnecessary logging

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -247,7 +247,6 @@ namespace Java.Interop {
 				}
 			}
 
-			Logger.Log (LogLevel.Info, "monodroid", $"Loaded type: {ret}");
 			return ret;
 		}
 

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -209,7 +209,11 @@ auto AssemblyStore::open_assembly (std::string_view const& name, int64_t &size) 
 
 	const AssemblyStoreIndexEntry *hash_entry = find_assembly_store_entry (name_hash, assembly_store_hashes, assembly_store.index_entry_count);
 	if (hash_entry == nullptr) {
-		log_warn (LOG_ASSEMBLY, "Assembly '{}' (hash 0x{:x}) not found"sv, optional_string (name.data ()), name_hash);
+		// This message should really be `log_warn`, but since CoreCLR attempts to load `AssemblyName.ni.dll` for each
+		// `AssemblyName.dll`, it creates a lot of non-actionable noise.
+		// TODO (in separate PR): generate hashes for the .ni.dll names and ignore them at the top of the function. Then restore
+		// `log_warn` here.
+		log_debug (LOG_ASSEMBLY, "Assembly '{}' (hash 0x{:x}) not found"sv, optional_string (name.data ()), name_hash);
 		return nullptr;
 	}
 

--- a/src/native/clr/host/host-jni.cc
+++ b/src/native/clr/host/host-jni.cc
@@ -8,8 +8,6 @@ using namespace xamarin::android;
 JNIEXPORT jint JNICALL
 JNI_OnLoad (JavaVM *vm, void *reserved)
 {
-	log_write (LOG_DEFAULT, LogLevel::Info, "JNI_OnLoad");
-
 	return Host::Java_JNI_OnLoad (vm, reserved);
 }
 

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -567,7 +567,6 @@ auto Host::get_java_class_name_for_TypeManager (jclass klass) noexcept -> char*
 
 auto Host::Java_JNI_OnLoad (JavaVM *vm, [[maybe_unused]] void *reserved) noexcept -> jint
 {
-	log_write (LOG_DEFAULT, LogLevel::Info, "Host OnLoad");
 	jvm = vm;
 
 	JNIEnv *env = nullptr;

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -91,7 +91,7 @@ namespace xamarin::android {
 				}
 			}
 
-			log_warn (LOG_DEFAULT, "Creating public update directory: `{}`", override_dir);
+			log_debug (LOG_DEFAULT, "Creating public update directory: `{}`", override_dir);
 			Util::create_public_directory (override_dir);
 		}
 

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -52,7 +52,7 @@ void
 Util::create_public_directory (std::string_view const& dir)
 {
 	mode_t m = umask (0);
-	int ret = mkdir (dir.data (), 0777);
+	int ret = create_directory (dir.data (), 0777);
 	if (ret < 0) {
 		if (errno == EEXIST) {
 			// Try to change the mode, just in case


### PR DESCRIPTION
Logging to logcat in Android is expensive and unpredictable in
terms of how much time it takes exactly.  Therefore, we try to
log as little as possible by default, reducing the delays.

This PR removes (or demotes to a lower priority) a number of log 
messages that were useful during testing and development, but are
an unnecessary noise for day-to-day app operation.