### PR TITLE
[native] Fix loading of shared libraries directly from the APK

### DIFF
--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -147,7 +147,7 @@ auto Host::zip_scan_callback (std::string_view const& apk_path, int apk_fd, dyna
 		}
 	}
 
-	if (!entry_name.starts_with (Zip::lib_prefix) || !entry_name.ends_with (Constants::dso_suffix)) {
+	if (!AndroidSystem::is_embedded_dso_mode_enabled () || !entry_name.starts_with (Zip::lib_prefix) || !entry_name.ends_with (Constants::dso_suffix)) {
 		return false;
 	}
 
@@ -156,6 +156,14 @@ auto Host::zip_scan_callback (std::string_view const& apk_path, int apk_fd, dyna
 	hash_t name_hash = xxhash::hash (lib_name.data (), lib_name.length ());
 	log_debug (LOG_ASSEMBLY, "Library name is: {}; hash == 0x{:x}", lib_name, name_hash);
 
+	DSOApkEntry *apk_entry = MonodroidDl::find_dso_apk_entry (name_hash);
+	if (apk_entry == nullptr) {
+		return false;
+	}
+
+	log_debug (LOG_ASSEMBLY, "Found matching DSO APK entry");
+	apk_entry->fd = apk_fd;
+	apk_entry->offset = offset;
 	return false;
 }
 

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -27,6 +27,7 @@
 #include <runtime-base/search.hh>
 #include <runtime-base/timing-internal.hh>
 #include <shared/log_types.hh>
+#include <shared/xxhash.hh>
 #include <startup/zip.hh>
 
 using namespace xamarin::android;
@@ -145,6 +146,16 @@ auto Host::zip_scan_callback (std::string_view const& apk_path, int apk_fd, dyna
 			return false; // This will make the scanner keep the APK open
 		}
 	}
+
+	if (!entry_name.starts_with (Zip::lib_prefix) || !entry_name.ends_with (Constants::dso_suffix)) {
+		return false;
+	}
+
+	log_debug (LOG_ASSEMBLY, "Found shared library in '{}': {}"sv, apk_path, entry_name.get ());
+	std::string_view lib_name { entry_name.get () + Zip::lib_prefix.length () };
+	hash_t name_hash = xxhash::hash (lib_name.data (), lib_name.length ());
+	log_debug (LOG_ASSEMBLY, "Library name is: {}; hash == 0x{:x}", lib_name, name_hash);
+
 	return false;
 }
 

--- a/src/native/clr/include/startup/zip.hh
+++ b/src/native/clr/include/startup/zip.hh
@@ -56,9 +56,11 @@ namespace xamarin::android {
 		static constexpr size_t lib_prefix_size = calc_size(apk_lib_dir_name, zip_path_separator, Constants::android_lib_abi, zip_path_separator);
 		static constexpr auto lib_prefix_array = concat_string_views<lib_prefix_size> (apk_lib_dir_name, zip_path_separator, Constants::android_lib_abi, zip_path_separator);
 
+	public:
 		// .data() must be used otherwise string_view length will include the trailing \0 in the array
 		static constexpr std::string_view lib_prefix { lib_prefix_array.data () };
 
+	private:
 		static constexpr size_t assembly_store_file_path_size = calc_size(lib_prefix, Constants::assembly_store_file_name);
 		static constexpr auto assembly_store_file_path_array = concat_string_views<assembly_store_file_path_size> (lib_prefix, Constants::assembly_store_file_name);
 

--- a/src/native/common/include/runtime-base/strings.hh
+++ b/src/native/common/include/runtime-base/strings.hh
@@ -722,7 +722,7 @@ namespace xamarin::android {
 		}
 
 		[[gnu::always_inline]]
-		auto starts_with_c (const char* s) noexcept -> bool
+		auto starts_with_c (const char* s) const noexcept -> bool
 		{
 			if (s == nullptr) {
 				return false;
@@ -732,19 +732,19 @@ namespace xamarin::android {
 		}
 
 		template<size_t Size> [[gnu::always_inline]]
-		auto starts_with (const char (&s)[Size]) noexcept -> bool
+		auto starts_with (const char (&s)[Size]) const noexcept -> bool
 		{
 			return starts_with (s, Size - 1);
 		}
 
 		[[gnu::always_inline]]
-		auto starts_with (std::string_view const& s) noexcept -> bool
+		auto starts_with (std::string_view const& s) const noexcept -> bool
 		{
 			return starts_with (s.data (), s.length ());
 		}
 
 		[[gnu::always_inline]]
-		auto ends_with (std::string_view const& s) noexcept -> bool
+		auto ends_with (std::string_view const& s) const noexcept -> bool
 		{
 			if (empty () || s.length () > buffer.size ()) {
 				return false;

--- a/src/native/mono/monodroid/embedded-assemblies-zip.cc
+++ b/src/native/mono/monodroid/embedded-assemblies-zip.cc
@@ -292,7 +292,7 @@ EmbeddedAssemblies::zip_load_assembly_store_entries (std::vector<uint8_t> const&
 		// Since it's not an assembly store, it's a shared library most likely and it is long enough for us not to have
 		// to check the length
 		if (Util::ends_with (entry_name, dso_suffix)) {
-			constexpr size_t apk_lib_prefix_len = apk_lib_prefix.size () - 1;
+			constexpr size_t apk_lib_prefix_len = apk_lib_prefix.length ();
 
 			const char *const name = entry_name.get () + apk_lib_prefix_len;
 			DSOApkEntry *apk_entry = reinterpret_cast<DSOApkEntry*>(reinterpret_cast<uint8_t*>(dso_apk_entries) + (sizeof(DSOApkEntry) * number_of_zip_dso_entries));


### PR DESCRIPTION
Fixes: #10383

This is an optimization for when shared libraries aren't extracted from the APK.
In this case, we can load them faster by using extended dlopen API provided by
Android, which allows us to skip path scanning by `dlopen`.

This is done by recording file offset of any .so library inside the APK at
application startup and then using it, together with the APK file descriptor
that we keep around, to load the library using Android extended version of
`dlopen`.

This does not apply to any libraries using JNI, as they have to be loaded
using the Java `System.loadLibrary` API (see cba39dcf72 and 1a62af3814)