### PR TITLE
[xabt] fix default trimmer switches for `Metrics`

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1645,6 +1645,18 @@ When `True`,
 files will be used
 to control `proguard` execution.
 
+## EventSourceSupport
+
+When set to `false`, disables .NET's [EventSource][eventsource]
+support from trimmed Android applications. Disabling this feature
+would prevent .NET diagnostic tools like `dotnet-counters` from
+functioning, but at the benefit of reduced application size.
+
+Set to `false` by default in `Release` mode, unless
+`$(EnableDiagnostics)` or `$(AndroidEnableProfiler)` are enabled.
+
+[eventsource]: https://learn.microsoft.com/dotnet/core/diagnostics/eventsource
+
 ## GenerateApplicationManifest
 
 Enables or disables the following MSBuild properties that emit values
@@ -1722,6 +1734,18 @@ The default value is False.
 ## MandroidI18n
 
 This MSBuild property is obsolete and is no longer supported.
+
+## MetricsSupport
+
+When set to `false`, disables .NET's [Metrics][dotnetmetrics] support
+from trimmed Android applications. Disabling this feature would
+prevent APIs such as `System.Diagnostics.Metrics` from functioning,
+but at the benefit of reduced application size.
+
+Set to `false` by default in `Release` mode, unless
+`$(EnableDiagnostics)` or `$(AndroidEnableProfiler)` are enabled.
+
+[dotnetmetrics]: https://learn.microsoft.com/dotnet/core/diagnostics/metrics
 
 ## MonoAndroidAssetPrefix
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -119,13 +119,10 @@
       Runtime libraries feature switches defaults
       Available feature switches: https://github.com/dotnet/runtime/blob/master/docs/workflow/trimming/feature-switches.md
      -->
-    <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Optimize)' == 'true'">false</DebuggerSupport>
     <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
     <EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == ''">false</EnableUnsafeBinaryFormatterSerialization>
-    <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
     <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == '' and '$(PublishTrimmed)' == 'true'">true</UseSystemResourceKeys>
     <Http3Support Condition="'$(Http3Support)' == ''">false</Http3Support>
-    <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == '' and '$(Optimize)' == 'true'">false</HttpActivityPropagationSupport>
     <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
     <StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
     <UseSizeOptimizedLinq Condition="'$(UseSizeOptimizedLinq)' == ''">true</UseSizeOptimizedLinq>
@@ -135,7 +132,6 @@
     <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == '' and '$(TrimMode)' == 'partial'">true</JsonSerializerIsReflectionEnabledByDefault>
     <!-- Set to disable throwing behavior, see: https://github.com/dotnet/runtime/issues/109724 -->
     <_DefaultValueAttributeSupport Condition="'$(_DefaultValueAttributeSupport)' == '' and '$(TrimMode)' == 'partial'">true</_DefaultValueAttributeSupport>
-    <MetricsSupport Condition="'$(MetricsSupport)' == '' and '$(Optimize)' == 'true'">false</MetricsSupport>
     <AndroidAvoidEmitForPerformance Condition="'$(AndroidAvoidEmitForPerformance)' == ''">$(AvoidEmitForPerformance)</AndroidAvoidEmitForPerformance>
     <AndroidAvoidEmitForPerformance Condition="'$(AndroidAvoidEmitForPerformance)' == ''">true</AndroidAvoidEmitForPerformance>
     <!-- Verify DI trimmability at development-time, but turn the validation off for production/trimmed builds. -->
@@ -149,6 +145,14 @@
 
     <!-- profiler won't work without internet permission, we must thus force it -->
     <AndroidNeedsInternetPermission Condition=" '$(AndroidEnableProfiler)' == 'true' ">True</AndroidNeedsInternetPermission>
+  </PropertyGroup>
+  <!-- Trimmer switches that default to OFF in Release mode -->
+  <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' and '$(Optimize)' == 'true' ">
+    <DebuggerSupport Condition=" '$(DebuggerSupport)' == '' ">false</DebuggerSupport>
+    <HttpActivityPropagationSupport Condition=" '$(HttpActivityPropagationSupport)' == '' ">false</HttpActivityPropagationSupport>
+    <!-- Only set if *not* using $(EnableDiagnostics) -->
+    <MetricsSupport Condition=" '$(MetricsSupport)' == '' and '$(AndroidEnableProfiler)' != 'true' ">false</MetricsSupport>
+    <EventSourceSupport Condition=" '$(EventSourceSupport)' == '' and '$(AndroidEnableProfiler)' != 'true' ">false</EventSourceSupport>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' and '$(GenerateApplicationManifest)' == 'true' ">
     <!-- Default to 1, if blank -->


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/MauiAspireWithTelemetry/tree/peppers
Context: https://github.com/dotnet/maui/pull/31058

We are in the process of adding `Metrics` to .NET MAUI to enable `dotnet-counters` such as:

    > dotnet-counters monitor --dsrouter android --counters Microsoft.Maui
    Press p to pause, r to resume, q to quit.
    Status: Running

    Name                                      Current Value
    [Microsoft.Maui]
        maui.layout.arrange_count ({times})               6
        maui.layout.arrange_duration (ns)
            Percentile
            50                                      518,656
            95                                    2,367,488
            99                                    2,367,488
        maui.layout.measure_count ({times})              11
        maui.layout.measure_duration (ns)
            Percentile
            50                                      389,632
            95                                   28,475,392
            99                                   28,475,392

For this to work, you'd unfortunately need to build the app with:

    dotnet build -c Release -p:EnableDiagnostics=true -p:MetricsSupport=true -p:EventSourceSupport=true

That's way too many properties to mess with!

So, we should make the defaults:

* For `Release` mode, `$(Optimize)` is `true`.

* Only if `$(AndroidEnableProfiler)` and `$(EnableDiagnostics)` are not `true`, then:

  * `$(MetricsSupport)` is `false`.

  * `$(EventSourceSupport)` is `false`.

I also refactored other properties that default to `false` in Release mode by checking the `$(Optimize)` property.