### PR TITLE
[ci] set `$(MicrobuildConnector)` for signing

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -47,6 +47,8 @@ variables:
 - ${{ if ne(variables['Build.DefinitionName'], 'Xamarin.Android-Private') }}:
   - name: DotNetFeedCredential
     value: dnceng-dotnet9
+- name: MicrobuildConnector
+  value: 'MicroBuild Signing Task (DevDiv)'
 - name: MicroBuildSignType
   ${{ if and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'Xamarin.Android')) }}:
     value: Real


### PR DESCRIPTION
Context: https://github.com/dotnet/macios/blob/5edc2969253e1b4ece64191993fdf7bb2863f6c3/tools/devops/automation/build-pipeline.yml#L65-L66

Trying to see what is different from signing in the dotnet/macios repo, they set `$(MicrobuildConnector)`, going to see if this helps.