### PR TITLE
Bump to DevDiv/android-platform-support/main@ab514b7a

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@3240f99cd6fc6ef50ec86ea9ffb1e4d9082e83a3
+DevDiv/android-platform-support:main@ab514b7a60a2bdbcb55e05fd847c5337ef648687

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1482,7 +1482,7 @@ namespace UnnamedProject
 		[NonParallelizable]
 		public void CheckLintErrorsAndWarnings ()
 		{
-			string disabledIssues = "StaticFieldLeak,ObsoleteSdkInt,AllowBackup,ExportedReceiver,RedundantLabel";
+			string disabledIssues = "StaticFieldLeak,ObsoleteSdkInt,AllowBackup,ExportedReceiver,RedundantLabel,AppLinkWarning";
 
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("AndroidLintEnabled", true.ToString ());


### PR DESCRIPTION
Changes: https://devdiv.visualstudio.com/DevDiv/_git/android-platform-support/branchCompare?baseVersion=GC3240f99cd6fc6ef50ec86ea9ffb1e4d9082e83a3&targetVersion=GCab514b7a60a2bdbcb55e05fd847c5337ef648687

* [manifest] set `path="cmdline-tools;19.0"`
* [xabdt] fix env vars containing `=` sign
* Recommend cmdline-tools 19.0
* Bump dotnet/android-tools/main@8a09cf7

Other changes:

* `CheckLintErrorsAndWarnings` test, ignores `AppLinkWarning`

    XA0102:  This intent filter has the format of an Android App Link but is missing the autoVerify attribute; add android:autoVerify="true" to ensure your domain will be validated and enable App Link-related Lint warnings. If you do not want clicked URLs to bring the user to your app, remove the android.intent.category.BROWSABLE category, or set android:autoVerify="false" to make it clear this is not intended to be an Android App Link. [AppLinkWarning]

This is likely caused by the new `lint` tool introduced in `cmdline-tools;19.0`.

Since the test looks like it would require a new API to really fix it, I disabled the warning for now.