### PR TITLE
[nuget.config] see if we can remove `dotnet9` feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,12 +9,10 @@
     <!-- ensure only the sources defined below are used -->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
-    <!-- This is for packages needed by debugger-libs -->
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
-    <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
+    <!-- This is for packages needed by debugger-libs -->
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <!-- Added manually for dotnet/runtime 9.0.5 -->
     <add key="darc-pub-dotnet-emsdk-3cddc1f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-3cddc1fe/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-runtime-207cda3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-207cda34/nuget/v3/index.json" />


### PR DESCRIPTION
I also moved the `dotnet-tools` feed down, as we've seen it timeout occasionally:

    Determining projects to restore...
    Retrying 'FindPackagesByIdAsync' for source 'https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/4828dfac-e9f8-49bc-acb6-319be99331fc/nuget/v3/flat2/xamarin.androidx.lifecycle.livedata.core.ktx/index.json'.
      The HTTP request to 'GET https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/4828dfac-e9f8-49bc-acb6-319be99331fc/nuget/v3/flat2/xamarin.androidx.lifecycle.livedata.core.ktx/index.json' has timed out after 100000ms.