### PR TITLE
[TrimmableTypeMap][NativeAOT] Auto-detect and scan runtime-only assemblies (fixes stripped runtime ACWs)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -86,6 +86,36 @@ _ResolveAssemblies MSBuild target.
       </ItemGroup>
   </Target>
 
+  <!--
+    Resolve-only variant used by the trimmable typemap generator to discover runtime-only assemblies.
+
+    The trimmable typemap generator runs in the RID-independent OUTER build over @(ReferencePath),
+    the compile closure, which omits runtime-only assemblies (e.g. the NativeAOT runtime host) that
+    have no ref-pack counterpart and are only pulled from the RID-specific runtime pack. Runtime-pack
+    resolution (ResolveRuntimePackAssets, reached via ResolveReferences) requires a single
+    RuntimeIdentifier, so the outer build invokes this target through the MSBuild task for one RID.
+
+    It stops after ResolveReferences - it does NOT run ComputeFilesToPublish/ILLink/ILC/AOT - and
+    returns the Android runtime-pack managed assemblies that are NOT already in @(ReferencePath)
+    (matched on filename). Those are exactly the runtime-only assemblies the outer generator would
+    otherwise miss; everything with a compile reference is already scanned via @(ReferencePath). Only
+    the Android runtime packs (Microsoft.Android.Runtime.*) can carry Java peers, so the .NET/BCL
+    runtime pack (Microsoft.NETCore.App.Runtime.*) is excluded to avoid scanning large BCL assemblies
+    that have none. The managed metadata is RID-independent, so resolving one RID suffices for all. -->
+  <Target Name="_ResolveRuntimeOnlyAssembliesForTypeMap"
+      DependsOnTargets="BuildOnlySettings;_FixupIntermediateAssembly;_PatchNuGetReferenceMetadata;ResolveReferences"
+      Returns="@(_TypeMapRuntimeOnlyAssembly)">
+    <ItemGroup>
+      <_TypeMapRuntimeOnlyAssembly Include="@(RuntimePackAsset)"
+          Condition=" '%(RuntimePackAsset.Extension)' == '.dll' and '%(RuntimePackAsset.AssetType)' == 'runtime' and $([System.String]::Copy('%(RuntimePackAsset.NuGetPackageId)').StartsWith('Microsoft.Android.Runtime')) " />
+      <!-- Drop any runtime-pack assembly that also has a compile reference (e.g. Mono.Android,
+           Java.Interop): the outer build already scans those via @(ReferencePath), and scanning both
+           the ref and runtime-pack copies would double-process the same assembly (GenerateTrimmableTypeMap
+           groups inputs by path). Match on filename to keep only the runtime-only assemblies. -->
+      <_TypeMapRuntimeOnlyAssembly Remove="@(ReferencePath)" MatchOnMetadata="Filename" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_FixupIntermediateAssembly" Condition=" '$(_OuterIntermediateAssembly)' != '' ">
     <ItemGroup>
       <IntermediateAssembly Remove="@(IntermediateAssembly)" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.NativeAOT.targets
@@ -27,6 +27,15 @@
       <_TrimmableTypeMapFrameworkIlcAssemblyNames Include="@(PrivateSdkAssemblies->'_%(Filename).TypeMap')" />
       <_TrimmableTypeMapFrameworkIlcAssemblyNames Include="@(ReferencePath->'_%(Filename).TypeMap')"
           Condition=" '%(ReferencePath.FrameworkAssembly)' == 'true' " />
+      <!-- Runtime-only assemblies (e.g. the NativeAOT runtime host Microsoft.Android.Runtime.NativeAOT)
+           come from the runtime pack and have no @(ReferencePath) counterpart, so their per-assembly
+           typemap DLLs are not caught by the rules above. Every runtime-pack managed assembly is a
+           framework/runtime assembly: classify its typemap DLL as framework so it stays an IlcReference
+           (ILC reads its conditional TypeMap attributes) but is removed from the unmanaged-entrypoint
+           roots, matching Mono.Android/Java.Interop. Their JCW native methods register via the runtime
+           registerNatives path. -->
+      <_TrimmableTypeMapFrameworkIlcAssemblyNames Include="@(RuntimePackAsset->'_%(Filename).TypeMap')"
+          Condition=" '%(RuntimePackAsset.Extension)' == '.dll' and '%(RuntimePackAsset.AssetType)' == 'runtime' " />
       <!-- The root assembly (_Microsoft.Android.TypeMaps) only contains TypeMapLoader.Initialize()
             and assembly-level attributes — no types that need vtable generation.
             Framework per-assembly typemap DLLs must remain IlcReference inputs so ILC can read
