### PR TITLE
`$(AndroidPackVersionSuffix)=rc.1`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>36.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/10.0.1xx-preview7

We branched for .NET 10 Preview 7 from 510fc086 into `release/10.0.1xx-preview7`; the main branch is now .NET 10 RC 1.