### PR TITLE
[tests] fix `GetString_Many()` test

### DIFF
--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/NUnitInstrumentation.cs
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/NUnitInstrumentation.cs
@@ -47,7 +47,6 @@ namespace UnitTestRunner
 				"AndroidNotWorking",
 				"CAS",
 				"InetAccess",
-				"MobileNotWorking",
 				"NotWorking",
 			};
 

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -887,12 +887,11 @@ namespace Xamarin.Android.NetTests {
 		}
 
 		[Test]
-		[Category ("MobileNotWorking")] // Missing encoding
 		public void GetString_Many ()
 		{
 			var client = new HttpClient (CreateHandler ());
-			var t1 = client.GetStringAsync ("http://example.org");
-			var t2 = client.GetStringAsync ("http://example.org");
+			var t1 = client.GetStringAsync ("https://google.com");
+			var t2 = client.GetStringAsync ("https://google.com");
 			Assert.IsTrue (Task.WaitAll (new [] { t1, t2 }, WaitTimeout));
 		}
 


### PR DESCRIPTION
The test is currently failing with:

    Expected: True
    But was:  False
    Stack trace
       at Xamarin.Android.NetTests.HttpClientIntegrationTestBase.GetString_Many()
       at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
       at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object , BindingFlags )

If I navigate to http://example.org in a browser, I just get a DNS error.

There are other tests in here that use https://google.com instead, so I switched to use it.

I also removed the `MobileNotWorking` category, which doesn't appear to be actually ignored because the test is running?