### PR TITLE
`$(AndroidPackVersionSuffix)=rc.2`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>36.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/10.0.1xx-rc1

We branched for .NET 10 RC 1 from cfd3915a into `release/10.0.1xx-rc1`; the main branch is now .NET 10 RC 2.