### PR TITLE
[tests] builds from forks skip `AssertCommercialBuild()` tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -31,17 +31,11 @@ namespace Xamarin.Android.Build.Tests
 		/// Checks if a commercial .NET for Android is available
 		/// * Defaults to Assert.Ignore ()
 		/// </summary>
-		public void AssertCommercialBuild (bool fail = false)
+		public void AssertCommercialBuild ()
 		{
 			if (!TestEnvironment.CommercialBuildAvailable) {
 				var message = $"'{TestName}' requires a commercial build of .NET for Android.";
-				var runningOnCI = false;
-				bool.TryParse (Environment.GetEnvironmentVariable ("RunningOnCI"), out runningOnCI);
-				if (fail || runningOnCI) {
-					Assert.Fail (message);
-				} else {
-					Assert.Ignore (message);
-				}
+				Assert.Inconclusive (message);
 			}
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -144,6 +144,8 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Build_From_Clean_DontIncludeRestore ()
 		{
+			AssertCommercialBuild (); // If <BuildApk/> runs, this test will fail without Fast Deployment
+
 			var proj = CreateApplicationProject ();
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.AutomaticNuGetRestore = false;
@@ -257,6 +259,8 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Build_JLO_Change ()
 		{
+			AssertCommercialBuild (); // If <BuildApk/> runs, this test will fail without Fast Deployment
+
 			var className = "Foo";
 			var proj = CreateApplicationProject ();
 			proj.Sources.Add (new BuildItem.Source ("Foo.cs") {


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10438

We can always call `Assert.Inconclusive()`, to prevent failing tests from contributors.