### PR TITLE
[xabt] fix `$(DiagnosticConfiguration)` ordering

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -66,9 +66,10 @@
     <DiagnosticPort Condition=" '$(DiagnosticPort)' == '' ">9000</DiagnosticPort>
     <DiagnosticSuspend Condition=" '$(DiagnosticSuspend)' == '' ">false</DiagnosticSuspend>
     <DiagnosticListenMode Condition=" '$(DiagnosticListenMode)' == '' ">connect</DiagnosticListenMode>
-    <DiagnosticConfiguration>$(DiagnosticAddress):$(DiagnosticPort),$(DiagnosticListenMode)</DiagnosticConfiguration>
+    <DiagnosticConfiguration>$(DiagnosticAddress):$(DiagnosticPort)</DiagnosticConfiguration>
     <DiagnosticConfiguration Condition=" '$(DiagnosticSuspend)' == 'true' ">$(DiagnosticConfiguration),suspend</DiagnosticConfiguration>
     <DiagnosticConfiguration Condition=" '$(DiagnosticSuspend)' != 'true' ">$(DiagnosticConfiguration),nosuspend</DiagnosticConfiguration>
+    <DiagnosticConfiguration>$(DiagnosticConfiguration),$(DiagnosticListenMode)</DiagnosticConfiguration>
   </PropertyGroup>
 
   <!--  User-facing configuration-specific defaults -->

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1099,9 +1099,9 @@ MONO_GC_PARAMS=bridge-implementation=new",
 					"The Environment variable \"MONO_GC_PARAMS\" was not set to expected value \"bridge-implementation=new\"."
 			);
 			StringAssert.Contains (
-					"DOTNET_DiagnosticPorts=127.0.0.1:9000,connect,nosuspend",
+					"DOTNET_DiagnosticPorts=127.0.0.1:9000,nosuspend,connect",
 					logcatOutput,
-					"The Environment variable \"DOTNET_DiagnosticPorts\" was not set to expected value \"127.0.0.1:9000,connect,nosuspend\"."
+					"The Environment variable \"DOTNET_DiagnosticPorts\" was not set to expected value \"127.0.0.1:9000,nosuspend,connect\"."
 			);
 			// NOTE: set when $(UseInterpreter) is true, default for Debug mode
 			if (!isRelease) {


### PR DESCRIPTION
It appears that setting `$DOTNET_DiagnosticPorts` does not work if you do:

    DOTNET_DiagnosticPorts=127.0.0.1:9000,connect,nosuspend

At runtime I see in the Android logs:

    08-13 16:05:39.075 15827 15827 I Mono    : ds_ipc_stream_factory_configure - Attempted to create Diagnostic Port from "0".
    08-13 16:05:39.099 15827 15827 I Mono    : ds_ipc_stream_factory_configure - Diagnostic Port creation failed
    08-13 16:05:39.099 15827 15827 D Mono    : ds_ipc_stream_factory_configure - Ignoring default LISTEN port
    08-13 16:05:39.099 15827 15827 F Mono    : At least one Diagnostic Port failed to be configured.

Android needs `connect` mode in order to work.

But it does work if you order them correctly...

    DOTNET_DiagnosticPorts=127.0.0.1:9000,nosuspend,connect

To solve this, I reordered how the `$(DiagnosticConfiguration)` MSBuild property is defined.