### PR TITLE
[xaprepare] Fix detection of the new Debian/sid version

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Android.Prepare
 			{ "bookworm/sid", "12" },
 			{ "trixie", "13" },
 			{ "trixie/sid", "13" },
+			{ "forky/sid", "14" },
 		};
 
 		protected Version DebianRelease { get; private set; } = new Version (0, 0);
@@ -105,7 +106,8 @@ namespace Xamarin.Android.Prepare
 			}
 
 			return debian_version!.IndexOf ("bookworm", StringComparison.OrdinalIgnoreCase) >= 0 ||
-			       debian_version!.IndexOf ("trixie", StringComparison.OrdinalIgnoreCase) >= 0;
+			       debian_version!.IndexOf ("trixie", StringComparison.OrdinalIgnoreCase) >= 0 ||
+			       debian_version!.IndexOf ("forky", StringComparison.OrdinalIgnoreCase) >= 0;
 		}
 
 		protected override bool EnsureVersionInformation (Context context)


### PR DESCRIPTION
Debian 13 (trixy) has just been released and, as of now, 
the "unstable" Debian distribution (always code-named `sid`) 
has no numeric version and `xaprepare` fails to detect it.

Fix this by adding information about `forky`, the next release
code name, and pretending it's version 14 (which it will be, eventually)