### PR TITLE
[NativeAOT] remove `@(KnownILCompilerPack)` hack

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -54,19 +54,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
     </IlcCompileDependsOn>
   </PropertyGroup>
 
-  <Target Name="_AndroidBeforeProcessFrameworkReferences"
-      BeforeTargets="ProcessFrameworkReferences">
-    <!-- HACK: https://github.com/dotnet/sdk/blob/2a4195bb70f47c15ff9e6d848c59517dc873e0f4/src/Layout/redist/targets/GenerateBundledVersions.targets#L397-L403 -->
-    <!-- Add Android runtime identifiers to @(KnownILCompilerPack) -->
-    <ItemGroup>
-      <KnownILCompilerPack
-          Update="Microsoft.DotNet.ILCompiler" 
-          Condition="'%(TargetFramework)' == 'net10.0'"
-          ILCompilerRuntimeIdentifiers="%(ILCompilerRuntimeIdentifiers);android-arm64;android-x64"
-      />
-    </ItemGroup>
-  </Target>
-
   <Target Name="_AndroidBeforeIlcCompile"
       DependsOnTargets="_PrepareLinking"
       BeforeTargets="SetupProperties">


### PR DESCRIPTION
In d84352c8, I was trying to workaround the error:

    D:\.nuget\packages\microsoft.dotnet.ilcompiler\10.0.0-rc.1.25412.102\build\Microsoft.NETCore.Native.Publish.targets(70,5):
    The PrivateSdkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative

But at that time, I was experimenting with the `$(PublishAotUsingRuntimePack)` property. This problem only occurs if `$(PublishAotUsingRuntimePack)` is *not* set, which we do by default in dotnet/android/main.

It appears we can just remove this workaround.