### PR TITLE
[WIP][CoreCLR] Fix Delegate marshalling to function pointers

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -17,7 +17,6 @@ namespace Xamarin.Android.Build.Tests
 	public class MonoAndroidExportTest : DeviceTest
 	{
 		[Test]
-		[Pairwise]
 		public void MonoAndroidExportReferencedAppStarts (
 			[Values (true, false)] bool embedAssemblies,
 			[Values (false, true)] bool isRelease,

--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -8,6 +8,7 @@ using Mono.Debugging.Client;
 using Mono.Debugging.Soft;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
+using Xamarin.Android.Tasks;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -15,30 +16,12 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("UsesDevice")]
 	public class MonoAndroidExportTest : DeviceTest
 	{
-#pragma warning disable 414
-		static object [] MonoAndroidExportTestCases = new object [] {
-			new object[] {
-				/* embedAssemblies */    true,
-				/* isRelease */          false,
-			},
-			new object[] {
-				/* embedAssemblies */    false,
-				/* isRelease */          false,
-			},
-			new object[] {
-				/* embedAssemblies */    true,
-				/* isRelease */          false,
-			},
-			new object[] {
-				/* embedAssemblies */    true,
-				/* isRelease */          true,
-			},
-		};
-#pragma warning restore 414
-
 		[Test]
-		[TestCaseSource (nameof (MonoAndroidExportTestCases))]
-		public void MonoAndroidExportReferencedAppStarts (bool embedAssemblies, bool isRelease)
+		[Pairwise]
+		public void MonoAndroidExportReferencedAppStarts (
+			[Values (true, false)] bool embedAssemblies,
+			[Values (false, true)] bool isRelease,
+			[Values (AndroidRuntime.MonoVM, AndroidRuntime.CoreCLR)] AndroidRuntime runtime)
 		{
 			AssertCommercialBuild ();
 			var proj = new XamarinAndroidApplicationProject () {
@@ -47,6 +30,7 @@ namespace Xamarin.Android.Build.Tests
 					new BuildItem.Reference ("Mono.Android.Export"),
 				},
 			};
+			proj.SetRuntime (runtime);
 			proj.Sources.Add (new BuildItem.Source ("ContainsExportedMethods.cs") {
 				TextContent = () => @"using System;
 using Java.Interop;


### PR DESCRIPTION
Fixes https://github.com/dotnet/android/issues/10472
Depends on https://github.com/dotnet/java-interop/pull/1364

Currently, we're running into an issue where the delegates for `[Export]` methods are created using `DynamicMethod` with `Action<...>` or `Func<...>` generic delegate types. These delegates cannot be marshalled to native function pointers because `Marshal.GetFunctionPointerForDelegate(...)`, which is called internally in the runtime when a `JniNativeMethodRegistration` struct instance is passed as an argument to a p/invoke, does not support delegates with generic types in CoreCLR (context: https://github.com/dotnet/runtime/issues/32963).

To work around this issue, we can dynamically create a new type with a new static method using `TypeBuilder` and `MethodBuilder`. Since this method is not a generic delegate, we can obtain a native function pointer to this method.

This change needs changing the `JniNativeMethodRegistration` struct in Java.Interop (https://github.com/dotnet/java-interop/pull/1364) because it now needs to hold an `IntPtr` instead of a `Delegate`.