### PR TITLE
[native] Ensure function_name() is part of log message

### DIFF
--- a/src/native/mono/shared/helpers.cc
+++ b/src/native/mono/shared/helpers.cc
@@ -35,7 +35,7 @@ Helpers::abort_application (LogCategories category, const char *message, bool lo
 
 		log_fatal (
 			category,
-			"Abort at {}:{}:{} ('%s')",
+			"Abort at {}:{}:{} ('{}')",
 			file_name,
 			sloc.line (),
 			sloc.column (),


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/117733

When a .NET for Android app aborts, the abort message should contain the file name, line number, column, and function name of the function which triggered the abort.

Insteda, we get the filename, line number, and column, but we get `%s` for the function name:

    F monodroid: Abort at mono-log-adapter.cc:46:3 ('%s')

Update the `log_fatal()` invocation within `mono-log-adapter.cc` to use `{}` instead of `%s`, in accordance with C++ `std::format`. This should cause `sloc.function_name()` to be properly part of the abort message.