### PR TITLE
Bumps com.android.tools.build:manifest-merger from 31.11.1 to 31.12.0

### DIFF
--- a/src/manifestmerger/build.gradle
+++ b/src/manifestmerger/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
     // https://mvnrepository.com/artifact/com.android.tools.build/manifest-merger
-    implementation 'com.android.tools.build:manifest-merger:31.11.1'
+    implementation 'com.android.tools.build:manifest-merger:31.12.0'
 }
 
 sourceSets {


### PR DESCRIPTION
Context: https://maven.google.com/web/index.html?q=com.android.tools.build#com.android.tools.build:manifest-merger:31.12.0
Context: https://android.googlesource.com/platform/tools/base/+/master/build-system/manifest-merger

Bumps com.android.tools.build:manifest-merger from 31.11.1 to 31.12.0.

Note that I was unable to locate a specific git tag for this release.