### PR TITLE
[TrimmableTypeMap] Generator correctness fixes

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ComponentElementBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ComponentElementBuilder.cs
@@ -44,8 +44,7 @@ static class ComponentElementBuilder
 			element.Add (CreateIntentFilterElement (intentFilter));
 		}
 
-		// Add <layout> element from a [Layout] attribute, if present
-		if (component.LayoutProperties is not null) {
+		if (component.Kind == ComponentKind.Activity && component.LayoutProperties is not null) {
 			var layout = CreateLayoutElement (component.LayoutProperties);
 			if (layout is not null) {
 				element.Add (layout);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
@@ -516,7 +516,7 @@ class ManifestGenerator
 		if (!placeholders.IsNullOrEmpty ()) {
 			foreach (var entry in placeholders.Split (PlaceholderSeparators, StringSplitOptions.RemoveEmptyEntries)) {
 				var eqIndex = entry.IndexOf ('=');
-				if (eqIndex > 0) {
+				if (eqIndex >= 0) {
 					var key = entry.Substring (0, eqIndex).Trim ();
 					var value = entry.Substring (eqIndex + 1).Trim ();
 					replacements ["${" + key + "}"] = value;

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -102,9 +102,22 @@ static class ModelBuilder
 			string jniName = kvp.Key;
 			var peersForName = kvp.Value;
 
-			// Sort aliases by managed type name for deterministic proxy naming
+			// Order aliases to match the java→managed selection the native runtime performs (see
+			// clr_typemap_java_to_managed / monovm_typemap_java_to_managed and NativeTypeMappingData):
+			// the runtime builds its java→managed map by processing the Mono.Android module first and
+			// keeping the first managed type that claims a Java name (first-writer-wins). GetTypeForSimpleReference
+			// returns the first (index [0]) alias, so put the Mono.Android peer first — e.g. java/lang/Object
+			// must resolve to Java.Lang.Object (Mono.Android), not Java.Interop.JavaObject. Remaining peers are
+			// ordered by ordinal managed type name for deterministic proxy naming.
 			if (peersForName.Count > 1) {
-				peersForName.Sort ((a, b) => StringComparer.Ordinal.Compare (a.ManagedTypeName, b.ManagedTypeName));
+				peersForName.Sort ((a, b) => {
+					bool aMonoAndroid = string.Equals (a.AssemblyName, "Mono.Android", StringComparison.Ordinal);
+					bool bMonoAndroid = string.Equals (b.AssemblyName, "Mono.Android", StringComparison.Ordinal);
+					if (aMonoAndroid != bMonoAndroid) {
+						return aMonoAndroid ? -1 : 1;
+					}
+					return StringComparer.Ordinal.Compare (a.ManagedTypeName, b.ManagedTypeName);
+				});
 			}
 
 			EmitPeers (model, jniName, peersForName, assemblyName, usedProxyNames);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -102,22 +102,8 @@ static class ModelBuilder
 			string jniName = kvp.Key;
 			var peersForName = kvp.Value;
 
-			// Order aliases to match the java→managed selection the native runtime performs (see
-			// clr_typemap_java_to_managed / monovm_typemap_java_to_managed and NativeTypeMappingData):
-			// the runtime builds its java→managed map by processing the Mono.Android module first and
-			// keeping the first managed type that claims a Java name (first-writer-wins). GetTypeForSimpleReference
-			// returns the first (index [0]) alias, so put the Mono.Android peer first — e.g. java/lang/Object
-			// must resolve to Java.Lang.Object (Mono.Android), not Java.Interop.JavaObject. Remaining peers are
-			// ordered by ordinal managed type name for deterministic proxy naming.
 			if (peersForName.Count > 1) {
-				peersForName.Sort ((a, b) => {
-					bool aMonoAndroid = string.Equals (a.AssemblyName, "Mono.Android", StringComparison.Ordinal);
-					bool bMonoAndroid = string.Equals (b.AssemblyName, "Mono.Android", StringComparison.Ordinal);
-					if (aMonoAndroid != bMonoAndroid) {
-						return aMonoAndroid ? -1 : 1;
-					}
-					return StringComparer.Ordinal.Compare (a.ManagedTypeName, b.ManagedTypeName);
-				});
+				peersForName.Sort (CompareAliasesForRuntimeResolution);
 			}
 
 			EmitPeers (model, jniName, peersForName, assemblyName, usedProxyNames);
@@ -152,6 +138,19 @@ static class ModelBuilder
 		model.IgnoresAccessChecksTo.AddRange (referencedAssemblies);
 
 		return model;
+	}
+
+	static int CompareAliasesForRuntimeResolution (JavaPeerInfo a, JavaPeerInfo b)
+	{
+		// Keep alias [0] aligned with the native java→managed map, which processes Mono.Android first.
+		bool aMonoAndroid = string.Equals (a.AssemblyName, "Mono.Android", StringComparison.Ordinal);
+		bool bMonoAndroid = string.Equals (b.AssemblyName, "Mono.Android", StringComparison.Ordinal);
+		if (aMonoAndroid != bMonoAndroid) {
+			return aMonoAndroid ? -1 : 1;
+		}
+
+		int result = StringComparer.Ordinal.Compare (a.ManagedTypeName, b.ManagedTypeName);
+		return result != 0 ? result : StringComparer.Ordinal.Compare (a.AssemblyName, b.AssemblyName);
 	}
 
 	static void EmitPeers (TypeMapAssemblyData model, string jniName,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Security.Cryptography;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
@@ -107,10 +108,26 @@ sealed class PEAssemblyBuilder
 			new PEHeaderBuilder (imageCharacteristics: Characteristics.Dll),
 			new MetadataRootBuilder (Metadata),
 			ILBuilder,
-			mappedFieldData: _mappedFieldData.Count > 0 ? _mappedFieldData : null);
+			mappedFieldData: _mappedFieldData.Count > 0 ? _mappedFieldData : null,
+			// Derive the PE content id (and thus the header TimeDateStamp/debug id) from a hash of the
+			// image so the bytes are fully deterministic. Without this, ManagedPEBuilder falls back to a
+			// time-based id, so every regeneration produces different bytes even for identical input; that
+			// churns the generated typemap assemblies and breaks incremental packaging (a no-op rebuild
+			// re-touches the .dll, forcing repackage + re-sign). The MVID is already deterministic.
+			deterministicIdProvider: DeterministicContentId);
 		var peBlob = new BlobBuilder ();
 		peBuilder.Serialize (peBlob);
 		peBlob.WriteContentTo (stream);
+	}
+
+	static BlobContentId DeterministicContentId (IEnumerable<Blob> content)
+	{
+		using var hash = IncrementalHash.CreateHash (HashAlgorithmName.SHA256);
+		foreach (var blob in content) {
+			var segment = blob.GetBytes ();
+			hash.AppendData (segment.Array!, segment.Offset, segment.Count);
+		}
+		return BlobContentId.FromHash (hash.GetHashAndReset ());
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -109,11 +110,7 @@ sealed class PEAssemblyBuilder
 			new MetadataRootBuilder (Metadata),
 			ILBuilder,
 			mappedFieldData: _mappedFieldData.Count > 0 ? _mappedFieldData : null,
-			// Derive the PE content id (and thus the header TimeDateStamp/debug id) from a hash of the
-			// image so the bytes are fully deterministic. Without this, ManagedPEBuilder falls back to a
-			// time-based id, so every regeneration produces different bytes even for identical input; that
-			// churns the generated typemap assemblies and breaks incremental packaging (a no-op rebuild
-			// re-touches the .dll, forcing repackage + re-sign). The MVID is already deterministic.
+			// ManagedPEBuilder otherwise uses a time-based id, changing bytes on every regeneration.
 			deterministicIdProvider: DeterministicContentId);
 		var peBlob = new BlobBuilder ();
 		peBuilder.Serialize (peBlob);
@@ -125,7 +122,14 @@ sealed class PEAssemblyBuilder
 		using var hash = IncrementalHash.CreateHash (HashAlgorithmName.SHA256);
 		foreach (var blob in content) {
 			var segment = blob.GetBytes ();
-			hash.AppendData (segment.Array!, segment.Offset, segment.Count);
+			if (segment.Count == 0) {
+				continue;
+			}
+			Debug.Assert (segment.Array is not null);
+			if (segment.Array is null) {
+				throw new InvalidOperationException ("PE content blob segment has no backing array.");
+			}
+			hash.AppendData (segment.Array, segment.Offset, segment.Count);
 		}
 		return BlobContentId.FromHash (hash.GetHashAndReset ());
 	}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
@@ -126,9 +126,6 @@ sealed class PEAssemblyBuilder
 				continue;
 			}
 			Debug.Assert (segment.Array is not null);
-			if (segment.Array is null) {
-				throw new InvalidOperationException ("PE content blob segment has no backing array.");
-			}
 			hash.AppendData (segment.Array, segment.Offset, segment.Count);
 		}
 		return BlobContentId.FromHash (hash.GetHashAndReset ());

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/ITrimmableTypeMapLogger.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/ITrimmableTypeMapLogger.cs
@@ -13,6 +13,7 @@ public interface ITrimmableTypeMapLogger
 	void LogRootingManifestReferencedTypeInfo (string javaTypeName, string managedTypeName);
 	void LogManifestReferencedTypeNotFoundWarning (string javaTypeName);
 	void LogLibraryManifestMergeWarning (string message);
+	void LogInvalidManifestPlaceholderWarning (string placeholders);
 	void LogUnresolvableJavaPeerSkippedWarning (
 		string managedTypeName,
 		string assemblyName,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -164,6 +164,7 @@ sealed class AssemblyIndex : IDisposable
 		// with the wrong AttributeName.
 		List<IntentFilterInfo>? intentFilters = null;
 		List<MetaDataInfo>? metaData = null;
+		Dictionary<string, object?>? layoutProperties = null;
 
 		foreach (var caHandle in typeDef.GetCustomAttributes ()) {
 			var ca = Reader.GetCustomAttribute (caHandle);
@@ -214,6 +215,8 @@ sealed class AssemblyIndex : IDisposable
 				metaData ??= new List<MetaDataInfo> ();
 				var (mdName, mdProps) = ParseNameAndProperties (ca);
 				metaData.Add (CreateMetaDataInfo (mdName, mdProps));
+			} else if (attrName == "LayoutAttribute") {
+				layoutProperties = ParseLayoutAttribute (ca);
 			} else if (attrInfo is null && ImplementsJniNameProviderAttribute (ca)) {
 				// Custom attribute implementing IJniNameProviderAttribute (e.g., user-defined [CustomJniName])
 				var name = TryGetNameProperty (ca);
@@ -231,6 +234,9 @@ sealed class AssemblyIndex : IDisposable
 			}
 			if (metaData is not null) {
 				attrInfo.MetaData.AddRange (metaData);
+			}
+			if (layoutProperties is not null) {
+				attrInfo.LayoutProperties = layoutProperties;
 			}
 		}
 
@@ -423,6 +429,18 @@ sealed class AssemblyIndex : IDisposable
 		}
 
 		return null;
