### PR TITLE
[CoreCLR] Ignore some assemblies when asked to load them

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -247,10 +247,6 @@ namespace Java.Interop {
 				}
 			}
 
-			if (Logger.LogAssembly) {
-				Logger.Log (LogLevel.Info, "monodroid", $"Loaded type: {ret}");
-			}
-
 			return ret;
 		}
 

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -247,6 +247,10 @@ namespace Java.Interop {
 				}
 			}
 
+			if (Logger.LogAssembly) {
+				Logger.Log (LogLevel.Info, "monodroid", $"Loaded type: {ret}");
+			}
+
 			return ret;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAssemblyStore.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAssemblyStore.cs
@@ -28,13 +28,20 @@ public class CreateAssemblyStore : AndroidTask
 	[Required]
 	public string [] SupportedAbis { get; set; } = [];
 
+	[Required]
+	public string TargetRuntime { get; set; } = "";
+
 	public bool UseAssemblyStore { get; set; }
 
 	[Output]
 	public ITaskItem [] AssembliesToAddToArchive { get; set; } = [];
 
+	AndroidRuntime targetRuntime;
+
 	public override bool RunTask ()
 	{
+		targetRuntime = MonoAndroidHelper.ParseAndroidRuntime (TargetRuntime);
+
 		// Get all the user and framework assemblies we may need to package
 		var assemblies = ResolvedFrameworkAssemblies.Concat (ResolvedUserAssemblies).Where (asm => !(ShouldSkipAssembly (asm))).ToArray ();
 
@@ -43,7 +50,7 @@ public class CreateAssemblyStore : AndroidTask
 			return !Log.HasLoggedErrors;
 		}
 
-		var store_builder = new AssemblyStoreBuilder (Log);
+		var store_builder = new AssemblyStoreBuilder (Log, targetRuntime);
 		var per_arch_assemblies = MonoAndroidHelper.GetPerArchAssemblies (assemblies, SupportedAbis, true);
 
 		foreach (var kvp in per_arch_assemblies) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreAssemblyInfo.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreAssemblyInfo.cs
@@ -16,8 +16,9 @@ class AssemblyStoreAssemblyInfo
 	public byte[] AssemblyNameNoExtBytes { get; }
 	public FileInfo? SymbolsFile         { get; set; }
 	public FileInfo? ConfigFile          { get; set; }
+	public bool Ignored                  { get; }
 
-	public AssemblyStoreAssemblyInfo (string sourceFilePath, ITaskItem assembly)
+	public AssemblyStoreAssemblyInfo (string sourceFilePath, ITaskItem assembly, bool assemblyIsIgnored = false)
 	{
 		Arch = MonoAndroidHelper.GetTargetArch (assembly);
 		if (Arch == AndroidTargetArch.None) {
@@ -25,6 +26,7 @@ class AssemblyStoreAssemblyInfo
 		}
 
 		SourceFile = new FileInfo (sourceFilePath);
+		Ignored = assemblyIsIgnored;
 
 		string? name = Path.GetFileName (SourceFile.Name);
 		if (name == null) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreBuilder.cs
@@ -13,10 +13,12 @@ class AssemblyStoreBuilder
 {
 	readonly TaskLoggingHelper log;
 	readonly AssemblyStoreGenerator storeGenerator;
+	readonly AndroidRuntime targetRuntime;
 
-	public AssemblyStoreBuilder (TaskLoggingHelper log)
+	public AssemblyStoreBuilder (TaskLoggingHelper log, AndroidRuntime targetRuntime)
 	{
 		this.log = log;
+		this.targetRuntime = targetRuntime;
 		storeGenerator = new (log);
 	}
 
@@ -38,6 +40,24 @@ class AssemblyStoreBuilder
 			}
 		}
 
