### PR TITLE
[xabt] `Xamarin.Android.Build.Tasks.dll` should be strong-named

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -17,7 +17,7 @@
     <DefineConstants>$(DefineConstants);TRACE;HAVE_CECIL;MSBUILD;XABT_MANIFEST_EXTENSIONS</DefineConstants>
     <AndroidGeneratedClassDirectory Condition=" '$(AndroidGeneratedClassDirectory)' == '' ">..\..\src\Mono.Android\obj\$(Configuration)\$(DotNetTargetFramework)\android-$(AndroidLatestStablePlatformId)\mcw</AndroidGeneratedClassDirectory>
     <NoWarn>8632</NoWarn>
-    <SignAssembly>false</SignAssembly>
+    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <Nullable>enable</Nullable>
     <!-- Causes issues with linker files imported from Mono -->


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/30948

MSBuild task assemblies can run on .NET framework when building inside Visual Studio.

If you have a .NET 8, .NET 9, and .NET 10 project in the same solution, the best way to support this is to strong name *and* version your assembly so that .NET framework can load multiple copies of it. This can also happen if you update the `$(TargetFramework)` while a project is open.

Unfortunately, #30948 uncovered an issue when .NET 9 and .NET 10:

* .NET 8 `Xamarin.Android.Build.Tasks.dll`: strong named
* .NET 9 `Xamarin.Android.Build.Tasks.dll`: *not* strong named
* .NET 10 `Xamarin.Android.Build.Tasks.dll`: *not* strong named

I suspect this went wrong in 003f5d16, but we didn't notice it until now because .NET 8 was strong-named and .NET 9 was not.

To fix this, we simply need to set `$(SignAssembly)` to `true`.

Prior to 003f5d16, this was set to false because the ILRepack process signed at the end of the repacking. When ILRepack was removed, we forgot to enable strong name signing! Whoops!