### PR TITLE
Restore "[One .NET] fix GetAndroidDependencies target with --no-restore"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -333,5 +333,18 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 				builder.AssertHasNoWarnings ();
 			}
 		}
+		
+		[Test]
+		public void GetAndroidDependencies()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using var builder = CreateApkBuilder ();
+			builder.Save (proj);
+
+			var dotnet = new DotNetCLI (Path.Combine (Root, builder.ProjectDirectory, proj.ProjectFilePath));
+
+			// `dotnet build -t:GetAndroidDependencies --no-restore` should succeed
+			Assert.IsTrue (dotnet.Build (target: "GetAndroidDependencies", norestore: true), $"{proj.ProjectName} should succeed");
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -93,9 +93,11 @@ namespace Xamarin.ProjectTools
 			return Execute (arguments.ToArray ());
 		}
 
-		public bool Build (string target = null, string runtimeIdentifier = null, string [] parameters = null)
+		public bool Build (string target = null, string runtimeIdentifier = null, string [] parameters = null, bool norestore = false)
 		{
 			var arguments = GetDefaultCommandLineArgs ("build", target, runtimeIdentifier, parameters);
+			if (norestore)
+				arguments.Add ("--no-restore");
 			return Execute (arguments.ToArray ());
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -41,7 +41,7 @@ projects.
   </Target>
 
   <PropertyGroup>
-    <_ResolveSdksDependsOnTargets>ResolveTargetingPackAssets</_ResolveSdksDependsOnTargets>
+    <_ResolveSdksDependsOnTargets>ProcessFrameworkReferences</_ResolveSdksDependsOnTargets>
   </PropertyGroup>
 
   <Target Name="_ResolveSdks" DependsOnTargets="$(_ResolveSdksDependsOnTargets)">


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/a21d1a7d54e811c89e36969d1214f5e31fc4b63a

This reverts commit a84eccb8.

I've noticed the following sometimes happens when a new .NET MAUI project is created in VS 2022 on Windows:

    dotnet\sdk\6.0.200-preview.22055.18\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(267,5):
    error NETSDK1004: Assets file 'obj\project.assets.json' not found.
    Run a NuGet package restore to generate this file.

I seem to only get this for MAUI projects and only *sometimes*. `dotnet new android` projects seem to always work fine.

When this error occurs, I think the dropdown fails to load the device list. What you end up with is the play button that just says `> Android Emulator`. After some amount of "fiddling", you can get the IDE to load the device list.

What I think is happening is:

1. NuGet restore takes longer in MAUI projects than `dotnet new android`

2. Sometimes `GetAndroidDependencies` runs *before* NuGet restore, and that triggers the above error.

I could validate this hypothesis with:

    > dotnet new android
    > dotnet build -t:GetAndroidDependencies --no-restore

And I get the above error! I could also reproduce in a test.