### PR TITLE
[tests] enable `GCBridge` category for CoreCLR

### DIFF
--- a/Documentation/workflow/UnitTests.md
+++ b/Documentation/workflow/UnitTests.md
@@ -63,21 +63,18 @@ To run ALL the [MSBuild Integration Tests](#msbuild-integration-tests) *and*
 all the [MSBuild Task Unit Tests](#msbuild-task-tests), run:
 
 ```sh
-./dotnet-local.sh test bin/TestDebug/net7.0/Xamarin.Android.Build.Tests.dll --filter=Category!=DotNetIgnore
+./dotnet-local.sh test bin/TestDebug/net7.0/Xamarin.Android.Build.Tests.dll
 ```
 
 To run ALL the supported [Device Integration Tests](#devive-integration-tests), run:
 
 ```sh
-./dotnet-local.sh test bin/TestDebug/MSBuildDeviceIntegration/net7.0/MSBuildDeviceIntegration.dll --filter=Category!=DotNetIgnore
+./dotnet-local.sh test bin/TestDebug/MSBuildDeviceIntegration/net7.0/MSBuildDeviceIntegration.dll
 ```
 
 If no Android device is attached, then the emulator will be created.
 The `ADB_TARGET` environment variable can be used to explicitly specify which
 Android device should be used when running Device Integration Tests.
-
-NOTE: Not all tests work under .NET for Android yet. So we need to filter
-them on the `DotNetIgnore` category.
 
 To run a specific test you can use the `Name=Value` argument for `--filter`,
 
@@ -106,21 +103,18 @@ To run ALL the [MSBuild Integration Tests](#msbuild-integration-tests) *and*
 all the [MSBuild Task Unit Tests](#msbuild-task-tests), run:
 
 ```cmd
-dotnet-local.cmd test bin\TestDebug\net7.0\Xamarin.Android.Build.Tests.dll --filter=Category!=DotNetIgnore
+dotnet-local.cmd test bin\TestDebug\net7.0\Xamarin.Android.Build.Tests.dll
 ```
 
 To run ALL the supported [Device Integration Tests](#devive-integration-tests), runs:
 
 ```cmd
-dotnet-local.cmd test bin\TestDebug\MSBuildDeviceIntegration\net7.0\MSBuildDeviceIntegration.dll --filter=Category!=DotNetIgnore
+dotnet-local.cmd test bin\TestDebug\MSBuildDeviceIntegration\net7.0\MSBuildDeviceIntegration.dll
 ```
 
 If no Android device is attached, then the emulator will be created.
 The `ADB_TARGET` environment variable can be used to explicitly specify which
 Android device should be used when running Device Integration Tests.
-
-NOTE: Not all tests work under .NET for Android yet. So we need to filter
-them on the `DotNetIgnore` category.
 
 To run a specific test you can use the `Name=Value` argument for the `--filter`,
 

--- a/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.NET.csproj
+++ b/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.NET.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);NO_MARSHAL_MEMBER_BUILDER_SUPPORT</DefineConstants>
-    <DefineConstants Condition=" '$(UseMonoRuntime)' == 'false' or '$(PublishAot)' == 'true' ">$(DefineConstants);NO_GC_BRIDGE_SUPPORT</DefineConstants>
+    <DefineConstants Condition=" '$(PublishAot)' == 'true' ">$(DefineConstants);NO_GC_BRIDGE_SUPPORT</DefineConstants>
     <JavaInteropTestDirectory>$(JavaInteropSourceDirectory)\tests\Java.Interop-Tests\</JavaInteropTestDirectory>
   </PropertyGroup>
 

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -30,9 +30,8 @@
         InetAccess excluded: https://github.com/dotnet/runtime/issues/73304
         NetworkInterfaces excluded: https://github.com/dotnet/runtime/issues/75155
     -->
-    <ExcludeCategories>DotNetIgnore</ExcludeCategories>
     <!-- TODO: https://github.com/dotnet/android/issues/10069 -->
-    <ExcludeCategories Condition=" '$(UseMonoRuntime)' == 'false' ">$(ExcludeCategories):CoreCLRIgnore:SSL:NTLM:GCBridge:RuntimeConfig</ExcludeCategories>
+    <ExcludeCategories Condition=" '$(UseMonoRuntime)' == 'false' ">$(ExcludeCategories):CoreCLRIgnore:SSL:NTLM:RuntimeConfig</ExcludeCategories>
     <!-- TODO: https://github.com/dotnet/android/issues/10079 -->
     <ExcludeCategories Condition=" '$(PublishAot)' == 'true' ">$(ExcludeCategories):NativeAOTIgnore:SSL:NTLM:GCBridge:AndroidClientHandler:Export:NativeTypeMap</ExcludeCategories>
     <!-- FIXME: LLVMIgnore https://github.com/dotnet/runtime/issues/89190 -->


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10198

We added CoreCLR "GC Bridge" support in 1f8f7195, but there are still some tests we can enable. Hopefully they pass! 🤞

I also did some cleanup of a `DotNetIgnore` category that is no longer used since Xamarin.Android was removed from this repo.