### PR TITLE
[build] Bump NDK to r28c

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "28";
-		public const string AndroidNdkPkgRevision = "28.0.13004108";
+		public const string AndroidNdkVersion = "28c";
+		public const string AndroidNdkPkgRevision = "28.2.13676358";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 21;
 


### PR DESCRIPTION
Changes: https://github.com/android/ndk/wiki/Changelog-r28#r28c

Nothing stands out in the upstream changes as affecting us.