+		storeGenerator.Add (storeAssemblyInfo);
+
+		ClrAddIgnoredNativeImageAssembly (assemblyItem);
+	}
+
+	// When CoreCLR tries to load an assembly (say `AssemblyName.dll`) it will always first try to load
+	// a "native image" assembly from `AssemblyName.ni.dll` which will **never** exist. The native image
+	// assemblies were once supported only on Windows and were never (nor will ever be) supported on
+	// Unix. In order to speed up load times, we add an empty entry for each `*.ni.dll` to the assembly
+	// store index.
+	void ClrAddIgnoredNativeImageAssembly (ITaskItem assemblyItem)
+	{
+		if (targetRuntime != AndroidRuntime.CoreCLR) {
+			return;
+		}
+
+		string ignoredName = Path.GetFileName (Path.ChangeExtension (assemblyItem.ItemSpec, ".ni.dll"));
+		var storeAssemblyInfo = new AssemblyStoreAssemblyInfo (ignoredName, assemblyItem, assemblyIsIgnored: true);
 		storeGenerator.Add (storeAssemblyInfo);
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreGenerator.Classes.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreGenerator.Classes.cs
@@ -32,18 +32,21 @@ partial class AssemblyStoreGenerator
 
 	sealed class AssemblyStoreIndexEntry
 	{
-		public const uint NativeSize32 = 2 * sizeof (uint);
-		public const uint NativeSize64 = sizeof (ulong) + sizeof (uint);
+		// We treat `bool` as `byte` here, since that's what gets written to the binary
+		public const uint NativeSize32 = 2 * sizeof (uint) + sizeof (byte);
+		public const uint NativeSize64 = sizeof (ulong) + sizeof (uint) + sizeof (byte);
 
 		public readonly string name;
 		public readonly ulong name_hash;
 		public readonly uint  descriptor_index;
+		public readonly bool ignore;
 
-		public AssemblyStoreIndexEntry (string name, ulong name_hash, uint descriptor_index)
+		public AssemblyStoreIndexEntry (string name, ulong name_hash, uint descriptor_index, bool ignore)
 		{
 			this.name = name;
 			this.name_hash = name_hash;
 			this.descriptor_index = descriptor_index;
+			this.ignore = ignore;
 		}
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2288,6 +2288,7 @@ because xbuild doesn't support framework reference assemblies.
   -->
   <CreateAssemblyStore
       Condition=" '$(_AndroidRuntime)' != 'NativeAOT' "
+      TargetRuntime="$(_AndroidRuntime)"
       AppSharedLibrariesDir="$(_AndroidApplicationSharedLibraryPath)"
       IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
       ResolvedFrameworkAssemblies="@(_BuildApkResolvedFrameworkAssemblies)"

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -211,7 +211,7 @@ auto AssemblyStore::open_assembly (std::string_view const& name, int64_t &size) 
 	if (hash_entry == nullptr) {
 		// This message should really be `log_warn`, but since CoreCLR attempts to load `AssemblyName.ni.dll` for each
 		// `AssemblyName.dll`, it creates a lot of non-actionable noise.
-		// TODO (in separate PR): generate hashes for the .ni.dll names and ignore them at the top of the function. Then restore
+		// TODO: generate hashes for the .ni.dll names and ignore them at the top of the function. Then restore
 		// `log_warn` here.
 		log_debug (LOG_ASSEMBLY, "Assembly '{}' (hash 0x{:x}) not found"sv, optional_string (name.data ()), name_hash);
 		return nullptr;

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -195,7 +195,6 @@ auto AssemblyStore::find_assembly_store_entry (hash_t hash, const AssemblyStoreI
 auto AssemblyStore::open_assembly (std::string_view const& name, int64_t &size) noexcept -> void*
 {
 	hash_t name_hash = xxhash::hash (name.data (), name.length ());
-	log_debug (LOG_ASSEMBLY, "AssemblyStore::open_assembly: looking for bundled name: '{}' (hash {:x})"sv, optional_string (name.data ()), name_hash);
 
 	if constexpr (Constants::is_debug_build) {
 		// In fastdev mode we might not have any assembly store.
@@ -206,17 +205,19 @@ auto AssemblyStore::open_assembly (std::string_view const& name, int64_t &size) 
 	}
 
 	const AssemblyStoreIndexEntry *hash_entry = find_assembly_store_entry (name_hash, assembly_store_hashes, assembly_store.index_entry_count);
-	if (hash_entry == nullptr) {
+	if (hash_entry == nullptr) [[unlikely]] {
+		size = 0;
 		log_warn (LOG_ASSEMBLY, "Assembly '{}' (hash 0x{:x}) not found"sv, name, name_hash);
 		return nullptr;
 	}
 
-	if (hash_entry->descriptor_index >= assembly_store.assembly_count) {
-		if (hash_entry->descriptor_index == ASSEMBLY_STORE_IGNORED_INDEX_ENTRY) {
-			log_debug (LOG_ASSEMBLY, "Assembly '{}' ignored"sv, name);
-			return nullptr;
-		}
+	if (hash_entry->ignore != 0) {
+		size = 0;
+		log_debug (LOG_ASSEMBLY, "Assembly '{}' ignored"sv, name);
+		return nullptr;
+	}
 
+	if (hash_entry->descriptor_index >= assembly_store.assembly_count) {
 		Helpers::abort_application (
 			LOG_ASSEMBLY,
 			std::format (

--- a/src/native/clr/include/constants.hh
+++ b/src/native/clr/include/constants.hh
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <sys/system_properties.h>
 
+#include <limits>
 #include <string_view>
 
 #include <shared/cpp-util.hh>

--- a/src/native/clr/include/host/assembly-store.hh
+++ b/src/native/clr/include/host/assembly-store.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <mutex>
 #include <string_view>
 #include <tuple>
@@ -11,6 +12,10 @@
 namespace xamarin::android {
 	class AssemblyStore
 	{
+		using assembly_index_t = decltype(AssemblyStoreIndexEntry::descriptor_index);
+
+		static constexpr assembly_index_t ASSEMBLY_STORE_IGNORED_INDEX_ENTRY = std::numeric_limits<assembly_index_t>::max ();
+
 	public:
 		static auto open_assembly (std::string_view const& name, int64_t &size) noexcept -> void*;
 

--- a/src/native/clr/include/host/assembly-store.hh
+++ b/src/native/clr/include/host/assembly-store.hh
@@ -12,10 +12,6 @@
 namespace xamarin::android {
 	class AssemblyStore
 	{
-		using assembly_index_t = decltype(AssemblyStoreIndexEntry::descriptor_index);
-
-		static constexpr assembly_index_t ASSEMBLY_STORE_IGNORED_INDEX_ENTRY = std::numeric_limits<assembly_index_t>::max ();
-
 	public:
 		static auto open_assembly (std::string_view const& name, int64_t &size) noexcept -> void*;
 

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -31,7 +31,7 @@ static constexpr uint32_t ASSEMBLY_STORE_ABI = 0x00040000;
 #endif
 
 // Increase whenever an incompatible change is made to the assembly store format
-static constexpr uint32_t ASSEMBLY_STORE_FORMAT_VERSION = 2 | ASSEMBLY_STORE_64BIT_FLAG | ASSEMBLY_STORE_ABI;
+static constexpr uint32_t ASSEMBLY_STORE_FORMAT_VERSION = 3 | ASSEMBLY_STORE_64BIT_FLAG | ASSEMBLY_STORE_ABI;
 
 static constexpr uint32_t MODULE_MAGIC_NAMES = 0x53544158; // 'XATS', little-endian
 static constexpr uint32_t MODULE_INDEX_MAGIC = 0x49544158; // 'XATI', little-endian
@@ -153,6 +153,7 @@ struct XamarinAndroidBundledAssembly
 // [HEADER]
 // [INDEX]
 // [ASSEMBLY_DESCRIPTORS]
+// [ASSEMBLY_NAMES]
 // [ASSEMBLY DATA]
 //
 // Formats of the sections above are as follows:
@@ -167,6 +168,7 @@ struct XamarinAndroidBundledAssembly
 // INDEX (variable size, HEADER.ENTRY_COUNT*2 entries, for assembly names with and without the extension)
 //  [NAME_HASH]          uint on 32-bit platforms, ulong on 64-bit platforms; xxhash of the assembly name
 //  [DESCRIPTOR_INDEX]   uint; index into in-store assembly descriptor array
+//  [IGNORE]             byte; if set to anything other than 0, the assembly is to be ignored when loading
 //
 // ASSEMBLY_DESCRIPTORS (variable size, HEADER.ENTRY_COUNT entries), each entry formatted as follows:
 //  [MAPPING_INDEX]      uint; index into a runtime array where assembly data pointers are stored
@@ -199,6 +201,7 @@ struct [[gnu::packed]] AssemblyStoreIndexEntry final
 {
 	xamarin::android::hash_t name_hash;
 	uint32_t descriptor_index;
+	uint8_t ignore; // Assembly should be ignored when loading, its data isn't actually there
 };
 
 struct [[gnu::packed]] AssemblyStoreEntryDescriptor final

--- a/src/native/mono/monodroid/embedded-assemblies.cc
+++ b/src/native/mono/monodroid/embedded-assemblies.cc
@@ -418,8 +418,13 @@ EmbeddedAssemblies::assembly_store_open_from_bundles (dynamic_local_string<SENSI
 	log_debug (LOG_ASSEMBLY, "assembly_store_open_from_bundles: looking for bundled name: '{}' (hash {:x})", optional_string (name.get ()), name_hash);
 
 	const AssemblyStoreIndexEntry *hash_entry = find_assembly_store_entry (name_hash, assembly_store_hashes, assembly_store.index_entry_count);
-	if (hash_entry == nullptr) {
+	if (hash_entry == nullptr) [[unlikely]] {
 		log_warn (LOG_ASSEMBLY, "Assembly '{}' (hash {:x}) not found", optional_string (name.get ()), name_hash);
+		return nullptr;
+	}
+
+	if (hash_entry->ignore != 0) {
+		log_debug (LOG_ASSEMBLY, "Assembly '{}' ignored"sv, optional_string (name.get ()));
 		return nullptr;
 	}
 

--- a/src/native/mono/xamarin-app-stub/xamarin-app.hh
+++ b/src/native/mono/xamarin-app-stub/xamarin-app.hh
@@ -34,7 +34,7 @@ static constexpr uint32_t ASSEMBLY_STORE_ABI = 0x00040000;
 #endif
 
 // Increase whenever an incompatible change is made to the assembly store format
-static constexpr uint32_t ASSEMBLY_STORE_FORMAT_VERSION = 2 | ASSEMBLY_STORE_64BIT_FLAG | ASSEMBLY_STORE_ABI;
+static constexpr uint32_t ASSEMBLY_STORE_FORMAT_VERSION = 3 | ASSEMBLY_STORE_64BIT_FLAG | ASSEMBLY_STORE_ABI;
 
 static constexpr uint32_t MODULE_MAGIC_NAMES = 0x53544158; // 'XATS', little-endian
 static constexpr uint32_t MODULE_INDEX_MAGIC = 0x49544158; // 'XATI', little-endian
@@ -149,6 +149,7 @@ struct XamarinAndroidBundledAssembly
 // INDEX (variable size, HEADER.ENTRY_COUNT*2 entries, for assembly names with and without the extension)
 //  [NAME_HASH]          uint on 32-bit platforms, ulong on 64-bit platforms; xxhash of the assembly name
 //  [DESCRIPTOR_INDEX]   uint; index into in-store assembly descriptor array
+//  [IGNORE]             byte; if set to anything other than 0, the assembly is to be ignored when loading
 //
 // ASSEMBLY_DESCRIPTORS (variable size, HEADER.ENTRY_COUNT entries), each entry formatted as follows:
 //  [MAPPING_INDEX]      uint; index into a runtime array where assembly data pointers are stored
@@ -181,6 +182,7 @@ struct [[gnu::packed]] AssemblyStoreIndexEntry final
 {
 	xamarin::android::hash_t name_hash;
 	uint32_t descriptor_index;
+	uint8_t ignore; // Assembly should be ignored when loading, its data isn't actually there
 };
 
 struct [[gnu::packed]] AssemblyStoreEntryDescriptor final

--- a/tools/assembly-store-reader-mk2/AssemblyStore/AssemblyStoreItem.cs
+++ b/tools/assembly-store-reader-mk2/AssemblyStore/AssemblyStoreItem.cs
@@ -16,11 +16,13 @@ abstract class AssemblyStoreItem
 	public uint ConfigOffset            { get; protected set; }
 	public uint ConfigSize              { get; protected set; }
 	public AndroidTargetArch TargetArch { get; protected set; }
+	public bool Ignore                  { get; }
 
-	protected AssemblyStoreItem (string name, bool is64Bit, List<ulong> hashes)
+	protected AssemblyStoreItem (string name, bool is64Bit, List<ulong> hashes, bool ignore)
 	{
 		Name = name;
 		Hashes = hashes.AsReadOnly ();
 		Is64Bit = is64Bit;
+		Ignore = ignore;
 	}
 }

--- a/tools/assembly-store-reader-mk2/AssemblyStore/StoreReader_V2.Classes.cs
+++ b/tools/assembly-store-reader-mk2/AssemblyStore/StoreReader_V2.Classes.cs
@@ -32,11 +32,13 @@ partial class StoreReader_V2
 	{
 		public readonly ulong name_hash;
 		public readonly uint  descriptor_index;
+		public readonly bool  ignore;
 
-		public IndexEntry (ulong name_hash, uint descriptor_index)
+		public IndexEntry (ulong name_hash, uint descriptor_index, bool ignore)
 		{
 			this.name_hash = name_hash;
 			this.descriptor_index = descriptor_index;
+			this.ignore = ignore;
 		}
 	}
 
@@ -56,8 +58,8 @@ partial class StoreReader_V2
 
 	sealed class StoreItem_V2 : AssemblyStoreItem
 	{
-		public StoreItem_V2 (AndroidTargetArch targetArch, string name, bool is64Bit, List<IndexEntry> indexEntries, EntryDescriptor descriptor)
-			: base (name, is64Bit, IndexToHashes (indexEntries))
+		public StoreItem_V2 (AndroidTargetArch targetArch, string name, bool is64Bit, List<IndexEntry> indexEntries, EntryDescriptor descriptor, bool ignore)
+			: base (name, is64Bit, IndexToHashes (indexEntries), ignore)
 		{
 			DataOffset = descriptor.data_offset;
 			DataSize = descriptor.data_size;
@@ -84,11 +86,13 @@ partial class StoreReader_V2
 		public readonly string Name;
 		public readonly List<IndexEntry> IndexEntries = new List<IndexEntry> ();
 		public readonly EntryDescriptor Descriptor;
+		public readonly bool Ignored;
 
-		public TemporaryItem (string name, EntryDescriptor descriptor)
+		public TemporaryItem (string name, EntryDescriptor descriptor, bool ignored)
 		{
 			Name = name;
 			Descriptor = descriptor;
+			Ignored = ignored;
 		}
 	}
 }

--- a/tools/assembly-store-reader-mk2/StorePrettyPrinter.cs
+++ b/tools/assembly-store-reader-mk2/StorePrettyPrinter.cs
@@ -36,16 +36,21 @@ class StorePrettyPrinter
 		foreach (AssemblyStoreItem assembly in assemblies) {
 			line.Clear ();
 			line.Append ("  ");
-			line.AppendLine (assembly.Name);
-			line.Append ("    PE image data: ");
-			FormatOffsetAndSize (line, assembly.DataOffset, assembly.DataSize);
-			line.AppendLine ();
-			line.Append ("       Debug data: ");
-			FormatOffsetAndSize (line, assembly.DebugOffset, assembly.DebugSize);
-			line.AppendLine ();
-			line.Append ("      Config data: ");
-			FormatOffsetAndSize (line, assembly.ConfigOffset, assembly.ConfigSize);
-			line.AppendLine ();
+			line.Append (assembly.Name);
+			if (assembly.Ignore) {
+				line.AppendLine (" <IGNORED>");
+			} else {
+				line.AppendLine ();
+				line.Append ("    PE image data: ");
+				FormatOffsetAndSize (line, assembly.DataOffset, assembly.DataSize);
+				line.AppendLine ();
+				line.Append ("       Debug data: ");
+				FormatOffsetAndSize (line, assembly.DebugOffset, assembly.DebugSize);
+				line.AppendLine ();
+				line.Append ("      Config data: ");
+				FormatOffsetAndSize (line, assembly.ConfigOffset, assembly.ConfigSize);
+				line.AppendLine ();
+			}
 			line.Append ("      Name hashes: ");
 			FormatHashes (line, assembly.Hashes);
 			line.AppendLine ();


### PR DESCRIPTION
Ignore assemblies whose names end in `.ni` and `.ni.dll`, when 
a load request is made via the CoreCLR host contract callback.

For each CoreCLR will ask to first load `Assembly.ni.dll`, NI
standing for Native Image. This is something that was used on
Windows long ago and it never was, nor will it be, supported on
Unix.

This is mostly a cosmetic change in that it prevents a false
warning about a missing assembly from being logged in logcat.
This, in itself, is a startup time improvement since those
warnings would always be logged during every application launch,
with logcat logging being very expensive (and unpredictable).

The message about a missing `.ni.dll` is still logged, but with
the Debug severity, which will cause it to show up only if the
`assembly` logging category is enabled (it is disabled by default)