### PR TITLE
[clr] fix environment variable setting

### DIFF
--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -223,11 +223,6 @@ AndroidSystem::setup_app_library_directories (jstring_array_wrapper& runtimeApks
 void
 AndroidSystem::setup_environment () noexcept
 {
-	if (application_config.environment_variable_count % 2 != 0) {
-		log_warn (LOG_DEFAULT, "Corrupted environment variable array: does not contain an even number of entries ({})", application_config.environment_variable_count);
-		return;
-	}
-
 	const char *var_name;
 	const char *var_value;
 	for (size_t i = 0uz; i < application_config.environment_variable_count; i++) {


### PR DESCRIPTION
Fixes: #10382
Context: f37158eae0111a6cdd25e870e412fcc74997d529

f37158eae switched to string blobs when storing environment variables
in `libxamarin-app.so`.

In case of an odd count of envvars, we'd fail to set them because
of a check that should have been removed in f37158eae
    
Remove verification that there's an even number of elements in the
environment variable array, it is no longer necessary.