@@ -65,6 +74,70 @@
       Condition=" '$(_OuterIntermediateOutputPath)' == '' "
       BeforeTargets="_ResolveAssemblies"
       DependsOnTargets="_GenerateTrimmableTypeMap" />
+
+  <!--
+    The trimmable typemap generator runs in the OUTER build over @(ReferencePath), which contains only
+    the compile closure (app + its references + the ref-pack framework assemblies). Runtime-only
+    assemblies - e.g. the NativeAOT runtime host Microsoft.Android.Runtime.NativeAOT - come from the
+    RID-specific runtime pack and have no ref-pack counterpart, so they are resolved only in the per-RID
+    inner build and are never in @(ReferencePath). Their Java Callable Wrapper types (e.g.
+    UncaughtExceptionMarshaler) would then be missing from the typemap and JCWs -> R8 has nothing to
+    keep -> on-device startup crash in JavaInteropRuntime.init (setDefaultUncaughtExceptionHandler).
+
+    Runtime-pack resolution (ResolveRuntimePackAssets) requires a single RuntimeIdentifier and must
+    happen before ILC. So, before _ResolveAssemblies spawns the per-RID ILC builds, run a lightweight
+    resolve-only pass for the first RID (the managed metadata is RID-independent) via
+    _ResolveRuntimeOnlyAssembliesForTypeMap, and cache the discovered runtime-only assemblies to a file.
+    This auto-detects every runtime-only Java-peer assembly - no assembly is hard-coded.
+
+    The nested resolve is gated on Inputs/Outputs so it only re-runs when the reference graph could have
+    changed (restore output or the cached build properties), not on every incremental build. The
+    always-run loader below reads the cached list into the item the generator consumes, keeping the
+    generator's Inputs stable across builds.
+  -->
+  <Target Name="_ResolveRuntimeOnlyAssembliesForTrimmableTypeMap"
+      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(_OuterIntermediateOutputPath)' == '' and '$(DesignTimeBuild)' != 'true' "
+      Inputs="$(ProjectAssetsFile);$(_AndroidBuildPropertiesCache)"
+      Outputs="$(_TypeMapOutputDirectory)runtime-only-assemblies.txt">
+    <PropertyGroup>
+      <_TrimmableTypeMapResolveRid Condition=" '$(RuntimeIdentifiers)' != '' ">$([System.String]::Copy('$(RuntimeIdentifiers)').Split(';')[0])</_TrimmableTypeMapResolveRid>
+      <_TrimmableTypeMapResolveRid Condition=" '$(_TrimmableTypeMapResolveRid)' == '' ">$(RuntimeIdentifier)</_TrimmableTypeMapResolveRid>
+      <!-- Item lists (e.g. @(IntermediateAssembly)) cannot be embedded directly in the MSBuild task's
+           Properties string, so flatten them into this property and pass it via AdditionalProperties
+           item metadata, mirroring _ResolveAssemblies. -->
+      <_TrimmableTypeMapResolveProperties>_ComputeFilesToPublishForRuntimeIdentifiers=true;SelfContained=true;DesignTimeBuild=$(DesignTimeBuild);AppendRuntimeIdentifierToOutputPath=true;ResolveAssemblyReferencesFindRelatedSatellites=false;SkipCompilerExecution=true;_OuterIntermediateAssembly=@(IntermediateAssembly);_OuterOutputPath=$(OutputPath);_OuterIntermediateOutputPath=$(IntermediateOutputPath);_AndroidNdkDirectory=$(_AndroidNdkDirectory)</_TrimmableTypeMapResolveProperties>
+    </PropertyGroup>
+    <ItemGroup Condition=" '$(_TrimmableTypeMapResolveRid)' != '' ">
+      <_TrimmableTypeMapResolveProject Include="$(MSBuildProjectFile)"
+          AdditionalProperties="RuntimeIdentifier=$(_TrimmableTypeMapResolveRid);$(_TrimmableTypeMapResolveProperties)" />
+    </ItemGroup>
+    <MSBuild
+        Condition=" '$(_TrimmableTypeMapResolveRid)' != '' "
+        Projects="@(_TrimmableTypeMapResolveProject)"
+        Targets="_ResolveRuntimeOnlyAssembliesForTypeMap">
+      <Output TaskParameter="TargetOutputs" ItemName="_ResolvedRuntimeOnlyAssemblyForTypeMap" />
+    </MSBuild>
+    <MakeDir Directories="$(_TypeMapOutputDirectory)" />
+    <WriteLinesToFile
+        File="$(_TypeMapOutputDirectory)runtime-only-assemblies.txt"
+        Lines="@(_ResolvedRuntimeOnlyAssemblyForTypeMap)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_TypeMapOutputDirectory)runtime-only-assemblies.txt" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_AddRuntimeOnlyAssembliesToTrimmableTypeMap"
+      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(_OuterIntermediateOutputPath)' == '' and '$(DesignTimeBuild)' != 'true' "
+      DependsOnTargets="_ResolveRuntimeOnlyAssembliesForTrimmableTypeMap"
+      BeforeTargets="_GenerateTrimmableTypeMap">
+    <ReadLinesFromFile
+        File="$(_TypeMapOutputDirectory)runtime-only-assemblies.txt"
+        Condition=" Exists('$(_TypeMapOutputDirectory)runtime-only-assemblies.txt') ">
+      <Output TaskParameter="Lines" ItemName="_AndroidTrimmableTypeMapExtraFrameworkAssembly" />
+    </ReadLinesFromFile>
+  </Target>
 
   <Target Name="_CollectTrimmableNativeAotDgmlFiles"
       Condition=" '$(PublishTrimmed)' == 'true' and '$(_ProguardProjectConfiguration)' != '' ">

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -99,7 +99,7 @@
       Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(DesignTimeBuild)' != 'true' and '@(ReferencePath->Count())' != '0' and '$(_OuterIntermediateOutputPath)' == '' "
       AfterTargets="CoreCompile"
       DependsOnTargets="_GetLibraryImports"
