### PR TITLE
[copilot] allow `copilot-setup-steps.yml` to fail

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,14 +18,16 @@ jobs:
       with:
         dotnet-version: '9.x'
 
-    - name: Run jenkins build
+    - name: Run android build
+      id: android-build
+      continue-on-error: true
       run: |
         make jenkins PREPARE_CI=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=Debug
       timeout-minutes: 60
 
     - name: Upload logs
       uses: actions/upload-artifact@v4
-      if: failure()
+      if: steps.android-build.outcome == 'failure'
       with:
         name: copilot-artifacts
         path: |


### PR DESCRIPTION
We found Copilot can go off track if:

* Copilot commits a build error (of any kind).
* You comment suggesting how to fix the build error.
* Copilot setup steps will now fail, and Copilot can't fix it!

So, once you are in this state, you can't really get Copilot back on track unless you manually fix it.

Going forward, we should:

* Allow the "build" step to fail
* Upload the logs as an artifact

Copilot should be able to do its work with a failing build.