+	}
+
+	Dictionary<string, object?> ParseLayoutAttribute (CustomAttribute ca)
+	{
+		var value = DecodeAttribute (ca);
+		var properties = new Dictionary<string, object?> (StringComparer.Ordinal);
+		foreach (var named in value.NamedArguments) {
+			if (named.Name is not null) {
+				properties [named.Name] = named.Value;
+			}
+		}
+		return properties;
 	}
 
 	IntentFilterInfo ParseIntentFilterAttribute (CustomAttribute ca)
@@ -712,6 +730,12 @@ class TypeAttributeInfo (string attributeName)
 	/// Metadata entries declared on this type via [MetaData] attributes.
 	/// </summary>
 	public List<MetaDataInfo> MetaData { get; } = [];
+
+	/// <summary>
+	/// Named property values from a [Layout] attribute on this type, or null if none.
+	/// Maps to the &lt;layout&gt; child element of the component in the manifest.
+	/// </summary>
+	public Dictionary<string, object?>? LayoutProperties { get; set; }
 }
 
 sealed class ApplicationAttributeInfo () : TypeAttributeInfo ("ApplicationAttribute")

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -2545,6 +2545,7 @@ public sealed class JavaPeerScanner : IDisposable
 			Properties = attrInfo.Properties,
 			IntentFilters = attrInfo.IntentFilters,
 			MetaData = attrInfo.MetaData,
