### PR TITLE
[build] set `$(PackageVersionSuffix)` for dotnet/android-tools

### DIFF
--- a/external/xamarin-android-tools.override.props
+++ b/external/xamarin-android-tools.override.props
@@ -1,6 +1,8 @@
 <Project>
   <!-- Import $(LibZipSharpVersion) -->
   <Import Project="..\Directory.Build.props" />
+  <Import Project="..\Configuration.props" />
+  <Import Project="..\build-tools\scripts\XAVersionInfo.targets" />
   <PropertyGroup>
     <AndroidToolsDisableMultiTargeting>true</AndroidToolsDisableMultiTargeting>
     <PackageOutputPath>$(MSBuildThisFileDirectory)..\bin\Build$(Configuration)\nuget-unsigned\</PackageOutputPath>
@@ -9,4 +11,9 @@
       https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-061c8b71/nuget/v3/index.json;
     </RestoreAdditionalProjectSources>
   </PropertyGroup>
+  <Target Name="_GetXAVersionInfo" BeforeTargets="SetVersion" DependsOnTargets="GetXAVersionInfo">
+    <PropertyGroup>
+      <PackageVersionSuffix>-preview.$(PackVersionCommitCount)</PackageVersionSuffix>
+    </PropertyGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/android-tools/pull/259

This adds the suffix:

    <PackageVersionSuffix>-preview.$(PackVersionCommitCount)</PackageVersionSuffix>

In order to allow the package to be published as a "transport" package with a non-stable version:

    packages\microsoft.dotnet.arcade.sdk\10.0.0-beta.25367.5\tools\SdkTasks\PublishArtifactsInManifest.proj(124,5): error :
    Package 'Xamarin.Android.Tools.AndroidSdk' has stable version '1.0.104' but is targeted at a non-isolated feed 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json'