-      Inputs="@(ReferencePath);@(PrivateSdkAssemblies);@(FrameworkAssemblies);@(ExtractedManifestDocuments);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
+      Inputs="@(ReferencePath);@(PrivateSdkAssemblies);@(FrameworkAssemblies);@(ExtractedManifestDocuments);@(_AndroidTrimmableTypeMapExtraFrameworkAssembly);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
       Outputs="$(_TrimmableTypeMapOutputStamp)">
 
     <ItemGroup>
@@ -108,9 +108,14 @@
       <_TypeMapInputAssemblies Include="@(ResolvedFrameworkAssemblies)" />
       <_TypeMapInputAssemblies Include="@(PrivateSdkAssemblies)" />
       <_TypeMapInputAssemblies Include="@(FrameworkAssemblies)" />
+      <!-- Runtime-only framework assemblies that have no counterpart in @(ReferencePath) (e.g. the
+           NativeAOT runtime host Microsoft.Android.Runtime.NativeAOT.dll, injected by the trimmable
+           NativeAOT targets). They carry Java Callable Wrapper types that must be in the typemap. -->
+      <_TypeMapInputAssemblies Include="@(_AndroidTrimmableTypeMapExtraFrameworkAssembly)" />
       <_TypeMapFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies)" />
       <_TypeMapFrameworkAssemblies Include="@(PrivateSdkAssemblies)" />
       <_TypeMapFrameworkAssemblies Include="@(FrameworkAssemblies)" />
+      <_TypeMapFrameworkAssemblies Include="@(_AndroidTrimmableTypeMapExtraFrameworkAssembly)" />
       <_TypeMapInputAssemblies Include="$(IntermediateOutputPath)$(TargetFileName)"
           Condition="Exists('$(IntermediateOutputPath)$(TargetFileName)')" />
       <!-- Library (.aar) manifests to merge into the app manifest. Only on the legacy manifest

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -68,6 +68,38 @@ namespace Xamarin.Android.Build.Tests {
 		}
 
 		[Test]