+			LayoutProperties = attrInfo.LayoutProperties,
 		};
 	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -274,6 +274,13 @@ public sealed class JavaPeerScanner : IDisposable
 		}
 	}
 
+	// Managed types that must never be emitted into the trimmable type map, keyed by
+	// (managed full name, assembly simple name). These are reflection-based ([RequiresUnreferencedCode])
+	// helpers that the trimmable runtime never activates via the type map; emitting proxies for them
+	// only produces IL2026 trim warnings.
+	static bool IsUnsupportedByTrimmableTypeMap (string managedFullName, string assemblyName) =>
+		managedFullName == "Java.Interop.ManagedPeer" && assemblyName == "Java.Interop";
+
 	void ScanAssembly (AssemblyIndex index, Dictionary<(string ManagedName, string AssemblyName), JavaPeerInfo> results)
 	{
 		foreach (var typeHandle in index.Reader.TypeDefinitions) {
@@ -285,6 +292,16 @@ public sealed class JavaPeerScanner : IDisposable
 			}
 
 			var fullName = MetadataTypeNameResolver.GetFullName (typeDef, index.Reader);
+
+			// Java.Interop.ManagedPeer is a reflection-based helper (marked
+			// [RequiresUnreferencedCode]) that is not supported by the trimmable type map: on the
+			// trimmable path native registration goes through IAndroidCallableWrapper.RegisterNatives
+			// and ManagedPeerNativeRegistration is disabled, so ManagedPeer is never activated via the
+			// type map. Emitting a proxy for it only produces IL2026 trim warnings (its constructors
+			// use reflection), so exclude it here.
+			if (IsUnsupportedByTrimmableTypeMap (fullName, index.AssemblyName)) {
+				continue;
+			}
 
 			// Temporarily allow [JniAddNativeMethodRegistrationAttribute] while we investigate
 			// which scenarios fail later in the trimmable typemap pipeline.

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -274,10 +274,7 @@ public sealed class JavaPeerScanner : IDisposable
 		}
 	}
 
