### PR TITLE
[tests] add a smoke test for `System.IO.Directory`

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="System\ExceptionTest.cs" />
     <Compile Include="System\TimeZoneTest.cs" />
     <Compile Include="System.Drawing\TypeConverterTest.cs" />
+    <Compile Include="System.IO\DirectoryTest.cs" />
     <Compile Include="System.IO\DriveInfoTest.cs" />
     <Compile Include="System.IO.Compression\GZipStreamTest.cs" />
     <Compile Include="System.Linq\LinqExpressionTest.cs" />

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System.IO/DirectoryTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System.IO/DirectoryTest.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+
+using NUnit.Framework;
+
+namespace System.IOTests;
+
+[TestFixture]
+public class DirectoryTest
+{
+    [Test]
+    public void GetFiles ()
+    {
+        var directory = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
+        Assert.IsTrue (Directory.Exists (directory), "Directory does not exist: " + directory);
+
+        // Write a file
+        File.WriteAllText (Path.Combine (directory, "testfile.txt"), "This is a test file.");
+
+        // Verify that GetFiles returns the file
+        string [] files = Directory.GetFiles (directory);
+        Assert.IsNotNull (files, "GetFiles returned null for directory: " + directory);
+        Assert.IsNotEmpty (files, "No files found in directory: " + directory);
+    }
+}


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10330

The problem fixed in #10330 makes me think we are missing a test.