### PR TITLE
[xabt] suppress `XA0101` for Razor class libraries

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -769,6 +769,55 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		[Test]
+		public void ContentBuildActionForRazor ()
+		{
+			var lib = new XamarinAndroidLibraryProject {
+				Sdk = "Microsoft.NET.Sdk.Razor",
+				EnableDefaultItems = true,
+				PackageReferences = {
+					new Package { Id = "Microsoft.AspNetCore.Components.Web", Version = "9.0.0" },
+				},
+				Sources = {
+					new BuildItem.Content ("_Imports.razor") {
+						TextContent = () => """
+							@using System.Net.Http
+							@using System.Net.Http.Json
+							@using Microsoft.AspNetCore.Components.Forms
+							@using Microsoft.AspNetCore.Components.Routing
+							@using Microsoft.AspNetCore.Components.Web
+							@using static Microsoft.AspNetCore.Components.Web.RenderMode
+							@using Microsoft.AspNetCore.Components.Web.Virtualization
+							@using Microsoft.JSInterop
+						""",
+					},
+					new BuildItem.Content ("Pages/Hello.razor") {
+						TextContent = () => """
+							@page "/counter"
+							<PageTitle>Counter</PageTitle>
+							<h1>Counter</h1>
+							<p role="status">Current count: @currentCount</p>
+							<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+							@code {
+								private int currentCount = 0;
+
+								private void IncrementCount()
+								{
+									currentCount++;
+								}
+							}
+						""",
+					},
+					new BuildItem.Content ("wwwroot/favicon.png") {
+						BinaryContent = () => XamarinAndroidApplicationProject.icon_binary_mdpi,
+					}
+				}
+			};
+			using var b = CreateDllBuilder ();
+			Assert.IsTrue (b.Build (lib), "library should have built successfully");
+			b.AssertHasNoWarnings ();
+		}
+
 		// Combination of class libraries that triggered the problem:
 		// error APT2144: invalid file path 'obj/Release/net8.0-android/lp/86.stamp'.
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -842,7 +842,7 @@ because xbuild doesn't support framework reference assemblies.
   <ItemGroup>
     <_ContentIncludedForCheck
       Include="@(Content)"
-      Condition="'%(Content.ExcludeFromContentCheck)' != 'true'" />
+      Condition="'%(Content.ExcludeFromContentCheck)' != 'true' and '%(Content.ExcludeFromSingleFile)' != 'true'" />
   </ItemGroup>
 
   <LogWarningsForFiles


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/blob/1ed2f8e9751753a1d249d129884a669363c1b832/src/StaticWebAssetsSdk/Sdk/Sdk.StaticWebAssets.StaticAssets.ProjectSystem.props#L30-L31
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2533207

1. Create a `dotnet new maui-blazor-web` project.

2. Open the `*.Shared.csproj`, the Razor class library project.

3. Change the `$(TargetFramework)` from `net9.0` to `net9.0-android`.

4. Build the project.

Get the warnings:

    hellomauiblazor.Shared net9.0-android succeeded with 11 warning(s) (0.4s) → hellomauiblazor.Shared\bin\Debug\net9.0-android\hellomauiblazor.Shared.dll
    wwwroot\app.css : warning XA0101: @(Content) build action is not supported
    wwwroot\bootstrap\bootstrap.min.css : warning XA0101: @(Content) build action is not supported
    wwwroot\bootstrap\bootstrap.min.css.map : warning XA0101: @(Content) build action is not supported
    wwwroot\favicon.png : warning XA0101: @(Content) build action is not supported
    Layout\MainLayout.razor : warning XA0101: @(Content) build action is not supported
    Layout\NavMenu.razor : warning XA0101: @(Content) build action is not supported
    Pages\Counter.razor : warning XA0101: @(Content) build action is not supported
    Pages\Home.razor : warning XA0101: @(Content) build action is not supported
    Pages\Weather.razor : warning XA0101: @(Content) build action is not supported
    Routes.razor : warning XA0101: @(Content) build action is not supported
    _Imports.razor : warning XA0101: @(Content) build action is not supported

Reviewing the code in the .NET SDK for Razor projects, they include most of these files such as:

    <!-- Publish everything under wwwroot, all JSON files, all config files and all Razor files -->
    <Content Include="wwwroot\**" ExcludeFromSingleFile="true" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />

`%(ExcludeFromSingleFile)` looks like a useful metadata here, as Android is basically "single file mode" no matter what. We set `$(EnableSingleFileAnalyzers)=true` by default, so we consider mobile a "single file" platform.

Let's suppress the `XA0101` warning for files that have `%(ExcludeFromSingleFile)` metadata, as this seems actually appropriate and solves the warnings in Razor class libraries.