### PR TITLE
[build] enable transitive trimmer warnings

### DIFF
--- a/build-tools/trim-analyzers/trim-analyzers.props
+++ b/build-tools/trim-analyzers/trim-analyzers.props
@@ -5,6 +5,9 @@
     <IsTrimmable>true</IsTrimmable>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <!-- Enable analyzers for transitive references: https://github.com/dotnet/runtime/pull/118180 -->
+    <VerifyReferenceTrimCompatibility>true</VerifyReferenceTrimCompatibility>
+    <VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility>
     <!-- In app projects, tells ILLink to emit warnings as errors -->
     <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
     <!--


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/pull/118180

The new warnings are opt-in under the following settings:

* `<VerifyReferenceTrimCompatibility>true</VerifyReferenceTrimCompatibility>`
* `<VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility>`