### PR TITLE
[Mono.Android] undo trimmer attribute to restore apk size

### DIFF
--- a/src/Mono.Android/Java.Lang/Object.cs
+++ b/src/Mono.Android/Java.Lang/Object.cs
@@ -141,29 +141,20 @@ namespace Java.Lang {
 			return (T?)PeekObject (handle, typeof (T));
 		}
 
-		public static T? GetObject<
-				[DynamicallyAccessedMembers (Constructors)]
-				T
-		> (IntPtr jnienv, IntPtr handle, JniHandleOwnership transfer)
+		public static T? GetObject<T> (IntPtr jnienv, IntPtr handle, JniHandleOwnership transfer)
 			where T : class, IJavaObject
 		{
 			JNIEnv.CheckHandle (jnienv);
 			return GetObject<T> (handle, transfer);
 		}
 
-		public static T? GetObject<
-				[DynamicallyAccessedMembers (Constructors)]
-				T
-		> (IntPtr handle, JniHandleOwnership transfer)
+		public static T? GetObject<T> (IntPtr handle, JniHandleOwnership transfer)
 			where T : class, IJavaObject
 		{
 			return _GetObject<T>(handle, transfer);
 		}
 
-		internal static T? _GetObject<
-				[DynamicallyAccessedMembers (Constructors)]
-				T
-		> (IntPtr handle, JniHandleOwnership transfer)
+		internal static T? _GetObject<T> (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
 				return default (T);
@@ -174,15 +165,19 @@ namespace Java.Lang {
 		internal static IJavaPeerable? GetObject (
 				IntPtr handle,
 				JniHandleOwnership transfer,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? type = null)
 		{
 			if (handle == IntPtr.Zero)
 				return null;
 
-			var r = JniEnvironment.Runtime.ValueManager.GetPeer (new JniObjectReference (handle), type);
+			var r = GetPeer (handle, type);
 			JNIEnv.DeleteRef (handle, transfer);
 			return r;
+
+			// FIXME: should use [DynamicallyAccessedMembers (Constructors)] in the future
+			[UnconditionalSuppressMessage ("Trimming", "IL2067:'targetType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'Java.Interop.JniRuntime.JniValueManager.GetPeer(JniObjectReference, Type)'.", Justification = "The MarkJavaObjects step preserves ctors on Java.Lang.Object subclasses.")]
+			static IJavaPeerable? GetPeer (IntPtr handle, Type? type) =>
+				JniEnvironment.Runtime.ValueManager.GetPeer (new JniObjectReference (handle), type);
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Never)]


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/31316#issuecomment-3225539739

In comparing apk sizes .NET 9 vs .NET 10, we found regressions in IL size, such as:

    +      76,464 lib/x86_64/libaot-Mono.Android.dll.so

Comparing, just the MSIL (not AOT output) some examples are `Java.IO.File` constructors:

    .NET 9:
        File()
        File(nint, JniHandleOwnership)
        File(string)
    .NET 10:
        File()
        File(nint, JniHandleOwnership)
        File(File?, string)
        File(string?, string)
        File(string)
        File(URI)

When passing `-p:LinkerDumpDependencies=true`, we can get some output from `ILLink`:

    <edge mark="1" b="MethodSpec:T Java.Lang.Object::GetObject&lt;Java.IO.File&gt;(System.IntPtr,Android.Runtime.JniHandleOwnership)" e="TypeDef:Java.IO.File" />
    <edge mark="1" b="Method:Java.IO.File Android.Content.ContextInvoker::get_CacheDir()" e="Method:System.Void Java.IO.File::.ctor(System.IntPtr,Android.Runtime.JniHandleOwnership)" />
    <edge mark="1" b="Method:Java.IO.File Android.Content.ContextInvoker::get_CacheDir()" e="Method:System.Void Java.IO.File::.cctor()" />
    <edge mark="1" b="Method:Java.IO.File Android.Content.ContextInvoker::get_CacheDir()" e="Method:System.Void Java.IO.File::.ctor(Java.IO.File,System.String)" />
    <edge mark="1" b="Method:Java.IO.File Android.Content.ContextInvoker::get_CacheDir()" e="Method:System.Void Java.IO.File::.ctor(System.String,System.String)" />
    <edge mark="1" b="Method:Java.IO.File Android.Content.ContextInvoker::get_CacheDir()" e="Method:System.Void Java.IO.File::.ctor(System.String)" />
    <edge mark="1" b="Method:Java.IO.File Android.Content.ContextInvoker::get_CacheDir()" e="Method:System.Void Java.IO.File::.ctor(Java.Net.URI)" />

Which leads me think this change is the cause:

* https://github.com/dotnet/android/commit/f800c1a6ee8d584f28d6b7a03485b7091e2d3115#diff-4d71f7134c2b6e3b0d272a17fc6c9261108c518ad039df1566b07205f6be06e9R146

Let's try just undoing the change and see if there is any impact on NativeAOT.

TODO: apk size difference