### PR TITLE
[build] update Android SDK components

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:dev/peppers/android-36@fcbeaa633aa5c03b6f044b6ab87727e6160177fc
+DevDiv/android-platform-support:main@4ee7f1c8cbf2b0d4cc661c6684f61e6e29676021

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@a8c83d7e7f77634433086d79fa3674f63cef3098
+DevDiv/android-platform-support:dev/peppers/android-36@fcbeaa633aa5c03b6f044b6ab87727e6160177fc

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:dev/peppers/platform-tools-fix@372a6b1f14eeb84f9f79a36b46167b041348d005
+DevDiv/android-platform-support:main@4ee7f1c8cbf2b0d4cc661c6684f61e6e29676021

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@4ee7f1c8cbf2b0d4cc661c6684f61e6e29676021
+DevDiv/android-platform-support:main@3240f99cd6fc6ef50ec86ea9ffb1e4d9082e83a3

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@4ee7f1c8cbf2b0d4cc661c6684f61e6e29676021
+DevDiv/android-platform-support:dev/peppers/platform-tools-fix@372a6b1f14eeb84f9f79a36b46167b041348d005

--- a/Configuration.props
+++ b/Configuration.props
@@ -118,10 +118,10 @@
     <XABuildToolsPackagePrefixLinux></XABuildToolsPackagePrefixLinux>
     <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">$(XABuildToolsPackagePrefixMacOS)</XABuildToolsPackagePrefix>
     <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Windows' ">$(XABuildToolsPackagePrefixWindows)</XABuildToolsPackagePrefix>
-    <XABuildToolsVersion>35</XABuildToolsVersion>
-    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">35.0.0</XABuildToolsFolder>
+    <XABuildToolsVersion>36</XABuildToolsVersion>
+    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">36.0.0</XABuildToolsFolder>
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' "></XAPlatformToolsPackagePrefix>
-    <XAPlatformToolsVersion>34.0.5</XAPlatformToolsVersion>
+    <XAPlatformToolsVersion>36.0.0</XAPlatformToolsVersion>
     <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.17.0</XABundleToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != ''">$(NUGET_PACKAGES)</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>
@@ -156,8 +156,8 @@
     <AvdManagerToolExe Condition=" '$(AvdManagerToolExe)' == '' and '$(HostOS)' == 'Windows' ">avdmanager.bat</AvdManagerToolExe>
     <AndroidToolPath Condition=" '$(AndroidToolPath)' == '' ">$(AndroidSdkFullPath)\tools</AndroidToolPath>
     <AndroidToolsBinPath Condition=" '$(AndroidToolsBinPath)' == '' ">$(AndroidToolPath)\bin</AndroidToolsBinPath>
-    <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">12.0</CommandLineToolsFolder>
-    <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">11076708_latest</CommandLineToolsVersion>
+    <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">19.0</CommandLineToolsFolder>
+    <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">13114758_latest</CommandLineToolsVersion>
     <CommandLineToolsBinPath Condition=" '$(CommandLineToolsBinPath)' == '' ">$(AndroidSdkFullPath)\cmdline-tools\$(CommandLineToolsFolder)\bin</CommandLineToolsBinPath>
     <!-- Version numbers and PkgVersion are found in https://dl-ssl.google.com/android/repository/repository2-3.xml -->
     <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">9364964</EmulatorVersion>

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.Linux.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.Linux.cs
@@ -9,5 +9,6 @@ namespace Xamarin.Android.Prepare
 		static readonly string osTag = "linux";
 		static readonly string altOsTag = osTag;
 		static readonly string cltOsTag = osTag;
+		static readonly string pltOsTag = osTag;
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.MacOS.cs
@@ -5,5 +5,6 @@ namespace Xamarin.Android.Prepare
 		static readonly string osTag = "darwin";
 		static readonly string altOsTag = "macosx";
 		static readonly string cltOsTag = "mac";
+		static readonly string pltOsTag = osTag;
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.Windows.cs
@@ -5,5 +5,6 @@ namespace Xamarin.Android.Prepare
 		static readonly string osTag = "windows";
 		static readonly string altOsTag = osTag;
 		static readonly string cltOsTag = "win";
+		static readonly string pltOsTag = cltOsTag;
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -117,7 +117,7 @@ namespace Xamarin.Android.Prepare
 					buildToolName: "android-sdk-cmdline-tools",
 					buildToolVersion: $"{CommandLineToolsFolder}.{CommandLineToolsVersion}"
 				),
-				new AndroidToolchainComponent ($"{XAPlatformToolsPackagePrefix}platform-tools_r{XAPlatformToolsVersion}-{osTag}",
+				new AndroidToolchainComponent ($"{XAPlatformToolsPackagePrefix}platform-tools_r{XAPlatformToolsVersion}-{pltOsTag}",
 					destDir: "platform-tools",
 					pkgRevision: XAPlatformToolsVersion,
 					buildToolName: "android-sdk-platform-tools",


### PR DESCRIPTION
Updates:

* `build-tools`: 35.0.0 -> 36.0.0
* `platform-tools`: 34.0.5 -> 36.0.0
* `cmdline-tools`: 12.0 -> 19.0

Specifically wanting a newer `platform-tools` to hopefully fix test failures in:

    InstallAndroidDependenciesTest("GoogleV2")
    _AndroidSdkDirectory was not set to new SDK path C:\a\_work\1\a\TestRelease\06-24_17.18.26\temp\InstallAndroidDependenciesTestGoogleV2\android-sdk. Please check the task output in 'install-deps.log'
    Expected: True
    But was:  False

It appears that `-t:InstallAndroidDependencies -p:AndroidManifestType=GoogleV2` is not installing `platform-tools` as the `34.0.5` version is not found in Google's manifest.