### PR TITLE
Fix an ABI break

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -102,8 +102,7 @@ namespace Android.Runtime {
 		}
 	}
 
-	// TODO: this shouldn't be public
-	public class AndroidObjectReferenceManager : JniRuntime.JniObjectReferenceManager {
+	internal class AndroidObjectReferenceManager : JniRuntime.JniObjectReferenceManager {
 		public override int GlobalReferenceCount {
 			get {return RuntimeNativeMethods._monodroid_gref_get ();}
 		}
@@ -187,7 +186,7 @@ namespace Android.Runtime {
 			var from  = log ? new StringBuilder (new StackTrace (true).ToString ()) : null;
 			int gc 		= RuntimeNativeMethods._monodroid_gref_log_new (value.Handle, ctype, r.Handle, ntype, tname, tid, from, 1);
 			if (gc >= JNIEnvInit.gref_gc_threshold) {
-				Logger.Log (LogLevel.Debug, "monodroid-gc", gc + " outstanding GREFs. Performing a full GC!");
+				Logger.Log (LogLevel.Warn, "monodroid-gc", gc + " outstanding GREFs. Performing a full GC!");
 				System.GC.Collect ();
 			}
 


### PR DESCRIPTION
Context: 869b0e03937e0c17a4cf3fbc85f50d80350b2576

869b0e0393 had an ABI break which exposed an internal JNI reference
manager (`AndroidObjectReferenceManager`) class as public in order
to use it from the NativeAOT runtime host.

Initially I thought the fix would be harder, but... it's not :) -
all we need to do is to make the class `internal`, which is what this
commit does.

Additionally, sort-of revert one more change in 869b0e0393, which
downgraded a GC diagnostic message from the `Info` log level to
`Debug`. The message is actually useful and warns about a potential
issue with the GC machinery, so let's emit it is as a warning.