### PR TITLE
[tests] fix `TestResolveToolsExists` test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -74,7 +74,9 @@ namespace Xamarin.ProjectTools
 		/// </summary>
 		public static string MonoAndroidFrameworkDirectory {
 			get {
-				var rootRefDir = Directory.GetDirectories (Path.Combine (DotNetPreviewPacksDirectory, $"Microsoft.Android.Ref.{XABuildConfig.AndroidDefaultTargetDotnetApiLevel}")).LastOrDefault ();
+				var targetPlatform = XABuildConfig.AndroidDefaultTargetDotnetApiLevel;
+				var versionString = targetPlatform.Minor == 0 ? $"{targetPlatform.Major}" : $"{targetPlatform.Major}.{targetPlatform.Minor}";
+				var rootRefDir = Directory.GetDirectories (Path.Combine (DotNetPreviewPacksDirectory, $"Microsoft.Android.Ref.{versionString}")).LastOrDefault ();
 				if (!Directory.Exists (rootRefDir)) {
 					throw new DirectoryNotFoundException ($"Unable to locate Microsoft.Android.Ref.");
 				}


### PR DESCRIPTION
Failing with:

    System.IO.DirectoryNotFoundException : Could not find a part of the path 'C:\a_work\1\s\bin\Release\dotnet\packs\Microsoft.Android.Ref.36.0'.

This was introduced in 35d471e7, but since the PR was from a fork we missed this one.