-	// Managed types that must never be emitted into the trimmable type map, keyed by
-	// (managed full name, assembly simple name). These are reflection-based ([RequiresUnreferencedCode])
-	// helpers that the trimmable runtime never activates via the type map; emitting proxies for them
-	// only produces IL2026 trim warnings.
+	// ManagedPeer depends on reflection-based registration; the trimmable path uses IAndroidCallableWrapper.
 	static bool IsUnsupportedByTrimmableTypeMap (string managedFullName, string assemblyName) =>
 		managedFullName == "Java.Interop.ManagedPeer" && assemblyName == "Java.Interop";
 
@@ -293,12 +290,6 @@ public sealed class JavaPeerScanner : IDisposable
 
 			var fullName = MetadataTypeNameResolver.GetFullName (typeDef, index.Reader);
 
-			// Java.Interop.ManagedPeer is a reflection-based helper (marked
-			// [RequiresUnreferencedCode]) that is not supported by the trimmable type map: on the
-			// trimmable path native registration goes through IAndroidCallableWrapper.RegisterNatives
-			// and ManagedPeerNativeRegistration is disabled, so ManagedPeer is never activated via the
-			// type map. Emitting a proxy for it only produces IL2026 trim warnings (its constructors
-			// use reflection), so exclude it here.
 			if (IsUnsupportedByTrimmableTypeMap (fullName, index.AssemblyName)) {
 				continue;
 			}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -155,6 +155,7 @@ public class TrimmableTypeMapGenerator
 				// Other codes (e.g. unresolvable type properties) are not yet assigned XA codes
 				// and are intentionally not surfaced here.
 			},
+			WarnInvalidPlaceholder = placeholders => logger.LogInvalidManifestPlaceholderWarning (placeholders),
 			LibraryManifests = config.LibraryManifests ?? [],
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -46,6 +46,8 @@ public class GenerateTrimmableTypeMap : AndroidTask
 			log.LogCodedWarning ("XA4250", Properties.Resources.XA4250, javaTypeName);
 		public void LogLibraryManifestMergeWarning (string message) =>
 			log.LogCodedWarning ("XA4302", Properties.Resources.XA4302, message);
