### PR TITLE
[build] update `$(ProductVersion)` to align with Android 16

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ProductVersion>13.2.99</ProductVersion>
+    <ProductVersion>16.0.0</ProductVersion>
     <!-- NuGet package version numbers. See Documentation/guides/OneDotNet.md.
          Rules:
          * Major/Minor match Android stable API level, such as 30.0 for API 30.


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/30948

I don't think this will solve dotnet/maui#30948, but it will at least reduce confusion if we put a 16.x version number on our MSBuild task assemblies.