### PR TITLE
[nativeaot] Implement _monodroid_weak_gref_delete

### DIFF
--- a/src/native/clr/host/internal-pinvokes-clr.cc
+++ b/src/native/clr/host/internal-pinvokes-clr.cc
@@ -66,11 +66,6 @@ void monodroid_timing_stop (managed_timing_sequence *sequence, const char *messa
 	timing->release_sequence (sequence);
 }
 
-void _monodroid_weak_gref_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable)
-{
-	OSBridge::_monodroid_weak_gref_delete (handle, type, threadName, threadId, from, from_writable);
-}
-
 void* _monodroid_timezone_get_default_id ()
 {
 	JNIEnv *env			 = OSBridge::ensure_jnienv ();

--- a/src/native/clr/host/internal-pinvokes-shared.cc
+++ b/src/native/clr/host/internal-pinvokes-shared.cc
@@ -29,6 +29,11 @@ void _monodroid_gref_log_delete (jobject handle, char type, const char *threadNa
 	OSBridge::_monodroid_gref_log_delete (handle, type, threadName, threadId, from, from_writable);
 }
 
+void _monodroid_weak_gref_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable)
+{
+	OSBridge::_monodroid_weak_gref_delete (handle, type, threadName, threadId, from, from_writable);
+}
+
 BridgeProcessingFtn clr_initialize_gc_bridge (
 	BridgeProcessingStartedFtn bridge_processing_started_callback,
 	BridgeProcessingFinishedFtn bridge_processing_finished_callback) noexcept

--- a/src/native/nativeaot/host/internal-pinvoke-stubs.cc
+++ b/src/native/nativeaot/host/internal-pinvoke-stubs.cc
@@ -56,17 +56,6 @@ void monodroid_timing_stop (
 	pinvoke_unreachable ();
 }
 
-void _monodroid_weak_gref_delete (
-	[[maybe_unused]] jobject handle,
-	[[maybe_unused]] char type,
-	[[maybe_unused]] const char *threadName,
-	[[maybe_unused]] int threadId,
-	[[maybe_unused]] const char *from,
-	[[maybe_unused]] int from_writable)
-{
-	pinvoke_unreachable ();
-}
-
 void* _monodroid_timezone_get_default_id ()
 {
 	pinvoke_unreachable ();


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10496#issuecomment-3307541946
Context: 869b0e03937e0c17a4cf3fbc85f50d80350b2576

The `_monodroid_weak_gref_delete` p/invoke wasn't implemented 
in 869b0e0393 as it was thought to be unused. However, the test
failure in #10496 shows that it's not true.

Bring the `_monodroid_weak_gref_delete` implementation to NativeAOT
host from the CoreCLR host.