### PR TITLE
[build] pack `Xamarin.Android.Tools.AndroidSdk`

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -60,6 +60,7 @@
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; build @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Sdk.Windows.binlog&quot; -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.NET.Sdk.Android.binlog&quot; &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Android.proj&quot;" />
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Microsoft.Android.Templates.binlog&quot; &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(_BinlogPrefix)Xamarin.Android.Tools.AndroidSdk.binlog&quot; &quot;$(XamarinAndroidSourcePath)external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj&quot;" />
     <ReplaceFileContents
         SourceFile="vs-workload.in.props"
         DestinationFile="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\vs-workload.props"

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -153,7 +153,8 @@
     <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
 
     <ItemGroup>
-      <ItemsToPush Include="$(OutputPath)*.nupkg" Kind="Package" />
+      <ItemsToPush Include="$(OutputPath)*.nupkg" Kind="Package" Exclude="$(OutputPath)Xamarin.Android.Tools.AndroidSdk.*.nupkg" />
+      <ItemsToPush Include="$(OutputPath)Xamarin.Android.Tools.AndroidSdk.*.nupkg" Kind="Package" IsShipping="false" ManifestArtifactData="Nonshipping=true" />
       <WorkloadArtifacts Include="$(OutputPath)*.zip" />
       <ItemsToPush Include="@(WorkloadArtifacts)" PublishFlatContainer="true" RelativeBlobPath="android/$(AndroidPackVersionLong)/%(Filename)%(Extension)" Kind="Blob" />
     </ItemGroup>

--- a/external/xamarin-android-tools.override.props
+++ b/external/xamarin-android-tools.override.props
@@ -3,6 +3,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AndroidToolsDisableMultiTargeting>true</AndroidToolsDisableMultiTargeting>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)..\bin\Build$(Configuration)\nuget-unsigned\</PackageOutputPath>
     <RestoreAdditionalProjectSources>
       https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-ef07c4f2/nuget/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-061c8b71/nuget/v3/index.json;


### PR DESCRIPTION
In order to consume `Xamarin.Android.Tools.AndroidSdk` more easily by other projects, let's build and redistribute it as a "transport pack".