### PR TITLE
[release/9.0.1xx] [build] update `$(ProductVersion)` to align with Android 15

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ProductVersion>13.2.99</ProductVersion>
+    <ProductVersion>15.0.0</ProductVersion>
     <!-- NuGet package version numbers. See Documentation/guides/OneDotNet.md.
          Rules:
          * Major/Minor match Android stable API level, such as 30.0 for API 30.


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/30948

I don't think this will solve dotnet/maui#30948, but it will at least reduce confusion if we put a 15.x version number on our .NET 9 MSBuild task assemblies.