### PR TITLE
[release/9.0.1xx] [xabt] Compute `$DOTNET_DiagnosticPorts` using MSBuild properties

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1535,6 +1535,67 @@ If `DebugType` is not set or is the empty string, then the
 `DebugSymbols` property controls whether or not the Application is
 debuggable.
 
+## DiagnosticAddress
+
+A value provided by `dotnet-dsrouter` such as `127.0.0.1`, the IP
+address component of `$(DiagnosticConfiguration)` or `$DOTNET_DiagnosticPorts`.
+
+Implicitly enables the Mono diagnostic component, meaning that
+`$(EnableDiagnostics)`/`$(AndroidEnableProfiler)` is set to `true`.
+
+Defaults to `127.0.0.1`.
+
+## DiagnosticConfiguration
+
+A value provided by `dotnet-dsrouter` for `$DOTNET_DiagnosticPorts` such as:
+
+* `127.0.0.1:9000,suspend,connect`
+* `127.0.0.1:9000,nosuspend,connect`
+
+Note that the `,` character will need to be escaped with `%2c` if
+passed in command-line to `dotnet build`:
+
+```dotnetcli
+dotnet build -c Release -p:DiagnosticConfiguration=127.0.0.1:9000%2csuspend%2cconnect
+```
+
+This will automatically set the `$DOTNET_DiagnosticPorts` environment
+variable packaged inside the application.
+
+Implicitly enables the Mono diagnostic component, meaning that
+`$(EnableDiagnostics)`/`$(AndroidEnableProfiler)` is set to `true`.
+
+## DiagnosticListenMode
+
+A value provided by `dotnet-dsrouter` such as `connect`, the listening
+mode component of `$(DiagnosticConfiguration)` or `$DOTNET_DiagnosticPorts`.
+
+Implicitly enables the Mono diagnostic component, meaning that
+`$(EnableDiagnostics)`/`$(AndroidEnableProfiler)` is set to `true`.
+
+Defaults to `connect`.
+
+## DiagnosticPort
+
+A value provided by `dotnet-dsrouter` such as `9000`, the port
+component of `$(DiagnosticConfiguration)` or `$DOTNET_DiagnosticPorts`.
+
+Implicitly enables the Mono diagnostic component, meaning that
+`$(EnableDiagnostics)`/`$(AndroidEnableProfiler)` is set to `true`.
+
+Defaults to `9000`.
+
+## DiagnosticSuspend
+
+A boolean value provided by `dotnet-dsrouter` such as `true/suspend`
+or `false/nosuspend`, a component of `$(DiagnosticConfiguration)`
+or `$DOTNET_DiagnosticPorts`.
+
+Implicitly enables the Mono diagnostic component, meaning that
+`$(EnableDiagnostics)`/`$(AndroidEnableProfiler)` is set to `true`.
+
+Defaults to `false`.
+
 ## EmbedAssembliesIntoApk
 
 A boolean property that

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -43,8 +43,9 @@
     <AndroidEnableRestrictToAttributes Condition=" '$(AndroidEnableRestrictToAttributes)' == '' ">obsolete</AndroidEnableRestrictToAttributes>
 
     <!-- Mono components -->
-    <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == ''">$(EnableDiagnostics)</AndroidEnableProfiler>
-    <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == ''">false</AndroidEnableProfiler>
+    <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == '' ">$(EnableDiagnostics)</AndroidEnableProfiler>
+    <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == '' and ('$(DiagnosticConfiguration)' != '' or '$(DiagnosticAddress)' != '' or '$(DiagnosticPort)' != '' or '$(DiagnosticSuspend)' != '' or '$(DiagnosticListenMode)' != '') ">true</AndroidEnableProfiler>
+    <AndroidEnableProfiler Condition=" '$(AndroidEnableProfiler)' == '' ">false</AndroidEnableProfiler>
 
     <!--
         Android package (apt/aab) alignment, expressed as the page size in kilobytes.  Two values are supported: 4 and 16.