+		public void Build_WithTrimmableTypeMap_KeepsNativeAotRuntimeHostAcws ()
+		{
+			const bool isRelease = true;
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.NativeAOT, release: isRelease)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+				LinkTool = "r8",
+			};
+			proj.SetRuntime (AndroidRuntime.NativeAOT);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+
+			var dexFile = builder.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes.dex"));
+			FileAssert.Exists (dexFile);
+
+			// Regression test: the NativeAOT runtime host assembly (Microsoft.Android.Runtime.NativeAOT) is
+			// resolved only in the per-RID inner build, so the RID-independent outer-build trimmable typemap
+			// generator never scanned it. Its only Java Callable Wrapper type, UncaughtExceptionMarshaler,
+			// therefore had no JCW and no typemap entry -> the runtime ACW is absent from classes.dex and the
+			// app crashes at startup in JavaInteropRuntime.init (setDefaultUncaughtExceptionHandler). A
+			// reference assembly for the host is now shipped in the SDK pack and fed to the generator. The JCW
+			// name is CRC-hashed (e.g. `scrc64...UncaughtExceptionMarshaler`), so match on the type name suffix.
+			Assert.IsTrue (DexUtils.ContainsClass ("UncaughtExceptionMarshaler;", dexFile, AndroidSdkPath),
+				$"`{dexFile}` should include the UncaughtExceptionMarshaler runtime ACW.");
+		}
+
+		[Test]
 		public void Build_WithTrimmableTypeMap_DeletesStaleGeneratedJavaSourcesAndCopies ()
 		{
 			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: false)) {


### PR DESCRIPTION
## Summary

Under the **trimmable** typemap on **NativeAOT**, the runtime host assembly `Microsoft.Android.Runtime.NativeAOT` — and its only Java Callable Wrapper type, `UncaughtExceptionMarshaler` — was **never scanned** by the typemap generator. Its JCW, typemap entry, and acw-map entry were all missing, so R8 had nothing to keep, the ACW was dropped from `classes.dex`, and the app crashed at startup in `JavaInteropRuntime.init` (`setDefaultUncaughtExceptionHandler`).

More generally: **any runtime-only assembly with Java peers was invisible to the typemap generator.** This fixes the whole class of problem, not just `UncaughtExceptionMarshaler`.

## Root cause

`_GenerateTrimmableTypeMap` runs in the **RID-independent outer build** over `@(ReferencePath)` (the compile closure: app + references + ref-pack framework assemblies). Runtime-only assemblies have **no ref-pack counterpart** and are only pulled from the **RID-specific runtime pack** in the per-RID inner build, so they never enter the generator's input set. Runtime-pack resolution (`ResolveRuntimePackAssets`) fundamentally requires a single `RuntimeIdentifier`.

## Fix — auto-detect via the SDK's own resolution

No hard-coded assembly names, no per-assembly reference-assembly plumbing:

- **`_ResolveRuntimeOnlyAssembliesForTypeMap`** (`Microsoft.Android.Sdk.AssemblyResolution.targets`): a resolve-only sibling of `_ComputeFilesToPublishForRuntimeIdentifiers` that stops after `ResolveReferences` (no `ComputeFilesToPublish`/ILLink/ILC/AOT) and returns the Android runtime-pack managed assemblies (`Microsoft.Android.Runtime.*`) that have **no** `@(ReferencePath)` counterpart (matched on `Filename`, so `Mono.Android`/`Java.Interop` aren't double-scanned; the .NET/BCL runtime pack is excluded).
- **`_ResolveRuntimeOnlyAssembliesForTrimmableTypeMap` + `_AddRuntimeOnlyAssembliesToTrimmableTypeMap`** (`Microsoft.Android.Sdk.TypeMap.Trimmable.NativeAOT.targets`): before `_ResolveAssemblies` spawns the per-RID ILC builds, run that target once via the MSBuild task for the first RID (managed metadata is RID-independent) and **cache** the result. The nested resolve is gated on `Inputs`/`Outputs` so it does **not** re-run on incremental no-op builds; an always-run loader reads the cached list into the generator's extra-framework input (`_AndroidTrimmableTypeMapExtraFrameworkAssembly`, plumbed through `Microsoft.Android.Sdk.TypeMap.Trimmable.targets`).
- **ILC framework classification** generalized: any runtime-pack managed assembly's per-assembly typemap DLL is treated as framework (`IlcReference` but not an unmanaged-entrypoint root), matching `Mono.Android`/`Java.Interop`, so its JCW native methods register via the runtime `registerNatives` path.

## Test

Adds `Build_WithTrimmableTypeMap_KeepsNativeAotRuntimeHostAcws`, which opts into the trimmable typemap on NativeAOT and asserts `classes.dex` retains the `UncaughtExceptionMarshaler` runtime ACW.

## Validation (local, `-c Release`)

- `Build_WithTrimmableTypeMap_KeepsNativeAotRuntimeHostAcws` passes.
- A NativeAOT + trimmable app build now generates `_Microsoft.Android.Runtime.NativeAOT.TypeMap.dll` (with the `UncaughtExceptionMarshaler` → `scrc64…/UncaughtExceptionMarshaler` entry + proxy), the JCW `.java`, and the acw-map entry.
- The runtime host typemap DLL is an `IlcReference` and **not** an `UnmanagedEntryPointsAssembly` (correct framework classification).
- No double-scanning of framework assemblies (one `_Mono.Android.TypeMap.dll` in the generator output).
- Incremental no-op builds **skip** the nested resolve (verified via binlog: `_ResolveRuntimeOnlyAssembliesForTrimmableTypeMap` up-to-date).

## Notes

The trimmable typemap is opt-in on `main` (`_AndroidTypeMapImplementation=trimmable`); this fix is dormant otherwise. Extracted from the "make trimmable the NativeAOT default" work (#11822) so it can be reviewed and merged independently.

## Issue references

Contributes to https://github.com/dotnet/android/issues/10933 and https://github.com/dotnet/android/issues/10793.