+		public void LogInvalidManifestPlaceholderWarning (string placeholders) =>
+			log.LogCodedWarning ("XA1010", Properties.Resources.XA1010, placeholders);
 		public void LogUnresolvableJavaPeerSkippedWarning (
 			string managedTypeName,
 			string assemblyName,

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
@@ -106,6 +106,25 @@ public class ManifestGeneratorTests
 	}
 
 	[Fact]
+	public void Placeholders_EmptyKey_ReplacesEmptyTokenWithoutWarning ()
+	{
+		var gen = CreateDefaultGenerator ();
+		var warnings = new List<string> ();
+		gen.WarnInvalidPlaceholder = warnings.Add;
+		gen.ManifestPlaceholders = "=val1";
+		var template = ParseTemplate ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.app">
+			  <uses-sdk />
+			  <application android:label="${}" />
+			</manifest>
+			""");
+		var doc = GenerateAndLoad (gen, template: template);
+		Assert.Empty (warnings);
+		Assert.Equal ("val1", (string?) doc.Root?.Element ("application")?.Attribute (AndroidNs + "label"));
+	}
+
+	[Fact]
 	public void Package_PlaceholderToken_ReplacedWithResolvedPackageName ()
 	{
 		// A template package that is a placeholder token (e.g. "${PACKAGENAME}") must be replaced
@@ -383,6 +402,24 @@ public class ManifestGeneratorTests
 		Assert.Equal ("center", (string?)layout?.Attribute (AndroidNs + "gravity"));
 		Assert.Equal ("300dp", (string?)layout?.Attribute (AndroidNs + "minWidth"));
 		Assert.Equal ("400dp", (string?)layout?.Attribute (AndroidNs + "minHeight"));
+	}
+
+	[Fact]
+	public void Service_LayoutAttributeElement_Ignored ()
+	{
+		var gen = CreateDefaultGenerator ();
+		var peer = CreatePeer ("com/example/app/MyService", new ComponentInfo {
+			Kind = ComponentKind.Service,
+			LayoutProperties = new Dictionary<string, object?> {
+				["DefaultWidth"] = "500dp",
+			},
+		});
+
+		var doc = GenerateAndLoad (gen, [peer]);
+		var service = doc.Root?.Element ("application")?.Element ("service");
+
+		Assert.NotNull (service);
+		Assert.Null (service?.Element ("layout"));
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -38,6 +38,8 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 			warnings?.Add ($"Manifest-referenced type '{javaTypeName}' was not found in any scanned assembly. It may be a framework type.");
 		public void LogLibraryManifestMergeWarning (string message) =>
 			warnings?.Add (message);
+		public void LogInvalidManifestPlaceholderWarning (string placeholders) =>
+			warnings?.Add ($"Invalid $(AndroidManifestPlaceholders) '{placeholders}'.");
 		public void LogUnresolvableJavaPeerSkippedWarning (
 			string managedTypeName,
 			string assemblyName,

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -116,12 +116,7 @@ public class ModelBuilderTests : FixtureTestBase
 		[Fact]
 		public void Build_AliasGroup_MonoAndroidPeerSortsFirst ()
 		{
-			// Mirror the native runtime's java→managed selection (clr_typemap_java_to_managed /
-			// monovm_typemap_java_to_managed): NativeTypeMappingData builds that map by processing the
-			// Mono.Android module first and keeping the first managed type to claim a Java name, so
-			// java/lang/Object resolves to Java.Lang.Object (Mono.Android), not Java.Interop.JavaObject
-			// (Java.Interop). GetTypeForSimpleReference returns alias index [0], so the Mono.Android peer
-			// must sort first. Declare them in the "wrong" order to prove the sort reorders them.
+			// Java.Interop first proves Mono.Android still becomes alias [0], matching runtime lookup.
 			var peers = new List<JavaPeerInfo> {
 				MakeMcwPeer ("java/lang/Object", "Java.Interop.JavaObject", "Java.Interop") with { IsFromJniTypeSignature = true },
 				MakeMcwPeer ("java/lang/Object", "Java.Lang.Object", "Mono.Android"),
@@ -129,7 +124,6 @@ public class ModelBuilderTests : FixtureTestBase
 
 			var model = BuildModel (peers, "MonoAndroid");
 
-			// The Mono.Android peer (Java.Lang.Object) must be alias index [0].
 			Assert.Equal ("java/lang/Object[0]", model.Entries [0].MapKey);
 			Assert.Contains ("Java.Lang.Object", model.Entries [0].ProxyTypeReference);
 			Assert.Equal ("java/lang/Object[1]", model.Entries [1].MapKey);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -114,6 +114,29 @@ public class ModelBuilderTests : FixtureTestBase
 		}
 
 		[Fact]
+		public void Build_AliasGroup_MonoAndroidPeerSortsFirst ()
+		{
+			// Mirror the native runtime's java→managed selection (clr_typemap_java_to_managed /
+			// monovm_typemap_java_to_managed): NativeTypeMappingData builds that map by processing the
+			// Mono.Android module first and keeping the first managed type to claim a Java name, so
+			// java/lang/Object resolves to Java.Lang.Object (Mono.Android), not Java.Interop.JavaObject
+			// (Java.Interop). GetTypeForSimpleReference returns alias index [0], so the Mono.Android peer
+			// must sort first. Declare them in the "wrong" order to prove the sort reorders them.
+			var peers = new List<JavaPeerInfo> {
+				MakeMcwPeer ("java/lang/Object", "Java.Interop.JavaObject", "Java.Interop") with { IsFromJniTypeSignature = true },
+				MakeMcwPeer ("java/lang/Object", "Java.Lang.Object", "Mono.Android"),
+			};
+
+			var model = BuildModel (peers, "MonoAndroid");
+
+			// The Mono.Android peer (Java.Lang.Object) must be alias index [0].
+			Assert.Equal ("java/lang/Object[0]", model.Entries [0].MapKey);
+			Assert.Contains ("Java.Lang.Object", model.Entries [0].ProxyTypeReference);
+			Assert.Equal ("java/lang/Object[1]", model.Entries [1].MapKey);
+			Assert.Contains ("Java.Interop.JavaObject", model.Entries [1].ProxyTypeReference);
+		}
+
+		[Fact]
 		public void Build_AliasWithMixedActivation_PrimaryNoActivation_AliasHasActivation ()
 		{
 			var peers = new List<JavaPeerInfo> {


### PR DESCRIPTION
Independent correctness fixes for the **trimmable type map** generator (the opt-in `-p:_AndroidTypeMapImplementation=trimmable` path). These stand alone and do **not** depend on making the trimmable type map the NativeAOT default (#11822) — extracting them keeps that PR focused and lets these be reviewed on their own.

### Fixes
- **Exclude `Java.Interop.ManagedPeer` from the type map** — it is a base infrastructure peer, not an app/binding type, and must not participate in java→managed resolution.
- **Emit `<layout>` element for the `[Layout]` attribute on activities** — the scanner now surfaces `[Layout]` and the manifest generator matches the legacy activity-only emission behavior.
- **Emit XA1010 for invalid `$(AndroidManifestPlaceholders)`** — proper diagnostic instead of a silent/obscure failure, while preserving legacy placeholder replacement behavior.
- **Byte-deterministic generated type map assemblies** — stable output across builds (reproducible builds; better incremental behavior).
- **Resolve `java/lang/Object` to `Java.Lang.Object`, not `Java.Interop.JavaObject`** — order alias groups Mono.Android-assembly-first to match the native runtime's java→managed selection (`clr_typemap_java_to_managed` / `monovm_typemap_java_to_managed`, built by `NativeTypeMappingData`: Mono.Android module first, first-writer-wins), with ordinal managed-name and assembly-name tie-breakers for deterministic proxy naming.

### Testing
- `Microsoft.Android.Sdk.TrimmableTypeMap.Tests`: **608/608 pass** (includes alias-ordering, placeholder, and layout activity-only regression tests).

Extracted from #11822.

## Issue references

Contributes to https://github.com/dotnet/android/issues/10933 and https://github.com/dotnet/android/issues/10793.
