### PR TITLE
[vscode] update recommended VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,9 @@
 {
     "recommendations": [
-      "ms-dotnettools.csharp",
+      "ms-dotnettools.csdevkit",
+      "ms-dotnettools.dotnet-maui",
       "ms-vscode.cpptools",
-      "ms-vscode.mono-debug",
-      "visualstudioexptteam.vscodeintellicode",
-      "streetsidesoftware.code-spell-checker",
-      "wghats.vscode-nxunit-test-adapter",
-      "derivitec-ltd.vscode-dotnet-adapter",
       "llvm-vs-code-extensions.lldb-dap",
+      "streetsidesoftware.code-spell-checker"
     ]
 }


### PR DESCRIPTION
For C# development, you should use:
* https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit
* https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui

So we should remove older extensions like:
* `ms-vscode.mono-debug`
* `visualstudioexptteam.vscodeintellicode`
* `wghats.vscode-nxunit-test-adapter`
* `derivitec-ltd.vscode-dotnet-adapter`

These are also sorted alphabetical now.