### PR TITLE
[NativeAOT] Initialize GC threshold much earlier

### DIFF
--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
@@ -17,6 +17,13 @@ static partial class JavaInteropRuntime
 		try {
 			AndroidLog.Print (AndroidLogLevel.Info, "JavaInteropRuntime", "JNI_OnLoad()");
 			XA_Host_NativeAOT_JNI_OnLoad (vm, reserved);
+			// This must be called before anything else, otherwise we'll see several spurious GC invocations and log messages
+			// similar to:
+			//
+			//  09-15 14:51:01.311 11071 11071 D monodroid-gc: 1 outstanding GREFs. Performing a full GC!
+			//
+			JNIEnvInit.NativeAotInitializeMaxGrefGet ();
+
 			LogcatTextWriter.Init ();
 			return (int) JniVersion.v1_6;
 		}

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -77,15 +77,20 @@ namespace Android.Runtime
 			androidRuntime!.TypeManager.RegisterNativeMembers (jniType, type, methods);
 		}
 
+		// This must be called by NativeAOT before InitializeJniRuntime, as early as possible
+		internal static void NativeAotInitializeMaxGrefGet ()
+		{
+			gref_gc_threshold = RuntimeNativeMethods._monodroid_max_gref_get ();
+			if (gref_gc_threshold != int.MaxValue) {
+				gref_gc_threshold = checked((gref_gc_threshold * 9) / 10);
+			}
+		}
+
 		// NOTE: should have different name than `Initialize` to avoid:
 		// * Assertion at /__w/1/s/src/mono/mono/metadata/icall.c:6258, condition `!only_unmanaged_callers_only' not met
 		internal static void InitializeJniRuntime (JniRuntime runtime)
 		{
 			androidRuntime = runtime;
-			gref_gc_threshold = RuntimeNativeMethods._monodroid_max_gref_get ();
-			if (gref_gc_threshold != int.MaxValue) {
-				gref_gc_threshold = checked((gref_gc_threshold * 9) / 10);
-			}
 			SetSynchronizationContext ();
 		}
 


### PR DESCRIPTION
The threshold value is used by the global reference creation routine to determine whether to [start GC collection][0]:

```csharp
if (gc >= JNIEnvInit.gref_gc_threshold) {
  Logger.Log (LogLevel.Debug, "monodroid-gc", gc + " outstanding GREFs. Performing a full GC!");
  System.GC.Collect ();
}
```

However, the threshold value was being initialized after we've already invoked some non-trivial managed code in the managed [NativeAOT runtime][1], too late to avoid at least a handful of `System.GC.Collect ()` calls:

    09-15 14:37:25.923 10761 10761 D monodroid-gc: 1 outstanding GREFs. Performing a full GC!
    09-15 14:37:25.923 10761 10761 D monodroid-gc: 2 outstanding GREFs. Performing a full GC!
    09-15 14:37:25.923 10761 10761 D monodroid-gc: 3 outstanding GREFs. Performing a full GC!
    09-15 14:37:25.924 10761 10761 D monodroid-gc: 3 outstanding GREFs. Performing a full GC!

Fix this by splitting the GC threshold value initialization into a separate method which is invoked as soon as possible from the `JNI_OnLoad` function exported by the NativeAOT application.

[0]: https://github.com/dotnet/android/blob/e72bf3626024fd1e27dd9cd26d7f8439bc088e19/src/Mono.Android/Android.Runtime/AndroidRuntime.cs#L178-L195
[1]: https://github.com/dotnet/android/blob/e72bf3626024fd1e27dd9cd26d7f8439bc088e19/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs#L60