@@ -53,6 +54,16 @@
         When changing this default, change the value of `DefaultZipAlignment` in `src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs` as well
     -->
     <AndroidZipAlignment Condition=" '$(AndroidZipAlignment)' == '' ">16</AndroidZipAlignment>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(AndroidEnableProfiler)' == 'true' and '$(DiagnosticConfiguration)' == '' ">
+    <DiagnosticAddress Condition=" '$(DiagnosticAddress)' == '' ">127.0.0.1</DiagnosticAddress>
+    <DiagnosticPort Condition=" '$(DiagnosticPort)' == '' ">9000</DiagnosticPort>
+    <DiagnosticSuspend Condition=" '$(DiagnosticSuspend)' == '' ">false</DiagnosticSuspend>
+    <DiagnosticListenMode Condition=" '$(DiagnosticListenMode)' == '' ">connect</DiagnosticListenMode>
+    <DiagnosticConfiguration>$(DiagnosticAddress):$(DiagnosticPort),$(DiagnosticListenMode)</DiagnosticConfiguration>
+    <DiagnosticConfiguration Condition=" '$(DiagnosticSuspend)' == 'true' ">$(DiagnosticConfiguration),suspend</DiagnosticConfiguration>
+    <DiagnosticConfiguration Condition=" '$(DiagnosticSuspend)' != 'true' ">$(DiagnosticConfiguration),nosuspend</DiagnosticConfiguration>
   </PropertyGroup>
 
   <!--  User-facing configuration-specific defaults -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1255,21 +1255,30 @@ namespace UnnamedProject
 		}
 
 		[Test]
-		public void PackageNamingPolicy ([Values ("LowercaseMD5", "LowercaseCrc64")] string packageNamingPolicy)
+		[TestCase (true, "LowercaseMD5", "")]
+		[TestCase (true, "LowercaseCrc64", "")]
+		[TestCase (false, "", "127.0.0.1:9000,suspend,connect")]
+		public void EnvironmentVariables (bool useInterpreter, string packageNamingPolicy, string diagnosticConfiguration)
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetProperty ("UseInterpreter", "true");
-			proj.SetProperty ("AndroidPackageNamingPolicy", packageNamingPolicy);
+			proj.SetProperty ("UseInterpreter", useInterpreter.ToString ());
+			if (!string.IsNullOrEmpty (packageNamingPolicy))
+				proj.SetProperty ("AndroidPackageNamingPolicy", packageNamingPolicy);
+			if (!string.IsNullOrEmpty (diagnosticConfiguration))
+				proj.SetProperty ("DiagnosticConfiguration", diagnosticConfiguration);
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 				var environment = b.Output.GetIntermediaryPath (Path.Combine ("__environment__.txt"));
 				FileAssert.Exists (environment);
 				var values = new List<string> {
-					$"__XA_PACKAGE_NAMING_POLICY__={packageNamingPolicy}"
+					$"__XA_PACKAGE_NAMING_POLICY__={packageNamingPolicy}",
+					"mono.enable_assembly_preload=0",
 				};
-				values.Add ("mono.enable_assembly_preload=0");
-				values.Add ("DOTNET_MODIFIABLE_ASSEMBLIES=Debug");
+				if (useInterpreter)
+					values.Add ("DOTNET_MODIFIABLE_ASSEMBLIES=Debug");
+				if (!string.IsNullOrEmpty (diagnosticConfiguration))
+					values.Add ($"DOTNET_DiagnosticPorts={diagnosticConfiguration}");
 				Assert.AreEqual (string.Join (Environment.NewLine, values), File.ReadAllText (environment).Trim ());
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1636,6 +1636,7 @@ because xbuild doesn't support framework reference assemblies.
     <_GeneratedAndroidEnvironment Include="__XA_PACKAGE_NAMING_POLICY__=$(AndroidPackageNamingPolicy)" />
     <_GeneratedAndroidEnvironment Include="mono.enable_assembly_preload=0" Condition=" '$(AndroidEnablePreloadAssemblies)' != 'True' " />
     <_GeneratedAndroidEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES=Debug" Condition=" '$(AndroidIncludeDebugSymbols)' == 'true' and '$(AndroidUseInterpreter)' == 'true' " />
