### PR TITLE
[ci] Enable PME when signing NuGet packages

### DIFF
--- a/.azuredevops/policies/branchClassification.yml‎
+++ b/.azuredevops/policies/branchClassification.yml‎
@@ -1,0 +1,13 @@
+name: branch_classification
+resource: repository
+disabled: false
+where:
+configuration:
+  branchClassificationSettings:
+    defaultClassification: nonproduction
+    ruleset:
+      - name: prod-branches
+        branchNames:
+          - main
+          - release/*
+        classification: production


### PR DESCRIPTION
Context: https://github.com/dotnet/macios/pull/23701
Context: https://github.com/dotnet/android/pull/10453

In 398602e, we moved to the new `MicroBuildTemplate` and `v4` signing template.

It appears there is an additional file we need for `real` signing to work.