### PR TITLE
$(AndroidPackVersionSuffix)=preview.1; main is 36.1.99

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,8 +36,8 @@
          * Major/Minor match Android stable API level, such as 30.0 for API 30.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>36.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
+    <AndroidPackVersion>36.1.99</AndroidPackVersion>
+    <AndroidPackVersionSuffix>preview.1</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/10.0.1xx

We branched for .NET 10 from 78f5f8cd4 into `release/10.0.1xx`; the main branch is now .NET 11.