+    <_GeneratedAndroidEnvironment Include="DOTNET_DiagnosticPorts=$(DiagnosticConfiguration)" Condition=" '$(DiagnosticConfiguration)' != '' " />
   </ItemGroup>
   <WriteLinesToFile
       File="$(IntermediateOutputPath)__environment__.txt"

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -967,12 +967,17 @@ MONO_GC_PARAMS=bridge-implementation=new",
 					}
 				}
 			};
+			proj.SetProperty ("DiagnosticAddress", "127.0.0.1");
+			proj.SetProperty ("DiagnosticPort", "9000");
+			proj.SetProperty ("DiagnosticSuspend", "false");
+			proj.SetProperty ("DiagnosticListenMode", "connect");
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", @"
 		Console.WriteLine (""Foo="" + Environment.GetEnvironmentVariable(""Foo""));
 		Console.WriteLine (""Bar34="" + Environment.GetEnvironmentVariable(""Bar34""));
 		Console.WriteLine (""Empty="" + Environment.GetEnvironmentVariable(""Empty""));
 		Console.WriteLine (""MONO_GC_PARAMS="" + Environment.GetEnvironmentVariable(""MONO_GC_PARAMS""));
 		Console.WriteLine (""DOTNET_MODIFIABLE_ASSEMBLIES="" + Environment.GetEnvironmentVariable(""DOTNET_MODIFIABLE_ASSEMBLIES""));
+		Console.WriteLine (""DOTNET_DiagnosticPorts="" + Environment.GetEnvironmentVariable(""DOTNET_DiagnosticPorts""));
 		");
 			var builder = CreateApkBuilder ();
 			Assert.IsTrue (builder.Build (proj), "`dotnet build` should succeed");
@@ -1005,6 +1010,11 @@ MONO_GC_PARAMS=bridge-implementation=new",
 					"MONO_GC_PARAMS=bridge-implementation=new",
 					logcatOutput,
 					"The Environment variable \"MONO_GC_PARAMS\" was not set to expected value \"bridge-implementation=new\"."
+			);
+			StringAssert.Contains (
+					"DOTNET_DiagnosticPorts=127.0.0.1:9000,connect,nosuspend",
+					logcatOutput,
+					"The Environment variable \"DOTNET_DiagnosticPorts\" was not set to expected value \"127.0.0.1:9000,connect,nosuspend\"."
 			);
 			// NOTE: set when $(UseInterpreter) is true, default for Debug mode
 			if (!isRelease) {


### PR DESCRIPTION
Backport of: #10351

If you run `dotnet-trace collect --dsrouter android`, it says:

    Start an application on android device with ONE of the following environment variables set:
    [Default Tracing]
    DOTNET_DiagnosticPorts=127.0.0.1:9000,nosuspend,connect
    [Startup Tracing]
    DOTNET_DiagnosticPorts=127.0.0.1:9000,suspend,connect

Setting `$DOTNET_DiagnosticPorts` is non-trivial, so as a step to simplify this, we are adding multiple MSBuild properties to configure this value.

This would allow the log message to say:

    Build and run an Android application such as:
    [Default Tracing]
    dotnet build -t:Run -c Release -p:DiagnosticAddress=127.0.0.1 -p:DiagnosticPort=9000 -p:DiagnosticSuspend=false -p:DiagnosticListenMode=connect
    [Startup Tracing]
    dotnet build -t:Run -c Release -p:DiagnosticAddress=127.0.0.1 -p:DiagnosticPort=9000 -p:DiagnosticSuspend=true -p:DiagnosticListenMode=connect

You could also set `$(DiagnosticConfiguration)`, but you would need to escape the `,` character with `%2c`.

Setting any of the new properties also implicitly means that `$(AndroidEnableProfiler)` is set to `true`.