### PR TITLE
[Mono.Android] Fix build warnings in hand-written code

### DIFF
--- a/src/Mono.Android/Android.Animation/AnimatorSet.cs
+++ b/src/Mono.Android/Android.Animation/AnimatorSet.cs
@@ -16,7 +16,8 @@ namespace Android.Animation
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (duration);
 				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
-				return global::Java.Lang.Object.GetObject<Android.Animation.Animator> (__rm.Handle, JniHandleOwnership.TransferLocalRef)!;
+				var __ret = global::Java.Lang.Object.GetObject<Android.Animation.Animator> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				return __ret ?? throw new InvalidOperationException ("Unable to marshal the return value to a managed Android.Animation.Animator instance.");
 			} finally {
 			}
 		}
@@ -34,7 +35,9 @@ namespace Android.Animation
 				return default;
 
 			try {
-				var __this = global::Java.Lang.Object.GetObject<Android.Animation.AnimatorSet> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+				var __this = global::Java.Lang.Object.GetObject<Android.Animation.AnimatorSet> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				if (__this is null)
+					throw new InvalidOperationException ("Unable to marshal the native handle to a managed Android.Animation.AnimatorSet instance.");
 				return JNIEnv.ToLocalJniHandle (__this.SetDuration (duration));
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);

--- a/src/Mono.Android/Android.Animation/AnimatorSet.cs
+++ b/src/Mono.Android/Android.Animation/AnimatorSet.cs
@@ -6,7 +6,7 @@ namespace Android.Animation
 {
 	public partial class AnimatorSet
 	{
-		static Delegate cb_setDuration_SetDuration_J_Landroid_animation_Animator_;
+		static Delegate? cb_setDuration_SetDuration_J_Landroid_animation_Animator_;
 
 		[Register ("setDuration", "(J)Landroid/animation/Animator;", "GetSetDuration_JHandler")]
 		public override unsafe Android.Animation.Animator SetDuration (long duration)
@@ -16,7 +16,7 @@ namespace Android.Animation
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (duration);
 				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
-				return global::Java.Lang.Object.GetObject<Android.Animation.Animator> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				return global::Java.Lang.Object.GetObject<Android.Animation.Animator> (__rm.Handle, JniHandleOwnership.TransferLocalRef)!;
 			} finally {
 			}
 		}
@@ -34,7 +34,7 @@ namespace Android.Animation
 				return default;
 
 			try {
-				var __this = global::Java.Lang.Object.GetObject<Android.Animation.AnimatorSet> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var __this = global::Java.Lang.Object.GetObject<Android.Animation.AnimatorSet> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 				return JNIEnv.ToLocalJniHandle (__this.SetDuration (duration));
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);

--- a/src/Mono.Android/Android.Animation/ValueAnimator.cs
+++ b/src/Mono.Android/Android.Animation/ValueAnimator.cs
@@ -6,7 +6,7 @@ namespace Android.Animation
 {
 	public partial class ValueAnimator
 	{
-		static Delegate cb_setDuration_SetDuration_J_Landroid_animation_Animator_;
+		static Delegate? cb_setDuration_SetDuration_J_Landroid_animation_Animator_;
 		
 		[Register ("setDuration", "(J)Landroid/animation/Animator;", "GetSetDuration_JHandler")]
 		public override unsafe Android.Animation.Animator SetDuration (long duration)
@@ -16,7 +16,7 @@ namespace Android.Animation
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (duration);
 				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
-				return global::Java.Lang.Object.GetObject<Android.Animation.Animator> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				return global::Java.Lang.Object.GetObject<Android.Animation.Animator> (__rm.Handle, JniHandleOwnership.TransferLocalRef)!;
 			} finally {
 			}
 		}
@@ -34,7 +34,7 @@ namespace Android.Animation
 				return default;
 
 			try {
-				var __this = global::Java.Lang.Object.GetObject<Android.Animation.ValueAnimator> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var __this = global::Java.Lang.Object.GetObject<Android.Animation.ValueAnimator> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 				return JNIEnv.ToLocalJniHandle (__this.SetDuration (duration));
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);

--- a/src/Mono.Android/Android.Animation/ValueAnimator.cs
+++ b/src/Mono.Android/Android.Animation/ValueAnimator.cs
@@ -16,7 +16,8 @@ namespace Android.Animation
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (duration);
 				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
-				return global::Java.Lang.Object.GetObject<Android.Animation.Animator> (__rm.Handle, JniHandleOwnership.TransferLocalRef)!;
+				var __ret = global::Java.Lang.Object.GetObject<Android.Animation.Animator> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				return __ret ?? throw new InvalidOperationException ("Unable to marshal the return value to a managed Android.Animation.Animator instance.");
 			} finally {
 			}
 		}
@@ -34,7 +35,9 @@ namespace Android.Animation
 				return default;
 
 			try {
-				var __this = global::Java.Lang.Object.GetObject<Android.Animation.ValueAnimator> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+				var __this = global::Java.Lang.Object.GetObject<Android.Animation.ValueAnimator> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				if (__this is null)
+					throw new InvalidOperationException ("Unable to marshal the native handle to a managed Android.Animation.ValueAnimator instance.");
 				return JNIEnv.ToLocalJniHandle (__this.SetDuration (duration));
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);

--- a/src/Mono.Android/Android.App/AlertDialog.cs
+++ b/src/Mono.Android/Android.App/AlertDialog.cs
@@ -17,14 +17,14 @@ namespace Android.App {
 
 			public event EventHandler<Android.Widget.AdapterView.ItemSelectedEventArgs> ItemSelected {
 				add {
-					AndroidEventHelper.AddEventHandler<AdapterView.IOnItemSelectedListener, AdapterView.IOnItemSelectedListenerImplementor>(
+					EventHelper.AddEventHandler<AdapterView.IOnItemSelectedListener, AdapterView.IOnItemSelectedListenerImplementor>(
 							ref weak_implementor_SetOnItemSelectedListener,
 							CreateItemSelectedImplementor,
 							__SetOnItemSelectedListener,
 							__h => __h.OnItemSelectedHandler += value);
 				}
 				remove {
-					AndroidEventHelper.RemoveEventHandler<AdapterView.IOnItemSelectedListener, AdapterView.IOnItemSelectedListenerImplementor>(
+					EventHelper.RemoveEventHandler<AdapterView.IOnItemSelectedListener, AdapterView.IOnItemSelectedListenerImplementor>(
 							ref weak_implementor_SetOnItemSelectedListener,
 							AdapterView.IOnItemSelectedListenerImplementor.__IsEmpty,
 							__SetOnItemSelectedListener,
@@ -34,14 +34,14 @@ namespace Android.App {
 
 			public event EventHandler<Android.Widget.AdapterView.NothingSelectedEventArgs> NothingSelected {
 				add {
-					AndroidEventHelper.AddEventHandler<AdapterView.IOnItemSelectedListener, AdapterView.IOnItemSelectedListenerImplementor>(
+					EventHelper.AddEventHandler<AdapterView.IOnItemSelectedListener, AdapterView.IOnItemSelectedListenerImplementor>(
 							ref weak_implementor_SetOnItemSelectedListener,
 							CreateItemSelectedImplementor,
 							__SetOnItemSelectedListener,
 							__h => __h.OnNothingSelectedHandler += value);
 				}
 				remove {
-					AndroidEventHelper.RemoveEventHandler<AdapterView.IOnItemSelectedListener, AdapterView.IOnItemSelectedListenerImplementor>(
+					EventHelper.RemoveEventHandler<AdapterView.IOnItemSelectedListener, AdapterView.IOnItemSelectedListenerImplementor>(
 							ref weak_implementor_SetOnItemSelectedListener,
 							AdapterView.IOnItemSelectedListenerImplementor.__IsEmpty,
 							__SetOnItemSelectedListener,

--- a/src/Mono.Android/Android.App/SyncContext.cs
+++ b/src/Mono.Android/Android.App/SyncContext.cs
@@ -25,7 +25,7 @@ namespace Android.App {
 			return true;
 		}
 
-		public override void Post (SendOrPostCallback d, object state)
+		public override void Post (SendOrPostCallback d, object? state)
 		{
 			var looper = Application.Context?.MainLooper;
 			if (!EnsureLooper (looper, d))
@@ -35,7 +35,7 @@ namespace Android.App {
 			}
 		}
 
-		public override void Send (SendOrPostCallback d, object state)
+		public override void Send (SendOrPostCallback d, object? state)
 		{
 			var looper = Looper.MainLooper;
 			if (!EnsureLooper (looper, d))

--- a/src/Mono.Android/Android.Bluetooth/BluetoothDevice.cs
+++ b/src/Mono.Android/Android.Bluetooth/BluetoothDevice.cs
@@ -6,11 +6,13 @@ namespace Android.Bluetooth
 	{
 		// These methods were obsoleted as a warning in API-31
 		[global::System.Obsolete ("This method has the wrong enumeration. Use the version that takes an 'Android.Bluetooth.BluetoothPhy' instead.")]
+		[global::System.Runtime.Versioning.ObsoletedOSPlatformAttribute ("android37.0")]
 		[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android26.0")]
 		public unsafe Android.Bluetooth.BluetoothGatt? ConnectGatt (Android.Content.Context? context, bool autoConnect, Android.Bluetooth.BluetoothGattCallback? @callback, [global::Android.Runtime.GeneratedEnum] Android.Bluetooth.BluetoothTransports transport, [global::Android.Runtime.GeneratedEnum] Android.Bluetooth.LE.ScanSettingsPhy phy)
 			=> ConnectGatt (context, autoConnect, @callback, transport, (Android.Bluetooth.BluetoothPhy) phy);
 
 		[global::System.Obsolete ("This method has the wrong enumeration. Use the version that takes an 'Android.Bluetooth.BluetoothPhy' instead.")]
+		[global::System.Runtime.Versioning.ObsoletedOSPlatformAttribute ("android37.0")]
 		[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android26.0")]
 		public unsafe Android.Bluetooth.BluetoothGatt? ConnectGatt (Android.Content.Context? context, bool autoConnect, Android.Bluetooth.BluetoothGattCallback? @callback, [global::Android.Runtime.GeneratedEnum] Android.Bluetooth.BluetoothTransports transport, [global::Android.Runtime.GeneratedEnum] Android.Bluetooth.LE.ScanSettingsPhy phy, Android.OS.Handler? handler)
 			=> ConnectGatt (context, autoConnect, @callback, transport, (Android.Bluetooth.BluetoothPhy) phy, handler);

--- a/src/Mono.Android/Android.Content.Res/IXmlResourceParser.cs
+++ b/src/Mono.Android/Android.Content.Res/IXmlResourceParser.cs
@@ -9,13 +9,13 @@ namespace Android.Content.Res
 	{
 		#region These members are dare defined here to avoid conflicts between IAttributeSet and IXmlPullParser.
 
-		int AttributeCount { get; }
+		new int AttributeCount { get; }
 		
-		string PositionDescription { get; }
+		new string PositionDescription { get; }
 		
-		string GetAttributeName (int pos);
-		string GetAttributeValue (int pos);
-		string? GetAttributeValue (string? ns, string? name);
+		new string GetAttributeName (int pos);
+		new string GetAttributeValue (int pos);
+		new string? GetAttributeValue (string? ns, string? name);
 		#endregion
 	}
 }

--- a/src/Mono.Android/Android.Graphics/AndroidBitmapInfo.cs
+++ b/src/Mono.Android/Android.Graphics/AndroidBitmapInfo.cs
@@ -58,7 +58,7 @@ namespace Android.Graphics {
 		}
 
 		/// <inheritdoc />
-		public override bool Equals (object value)
+		public override bool Equals (object? value)
 		{
 			if (!(value is AndroidBitmapInfo))
 				return false;

--- a/src/Mono.Android/Android.Graphics/Color.cs
+++ b/src/Mono.Android/Android.Graphics/Color.cs
@@ -82,7 +82,7 @@ namespace Android.Graphics
 			return FormattableString.Invariant ($"Color [A={A}, R={R}, G={G}, B={B}]");
 		}
 
-		public override bool Equals (object obj)
+		public override bool Equals (object? obj)
 		{
 			if (!(obj is Color))
 				return false;
@@ -426,7 +426,7 @@ namespace Android.Graphics
 			get { return typeof (int); }
 		}
 
-		public override Color CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type targetType)
+		public override Color CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
 		{
 			throw new NotImplementedException ();
 		}
@@ -443,7 +443,7 @@ namespace Android.Graphics
 
 		[RequiresDynamicCode (ExpressionRequiresUnreferencedCode)]
 		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 			var c = typeof (Color).GetConstructor (new[]{typeof (int)})!;
 			var v = Expression.Variable (typeof (Color), sourceValue.Name + "_val");

--- a/src/Mono.Android/Android.OS/AsyncTask.cs
+++ b/src/Mono.Android/Android.OS/AsyncTask.cs
@@ -19,7 +19,7 @@ namespace Android.OS {
 	> : AsyncTask {
 
 		static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("android/os/AsyncTask", ref java_class_handle);
 			}

--- a/src/Mono.Android/Android.Runtime/InputStreamAdapter.cs
+++ b/src/Mono.Android/Android.Runtime/InputStreamAdapter.cs
@@ -28,13 +28,15 @@ namespace Android.Runtime {
 			return BaseStream.ReadByte ();
 		}
 
-		public override int Read (byte[] bytes)
+		public override int Read (byte[]? bytes)
 		{
+			ArgumentNullException.ThrowIfNull (bytes);
 			return Read (bytes, 0, bytes.Length);
 		}
 
-		public override int Read (byte[] bytes, int offset, int length)
+		public override int Read (byte[]? bytes, int offset, int length)
 		{
+			ArgumentNullException.ThrowIfNull (bytes);
 			int res = BaseStream.Read (bytes, offset, length);
 			if (res == 0)
 				return -1;

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -442,7 +442,7 @@ namespace Android.Runtime {
 				return NewObject (jclass, jmethod, p);
 		}
 
-		public static string GetClassNameFromInstance (IntPtr jobject)
+		public static string? GetClassNameFromInstance (IntPtr jobject)
 		{
 			return JniEnvironment.Types.GetJniTypeNameFromInstance (new JniObjectReference (jobject));
 		}
@@ -634,8 +634,8 @@ namespace Android.Runtime {
 				dest [i] = GetString (GetObjectArrayElement (src, i), JniHandleOwnership.TransferLocalRef)!;
 		}
 
-		static Dictionary<Type, Func<Type?, IntPtr, int, object?>>? nativeArrayElementToManaged;
-		static Dictionary<Type, Func<Type?, IntPtr, int, object?>> NativeArrayElementToManaged {
+		static Dictionary<Type, NativeArrayElementToManagedConverter>? nativeArrayElementToManaged;
+		static Dictionary<Type, NativeArrayElementToManagedConverter> NativeArrayElementToManaged {
 			get {
 				if (nativeArrayElementToManaged != null)
 					return nativeArrayElementToManaged;
@@ -646,9 +646,12 @@ namespace Android.Runtime {
 			}
 		}
 
-		static Dictionary<Type, Func<Type?, IntPtr, int, object?>> CreateNativeArrayElementToManaged ()
+		delegate object? NativeArrayElementToManagedConverter (
+			[DynamicallyAccessedMembers (Constructors)] Type? elementType, IntPtr array, int index);
+
+		static Dictionary<Type, NativeArrayElementToManagedConverter> CreateNativeArrayElementToManaged ()
 		{
-			return new Dictionary<Type, Func<Type?, IntPtr, int, object?>> () {
+			return new Dictionary<Type, NativeArrayElementToManagedConverter> () {
 				{ typeof (bool), (type, source, index) => {
 					var r = new bool [1];
 					_GetBooleanArrayRegion (source, index, 1, r);
@@ -695,23 +698,20 @@ namespace Android.Runtime {
 						return new Java.Lang.String (elem, JniHandleOwnership.TransferLocalRef);
 					return GetString (elem, JniHandleOwnership.TransferLocalRef);
 				} },
-				{ typeof (IJavaObject), (type, source, index) => {
-					AssertIsJavaObject (type);
-
-					IntPtr elem = GetObjectArrayElement (source, index);
-					return GetObject (elem, type);
-
-					// FIXME: Since a Dictionary<Type, Func> is used here, the trimmer will not be able to properly analyze `Type t`
-					// error IL2111: Method 'lambda expression' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
-					[UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = "FIXME: https://github.com/xamarin/xamarin-android/issues/8724")]
-					static object? GetObject (IntPtr e, Type t) =>
-						Java.Lang.Object.GetObject (e, JniHandleOwnership.TransferLocalRef, t);
-				} },
+				{ typeof (IJavaObject), ConvertIJavaObject },
 				{ typeof (Array), (type, source, index) => {
 					IntPtr  elem      = GetObjectArrayElement (source, index);
 					return GetArray (elem, JniHandleOwnership.TransferLocalRef, type);
 				} },
 			};
+
+			static object? ConvertIJavaObject ([DynamicallyAccessedMembers (Constructors)] Type? elementType, IntPtr source, int index)
+			{
+				AssertIsJavaObject (elementType);
+
+				IntPtr elem = GetObjectArrayElement (source, index);
+				return Java.Lang.Object.GetObject (elem, JniHandleOwnership.TransferLocalRef, elementType);
+			}
 		}
 
 		static TValue GetConverter<TValue>(Dictionary<Type, TValue> dict, Type? elementType, IntPtr array)
@@ -726,7 +726,7 @@ namespace Android.Runtime {
 			}
 
 			if (array != IntPtr.Zero) {
-				string type = GetClassNameFromInstance (array);
+				string? type = GetClassNameFromInstance (array);
 				if (type == null || type.Length < 1 || type [0] != '[')
 					throw new InvalidOperationException ("Unsupported java array type: " + type);
 
@@ -805,7 +805,8 @@ namespace Android.Runtime {
 		}
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
-		public static void CopyArray (IntPtr src, Array dest, Type? elementType = null)
+		[RequiresUnreferencedCode ("The elementType parameter is used to determine the type of the elements in the destination array. This method can fail in trimming scenarios for multi-rank arrays.")]
+		public static void CopyArray (IntPtr src, Array dest, [DynamicallyAccessedMembers (Constructors)] Type? elementType = null)
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 		{
 			if (dest == null)
@@ -842,7 +843,8 @@ namespace Android.Runtime {
 				throw new NotSupportedException ("Don't know how to convert type '" + targetType.FullName + "' to an Android.Runtime.IJavaObject.");
 		}
 
-		public static void CopyArray<T> (IntPtr src, T[] dest)
+		[RequiresUnreferencedCode ("The elementType parameter is used to determine the type of the elements in the destination array. This method can fail in trimming scenarios for multi-rank arrays.")]
+		public static void CopyArray<[DynamicallyAccessedMembers (Constructors)] T> (IntPtr src, T[] dest)
 		{
 			if (dest == null)
 				throw new ArgumentNullException ("dest");

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -495,6 +495,8 @@ namespace Android.Runtime {
 				if (RuntimeFeature.IsMonoRuntime) {
 					ret = monovm_typemap_managed_to_java (type, mvidptr);
 				} else if (RuntimeFeature.IsCoreClrRuntime) {
+					if (type.FullName is null)
+						return null;
 					ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, (IntPtr)mvidptr);
 				} else {
 					throw new NotSupportedException ("Internal error: unknown runtime not supported");

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -26,14 +26,11 @@ namespace Android.Runtime {
 
 		static Array ArrayCreateInstance (Type elementType, int length)
 		{
-			if (RuntimeFeature.TrimmableTypeMap) {
-				if (RuntimeFeature.IsCoreClrRuntime) {
-					// CoreCLR runtime type loader can construct any T[] dynamically.
-					// IsDynamicCodeSupported is a [FeatureGuard] so this branch is
-					// dead-coded under PublishAot.
-					return Array.CreateInstance (elementType, length);
-				}
+			if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported) {
+				return Array.CreateInstance (elementType, length);
+			}
 
+			if (RuntimeFeature.TrimmableTypeMap) {
 				if (RuntimeFeature.IsNativeAotRuntime) {
 					// NativeAOT: resolve via per-rank typemap + generated array proxy.
 					if (TrimmableTypeMap.Instance.TryGetArrayProxy (elementType, additionalRank: 1, out var arrayProxy)) {
@@ -49,9 +46,18 @@ namespace Android.Runtime {
 					$"ensure the mapping is emitted for that rank (for example by increasing _AndroidTrimmableTypeMapMaxArrayRank) or report an issue.");
 			}
 
-			#pragma warning disable IL3050 // legacy fallback path
-			return Array.CreateInstance (elementType, length);
-			#pragma warning restore IL3050
+			if (RuntimeFeature.ManagedTypeMap) {
+				return ArrayCreateInstanceWithSuppression (elementType, length);
+
+				[UnconditionalSuppressMessage ("Trimming", "IL3050:RequiresDynamicCode",
+					Justification = "Temporarily suppressed for the \"ManagedTypeMap\".")]
+				Array ArrayCreateInstanceWithSuppression (Type elementType, int length)
+				{
+					return Array.CreateInstance (elementType, length);
+				}
+			}
+
+			throw new NotSupportedException ($"It is not possible to create an array with element type '{elementType}'.");
 		}
 
 		static int GetArrayRank (Type elementType, out Type leafElementType)

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -634,8 +634,8 @@ namespace Android.Runtime {
 				dest [i] = GetString (GetObjectArrayElement (src, i), JniHandleOwnership.TransferLocalRef)!;
 		}
 
-		static Dictionary<Type, NativeArrayElementToManagedConverter>? nativeArrayElementToManaged;
-		static Dictionary<Type, NativeArrayElementToManagedConverter> NativeArrayElementToManaged {
+		static Dictionary<Type, Func<Type?, IntPtr, int, object?>>? nativeArrayElementToManaged;
+		static Dictionary<Type, Func<Type?, IntPtr, int, object?>> NativeArrayElementToManaged {
 			get {
 				if (nativeArrayElementToManaged != null)
 					return nativeArrayElementToManaged;
@@ -646,12 +646,9 @@ namespace Android.Runtime {
 			}
 		}
 
-		delegate object? NativeArrayElementToManagedConverter (
-			[DynamicallyAccessedMembers (Constructors)] Type? elementType, IntPtr array, int index);
-
-		static Dictionary<Type, NativeArrayElementToManagedConverter> CreateNativeArrayElementToManaged ()
+		static Dictionary<Type, Func<Type?, IntPtr, int, object?>> CreateNativeArrayElementToManaged ()
 		{
-			return new Dictionary<Type, NativeArrayElementToManagedConverter> () {
+			return new Dictionary<Type, Func<Type?, IntPtr, int, object?>> () {
 				{ typeof (bool), (type, source, index) => {
 					var r = new bool [1];
 					_GetBooleanArrayRegion (source, index, 1, r);
@@ -698,20 +695,23 @@ namespace Android.Runtime {
 						return new Java.Lang.String (elem, JniHandleOwnership.TransferLocalRef);
 					return GetString (elem, JniHandleOwnership.TransferLocalRef);
 				} },
-				{ typeof (IJavaObject), ConvertIJavaObject },
+				{ typeof (IJavaObject), (type, source, index) => {
+					AssertIsJavaObject (type);
+
+					IntPtr elem = GetObjectArrayElement (source, index);
+					return GetObject (elem, type);
+
+					// FIXME: Since a Dictionary<Type, Func> is used here, the trimmer will not be able to properly analyze `Type t`
+					// error IL2111: Method 'lambda expression' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+					[UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = "FIXME: https://github.com/xamarin/xamarin-android/issues/8724")]
+					static object? GetObject (IntPtr e, Type? t) =>
+						Java.Lang.Object.GetObject (e, JniHandleOwnership.TransferLocalRef, t);
+				} },
 				{ typeof (Array), (type, source, index) => {
 					IntPtr  elem      = GetObjectArrayElement (source, index);
 					return GetArray (elem, JniHandleOwnership.TransferLocalRef, type);
 				} },
 			};
-
-			static object? ConvertIJavaObject ([DynamicallyAccessedMembers (Constructors)] Type? elementType, IntPtr source, int index)
-			{
-				AssertIsJavaObject (elementType);
-
-				IntPtr elem = GetObjectArrayElement (source, index);
-				return Java.Lang.Object.GetObject (elem, JniHandleOwnership.TransferLocalRef, elementType);
-			}
 		}
 
 		static TValue GetConverter<TValue>(Dictionary<Type, TValue> dict, Type? elementType, IntPtr array)
@@ -805,8 +805,7 @@ namespace Android.Runtime {
 		}
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
-		[RequiresUnreferencedCode ("The elementType parameter is used to determine the type of the elements in the destination array. This method can fail in trimming scenarios for multi-rank arrays.")]
-		public static void CopyArray (IntPtr src, Array dest, [DynamicallyAccessedMembers (Constructors)] Type? elementType = null)
+		public static void CopyArray (IntPtr src, Array dest, Type? elementType = null)
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 		{
 			if (dest == null)
@@ -843,8 +842,7 @@ namespace Android.Runtime {
 				throw new NotSupportedException ("Don't know how to convert type '" + targetType.FullName + "' to an Android.Runtime.IJavaObject.");
 		}
 
-		[RequiresUnreferencedCode ("The elementType parameter is used to determine the type of the elements in the destination array. This method can fail in trimming scenarios for multi-rank arrays.")]
-		public static void CopyArray<[DynamicallyAccessedMembers (Constructors)] T> (IntPtr src, T[] dest)
+		public static void CopyArray<T> (IntPtr src, T[] dest)
 		{
 			if (dest == null)
 				throw new ArgumentNullException ("dest");

--- a/src/Mono.Android/Android.Runtime/JavaCollection.cs
+++ b/src/Mono.Android/Android.Runtime/JavaCollection.cs
@@ -389,12 +389,12 @@ namespace Android.Runtime {
 			return GetEnumerator ()!;
 		}
 
-		public IEnumerator<T?> GetEnumerator ()
+		public new IEnumerator<T?> GetEnumerator ()
 		{
 			return System.Linq.Extensions.ToEnumerator_Dispose<T> (Iterator());
 		}
 		
-		public static ICollection<T>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
+		public new static ICollection<T>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
 				return null;

--- a/src/Mono.Android/Android.Runtime/JavaDictionary.cs
+++ b/src/Mono.Android/Android.Runtime/JavaDictionary.cs
@@ -518,11 +518,11 @@ namespace Android.Runtime {
 			}
 		}
 
-		public ICollection<K> Keys {
+		public new ICollection<K> Keys {
 			get { return new JavaSet<K> (GetKeys (), JniHandleOwnership.TransferLocalRef); }
 		}
 
-		public ICollection<V> Values {
+		public new ICollection<V> Values {
 			get { return new JavaCollection<V> (GetValues (), JniHandleOwnership.TransferLocalRef); }
 		}
 
@@ -588,7 +588,7 @@ namespace Android.Runtime {
 			return GetEnumerator ();
 		}
 
-		public IEnumerator<KeyValuePair<K, V>> GetEnumerator ()
+		public new IEnumerator<KeyValuePair<K, V>> GetEnumerator ()
 		{
 			foreach (K key in Keys)
 #pragma warning disable CS8604 // Possible null reference argument.
@@ -640,7 +640,7 @@ namespace Android.Runtime {
 			return ContainsKey (key);
 		}
 		
-		public static IDictionary<K, V>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
+		public new static IDictionary<K, V>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
 				return null;

--- a/src/Mono.Android/Android.Runtime/JavaList.cs
+++ b/src/Mono.Android/Android.Runtime/JavaList.cs
@@ -785,7 +785,7 @@ namespace Android.Runtime {
 
 		// C#'s IList<T> allows nulls but is not annotated as MaybeNull.
 		[MaybeNull]
-		public T this [int index] {
+		public new T this [int index] {
 			[return: MaybeNull]
 #pragma warning disable CS8766 // Nullability of reference types in return type doesn't match implicitly implemented member because of nullability attributes.
 			get {
@@ -879,7 +879,7 @@ namespace Android.Runtime {
 			return GetEnumerator ()!;
 		}
 
-		public IEnumerator<T?> GetEnumerator ()
+		public new IEnumerator<T?> GetEnumerator ()
 		{
 			return System.Linq.Extensions.ToEnumerator_Dispose<T> (Iterator ());
 		}
@@ -960,7 +960,7 @@ namespace Android.Runtime {
 			return true;
 		}
 		
-		public static IList<T>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
+		public new static IList<T>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
 				return null;

--- a/src/Mono.Android/Android.Runtime/JavaList.cs
+++ b/src/Mono.Android/Android.Runtime/JavaList.cs
@@ -585,7 +585,7 @@ namespace Android.Runtime {
 			return true;
 		}
 		
-		public virtual bool Equals (Java.Lang.Object obj)
+		public virtual new bool Equals (Java.Lang.Object obj)
 		{
 			var collection = obj as JavaList;
 			if (collection == null || Count != collection.Count)

--- a/src/Mono.Android/Android.Runtime/JavaObject.cs
+++ b/src/Mono.Android/Android.Runtime/JavaObject.cs
@@ -104,11 +104,11 @@ namespace Android.Runtime {
 			return inst.GetHashCode ();
 		}
 
-		public override string? ToString ()
+		public override string ToString ()
 		{
 			if (inst == null)
 				return "";
-			return inst.ToString ();
+			return inst.ToString () ?? "";
 		}
 	}
 }

--- a/src/Mono.Android/Android.Runtime/JavaProxyThrowable.cs
+++ b/src/Mono.Android/Android.Runtime/JavaProxyThrowable.cs
@@ -11,7 +11,7 @@ namespace Android.Runtime {
 
 	sealed class JavaProxyThrowable : Java.Lang.Error {
 
-		public  readonly Exception InnerException;
+		public  readonly new Exception InnerException;
 
 		JavaProxyThrowable (string message, Exception innerException)
 			: base (message)

--- a/src/Mono.Android/Android.Runtime/JavaSet.cs
+++ b/src/Mono.Android/Android.Runtime/JavaSet.cs
@@ -393,7 +393,7 @@ namespace Android.Runtime {
 			return GetEnumerator ()!;
 		}
 
-		public IEnumerator<T> GetEnumerator ()
+		public new IEnumerator<T> GetEnumerator ()
 		{
 			return System.Linq.Extensions.ToEnumerator_Dispose<T> (Iterator ());
 		}
@@ -426,7 +426,7 @@ namespace Android.Runtime {
 			});
 		}
 
-		public static ICollection<T>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
+		public new static ICollection<T>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
 				return null;

--- a/src/Mono.Android/Android.Runtime/OutputStreamAdapter.cs
+++ b/src/Mono.Android/Android.Runtime/OutputStreamAdapter.cs
@@ -29,13 +29,15 @@ namespace Android.Runtime
 			BaseStream.Flush ();
 		}
 
-		public override void Write (byte[] buffer)
+		public override void Write (byte[]? buffer)
 		{
-			BaseStream.Write (buffer, 0, buffer?.Length ?? 0);
+			ArgumentNullException.ThrowIfNull (buffer);
+			BaseStream.Write (buffer, 0, buffer.Length);
 		}
 
-		public override void Write (byte[] buffer, int offset, int length)
+		public override void Write (byte[]? buffer, int offset, int length)
 		{
+			ArgumentNullException.ThrowIfNull (buffer);
 			BaseStream.Write (buffer, offset, length);
 		}
 

--- a/src/Mono.Android/Android.Runtime/RuntimeNativeMethods.cs
+++ b/src/Mono.Android/Android.Runtime/RuntimeNativeMethods.cs
@@ -115,7 +115,7 @@ namespace Android.Runtime
 
 		[LibraryImport (RuntimeConstants.InternalDllName, StringMarshalling = StringMarshalling.Utf8)]
 		[UnmanagedCallConv (CallConvs = new[] { typeof (CallConvCdecl) })]
-		internal static partial IntPtr clr_typemap_managed_to_java (string fullName, IntPtr mvid);
+		internal static partial IntPtr clr_typemap_managed_to_java (string? fullName, IntPtr mvid);
 
 		[LibraryImport (RuntimeConstants.InternalDllName, StringMarshalling = StringMarshalling.Utf8)]
 		[UnmanagedCallConv (CallConvs = new[] { typeof (CallConvCdecl) })]

--- a/src/Mono.Android/Android.Runtime/RuntimeNativeMethods.cs
+++ b/src/Mono.Android/Android.Runtime/RuntimeNativeMethods.cs
@@ -115,7 +115,7 @@ namespace Android.Runtime
 
 		[LibraryImport (RuntimeConstants.InternalDllName, StringMarshalling = StringMarshalling.Utf8)]
 		[UnmanagedCallConv (CallConvs = new[] { typeof (CallConvCdecl) })]
-		internal static partial IntPtr clr_typemap_managed_to_java (string? fullName, IntPtr mvid);
+		internal static partial IntPtr clr_typemap_managed_to_java (string fullName, IntPtr mvid);
 
 		[LibraryImport (RuntimeConstants.InternalDllName, StringMarshalling = StringMarshalling.Utf8)]
 		[UnmanagedCallConv (CallConvs = new[] { typeof (CallConvCdecl) })]

--- a/src/Mono.Android/Android.Runtime/XmlPullParserReader.cs
+++ b/src/Mono.Android/Android.Runtime/XmlPullParserReader.cs
@@ -25,7 +25,7 @@ namespace Android.Runtime
 			source.Close ();
 		}
 
-		public static XmlResourceParserReader? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
+		public new static XmlResourceParserReader? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			return FromNative (handle, transfer);
 		}

--- a/src/Mono.Android/Android.Runtime/XmlReaderPullParser.cs
+++ b/src/Mono.Android/Android.Runtime/XmlReaderPullParser.cs
@@ -197,8 +197,10 @@ namespace Android.Runtime
 			return false;
 		}
 	
-		public string? GetNamespace (string prefix)
+		public string? GetNamespace (string? prefix)
 		{
+			if (prefix == null)
+				return null;
 			return r.LookupNamespace (prefix);
 		}
 	
@@ -222,7 +224,7 @@ namespace Android.Runtime
 			throw new NotSupportedException ();
 		}
 	
-		public char[] GetTextCharacters (int[] holderForStartAndLength)
+		public char[] GetTextCharacters (int[]? holderForStartAndLength)
 		{
 			throw new NotSupportedException ();
 		}

--- a/src/Mono.Android/Android.Runtime/XmlReaderPullParser.cs
+++ b/src/Mono.Android/Android.Runtime/XmlReaderPullParser.cs
@@ -9,7 +9,7 @@ namespace Android.Runtime
 {
 	public class XmlReaderResourceParser : XmlReaderPullParser, IXmlResourceParser
 	{
-		public static IntPtr ToLocalJniHandle (XmlReader? value)
+		public new static IntPtr ToLocalJniHandle (XmlReader? value)
 		{
 			if (value == null)
 				return IntPtr.Zero;

--- a/src/Mono.Android/Android.Util/SparseArray.cs
+++ b/src/Mono.Android/Android.Util/SparseArray.cs
@@ -36,7 +36,7 @@ namespace Android.Util
 		
 		static IntPtr id_get_I;
 		[Register ("get", "(I)Ljava/lang/Object;", "")]
-		public virtual E Get (int key)
+		public new virtual E Get (int key)
 		{
 			if (id_get_I == IntPtr.Zero)
 				id_get_I = JNIEnv.GetMethodID (class_ref, "get", "(I)Ljava/lang/Object;");
@@ -90,7 +90,7 @@ namespace Android.Util
 		
 		static IntPtr id_valueAt_I;
 		[Register ("valueAt", "(I)Ljava/lang/Object;", "")]
-		public virtual E ValueAt (int index)
+		public new virtual E ValueAt (int index)
 		{
 			if (id_valueAt_I == IntPtr.Zero)
 				id_valueAt_I = JNIEnv.GetMethodID (class_ref, "valueAt", "(I)Ljava/lang/Object;");

--- a/src/Mono.Android/Android.Widget/AdapterView.cs
+++ b/src/Mono.Android/Android.Widget/AdapterView.cs
@@ -130,7 +130,7 @@ namespace Android.Widget {
 		}
 
 		protected override Java.Lang.Object? RawAdapter {
-			get { return JavaObjectExtensions.JavaCast<Java.Lang.Object>(JavaConvert.ToJavaObject (Adapter))!; }
+			get { return JavaObjectExtensions.JavaCast<Java.Lang.Object>(JavaConvert.ToJavaObject (Adapter)); }
 			set { Adapter = JavaConvert.FromJavaObject<T>(value)!; }
 		}
 

--- a/src/Mono.Android/Android.Widget/AdapterView.cs
+++ b/src/Mono.Android/Android.Widget/AdapterView.cs
@@ -129,7 +129,7 @@ namespace Android.Widget {
 			}
 		}
 
-		protected override Java.Lang.Object RawAdapter {
+		protected override Java.Lang.Object? RawAdapter {
 			get { return JavaObjectExtensions.JavaCast<Java.Lang.Object>(JavaConvert.ToJavaObject (Adapter))!; }
 			set { Adapter = JavaConvert.FromJavaObject<T>(value)!; }
 		}

--- a/src/Mono.Android/Android.Widget/ArrayAdapter.cs
+++ b/src/Mono.Android/Android.Widget/ArrayAdapter.cs
@@ -178,7 +178,7 @@ namespace Android.Widget {
 
 		static IntPtr id_createFromResource_Landroid_content_Context_II;
 		[Register ("createFromResource", "(Landroid/content/Context;II)Landroid/widget/ArrayAdapter;", "")]
-		public static Android.Widget.ArrayAdapter<Java.Lang.ICharSequence> CreateFromResource (Android.Content.Context context, int textArrayResId, int textViewResId)
+		public new static Android.Widget.ArrayAdapter<Java.Lang.ICharSequence> CreateFromResource (Android.Content.Context context, int textArrayResId, int textViewResId)
 		{
 			if (id_createFromResource_Landroid_content_Context_II == IntPtr.Zero)
 				id_createFromResource_Landroid_content_Context_II = JNIEnv.GetStaticMethodID (class_ref, "createFromResource", "(Landroid/content/Context;II)Landroid/widget/ArrayAdapter;");

--- a/src/Mono.Android/Android.Widget/ArrayAdapter.cs
+++ b/src/Mono.Android/Android.Widget/ArrayAdapter.cs
@@ -189,7 +189,7 @@ namespace Android.Widget {
 
 		static IntPtr id_getItem_I;
 		[Register ("getItem", "(I)Ljava/lang/Object;", "GetGetItem_IHandler")]
-		public T? GetItem (int position)
+		public new T? GetItem (int position)
 		{
 			if (id_getItem_I == IntPtr.Zero)
 				id_getItem_I = JNIEnv.GetMethodID (class_ref, "getItem", "(I)Ljava/lang/Object;");
@@ -234,7 +234,7 @@ namespace Android.Widget {
 
 		static IntPtr id_sort_Ljava_util_Comparator_;
 		[Register ("sort", "(Ljava/util/Comparator;)V", "GetSort_Ljava_util_Comparator_Handler")]
-		public void Sort (Java.Util.IComparator comparator)
+		public new void Sort (Java.Util.IComparator comparator)
 		{
 			if (id_sort_Ljava_util_Comparator_ == IntPtr.Zero)
 				id_sort_Ljava_util_Comparator_ = JNIEnv.GetMethodID (class_ref, "sort", "(Ljava/util/Comparator;)V");

--- a/src/Mono.Android/Android.Widget/BaseAdapter.cs
+++ b/src/Mono.Android/Android.Widget/BaseAdapter.cs
@@ -10,7 +10,7 @@ namespace Android.Widget {
 	public abstract partial class BaseAdapter<T> : BaseAdapter {
 
 		static IntPtr java_class_handle;
-		static IntPtr class_ref {
+		static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("android/widget/BaseAdapter", ref java_class_handle);
 			}

--- a/src/Mono.Android/Java.Interop/JavaConvert.cs
+++ b/src/Mono.Android/Java.Interop/JavaConvert.cs
@@ -92,10 +92,21 @@ namespace Java.Interop {
 					var factoryConverter = TryGetFactoryBasedConverter (target);
 					if (factoryConverter != null)
 						return factoryConverter;
-				} else {
+				} else if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported) {
 					var factoryConverter = TryMakeGenericCollectionTypeFactory (target);
 					if (factoryConverter != null)
 						return factoryConverter;
+				} else if (RuntimeFeature.ManagedTypeMap) {
+					var factoryConverter = TryMakeGenericCollectionTypeFactoryWithSuppression (target);
+					if (factoryConverter != null)
+						return factoryConverter;
+
+					[UnconditionalSuppressMessage ("AotAnalysis", "IL3050:RequiresDynamicCode",
+						Justification = "Temporary suppression for ManagedTypeMap")]
+					static Func<IntPtr, JniHandleOwnership, object?>? TryMakeGenericCollectionTypeFactoryWithSuppression (Type target)
+						=> TryMakeGenericCollectionTypeFactory (target);
+				} else {
+					throw new NotSupportedException ($"Cannot convert Java collection elements to closed generic array element type '{target}' because the runtime does not support dynamic code generation.");
 				}
 			}
 
@@ -110,6 +121,7 @@ namespace Java.Interop {
 
 			[UnconditionalSuppressMessage ("ReflectionAnalysis", "IL2055:RequiresUnreferencedCode",
 				Justification = "The target generic type is expected to be preserved by the trimmer as the target type in marshaling.")]
+			[RequiresDynamicCode ("This API uses reflection to create generic types at runtime, which is not supported in AOT scenarios.")]
 			static Func<IntPtr, JniHandleOwnership, object?>? TryMakeGenericCollectionTypeFactory (Type target)
 			{
 				if (target.GetGenericTypeDefinition() == typeof (IDictionary<,>)) {

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -42,7 +42,7 @@ namespace Java.Interop
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
 	public abstract class JavaPeerProxy : Attribute
 	{
-		private protected JavaPeerProxy (string jniName, Type targetType)
+		protected JavaPeerProxy (string jniName, Type targetType)
 		{
 			ArgumentNullException.ThrowIfNull (jniName);
 			ArgumentNullException.ThrowIfNull (targetType);

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -59,7 +59,7 @@ namespace Java.Interop {
 		}
 
 		class TypeNameComparer : IComparer<string> {
-			public int Compare (string x, string y)
+			public int Compare (string? x, string? y)
 			{
 				if (object.ReferenceEquals (x, y))
 					return 0;

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -238,7 +238,11 @@ namespace Java.Interop {
 				return null;
 			}
 
-			string managedAssemblyName = Marshal.PtrToStringAnsi (managedAssemblyNamePointer);
+			string? managedAssemblyName = Marshal.PtrToStringAnsi (managedAssemblyNamePointer);
+			if (managedAssemblyName is null) {
+				return null;
+			}
+
 			Assembly assembly = Assembly.Load (managedAssemblyName);
 			Type? ret = null;
 			foreach (Module module in assembly.Modules) {
@@ -308,9 +312,11 @@ namespace Java.Interop {
 			string? class_name = GetClassName (class_ptr);
 			lock (TypeManagerMapDictionaries.AccessLock) {
 				while (class_ptr != IntPtr.Zero) {
-					type = GetJavaToManagedTypeCore (class_name);
-					if (type != null) {
-						break;
+					if (!string.IsNullOrEmpty (class_name)) {
+						type = GetJavaToManagedTypeCore (class_name);
+						if (type != null) {
+							break;
+						}
 					}
 
 					IntPtr super_class_ptr = JNIEnv.GetSuperclass (class_ptr);

--- a/src/Mono.Android/Java.Lang/StringBuffer.cs
+++ b/src/Mono.Android/Java.Lang/StringBuffer.cs
@@ -9,7 +9,7 @@ namespace Java.Lang
 {
 	public partial class StringBuffer
 	{
-		public IAppendable Append (string s, int start, int end)
+		public new IAppendable Append (string s, int start, int end)
 		{
 			return Append (new Java.Lang.String (s), start, end);
 		}

--- a/src/Mono.Android/Java.Lang/StringBuilder.cs
+++ b/src/Mono.Android/Java.Lang/StringBuilder.cs
@@ -9,7 +9,7 @@ namespace Java.Lang
 {
 	public partial class StringBuilder
 	{
-		public IAppendable Append (string s, int start, int end)
+		public new IAppendable Append (string s, int start, int end)
 		{
 			return Append (new Java.Lang.String (s), start, end);
 		}

--- a/src/Mono.Android/Java.Util/Spliterators.cs
+++ b/src/Mono.Android/Java.Util/Spliterators.cs
@@ -11,12 +11,12 @@ namespace Java.Util
 	{
 		public partial class AbstractSpliterator
 		{
-			public abstract bool TryAdvance (IConsumer action);
+			public abstract bool TryAdvance (IConsumer? action);
 		}
 
 		internal partial class AbstractSpliteratorInvoker
 		{
-			public override unsafe bool TryAdvance (IConsumer action)
+			public override unsafe bool TryAdvance (IConsumer? action)
 			{
 				const string __id = "tryAdvance.(Ljava/util/function/Consumer;)V";
 				IntPtr native_action = JNIEnv.ToLocalJniHandle (action);

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
@@ -312,6 +312,7 @@ static class JavaMarshalRegisteredPeers
 			}
 		}
 
+#pragma warning disable CS0649 // Field 'JavaMarshalRegisteredPeers.HandleContext.JniObjectReferenceControlBlock.*' is never assigned to, and will always have its default value 0
 		// This is an internal mirror of the Java.Interop.JniObjectReferenceControlBlock
 		private struct JniObjectReferenceControlBlock
 		{
@@ -320,6 +321,7 @@ static class JavaMarshalRegisteredPeers
 			public IntPtr weak_handle;
 			public int refs_added;
 		}
+#pragma warning restore CS0649
 
 		public static GCHandle GetAssociatedGCHandle (HandleContext* context)
 		{

--- a/src/Mono.Android/Microsoft.Android.Runtime/JniRemappingLookup.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JniRemappingLookup.cs
@@ -10,12 +10,14 @@ namespace Microsoft.Android.Runtime;
 
 static class JniRemappingLookup
 {
+#pragma warning disable CS0649 // Field 'JniRemappingLookup.JniRemappingReplacementMethod.target_type' is never assigned to, and will always have its default value null
 	struct JniRemappingReplacementMethod
 	{
 		public string? target_type;
 		public string? target_name;
 		public bool    is_static;
 	}
+#pragma warning restore CS0649
 
 	internal static IReadOnlyList<string> GetStaticMethodFallbackTypes (string jniSimpleReference, bool useReplacementTypes)
 	{

--- a/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeManager.cs
@@ -8,7 +8,7 @@ using Java.Interop.Tools.TypeNameMappings;
 namespace Microsoft.Android.Runtime;
 
 [UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Temporary suppression for Java.Interop reflection manager base.")]
-[UnconditionalSuppressMessage ("Trimming", "IL3050", Justification = "Temporary suppression for Java.Interop reflection manager base.")]
+[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Temporary suppression for Java.Interop reflection manager base.")]
 class ManagedTypeManager : JniRuntime.ReflectionJniTypeManager {
 
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;

--- a/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeManager.cs
@@ -8,7 +8,6 @@ using Java.Interop.Tools.TypeNameMappings;
 namespace Microsoft.Android.Runtime;
 
 [UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Temporary suppression for Java.Interop reflection manager base.")]
-[UnconditionalSuppressMessage ("Trimming", "IL3050", Justification = "Temporary suppression for Java.Interop reflection manager base.")]
 class ManagedTypeManager : JniRuntime.ReflectionJniTypeManager {
 
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;

--- a/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeManager.cs
@@ -8,6 +8,7 @@ using Java.Interop.Tools.TypeNameMappings;
 namespace Microsoft.Android.Runtime;
 
 [UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Temporary suppression for Java.Interop reflection manager base.")]
+[UnconditionalSuppressMessage ("Trimming", "IL3050", Justification = "Temporary suppression for Java.Interop reflection manager base.")]
 class ManagedTypeManager : JniRuntime.ReflectionJniTypeManager {
 
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
@@ -52,24 +52,21 @@ class TrimmableTypeMapTypeManager : JniRuntime.JniTypeManager
 		{
 			Debug.Assert (elementType != typeof (void), "Cannot create an array of void");
 
-			// We only pre-generate the array types proxy map for Native AOT because we can't manipulate types at runtime.
-			// For CoreCLR, we take advantage of the dynamic runtime and we save app size by not pre-generating the array types proxy map.
-			if (RuntimeFeature.IsNativeAotRuntime) {
-				return TrimmableTypeMap.Instance.TryGetArrayProxy (elementType, typeSignature.ArrayRank, out var arrayProxy)
-					? arrayProxy.GetArrayTypes ()
-					: [];
-			}
-			
-			if (RuntimeFeature.IsCoreClrRuntime) {
+			if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported) {
 				return GetArrayTypesForCoreClr (typeSignature, elementType);
 			}
-			
-			throw new NotSupportedException ("Unsupported runtime.");
+
+			// We only pre-generate the array types proxy map for Native AOT because we can't manipulate types at runtime.
+			// For CoreCLR, we take advantage of the dynamic runtime and we save app size by not pre-generating the array types proxy map.
+			return TrimmableTypeMap.Instance.TryGetArrayProxy (elementType, typeSignature.ArrayRank, out var arrayProxy)
+				? arrayProxy.GetArrayTypes ()
+				: [];
 
 			[UnconditionalSuppressMessage ("Trimming", "IL2026:RequiresUnreferencedCode",
 				Justification = "This API is called as part of Java to .NET type marshalling when the target type is expected as the input " +
 					"parameter of the target method, so it must be seen by the IL trimmer. This justification would not hold for Native AOT " +
 					"but this codepath is only reachable on CoreCLR.")]
+			[RequiresDynamicCode ("This API uses reflection to create generic types at runtime, which is not supported in AOT scenarios.")]
 			static IEnumerable<Type> GetArrayTypesForCoreClr (JniTypeSignature typeSignature, Type elementType)
 			{
 				if (IsKeyword (typeSignature)) {

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>Android</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
-    <NoWarn>0618;0809;0108;0114;0465;8609;8610;8614;8617;8613;8764;8765;8766;8767;RS0041;IL3050</NoWarn>
+    <NoWarn>0618;0809;0108;0114;0465;8609;8610;8614;8617;8613;8764;8765;8766;8767;RS0041</NoWarn>
     <WarningsAsErrors>$(WarningsAsErrors);CS2002</WarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);JAVA_INTEROP</DefineConstants>

--- a/src/Mono.Android/Org.Apache.Http.Impl.Cookie/BasicClientCookie.cs
+++ b/src/Mono.Android/Org.Apache.Http.Impl.Cookie/BasicClientCookie.cs
@@ -2,27 +2,27 @@ namespace Org.Apache.Http.Impl.Cookie
 {
 	public partial class BasicClientCookie
 	{
-		public void SetComment (string comment)
+		public void SetComment (string? comment)
 		{
 			Comment = comment;
 		}
 		
-		public void SetDomain (string domain)
+		public void SetDomain (string? domain)
 		{
 			Domain = domain;
 		}
 		
-		public void SetExpiryDate (Java.Util.Date date)
+		public void SetExpiryDate (Java.Util.Date? date)
 		{
 			ExpiryDate = date;
 		}
 		
-		public void SetPath (string path)
+		public void SetPath (string? path)
 		{
 			Path = path;
 		}
 		
-		public void SetValue (string value)
+		public void SetValue (string? value)
 		{
 			Value = value;
 		}

--- a/src/Mono.Android/PublicAPI/API-37/PublicAPI.Unshipped.txt
+++ b/src/Mono.Android/PublicAPI/API-37/PublicAPI.Unshipped.txt
@@ -2342,6 +2342,8 @@ Android.Widget.Photopicker.AspectRatio
 Android.Widget.Photopicker.AspectRatio.Portrait916 = 1 -> Android.Widget.Photopicker.AspectRatio
 Android.Widget.Photopicker.AspectRatio.Square11 = 0 -> Android.Widget.Photopicker.AspectRatio
 Android.Widget.Photopicker.AspectRatio.Undefined = -1 -> Android.Widget.Photopicker.AspectRatio
+Java.Interop.BaseExportAttribute
+Java.Interop.BaseExportAttribute.BaseExportAttribute() -> void
 Java.Interop.IAndroidCallableWrapper
 Java.Interop.IAndroidCallableWrapper.RegisterNatives(Java.Interop.JniType! nativeClass) -> void
 Java.Interop.JavaArrayProxy
@@ -2353,12 +2355,11 @@ Java.Interop.JavaPeerContainerFactory
 Java.Interop.JavaPeerContainerFactory.JavaPeerContainerFactory() -> void
 Java.Interop.JavaPeerContainerFactory<T>
 Java.Interop.JavaPeerProxy
-Java.Interop.JavaPeerProxy.InvokerType.get -> System.Type?
-Java.Interop.JavaPeerProxy.JavaPeerProxy(string! jniName, System.Type! targetType, System.Type? invokerType) -> void
+Java.Interop.JavaPeerProxy.JavaPeerProxy(string! jniName, System.Type! targetType) -> void
 Java.Interop.JavaPeerProxy.JniName.get -> string!
 Java.Interop.JavaPeerProxy.TargetType.get -> System.Type!
 Java.Interop.JavaPeerProxy<T>
-Java.Interop.JavaPeerProxy<T>.JavaPeerProxy(string! jniName, System.Type? invokerType) -> void
+Java.Interop.JavaPeerProxy<T>.JavaPeerProxy(string! jniName) -> void
 Java.Lang.ICharSequence.GetChars(int srcBegin, int srcEnd, char[]! dst, int dstBegin) -> void
 Java.Lang.IllegalCallerException
 Java.Lang.IllegalCallerException.IllegalCallerException() -> void

--- a/src/Mono.Android/PublicAPI/API-37/PublicAPI.Unshipped.txt
+++ b/src/Mono.Android/PublicAPI/API-37/PublicAPI.Unshipped.txt
@@ -1,4 +1,2422 @@
 #nullable enable
+*REMOVED*Android.App.Admin.DevicePolicyManager.SetDeviceOwnerLockScreenInfo(Android.Content.ComponentName! admin, string? info) -> void
+*REMOVED*Android.App.AppFunctions.AppFunctionManager.SetAppFunctionEnabled(string! functionIdentifier, Android.App.AppFunctions.AppFunctionState newEnabledState, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+*REMOVED*Android.App.AppFunctions.AppFunctionState.Default = 0 -> Android.App.AppFunctions.AppFunctionState
+*REMOVED*Android.App.AppFunctions.AppFunctionState.Disabled = 2 -> Android.App.AppFunctions.AppFunctionState
+*REMOVED*Android.App.AppFunctions.AppFunctionState.Enabled = 1 -> Android.App.AppFunctions.AppFunctionState
+*REMOVED*Android.App.Notification.IExtender.Extend(Android.App.Notification.Builder? builder) -> Android.App.Notification.Builder?
+*REMOVED*Android.Bluetooth.BluetoothGattServer.SendResponse(Android.Bluetooth.BluetoothDevice? device, int requestId, Android.Bluetooth.ProfileState status, int offset, byte[]? value) -> bool
+*REMOVED*Android.Health.Connect.DataTypes.CyclingPedalingCadenceRecord.Builder.Builder(Android.Health.Connect.DataTypes.Metadata! metadata, Java.Time.Instant! startTime, Java.Time.Instant! endTime, System.Collections.Generic.IList<Android.Health.Connect.DataTypes.CyclingPedalingCadenceRecord.CyclingPedalingCadenceRecordSample!>! cyclingPedalingCadenceRecordSamples) -> void
+*REMOVED*Android.Health.Connect.DataTypes.SpeedRecord.Builder.Builder(Android.Health.Connect.DataTypes.Metadata! metadata, Java.Time.Instant! startTime, Java.Time.Instant! endTime, System.Collections.Generic.IList<Android.Health.Connect.DataTypes.SpeedRecord.SpeedRecordSample!>! speedRecordSamples) -> void
+*REMOVED*Android.Health.Connect.DataTypes.StepsCadenceRecord.Builder.Builder(Android.Health.Connect.DataTypes.Metadata! metadata, Java.Time.Instant! startTime, Java.Time.Instant! endTime, System.Collections.Generic.IList<Android.Health.Connect.DataTypes.StepsCadenceRecord.StepsCadenceRecordSample!>! stepsCadenceRecordSamples) -> void
+*REMOVED*Android.Net.Wifi.Rtt.ResponderConfig.Builder.SetMacAddress(Android.Net.MacAddress! macAddress) -> Android.Net.Wifi.Rtt.ResponderConfig.Builder!
+*REMOVED*Android.Nfc.NfcAdapter.ResetDiscoveryTechnology(Android.App.Activity! activity) -> void
+*REMOVED*Android.Nfc.NfcAdapter.SetDiscoveryTechnology(Android.App.Activity! activity, Android.Nfc.NfcReaderFlags pollTechnology, Android.Nfc.NfcListenFlags listenTechnology) -> void
+*REMOVED*Android.OS.Bundle.GetByteArray(string? key) -> byte[]?
+*REMOVED*Android.OS.Bundle.PutByteArray(string? key, byte[]? value) -> void
+*REMOVED*Android.Runtime.XmlReaderPullParser.GetNamespace(string! prefix) -> string?
+*REMOVED*Android.Runtime.XmlReaderPullParser.GetTextCharacters(int[]! holderForStartAndLength) -> char[]!
+*REMOVED*Android.Telecom.CallControl.Answer(Android.Telecom.CallType videoState, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+*REMOVED*Android.Telecom.CallControl.RequestVideoState(Android.Telecom.CallType videoState, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+*REMOVED*Android.Text.IInputType
+*REMOVED*Org.Apache.Http.Impl.Cookie.BasicClientCookie.SetComment(string! comment) -> void
+*REMOVED*Org.Apache.Http.Impl.Cookie.BasicClientCookie.SetDomain(string! domain) -> void
+*REMOVED*Org.Apache.Http.Impl.Cookie.BasicClientCookie.SetExpiryDate(Java.Util.Date! date) -> void
+*REMOVED*Org.Apache.Http.Impl.Cookie.BasicClientCookie.SetPath(string! path) -> void
+*REMOVED*Org.Apache.Http.Impl.Cookie.BasicClientCookie.SetValue(string! value) -> void
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.AndroidClientHandler() -> void
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.AssertSelf() -> void
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.ConnectTimeout.get -> System.TimeSpan
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.ConnectTimeout.set -> void
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.PreAuthenticationData.get -> Xamarin.Android.Net.AuthenticationData?
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.PreAuthenticationData.set -> void
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.ProxyAuthenticationRequested.get -> bool
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.ReadTimeout.get -> System.TimeSpan
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.ReadTimeout.set -> void
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.RequestNeedsAuthorization.get -> bool
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.RequestedAuthentication.get -> System.Collections.Generic.IList<Xamarin.Android.Net.AuthenticationData!>?
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.TrustedCerts.get -> System.Collections.Generic.IList<Java.Security.Cert.Certificate!>?
+*REMOVED*REMOVED Xamarin.Android.Net.AndroidClientHandler.TrustedCerts.set -> void
+*REMOVED*REMOVED override Xamarin.Android.Net.AndroidClientHandler.Dispose(bool disposing) -> void
+*REMOVED*REMOVED override Xamarin.Android.Net.AndroidClientHandler.SendAsync(System.Net.Http.HttpRequestMessage! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
+*REMOVED*REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.ConfigureCustomSSLSocketFactory(Javax.Net.Ssl.HttpsURLConnection! connection) -> Javax.Net.Ssl.SSLSocketFactory?
+*REMOVED*REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.ConfigureKeyManagerFactory(Java.Security.KeyStore? keyStore) -> Javax.Net.Ssl.KeyManagerFactory?
+*REMOVED*REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.ConfigureKeyStore(Java.Security.KeyStore? keyStore) -> Java.Security.KeyStore?
+*REMOVED*REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.ConfigureTrustManagerFactory(Java.Security.KeyStore? keyStore) -> Javax.Net.Ssl.TrustManagerFactory?
+*REMOVED*REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.GetJavaProxy(System.Uri! destination, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Java.Net.Proxy?>!
+*REMOVED*REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.GetSSLHostnameVerifier(Javax.Net.Ssl.HttpsURLConnection! connection) -> Javax.Net.Ssl.IHostnameVerifier?
+*REMOVED*REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.SetupRequest(System.Net.Http.HttpRequestMessage! request, Java.Net.HttpURLConnection! conn) -> System.Threading.Tasks.Task!
+*REMOVED*REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.WriteRequestContentToOutput(System.Net.Http.HttpRequestMessage! request, Java.Net.HttpURLConnection! httpConnection, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+*REMOVED*abstract Java.Util.Spliterators.AbstractSpliterator.TryAdvance(Java.Util.Functions.IConsumer! action) -> bool
+*REMOVED*const Android.App.AppFunctions.AppFunctionManager.AppFunctionStateDefault = Android.App.AppFunctions.AppFunctionState.Default -> Android.App.AppFunctions.AppFunctionState
+*REMOVED*const Android.App.AppFunctions.AppFunctionManager.AppFunctionStateDisabled = Android.App.AppFunctions.AppFunctionState.Disabled -> Android.App.AppFunctions.AppFunctionState
+*REMOVED*const Android.App.AppFunctions.AppFunctionManager.AppFunctionStateEnabled = Android.App.AppFunctions.AppFunctionState.Enabled -> Android.App.AppFunctions.AppFunctionState
+*REMOVED*const Android.Media.MediaCodecInfo.CodecProfileLevel.VP9Profile3HDR = Android.Media.MediaCodecProfileType.Av1profilemain10hdr10plus -> Android.Media.MediaCodecProfileType
+*REMOVED*override Android.Graphics.AndroidBitmapInfo.Equals(object! value) -> bool
+*REMOVED*override Android.Graphics.Color.Equals(object! obj) -> bool
+*REMOVED*override Android.Graphics.ColorValueMarshaler.CreateGenericValue(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions options, System.Type! targetType) -> Android.Graphics.Color
+*REMOVED*override Android.Graphics.ColorValueMarshaler.CreateParameterToManagedExpression(Java.Interop.Expressions.JniValueMarshalerContext! context, System.Linq.Expressions.ParameterExpression! sourceValue, System.Reflection.ParameterAttributes synchronize, System.Type! targetType) -> System.Linq.Expressions.Expression!
+*REMOVED*override Android.Runtime.InputStreamAdapter.Read(byte[]! bytes) -> int
+*REMOVED*override Android.Runtime.InputStreamAdapter.Read(byte[]! bytes, int offset, int length) -> int
+*REMOVED*override Android.Runtime.OutputStreamAdapter.Write(byte[]! buffer) -> void
+*REMOVED*override Android.Runtime.OutputStreamAdapter.Write(byte[]! buffer, int offset, int length) -> void
+*REMOVED*override Android.Widget.AdapterView<T>.RawAdapter.get -> Java.Lang.Object!
+*REMOVED*override Java.Lang.StringBuffer.GetChars(int srcBegin, int srcEnd, char[]? dst, int dstBegin) -> void
+*REMOVED*override Java.Lang.StringBuilder.GetChars(int srcBegin, int srcEnd, char[]? dst, int dstBegin) -> void
+*REMOVED*override System.Drawing.PointConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext! context, System.Type! sourceType) -> bool
+*REMOVED*override System.Drawing.PointConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext! context, System.Type! destinationType) -> bool
+*REMOVED*override System.Drawing.PointConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext! context, System.Globalization.CultureInfo! culture, object! value) -> object?
+*REMOVED*override System.Drawing.PointConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext! context, System.Globalization.CultureInfo! culture, object! value, System.Type! destinationType) -> object?
+*REMOVED*override System.Drawing.PointConverter.CreateInstance(System.ComponentModel.ITypeDescriptorContext! context, System.Collections.IDictionary! propertyValues) -> object!
+*REMOVED*override System.Drawing.PointConverter.GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext! context) -> bool
+*REMOVED*override System.Drawing.PointConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext! context, object! value, System.Attribute![]! attributes) -> System.ComponentModel.PropertyDescriptorCollection?
+*REMOVED*override System.Drawing.PointConverter.GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext! context) -> bool
+*REMOVED*override System.Drawing.RectangleConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext! context, System.Type! sourceType) -> bool
+*REMOVED*override System.Drawing.RectangleConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext! context, System.Type! destinationType) -> bool
+*REMOVED*override System.Drawing.RectangleConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext! context, System.Globalization.CultureInfo! culture, object! value) -> object?
+*REMOVED*override System.Drawing.RectangleConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext! context, System.Globalization.CultureInfo! culture, object! value, System.Type! destinationType) -> object?
+*REMOVED*override System.Drawing.RectangleConverter.CreateInstance(System.ComponentModel.ITypeDescriptorContext! context, System.Collections.IDictionary! propertyValues) -> object!
+*REMOVED*override System.Drawing.RectangleConverter.GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext! context) -> bool
+*REMOVED*override System.Drawing.RectangleConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext! context, object! value, System.Attribute![]! attributes) -> System.ComponentModel.PropertyDescriptorCollection?
+*REMOVED*override System.Drawing.RectangleConverter.GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext! context) -> bool
+*REMOVED*override System.Drawing.SizeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext! context, System.Type! sourceType) -> bool
+*REMOVED*override System.Drawing.SizeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext! context, System.Type! destinationType) -> bool
+*REMOVED*override System.Drawing.SizeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext! context, System.Globalization.CultureInfo! culture, object! value) -> object?
+*REMOVED*override System.Drawing.SizeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext! context, System.Globalization.CultureInfo! culture, object! value, System.Type! destinationType) -> object?
+*REMOVED*override System.Drawing.SizeConverter.CreateInstance(System.ComponentModel.ITypeDescriptorContext! context, System.Collections.IDictionary! propertyValues) -> object!
+*REMOVED*override System.Drawing.SizeConverter.GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext! context) -> bool
+*REMOVED*override System.Drawing.SizeConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext! context, object! value, System.Attribute![]! attributes) -> System.ComponentModel.PropertyDescriptorCollection?
+*REMOVED*override System.Drawing.SizeConverter.GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext! context) -> bool
+*REMOVED*override System.Drawing.SizeFConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext! context, System.Type! sourceType) -> bool
+*REMOVED*override System.Drawing.SizeFConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext! context, System.Type! destinationType) -> bool
+*REMOVED*override System.Drawing.SizeFConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext! context, System.Globalization.CultureInfo! culture, object! value) -> object?
+*REMOVED*override System.Drawing.SizeFConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext! context, System.Globalization.CultureInfo! culture, object! value, System.Type! destinationType) -> object?
+*REMOVED*override System.Drawing.SizeFConverter.CreateInstance(System.ComponentModel.ITypeDescriptorContext! context, System.Collections.IDictionary! propertyValues) -> object!
+*REMOVED*override System.Drawing.SizeFConverter.GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext! context) -> bool
+*REMOVED*override System.Drawing.SizeFConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext! context, object! value, System.Attribute![]! attributes) -> System.ComponentModel.PropertyDescriptorCollection?
+*REMOVED*override System.Drawing.SizeFConverter.GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext! context) -> bool
+*REMOVED*override sealed Android.Text.SpannableString.GetChars(int start, int end, char[]? dest, int off) -> void
+*REMOVED*static Android.Runtime.JNIEnv.GetClassNameFromInstance(nint jobject) -> string!
+*REMOVED*static Android.Security.NetworkSecurityPolicy.Instance.get -> Android.Security.NetworkSecurityPolicy?
+*REMOVED*virtual Android.App.Admin.DevicePolicyManager.EnableSystemApp(Android.Content.ComponentName! admin, Android.Content.Intent? intent) -> int
+*REMOVED*virtual Android.App.Admin.DevicePolicyManager.EnableSystemApp(Android.Content.ComponentName! admin, string? packageName) -> void
+*REMOVED*virtual Android.App.Admin.DevicePolicyManager.SetDeviceOwnerLockScreenInfo(Android.Content.ComponentName! admin, Java.Lang.ICharSequence? info) -> void
+*REMOVED*virtual Android.App.Admin.DevicePolicyManager.SetPermissionPolicy(Android.Content.ComponentName! admin, Android.App.Admin.PermissionPolicy policy) -> void
+*REMOVED*virtual Android.Net.Http.HttpEngine.Builder.SetConnectionMigrationOptions(Android.Net.Http.ConnectionMigrationOptions! connectionMigrationOptions) -> Android.Net.Http.HttpEngine.Builder!
+*REMOVED*virtual Android.Net.Http.HttpEngine.Builder.SetDnsOptions(Android.Net.Http.DnsOptions! dnsOptions) -> Android.Net.Http.HttpEngine.Builder!
+*REMOVED*virtual Android.Net.Http.HttpEngine.Builder.SetQuicOptions(Android.Net.Http.QuicOptions! quicOptions) -> Android.Net.Http.HttpEngine.Builder!
+*REMOVED*virtual Android.Net.Wifi.P2p.WifiP2pManager.SetConnectionRequestResult(Android.Net.Wifi.P2p.WifiP2pManager.Channel! c, Android.Net.MacAddress! deviceAddress, int result, string? pin, Android.Net.Wifi.P2p.WifiP2pManager.IActionListener? listener) -> void
+*REMOVED*virtual Android.Nfc.CardEmulators.HostApduService.ProcessPollingFrames(System.Collections.Generic.IList<Android.Nfc.CardEmulators.PollingFrame!>! frame) -> void
+Android.AdServices.OnDevicePersonalization.OnDevicePersonalizationException.OnDevicePersonalizationException(int errorCode) -> void
+Android.AdServices.OnDevicePersonalization.OnDevicePersonalizationException.OnDevicePersonalizationException(int errorCode, Java.Lang.Throwable? cause) -> void
+Android.AdServices.OnDevicePersonalization.OnDevicePersonalizationException.OnDevicePersonalizationException(int errorCode, string? message) -> void
+Android.AdServices.OnDevicePersonalization.OnDevicePersonalizationException.OnDevicePersonalizationException(int errorCode, string? message, Java.Lang.Throwable? cause) -> void
+Android.App.ActionEmphasis
+Android.App.ActionEmphasis.Auto = 0 -> Android.App.ActionEmphasis
+Android.App.ActionEmphasis.Primary = 1 -> Android.App.ActionEmphasis
+Android.App.ActionEmphasis.Secondary = 2 -> Android.App.ActionEmphasis
+Android.App.ActionStyle
+Android.App.ActionStyle.Auto = 0 -> Android.App.ActionStyle
+Android.App.ActionStyle.IconAndText = 2 -> Android.App.ActionStyle
+Android.App.ActionStyle.IconOnly = 3 -> Android.App.ActionStyle
+Android.App.ActionStyle.TextOnly = 1 -> Android.App.ActionStyle
+Android.App.Activity.IsHandoffEnabled.get -> bool
+Android.App.Activity.SetHandoffEnabled(bool handoffEnabled, Android.App.HandoffActivityParams? handoffActivityParams) -> void
+Android.App.ActivityManager.MemoryInfo.FreeMem.get -> long
+Android.App.ActivityManager.MemoryInfo.FreeMem.set -> void
+Android.App.ActivityManager.TaskDescription.Builder.SetBadge(Android.Graphics.Drawables.Icon? badge) -> Android.App.ActivityManager.TaskDescription.Builder!
+Android.App.ActivityManager.TaskDescription.Builder.SetIcon(Android.Graphics.Drawables.Icon? icon) -> Android.App.ActivityManager.TaskDescription.Builder!
+Android.App.ActivityManagerAppTaskWindowingLayer
+Android.App.ActivityManagerAppTaskWindowingLayer.NormalApp = 1 -> Android.App.ActivityManagerAppTaskWindowingLayer
+Android.App.ActivityManagerAppTaskWindowingLayer.Pinned = 2 -> Android.App.ActivityManagerAppTaskWindowingLayer
+Android.App.ActivityManagerAppTaskWindowingLayer.Undefined = 0 -> Android.App.ActivityManagerAppTaskWindowingLayer
+Android.App.ActivityManagerAppTaskWindowingLayerResult
+Android.App.ActivityManagerAppTaskWindowingLayerResult.Granted = 0 -> Android.App.ActivityManagerAppTaskWindowingLayerResult
+Android.App.ActivityManagerAppTaskWindowingLayerResult.Rejected = 1 -> Android.App.ActivityManagerAppTaskWindowingLayerResult
+Android.App.Admin.DevicePolicyManager.SetDeviceOwnerLockScreenInfo(Android.Content.ComponentName? admin, string? info) -> void
+Android.App.AnrType
+Android.App.AnrType.AppTriggered = 7 -> Android.App.AnrType
+Android.App.AnrType.ApplicationStart = 10 -> Android.App.AnrType
+Android.App.AnrType.BroadcastOfIntent = 3 -> Android.App.AnrType
+Android.App.AnrType.ContentProviderNotResponding = 6 -> Android.App.AnrType
+Android.App.AnrType.ExecuteService = 5 -> Android.App.AnrType
+Android.App.AnrType.ForegroundShortServiceTimeout = 8 -> Android.App.AnrType
+Android.App.AnrType.InputDispatch = 2 -> Android.App.AnrType
+Android.App.AnrType.InputDispatchNoFocusedWindow = 1 -> Android.App.AnrType
+Android.App.AnrType.JobServiceStart = 9 -> Android.App.AnrType
+Android.App.AnrType.Other = 0 -> Android.App.AnrType
+Android.App.AnrType.StartForegroundService = 4 -> Android.App.AnrType
+Android.App.AnrTypes
+Android.App.AnrWarningResult
+Android.App.AnrWarningResult.AnrId.get -> int
+Android.App.AnrWarningResult.AnrType.get -> int
+Android.App.AnrWarningResult.ConsumedMillis.get -> long
+Android.App.AnrWarningResult.DescribeContents() -> int
+Android.App.AnrWarningResult.Description.get -> string!
+Android.App.AnrWarningResult.InterfaceConsts
+Android.App.AnrWarningResult.TimeoutMillis.get -> long
+Android.App.AnrWarningResult.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppFunctions.AppFunctionActivityId
+Android.App.AppFunctions.AppFunctionActivityId.DescribeContents() -> int
+Android.App.AppFunctions.AppFunctionActivityId.InterfaceConsts
+Android.App.AppFunctions.AppFunctionActivityId.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppFunctions.AppFunctionActivityState
+Android.App.AppFunctions.AppFunctionActivityState.ActivityId.get -> Android.App.AppFunctions.AppFunctionActivityId!
+Android.App.AppFunctions.AppFunctionActivityState.DescribeContents() -> int
+Android.App.AppFunctions.AppFunctionActivityState.FunctionNames.get -> Android.Util.ArraySet!
+Android.App.AppFunctions.AppFunctionActivityState.InterfaceConsts
+Android.App.AppFunctions.AppFunctionActivityState.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppFunctions.AppFunctionEnabledState
+Android.App.AppFunctions.AppFunctionEnabledState.Default = 0 -> Android.App.AppFunctions.AppFunctionEnabledState
+Android.App.AppFunctions.AppFunctionEnabledState.Disabled = 2 -> Android.App.AppFunctions.AppFunctionEnabledState
+Android.App.AppFunctions.AppFunctionEnabledState.Enabled = 1 -> Android.App.AppFunctions.AppFunctionEnabledState
+Android.App.AppFunctions.AppFunctionManager.GetAppFunctionActivityStates(System.Collections.Generic.ICollection<Android.App.AppFunctions.AppFunctionActivityId!>! activityIds, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.App.AppFunctions.AppFunctionManager.GetAppFunctionStates(System.Collections.Generic.IList<Android.App.AppFunctions.AppFunctionName!>! appFunctionNames, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.App.AppFunctions.AppFunctionManager.ObserveAppFunctions(Java.Util.Concurrent.IExecutor! executor, Android.App.AppFunctions.IAppFunctionObserver! appFunctionObserver) -> Android.App.AppFunctions.IAppFunctionObservation!
+Android.App.AppFunctions.AppFunctionManager.RegisterAppFunction(string! functionIdentifier, Java.Util.Concurrent.IExecutor! executor, Android.App.AppFunctions.IAppFunction! appFunction) -> Android.App.AppFunctions.IAppFunctionRegistration!
+Android.App.AppFunctions.AppFunctionManager.RegisterAppFunctions(System.Collections.Generic.IList<Android.App.AppFunctions.RegisterAppFunctionRequest!>! requests) -> Android.App.AppFunctions.IAppFunctionRegistration!
+Android.App.AppFunctions.AppFunctionManager.SearchAppFunctions(Android.App.AppFunctions.AppFunctionSearchSpec! searchSpec, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.App.AppFunctions.AppFunctionManager.SetAppFunctionEnabled(string! functionIdentifier, Android.App.AppFunctions.AppFunctionEnabledState newEnabledState, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.App.AppFunctions.AppFunctionMetadata
+Android.App.AppFunctions.AppFunctionMetadata.DescribeContents() -> int
+Android.App.AppFunctions.AppFunctionMetadata.InterfaceConsts
+Android.App.AppFunctions.AppFunctionMetadata.MetadataDocument.get -> Android.App.AppSearch.GenericDocument!
+Android.App.AppFunctions.AppFunctionMetadata.Name.get -> Android.App.AppFunctions.AppFunctionName!
+Android.App.AppFunctions.AppFunctionMetadata.PackageMetadata.get -> Android.App.AppFunctions.AppFunctionPackageMetadata!
+Android.App.AppFunctions.AppFunctionMetadata.SchemaMetadata.get -> Android.App.AppFunctions.AppFunctionSchemaMetadata?
+Android.App.AppFunctions.AppFunctionMetadata.Scope.get -> int
+Android.App.AppFunctions.AppFunctionMetadata.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppFunctions.AppFunctionMetadataScope
+Android.App.AppFunctions.AppFunctionMetadataScope.Activity = 1 -> Android.App.AppFunctions.AppFunctionMetadataScope
+Android.App.AppFunctions.AppFunctionMetadataScope.Global = 0 -> Android.App.AppFunctions.AppFunctionMetadataScope
+Android.App.AppFunctions.AppFunctionName
+Android.App.AppFunctions.AppFunctionName.AppFunctionName(string! packageName, string! functionIdentifier) -> void
+Android.App.AppFunctions.AppFunctionName.DescribeContents() -> int
+Android.App.AppFunctions.AppFunctionName.FunctionIdentifier.get -> string!
+Android.App.AppFunctions.AppFunctionName.InterfaceConsts
+Android.App.AppFunctions.AppFunctionName.PackageName.get -> string!
+Android.App.AppFunctions.AppFunctionName.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppFunctions.AppFunctionPackageMetadata
+Android.App.AppFunctions.AppFunctionPackageMetadata.DescribeContents() -> int
+Android.App.AppFunctions.AppFunctionPackageMetadata.InterfaceConsts
+Android.App.AppFunctions.AppFunctionPackageMetadata.MetadataDocument.get -> Android.App.AppSearch.GenericDocument!
+Android.App.AppFunctions.AppFunctionPackageMetadata.PackageName.get -> string!
+Android.App.AppFunctions.AppFunctionPackageMetadata.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppFunctions.AppFunctionSchemaMetadata
+Android.App.AppFunctions.AppFunctionSchemaMetadata.AppFunctionSchemaMetadata(string! schemaCategory, string! schemaName, long schemaVersion) -> void
+Android.App.AppFunctions.AppFunctionSchemaMetadata.Category.get -> string!
+Android.App.AppFunctions.AppFunctionSchemaMetadata.DescribeContents() -> int
+Android.App.AppFunctions.AppFunctionSchemaMetadata.InterfaceConsts
+Android.App.AppFunctions.AppFunctionSchemaMetadata.Name.get -> string!
+Android.App.AppFunctions.AppFunctionSchemaMetadata.Version.get -> long
+Android.App.AppFunctions.AppFunctionSchemaMetadata.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppFunctions.AppFunctionSearchSpec
+Android.App.AppFunctions.AppFunctionSearchSpec.Builder
+Android.App.AppFunctions.AppFunctionSearchSpec.Builder.Build() -> Android.App.AppFunctions.AppFunctionSearchSpec!
+Android.App.AppFunctions.AppFunctionSearchSpec.Builder.Builder() -> void
+Android.App.AppFunctions.AppFunctionSearchSpec.Builder.SetFunctionNames(System.Collections.Generic.ICollection<Android.App.AppFunctions.AppFunctionName!>? functionNames) -> Android.App.AppFunctions.AppFunctionSearchSpec.Builder!
+Android.App.AppFunctions.AppFunctionSearchSpec.Builder.SetMinSchemaVersion(long minSchemaVersion) -> Android.App.AppFunctions.AppFunctionSearchSpec.Builder!
+Android.App.AppFunctions.AppFunctionSearchSpec.Builder.SetPackageNames(System.Collections.Generic.ICollection<string!>? packageNames) -> Android.App.AppFunctions.AppFunctionSearchSpec.Builder!
+Android.App.AppFunctions.AppFunctionSearchSpec.Builder.SetSchemaCategory(string? schemaCategory) -> Android.App.AppFunctions.AppFunctionSearchSpec.Builder!
+Android.App.AppFunctions.AppFunctionSearchSpec.Builder.SetSchemaName(string? schemaName) -> Android.App.AppFunctions.AppFunctionSearchSpec.Builder!
+Android.App.AppFunctions.AppFunctionSearchSpec.Builder.SetScopes(System.Collections.Generic.ICollection<Java.Lang.Integer!>? scopes) -> Android.App.AppFunctions.AppFunctionSearchSpec.Builder!
+Android.App.AppFunctions.AppFunctionSearchSpec.DescribeContents() -> int
+Android.App.AppFunctions.AppFunctionSearchSpec.FunctionNames.get -> System.Collections.Generic.ICollection<Android.App.AppFunctions.AppFunctionName!>?
+Android.App.AppFunctions.AppFunctionSearchSpec.InterfaceConsts
+Android.App.AppFunctions.AppFunctionSearchSpec.MinSchemaVersion.get -> long
+Android.App.AppFunctions.AppFunctionSearchSpec.PackageNames.get -> System.Collections.Generic.ICollection<string!>?
+Android.App.AppFunctions.AppFunctionSearchSpec.SchemaCategory.get -> string?
+Android.App.AppFunctions.AppFunctionSearchSpec.SchemaName.get -> string?
+Android.App.AppFunctions.AppFunctionSearchSpec.Scopes.get -> System.Collections.Generic.ICollection<Java.Lang.Integer!>?
+Android.App.AppFunctions.AppFunctionSearchSpec.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppFunctions.AppFunctionState.ActivityIds.get -> Android.Util.ArraySet?
+Android.App.AppFunctions.AppFunctionState.DescribeContents() -> int
+Android.App.AppFunctions.AppFunctionState.FunctionName.get -> Android.App.AppFunctions.AppFunctionName!
+Android.App.AppFunctions.AppFunctionState.InterfaceConsts
+Android.App.AppFunctions.AppFunctionState.IsEnabled.get -> bool
+Android.App.AppFunctions.AppFunctionState.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppFunctions.AppFunctionUriGrant
+Android.App.AppFunctions.AppFunctionUriGrant.AppFunctionUriGrant(Android.Net.Uri! uri, int modeFlags) -> void
+Android.App.AppFunctions.AppFunctionUriGrant.DescribeContents() -> int
+Android.App.AppFunctions.AppFunctionUriGrant.InterfaceConsts
+Android.App.AppFunctions.AppFunctionUriGrant.ModeFlags.get -> int
+Android.App.AppFunctions.AppFunctionUriGrant.Uri.get -> Android.Net.Uri!
+Android.App.AppFunctions.AppFunctionUriGrant.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppFunctions.ExecuteAppFunctionRequest.ActivityId.get -> Android.App.AppFunctions.AppFunctionActivityId?
+Android.App.AppFunctions.ExecuteAppFunctionRequest.Attribution.get -> Android.App.AppInteractionAttribution?
+Android.App.AppFunctions.ExecuteAppFunctionRequest.Builder.Builder(Android.App.AppFunctions.AppFunctionName! appFunctionName) -> void
+Android.App.AppFunctions.ExecuteAppFunctionRequest.Builder.SetActivityId(Android.App.AppFunctions.AppFunctionActivityId? activityId) -> Android.App.AppFunctions.ExecuteAppFunctionRequest.Builder!
+Android.App.AppFunctions.ExecuteAppFunctionRequest.Builder.SetAttribution(Android.App.AppInteractionAttribution! attribution) -> Android.App.AppFunctions.ExecuteAppFunctionRequest.Builder!
+Android.App.AppFunctions.ExecuteAppFunctionResponse.ExecuteAppFunctionResponse(Android.App.AppSearch.GenericDocument! resultDocument, Android.OS.Bundle! extras, System.Collections.Generic.IList<Android.App.AppFunctions.AppFunctionUriGrant!>! uriGrants) -> void
+Android.App.AppFunctions.ExecuteAppFunctionResponse.UriGrants.get -> System.Collections.Generic.IList<Android.App.AppFunctions.AppFunctionUriGrant!>!
+Android.App.AppFunctions.IAppFunction
+Android.App.AppFunctions.IAppFunction.OnExecuteAppFunction(Android.App.AppFunctions.ExecuteAppFunctionRequest! p0, Android.OS.CancellationSignal! p1, Android.OS.IOutcomeReceiver! p2) -> void
+Android.App.AppFunctions.IAppFunctionObservation
+Android.App.AppFunctions.IAppFunctionObservation.Cancel() -> void
+Android.App.AppFunctions.IAppFunctionObserver
+Android.App.AppFunctions.IAppFunctionObserver.OnAppFunctionMetadataChanged(System.Collections.Generic.ICollection<string!>! changedPackageNames) -> void
+Android.App.AppFunctions.IAppFunctionObserver.OnAppFunctionStatesChanged(System.Collections.Generic.ICollection<Android.App.AppFunctions.AppFunctionName!>! changedFunctionNames) -> void
+Android.App.AppFunctions.IAppFunctionRegistration
+Android.App.AppFunctions.IAppFunctionRegistration.Unregister() -> void
+Android.App.AppFunctions.RegisterAppFunctionRequest
+Android.App.AppFunctions.RegisterAppFunctionRequest.AppFunction.get -> Android.App.AppFunctions.IAppFunction!
+Android.App.AppFunctions.RegisterAppFunctionRequest.Executor.get -> Java.Util.Concurrent.IExecutor!
+Android.App.AppFunctions.RegisterAppFunctionRequest.FunctionIdentifier.get -> string!
+Android.App.AppFunctions.RegisterAppFunctionRequest.RegisterAppFunctionRequest(string! functionIdentifier, Java.Util.Concurrent.IExecutor! executor, Android.App.AppFunctions.IAppFunction! appFunction) -> void
+Android.App.AppInteractionAttribution
+Android.App.AppInteractionAttribution.Builder
+Android.App.AppInteractionAttribution.Builder.Build() -> Android.App.AppInteractionAttribution!
+Android.App.AppInteractionAttribution.Builder.Builder(int interactionType) -> void
+Android.App.AppInteractionAttribution.Builder.SetCustomInteractionType(string! customInteractionType) -> Android.App.AppInteractionAttribution.Builder!
+Android.App.AppInteractionAttribution.Builder.SetInteractionUri(Android.Net.Uri? interactionUri) -> Android.App.AppInteractionAttribution.Builder!
+Android.App.AppInteractionAttribution.CustomInteractionType.get -> string?
+Android.App.AppInteractionAttribution.DescribeContents() -> int
+Android.App.AppInteractionAttribution.InteractionType.get -> int
+Android.App.AppInteractionAttribution.InteractionUri.get -> Android.Net.Uri?
+Android.App.AppInteractionAttribution.InterfaceConsts
+Android.App.AppInteractionAttribution.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppInteractionAttributionInteractionType
+Android.App.AppInteractionAttributionInteractionType.Other = 0 -> Android.App.AppInteractionAttributionInteractionType
+Android.App.AppInteractionAttributionInteractionType.UserQuery = 1 -> Android.App.AppInteractionAttributionInteractionType
+Android.App.AppInteractionAttributionInteractionType.UserScheduled = 2 -> Android.App.AppInteractionAttributionInteractionType
+Android.App.AppInteractionContract
+Android.App.AppInteractionContract.InterfaceConsts
+Android.App.AppSearch.AppSearchAccount
+Android.App.AppSearch.AppSearchAccount.AccountId.get -> string?
+Android.App.AppSearch.AppSearchAccount.AccountName.get -> string?
+Android.App.AppSearch.AppSearchAccount.AccountType.get -> string?
+Android.App.AppSearch.AppSearchAccount.AppSearchAccount(Android.App.AppSearch.GenericDocument! document) -> void
+Android.App.AppSearch.AppSearchAccount.Builder
+Android.App.AppSearch.AppSearchAccount.Builder.Builder(string! namespace, string! id) -> void
+Android.App.AppSearch.AppSearchAccount.Builder.SetAccountId(string! accountId) -> Android.App.AppSearch.AppSearchAccount.Builder!
+Android.App.AppSearch.AppSearchAccount.Builder.SetAccountName(string! accountName) -> Android.App.AppSearch.AppSearchAccount.Builder!
+Android.App.AppSearch.AppSearchAccount.Builder.SetAccountType(string! accountType) -> Android.App.AppSearch.AppSearchAccount.Builder!
+Android.App.AppSearch.AppSearchResultCode.Unavailable = 14 -> Android.App.AppSearch.AppSearchResultCode
+Android.App.AppSearch.AppSearchSchema.BlobHandlePropertyConfig.Builder.SetDescription(string! description) -> Android.App.AppSearch.AppSearchSchema.BlobHandlePropertyConfig.Builder!
+Android.App.AppSearch.AppSearchSchema.BooleanPropertyConfig.Builder.SetDescription(string! description) -> Android.App.AppSearch.AppSearchSchema.BooleanPropertyConfig.Builder!
+Android.App.AppSearch.AppSearchSchema.Builder.SetDescription(string! description) -> Android.App.AppSearch.AppSearchSchema.Builder!
+Android.App.AppSearch.AppSearchSchema.BytesPropertyConfig.Builder.SetDescription(string! description) -> Android.App.AppSearch.AppSearchSchema.BytesPropertyConfig.Builder!
+Android.App.AppSearch.AppSearchSchema.Description.get -> string!
+Android.App.AppSearch.AppSearchSchema.DocumentPropertyConfig.Builder.SetDescription(string! description) -> Android.App.AppSearch.AppSearchSchema.DocumentPropertyConfig.Builder!
+Android.App.AppSearch.AppSearchSchema.DoublePropertyConfig.Builder.SetDescription(string! description) -> Android.App.AppSearch.AppSearchSchema.DoublePropertyConfig.Builder!
+Android.App.AppSearch.AppSearchSchema.EmbeddingPropertyConfig.Builder.SetDescription(string! description) -> Android.App.AppSearch.AppSearchSchema.EmbeddingPropertyConfig.Builder!
+Android.App.AppSearch.AppSearchSchema.LongPropertyConfig.Builder.SetDescription(string! description) -> Android.App.AppSearch.AppSearchSchema.LongPropertyConfig.Builder!
+Android.App.AppSearch.AppSearchSchema.StringPropertyConfig.Builder.SetDescription(string! description) -> Android.App.AppSearch.AppSearchSchema.StringPropertyConfig.Builder!
+Android.App.AppSearch.GetSchemaResponse.Builder.ClearSchemaTypeWipeoutAccountPropertyPaths(string! schemaType) -> Android.App.AppSearch.GetSchemaResponse.Builder!
+Android.App.AppSearch.GetSchemaResponse.Builder.SetSchemaTypeWipeoutAccountPropertyPaths(string! schemaType, System.Collections.Generic.ICollection<Android.App.AppSearch.PropertyPath!>! accountPropertyPaths) -> Android.App.AppSearch.GetSchemaResponse.Builder!
+Android.App.AppSearch.GetSchemaResponse.SchemasWipeoutAccountPropertyPaths.get -> System.Collections.Generic.IDictionary<string!, System.Collections.Generic.ICollection<Android.App.AppSearch.PropertyPath!>!>!
+Android.App.AppSearch.SchemaRequestPermissions.PrivateComputeCoreUidAccess = 12 -> Android.App.AppSearch.SchemaRequestPermissions
+Android.App.AppSearch.SearchResult.EmbeddingMatchInfo
+Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.DescribeContents() -> int
+Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.EmbeddingMatchInfo(double semanticScore, int queryEmbeddingVectorIndex, int embeddingSearchMetricType) -> void
+Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.EmbeddingSearchMetricType.get -> int
+Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.InterfaceConsts
+Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.QueryEmbeddingVectorIndex.get -> int
+Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.SemanticScore.get -> double
+Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppSearch.SearchResult.MatchInfo.Builder.SetEmbeddingMatch(Android.App.AppSearch.SearchResult.EmbeddingMatchInfo? embeddingMatch) -> Android.App.AppSearch.SearchResult.MatchInfo.Builder!
+Android.App.AppSearch.SearchResult.MatchInfo.EmbeddingMatch.get -> Android.App.AppSearch.SearchResult.EmbeddingMatchInfo?
+Android.App.AppSearch.SearchResult.MatchInfo.TextMatch.get -> Android.App.AppSearch.SearchResult.TextMatchInfo?
+Android.App.AppSearch.SearchResult.MatchRange.DescribeContents() -> int
+Android.App.AppSearch.SearchResult.MatchRange.InterfaceConsts
+Android.App.AppSearch.SearchResult.MatchRange.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppSearch.SearchResult.TextMatchInfo
+Android.App.AppSearch.SearchResult.TextMatchInfo.DescribeContents() -> int
+Android.App.AppSearch.SearchResult.TextMatchInfo.ExactMatch.get -> string?
+Android.App.AppSearch.SearchResult.TextMatchInfo.ExactMatchFormatted.get -> Java.Lang.ICharSequence!
+Android.App.AppSearch.SearchResult.TextMatchInfo.ExactMatchRange.get -> Android.App.AppSearch.SearchResult.MatchRange!
+Android.App.AppSearch.SearchResult.TextMatchInfo.FullText.get -> string!
+Android.App.AppSearch.SearchResult.TextMatchInfo.InterfaceConsts
+Android.App.AppSearch.SearchResult.TextMatchInfo.Snippet.get -> string?
+Android.App.AppSearch.SearchResult.TextMatchInfo.SnippetFormatted.get -> Java.Lang.ICharSequence!
+Android.App.AppSearch.SearchResult.TextMatchInfo.SnippetRange.get -> Android.App.AppSearch.SearchResult.MatchRange!
+Android.App.AppSearch.SearchResult.TextMatchInfo.Submatch.get -> string?
+Android.App.AppSearch.SearchResult.TextMatchInfo.SubmatchFormatted.get -> Java.Lang.ICharSequence!
+Android.App.AppSearch.SearchResult.TextMatchInfo.SubmatchRange.get -> Android.App.AppSearch.SearchResult.MatchRange!
+Android.App.AppSearch.SearchResult.TextMatchInfo.TextMatchInfo(Android.App.AppSearch.SearchResult.MatchRange! exactMatchRange, Android.App.AppSearch.SearchResult.MatchRange! submatchRange, Android.App.AppSearch.SearchResult.MatchRange! snippetRange) -> void
+Android.App.AppSearch.SearchResult.TextMatchInfo.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.AppSearch.SearchSpec.Builder.SetRetrieveEmbeddingMatchInfos(bool retrieveEmbeddingMatchInfos) -> Android.App.AppSearch.SearchSpec.Builder!
+Android.App.AppSearch.SearchSpec.ShouldRetrieveEmbeddingMatchInfos() -> bool
+Android.App.AppSearch.SetSchemaRequest.Builder.SetSchemaTypeWipeoutAccountPropertyPaths(string! schemaType, System.Collections.Generic.ICollection<Android.App.AppSearch.PropertyPath!>! accountPropertyPaths, bool autoWipeout) -> Android.App.AppSearch.SetSchemaRequest.Builder!
+Android.App.AppSearch.SetSchemaRequest.SchemasWipeoutAccountPropertyPaths.get -> System.Collections.Generic.IDictionary<string!, System.Collections.Generic.ICollection<string!>!>!
+Android.App.ApplicationAttribute.EnableOnBackInvokedCallback.get -> bool
+Android.App.ApplicationAttribute.EnableOnBackInvokedCallback.set -> void
+Android.App.ApplicationAttribute.PageSizeCompat.get -> string?
+Android.App.ApplicationAttribute.PageSizeCompat.set -> void
+Android.App.ApplicationExitInfo.AnrInfo
+Android.App.ApplicationExitInfo.AnrInfo.AnrId.get -> int
+Android.App.ApplicationExitInfo.AnrInfo.AnrType.get -> int
+Android.App.ApplicationExitInfo.AnrInfo.DescribeContents() -> int
+Android.App.ApplicationExitInfo.AnrInfo.InterfaceConsts
+Android.App.ApplicationExitInfo.AnrInfo.IsUserPerceptible.get -> bool
+Android.App.ApplicationExitInfo.AnrInfo.TimeoutMillis.get -> long
+Android.App.ApplicationExitInfo.AnrInfo.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.ApplicationExitInfo.GetAnrInfo() -> Android.App.ApplicationExitInfo.AnrInfo?
+Android.App.AutomaticZenRuleType.Transit = 8 -> Android.App.AutomaticZenRuleType
+Android.App.Backup.BackupTransportFlags.CrossPlatformDataTransferIos = 8 -> Android.App.Backup.BackupTransportFlags
+Android.App.Backup.FullRestoreDataInput
+Android.App.Backup.FullRestoreDataInput.FullRestoreDataInput(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.App.FixedDateFormat
+Android.App.FixedDateFormat.Automatic = 0 -> Android.App.FixedDateFormat
+Android.App.FixedDateFormat.LongDate = 1 -> Android.App.FixedDateFormat
+Android.App.FixedDateFormat.ShortDate = 2 -> Android.App.FixedDateFormat
+Android.App.HandoffActivityData
+Android.App.HandoffActivityData.Builder
+Android.App.HandoffActivityData.Builder.Build() -> Android.App.HandoffActivityData!
+Android.App.HandoffActivityData.Builder.Builder(Android.Content.ComponentName! componentName) -> void
+Android.App.HandoffActivityData.Builder.SetExtras(Android.OS.PersistableBundle! extras) -> Android.App.HandoffActivityData.Builder!
+Android.App.HandoffActivityData.Builder.SetFallbackUri(Android.Net.Uri? fallbackUri) -> Android.App.HandoffActivityData.Builder!
+Android.App.HandoffActivityData.ComponentName.get -> Android.Content.ComponentName?
+Android.App.HandoffActivityData.DescribeContents() -> int
+Android.App.HandoffActivityData.Extras.get -> Android.OS.PersistableBundle!
+Android.App.HandoffActivityData.FallbackUri.get -> Android.Net.Uri?
+Android.App.HandoffActivityData.InterfaceConsts
+Android.App.HandoffActivityData.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.HandoffActivityDataRequestInfo
+Android.App.HandoffActivityDataRequestInfo.HandoffActivityDataRequestInfo(bool isActiveRequest) -> void
+Android.App.HandoffActivityDataRequestInfo.IsActiveRequest.get -> bool
+Android.App.HandoffActivityParams
+Android.App.HandoffActivityParams.Builder
+Android.App.HandoffActivityParams.Builder.Build() -> Android.App.HandoffActivityParams!
+Android.App.HandoffActivityParams.Builder.Builder() -> void
+Android.App.HandoffActivityParams.Builder.SetAllowHandoffWithoutPackageInstalled(bool allowHandoffWithoutPackageInstalled) -> Android.App.HandoffActivityParams.Builder!
+Android.App.HandoffActivityParams.DescribeContents() -> int
+Android.App.HandoffActivityParams.InterfaceConsts
+Android.App.HandoffActivityParams.IsAllowHandoffWithoutPackageInstalled.get -> bool
+Android.App.HandoffActivityParams.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.InfeasibleActivityOptionsException
+Android.App.InfeasibleActivityOptionsException.InfeasibleActivityOptionsException(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.App.KeyguardManager.DeviceLockedStateEventArgs
+Android.App.KeyguardManager.DeviceLockedStateEventArgs.DeviceLockedStateEventArgs(bool isDeviceLocked) -> void
+Android.App.KeyguardManager.DeviceLockedStateEventArgs.IsDeviceLocked.get -> bool
+Android.App.KeyguardManager.IDeviceLockedStateListener
+Android.App.KeyguardManager.IDeviceLockedStateListener.OnDeviceLockedStateChanged(bool isDeviceLocked) -> void
+Android.App.Notification.Action.Builder.SetEmphasisHint(int emphasis) -> Android.App.Notification.Action.Builder!
+Android.App.Notification.Action.Builder.SetStyleHint(int style) -> Android.App.Notification.Action.Builder!
+Android.App.Notification.BridgedNotificationMetadata
+Android.App.Notification.BridgedNotificationMetadata.AppIcon.get -> Android.Graphics.Drawables.Icon!
+Android.App.Notification.BridgedNotificationMetadata.BridgedNotificationMetadata(string! originDeviceName, string! packageName, string! channelId, Android.Graphics.Drawables.Icon! appIcon) -> void
+Android.App.Notification.BridgedNotificationMetadata.ChannelId.get -> string!
+Android.App.Notification.BridgedNotificationMetadata.DescribeContents() -> int
+Android.App.Notification.BridgedNotificationMetadata.InterfaceConsts
+Android.App.Notification.BridgedNotificationMetadata.OriginDeviceName.get -> string!
+Android.App.Notification.BridgedNotificationMetadata.PackageName.get -> string!
+Android.App.Notification.BridgedNotificationMetadata.WriteToParcel(Android.OS.Parcel! out, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.Notification.IExtender.Extend(Android.App.Notification.Builder! builder) -> Android.App.Notification.Builder!
+Android.App.Notification.Metric
+Android.App.Notification.Metric.FixedDate
+Android.App.Notification.Metric.FixedDate.FixedDate(Java.Time.LocalDate! value) -> void
+Android.App.Notification.Metric.FixedDate.FixedDate(Java.Time.LocalDate! value, int format) -> void
+Android.App.Notification.Metric.FixedDate.Format.get -> int
+Android.App.Notification.Metric.FixedDate.Value.get -> Java.Time.LocalDate!
+Android.App.Notification.Metric.FixedFloat
+Android.App.Notification.Metric.FixedFloat.FixedFloat(float value) -> void
+Android.App.Notification.Metric.FixedFloat.FixedFloat(float value, Java.Lang.ICharSequence? unit) -> void
+Android.App.Notification.Metric.FixedFloat.FixedFloat(float value, Java.Lang.ICharSequence? unit, int minFractionDigits, int maxFractionDigits) -> void
+Android.App.Notification.Metric.FixedFloat.FixedFloat(float value, string? unit) -> void
+Android.App.Notification.Metric.FixedFloat.FixedFloat(float value, string? unit, int minFractionDigits, int maxFractionDigits) -> void
+Android.App.Notification.Metric.FixedFloat.MaxFractionDigits.get -> int
+Android.App.Notification.Metric.FixedFloat.MinFractionDigits.get -> int
+Android.App.Notification.Metric.FixedFloat.Unit.get -> string?
+Android.App.Notification.Metric.FixedFloat.UnitFormatted.get -> Java.Lang.ICharSequence?
+Android.App.Notification.Metric.FixedFloat.Value.get -> float
+Android.App.Notification.Metric.FixedInt
+Android.App.Notification.Metric.FixedInt.FixedInt(int value) -> void
+Android.App.Notification.Metric.FixedInt.FixedInt(int value, Java.Lang.ICharSequence? unit) -> void
+Android.App.Notification.Metric.FixedInt.FixedInt(int value, string? unit) -> void
+Android.App.Notification.Metric.FixedInt.Unit.get -> string?
+Android.App.Notification.Metric.FixedInt.UnitFormatted.get -> Java.Lang.ICharSequence?
+Android.App.Notification.Metric.FixedInt.Value.get -> int
+Android.App.Notification.Metric.FixedText
+Android.App.Notification.Metric.FixedText.FixedText(Java.Lang.ICharSequence! value) -> void
+Android.App.Notification.Metric.FixedText.FixedText(Java.Lang.ICharSequence! value, Java.Lang.ICharSequence? unit) -> void
+Android.App.Notification.Metric.FixedText.FixedText(string! value) -> void
+Android.App.Notification.Metric.FixedText.FixedText(string! value, string? unit) -> void
+Android.App.Notification.Metric.FixedText.Unit.get -> string?
+Android.App.Notification.Metric.FixedText.UnitFormatted.get -> Java.Lang.ICharSequence?
+Android.App.Notification.Metric.FixedText.Value.get -> string?
+Android.App.Notification.Metric.FixedText.ValueFormatted.get -> Java.Lang.ICharSequence!
+Android.App.Notification.Metric.FixedTime
+Android.App.Notification.Metric.FixedTime.FixedTime(Java.Time.LocalTime! value) -> void
+Android.App.Notification.Metric.FixedTime.Value.get -> Java.Time.LocalTime!
+Android.App.Notification.Metric.Label.get -> string?
+Android.App.Notification.Metric.LabelFormatted.get -> Java.Lang.ICharSequence!
+Android.App.Notification.Metric.Metric(Android.App.Notification.Metric.MetricValue! value, Java.Lang.ICharSequence! label) -> void
+Android.App.Notification.Metric.Metric(Android.App.Notification.Metric.MetricValue! value, Java.Lang.ICharSequence! label, int semanticStyle) -> void
+Android.App.Notification.Metric.Metric(Android.App.Notification.Metric.MetricValue! value, string! label) -> void
+Android.App.Notification.Metric.Metric(Android.App.Notification.Metric.MetricValue! value, string! label, int semanticStyle) -> void
+Android.App.Notification.Metric.MetricValue
+Android.App.Notification.Metric.MetricValue.MetricValue(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.App.Notification.Metric.SemanticStyle.get -> int
+Android.App.Notification.Metric.TimeDifference
+Android.App.Notification.Metric.TimeDifference.Format.get -> int
+Android.App.Notification.Metric.TimeDifference.IsStopwatch.get -> bool
+Android.App.Notification.Metric.TimeDifference.IsTimer.get -> bool
+Android.App.Notification.Metric.TimeDifference.PausedDuration.get -> Java.Time.Duration?
+Android.App.Notification.Metric.TimeDifference.ZeroElapsedRealtime.get -> Java.Lang.Long?
+Android.App.Notification.Metric.TimeDifference.ZeroTime.get -> Java.Time.Instant?
+Android.App.Notification.Metric.Value.get -> Android.App.Notification.Metric.MetricValue!
+Android.App.Notification.MetricStyle
+Android.App.Notification.MetricStyle.AddMetric(Android.App.Notification.Metric! metric) -> Android.App.Notification.MetricStyle!
+Android.App.Notification.MetricStyle.CriticalMetric.get -> Android.App.Notification.Metric?
+Android.App.Notification.MetricStyle.MetricStyle() -> void
+Android.App.Notification.MetricStyle.Metrics.get -> System.Collections.Generic.IList<Android.App.Notification.Metric!>!
+Android.App.Notification.MetricStyle.SetCriticalMetric(int index) -> Android.App.Notification.MetricStyle!
+Android.App.Notification.MetricStyle.SetMetrics(System.Collections.Generic.IList<Android.App.Notification.Metric!>! metrics) -> Android.App.Notification.MetricStyle!
+Android.App.Notification.ProgressStyle.Point.SemanticStyle.get -> int
+Android.App.Notification.ProgressStyle.Point.SetSemanticStyle(int semanticStyle) -> Android.App.Notification.ProgressStyle.Point!
+Android.App.Notification.ProgressStyle.Segment.SemanticStyle.get -> int
+Android.App.Notification.ProgressStyle.Segment.SetSemanticStyle(int semanticStyle) -> Android.App.Notification.ProgressStyle.Segment!
+Android.App.Notification.ProjectedExtender
+Android.App.Notification.ProjectedExtender.ContentIntent.get -> Android.App.PendingIntent?
+Android.App.Notification.ProjectedExtender.Extend(Android.App.Notification.Builder! builder) -> Android.App.Notification.Builder!
+Android.App.Notification.ProjectedExtender.ProjectedExtender() -> void
+Android.App.Notification.ProjectedExtender.ProjectedExtender(Android.App.Notification! notification) -> void
+Android.App.Notification.ProjectedExtender.SetContentIntent(Android.App.PendingIntent? intent) -> Android.App.Notification.ProjectedExtender!
+Android.App.NotificationChannel.OriginalImportance.get -> int
+Android.App.NotificationSemanticStyle
+Android.App.NotificationSemanticStyle.Caution = 3 -> Android.App.NotificationSemanticStyle
+Android.App.NotificationSemanticStyle.Danger = 4 -> Android.App.NotificationSemanticStyle
+Android.App.NotificationSemanticStyle.Info = 1 -> Android.App.NotificationSemanticStyle
+Android.App.NotificationSemanticStyle.Safe = 2 -> Android.App.NotificationSemanticStyle
+Android.App.NotificationSemanticStyle.Unspecified = 0 -> Android.App.NotificationSemanticStyle
+Android.App.PermissionUI.ILocationButtonClient
+Android.App.PermissionUI.ILocationButtonClient.OnPermissionResult(bool isGranted) -> void
+Android.App.PermissionUI.ILocationButtonClient.OnSessionError(Java.Lang.Throwable! cause) -> void
+Android.App.PermissionUI.ILocationButtonClient.OnSessionOpened(Android.App.PermissionUI.ILocationButtonSession! session) -> void
+Android.App.PermissionUI.ILocationButtonProvider
+Android.App.PermissionUI.ILocationButtonProvider.OpenSession(Android.App.Activity! activity, Android.OS.IBinder! hostToken, int displayId, Android.App.PermissionUI.LocationButtonRequest! request, Java.Util.Concurrent.IExecutor! clientExecutor, Android.App.PermissionUI.ILocationButtonClient! client) -> void
+Android.App.PermissionUI.ILocationButtonSession
+Android.App.PermissionUI.ILocationButtonSession.ChangeConfiguration(Android.Content.Res.Configuration! newConfig) -> void
+Android.App.PermissionUI.ILocationButtonSession.Close() -> void
+Android.App.PermissionUI.ILocationButtonSession.Resize(int width, int height) -> void
+Android.App.PermissionUI.ILocationButtonSession.SetBackgroundColor(Android.Graphics.Color color) -> void
+Android.App.PermissionUI.ILocationButtonSession.SetCornerRadius(float cornerRadius) -> void
+Android.App.PermissionUI.ILocationButtonSession.SetIconTint(Android.Graphics.Color color) -> void
+Android.App.PermissionUI.ILocationButtonSession.SetPadding(int left, int top, int right, int bottom) -> void
+Android.App.PermissionUI.ILocationButtonSession.SetPressedCornerRadius(float cornerRadius) -> void
+Android.App.PermissionUI.ILocationButtonSession.SetStrokeColor(Android.Graphics.Color color) -> void
+Android.App.PermissionUI.ILocationButtonSession.SetStrokeWidth(int width) -> void
+Android.App.PermissionUI.ILocationButtonSession.SetTextColor(Android.Graphics.Color color) -> void
+Android.App.PermissionUI.ILocationButtonSession.SetTextType(int textType) -> void
+Android.App.PermissionUI.ILocationButtonSession.SurfacePackage.get -> Android.Views.SurfaceControlViewHost.SurfacePackage!
+Android.App.PermissionUI.LocationButtonProviderFactory
+Android.App.PermissionUI.LocationButtonProviderFactory.LocationButtonProviderFactory(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.App.PermissionUI.LocationButtonRequest
+Android.App.PermissionUI.LocationButtonRequest.BackgroundColor.get -> Android.Graphics.Color
+Android.App.PermissionUI.LocationButtonRequest.Builder
+Android.App.PermissionUI.LocationButtonRequest.Builder.Build() -> Android.App.PermissionUI.LocationButtonRequest!
+Android.App.PermissionUI.LocationButtonRequest.Builder.Builder(int width, int height, Android.Content.Res.Configuration! configuration) -> void
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetBackgroundColor(Android.Graphics.Color backgroundColor) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetCornerRadius(float cornerRadius) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetIconTint(Android.Graphics.Color iconTint) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetPaddingBottom(int paddingBottom) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetPaddingLeft(int paddingLeft) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetPaddingRight(int paddingRight) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetPaddingTop(int paddingTop) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetPressedCornerRadius(float cornerRadius) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetStrokeColor(Android.Graphics.Color strokeColor) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetStrokeWidth(int strokeWidth) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetTextColor(Android.Graphics.Color textColor) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Builder.SetTextType(int textType) -> Android.App.PermissionUI.LocationButtonRequest.Builder!
+Android.App.PermissionUI.LocationButtonRequest.Configuration.get -> Android.Content.Res.Configuration!
+Android.App.PermissionUI.LocationButtonRequest.CornerRadius.get -> float
+Android.App.PermissionUI.LocationButtonRequest.DescribeContents() -> int
+Android.App.PermissionUI.LocationButtonRequest.Height.get -> int
+Android.App.PermissionUI.LocationButtonRequest.IconTint.get -> Android.Graphics.Color
+Android.App.PermissionUI.LocationButtonRequest.InterfaceConsts
+Android.App.PermissionUI.LocationButtonRequest.PaddingBottom.get -> int
+Android.App.PermissionUI.LocationButtonRequest.PaddingLeft.get -> int
+Android.App.PermissionUI.LocationButtonRequest.PaddingRight.get -> int
+Android.App.PermissionUI.LocationButtonRequest.PaddingTop.get -> int
+Android.App.PermissionUI.LocationButtonRequest.PressedCornerRadius.get -> float
+Android.App.PermissionUI.LocationButtonRequest.StrokeColor.get -> Android.Graphics.Color
+Android.App.PermissionUI.LocationButtonRequest.StrokeWidth.get -> int
+Android.App.PermissionUI.LocationButtonRequest.TextColor.get -> Android.Graphics.Color
+Android.App.PermissionUI.LocationButtonRequest.TextType.get -> int
+Android.App.PermissionUI.LocationButtonRequest.Width.get -> int
+Android.App.PermissionUI.LocationButtonRequest.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.PermissionUI.LocationButtonSession
+Android.App.PermissionUI.LocationButtonSessionTextType
+Android.App.PermissionUI.LocationButtonSessionTextType.NearMyPreciseLocation = 4 -> Android.App.PermissionUI.LocationButtonSessionTextType
+Android.App.PermissionUI.LocationButtonSessionTextType.NearYourPreciseLocation = 5 -> Android.App.PermissionUI.LocationButtonSessionTextType
+Android.App.PermissionUI.LocationButtonSessionTextType.None = 0 -> Android.App.PermissionUI.LocationButtonSessionTextType
+Android.App.PermissionUI.LocationButtonSessionTextType.PreciseLocation = 1 -> Android.App.PermissionUI.LocationButtonSessionTextType
+Android.App.PermissionUI.LocationButtonSessionTextType.SharePreciseLocation = 3 -> Android.App.PermissionUI.LocationButtonSessionTextType
+Android.App.PermissionUI.LocationButtonSessionTextType.UsePreciseLocation = 2 -> Android.App.PermissionUI.LocationButtonSessionTextType
+Android.App.PrivateCompute.DataMigrationToPccService
+Android.App.PrivateCompute.DataMigrationToPccService.DataMigrationToPccService() -> void
+Android.App.PrivateCompute.DataMigrationToPccService.DataMigrationToPccService(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.App.PrivateCompute.MigrationError
+Android.App.PrivateCompute.MigrationError.InvocationFailed = 1 -> Android.App.PrivateCompute.MigrationError
+Android.App.PrivateCompute.MigrationError.Timeout = 2 -> Android.App.PrivateCompute.MigrationError
+Android.App.PrivateCompute.MigrationException
+Android.App.PrivateCompute.MigrationException.ErrorCode.get -> int
+Android.App.PrivateCompute.MigrationException.MigrationException(int errorCode, string? message) -> void
+Android.App.PrivateCompute.MigrationRequestResult
+Android.App.PrivateCompute.MigrationRequestResult.DescribeContents() -> int
+Android.App.PrivateCompute.MigrationRequestResult.Extras.get -> Android.OS.PersistableBundle!
+Android.App.PrivateCompute.MigrationRequestResult.InterfaceConsts
+Android.App.PrivateCompute.MigrationRequestResult.MigrationRequestResult(int status, Android.OS.PersistableBundle? extras) -> void
+Android.App.PrivateCompute.MigrationRequestResult.Status.get -> int
+Android.App.PrivateCompute.MigrationRequestResult.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.App.PrivateCompute.MigrationStatus
+Android.App.PrivateCompute.MigrationStatus.Accepted = 1 -> Android.App.PrivateCompute.MigrationStatus
+Android.App.PrivateCompute.MigrationStatus.Rejected = 2 -> Android.App.PrivateCompute.MigrationStatus
+Android.App.PrivateCompute.PccClient
+Android.App.PrivateCompute.PccClient.PccClient(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.App.PrivateCompute.PccSandboxManager
+Android.App.PrivateCompute.PccSandboxManager.IsPccTrustedSystemComponent(int uid, string? packageName) -> bool
+Android.App.PrivateCompute.PccSandboxManager.IsPrivateComputeServicesUid(int uid) -> bool
+Android.App.PrivateCompute.PccSandboxManager.StartNonPccProcessForDataMigration(Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.App.PrivateCompute.PccSandboxManager.WriteToAuditLog(Android.OS.PersistableBundle! data) -> void
+Android.App.PrivateCompute.PccService
+Android.App.PrivateCompute.PccService.PccService() -> void
+Android.App.PrivateCompute.PccService.PccService(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.App.SemanticAction.Pause = 14 -> Android.App.SemanticAction
+Android.App.SemanticAction.Play = 13 -> Android.App.SemanticAction
+Android.App.SemanticAction.Stop = 15 -> Android.App.SemanticAction
+Android.App.ShowPowerMenuResult
+Android.App.ShowPowerMenuResult.Disabled = 1 -> Android.App.ShowPowerMenuResult
+Android.App.ShowPowerMenuResult.Showing = 0 -> Android.App.ShowPowerMenuResult
+Android.App.ShowPowerMenuResult.Unknown = -1 -> Android.App.ShowPowerMenuResult
+Android.App.TaskLocation
+Android.App.TaskLocation.TaskLocation(int displayId, Android.Graphics.Rect! bounds) -> void
+Android.App.TaskLocation.TaskLocation(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.App.TimeDifferenceFormat
+Android.App.TimeDifferenceFormat.Adaptive = 1 -> Android.App.TimeDifferenceFormat
+Android.App.TimeDifferenceFormat.Chronometer = 2 -> Android.App.TimeDifferenceFormat
+Android.App.UsesFeatureAttribute.Version.set -> void
+Android.App.UsesPermissionAttribute.UsesPermissionFlags.get -> string?
+Android.App.UsesPermissionAttribute.UsesPermissionFlags.set -> void
+Android.App.VoiceInteractions.ReadScreenContextRequestState
+Android.App.VoiceInteractions.ReadScreenContextRequestState.Granted = 0 -> Android.App.VoiceInteractions.ReadScreenContextRequestState
+Android.App.VoiceInteractions.ReadScreenContextRequestState.Requestable = 1 -> Android.App.VoiceInteractions.ReadScreenContextRequestState
+Android.App.VoiceInteractions.ReadScreenContextRequestState.Unrequestable = 2 -> Android.App.VoiceInteractions.ReadScreenContextRequestState
+Android.App.VoiceInteractions.VoiceInteractionManager
+Android.App.VoiceInteractions.VoiceInteractionManager.CanReadScreenContext() -> bool
+Android.App.VoiceInteractions.VoiceInteractionManager.CreateRequestReadScreenContextIntent() -> Android.Content.Intent!
+Android.App.VoiceInteractions.VoiceInteractionManager.ReadScreenContextRequestState.get -> int
+Android.Appwidget.AppWidgetEvent
+Android.Appwidget.AppWidgetEvent.AppWidgetId.get -> int
+Android.Appwidget.AppWidgetEvent.DescribeContents() -> int
+Android.Appwidget.AppWidgetEvent.End.get -> Java.Time.Instant!
+Android.Appwidget.AppWidgetEvent.GetClickedIds() -> int[]?
+Android.Appwidget.AppWidgetEvent.GetScrolledIds() -> int[]?
+Android.Appwidget.AppWidgetEvent.InterfaceConsts
+Android.Appwidget.AppWidgetEvent.Position.get -> Android.Graphics.Rect?
+Android.Appwidget.AppWidgetEvent.Start.get -> Java.Time.Instant!
+Android.Appwidget.AppWidgetEvent.VisibleDuration.get -> Java.Time.Duration!
+Android.Appwidget.AppWidgetEvent.WriteToParcel(Android.OS.Parcel! out, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Bluetooth.BluetoothAdapter.IsLeHighDataThroughputPhySupported() -> int
+Android.Bluetooth.BluetoothDevice.CancelBondProcess() -> bool
+Android.Bluetooth.BluetoothDevice.Connect() -> int
+Android.Bluetooth.BluetoothDevice.ConnectGatt(Android.Bluetooth.BluetoothGattConnectionSettings! gattConnectionSettings, Java.Util.Concurrent.IExecutor! executor, Android.Bluetooth.BluetoothGattCallback! callback) -> Android.Bluetooth.BluetoothGatt?
+Android.Bluetooth.BluetoothDevice.CreateBond(int transport) -> bool
+Android.Bluetooth.BluetoothDevice.Disconnect() -> int
+Android.Bluetooth.BluetoothDevice.FetchUuids(int transport) -> bool
+Android.Bluetooth.BluetoothDevice.GetBondStatus(int transport) -> Android.Bluetooth.BondStatus?
+Android.Bluetooth.BluetoothDevice.GetEncryptionStatus(int transport) -> Android.Bluetooth.EncryptionStatus?
+Android.Bluetooth.BluetoothDevice.IsConnected(int transport) -> bool
+Android.Bluetooth.BluetoothDevice.KeyMissingCount.get -> int
+Android.Bluetooth.BluetoothDeviceBondLossReason
+Android.Bluetooth.BluetoothDeviceBondLossReason.BredrAuthFailure = 1 -> Android.Bluetooth.BluetoothDeviceBondLossReason
+Android.Bluetooth.BluetoothDeviceBondLossReason.BredrIncomingPairing = 2 -> Android.Bluetooth.BluetoothDeviceBondLossReason
+Android.Bluetooth.BluetoothDeviceBondLossReason.LeEncryptFailure = 3 -> Android.Bluetooth.BluetoothDeviceBondLossReason
+Android.Bluetooth.BluetoothDeviceBondLossReason.LeIncomingPairing = 4 -> Android.Bluetooth.BluetoothDeviceBondLossReason
+Android.Bluetooth.BluetoothDeviceBondLossReason.Unknown = 0 -> Android.Bluetooth.BluetoothDeviceBondLossReason
+Android.Bluetooth.BluetoothDeviceEncryptionAlgorithm.Unknown = 3 -> Android.Bluetooth.BluetoothDeviceEncryptionAlgorithm
+Android.Bluetooth.BluetoothDevicePairingAlgorithm
+Android.Bluetooth.BluetoothDevicePairingAlgorithm.BredrLegacy = 1 -> Android.Bluetooth.BluetoothDevicePairingAlgorithm
+Android.Bluetooth.BluetoothDevicePairingAlgorithm.BredrSsp = 2 -> Android.Bluetooth.BluetoothDevicePairingAlgorithm
+Android.Bluetooth.BluetoothDevicePairingAlgorithm.LeLegacy = 0 -> Android.Bluetooth.BluetoothDevicePairingAlgorithm
+Android.Bluetooth.BluetoothDevicePairingAlgorithm.Sc = 3 -> Android.Bluetooth.BluetoothDevicePairingAlgorithm
+Android.Bluetooth.BluetoothGatt.RequestSubrateMode(int subrateMode) -> int
+Android.Bluetooth.BluetoothGattConnectionSettings
+Android.Bluetooth.BluetoothGattConnectionSettings.Builder
+Android.Bluetooth.BluetoothGattConnectionSettings.Builder.Build() -> Android.Bluetooth.BluetoothGattConnectionSettings!
+Android.Bluetooth.BluetoothGattConnectionSettings.Builder.Builder() -> void
+Android.Bluetooth.BluetoothGattConnectionSettings.Builder.SetAutoConnectEnabled(bool autoConnectEnabled) -> Android.Bluetooth.BluetoothGattConnectionSettings.Builder!
+Android.Bluetooth.BluetoothGattConnectionSettings.Builder.SetAutomaticMtuEnabled(bool automaticMtuEnabled) -> Android.Bluetooth.BluetoothGattConnectionSettings.Builder!
+Android.Bluetooth.BluetoothGattConnectionSettings.Builder.SetOpportunisticEnabled(bool opportunisticEnabled) -> Android.Bluetooth.BluetoothGattConnectionSettings.Builder!
+Android.Bluetooth.BluetoothGattConnectionSettings.Builder.SetTransport(int transport) -> Android.Bluetooth.BluetoothGattConnectionSettings.Builder!
+Android.Bluetooth.BluetoothGattConnectionSettings.IsAutoConnectEnabled.get -> bool
+Android.Bluetooth.BluetoothGattConnectionSettings.IsAutomaticMtuEnabled.get -> bool
+Android.Bluetooth.BluetoothGattConnectionSettings.IsOpportunisticEnabled.get -> bool
+Android.Bluetooth.BluetoothGattConnectionSettings.Transport.get -> int
+Android.Bluetooth.BluetoothGattServer.SendResponse(Android.Bluetooth.BluetoothDevice! device, int requestId, Android.Bluetooth.ProfileState status, int offset, byte[]? value) -> bool
+Android.Bluetooth.BluetoothLeAudioCodecConfig.Builder.SetCodecId(long codecId) -> Android.Bluetooth.BluetoothLeAudioCodecConfig.Builder!
+Android.Bluetooth.BluetoothLeAudioCodecConfig.CodecId.get -> long
+Android.Bluetooth.BluetoothLeSourceCodecType.OpusHiRes = 2 -> Android.Bluetooth.BluetoothLeSourceCodecType
+Android.Bluetooth.BluetoothLeSourceCodecType.VendorSpecific = 255 -> Android.Bluetooth.BluetoothLeSourceCodecType
+Android.Bluetooth.BluetoothPhy.PhyLeHdt = 5 -> Android.Bluetooth.BluetoothPhy
+Android.Bluetooth.BluetoothPhy.PhyLeHdtMask = 16 -> Android.Bluetooth.BluetoothPhy
+Android.Bluetooth.BondStatus
+Android.Bluetooth.BondStatus.BondStatus(int pairingAlgorithm, int pairingVariant) -> void
+Android.Bluetooth.BondStatus.PairingAlgorithm.get -> int
+Android.Bluetooth.BondStatus.PairingVariant.get -> int
+Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorAvdtpDiscoveryFailed = 1403 -> Android.Bluetooth.CurrentBluetoothStatusCodes
+Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorInsufficientResources = 1404 -> Android.Bluetooth.CurrentBluetoothStatusCodes
+Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorRfcommConnectionFailed = 1405 -> Android.Bluetooth.CurrentBluetoothStatusCodes
+Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorRoleSwitchFailed = 1402 -> Android.Bluetooth.CurrentBluetoothStatusCodes
+Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorSdpDiscoveryFailed = 1400 -> Android.Bluetooth.CurrentBluetoothStatusCodes
+Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorStreamConnectionFailed = 1401 -> Android.Bluetooth.CurrentBluetoothStatusCodes
+Android.Bluetooth.EncryptionStatus
+Android.Bluetooth.EncryptionStatus.Algorithm.get -> int
+Android.Bluetooth.EncryptionStatus.EncryptionStatus(int keySize, int algorithm) -> void
+Android.Bluetooth.EncryptionStatus.KeySize.get -> int
+Android.Bluetooth.GattSubrateMode
+Android.Bluetooth.GattSubrateMode.Balanced = 2 -> Android.Bluetooth.GattSubrateMode
+Android.Bluetooth.GattSubrateMode.High = 3 -> Android.Bluetooth.GattSubrateMode
+Android.Bluetooth.GattSubrateMode.Low = 1 -> Android.Bluetooth.GattSubrateMode
+Android.Bluetooth.GattSubrateMode.NotUpdated = 255 -> Android.Bluetooth.GattSubrateMode
+Android.Bluetooth.GattSubrateMode.Off = 0 -> Android.Bluetooth.GattSubrateMode
+Android.Bluetooth.GattSubrateMode.SystemUpdate = 99 -> Android.Bluetooth.GattSubrateMode
+Android.Bluetooth.LE.AdvertiseTxPower.MaxAvailable = 20 -> Android.Bluetooth.LE.AdvertiseTxPower
+Android.Bluetooth.LE.ScanSettings.Builder.SetRssiThreshold(int rssiThreshold) -> Android.Bluetooth.LE.ScanSettings.Builder!
+Android.Bluetooth.LE.ScanSettings.Builder.SetScanType(int scanType) -> Android.Bluetooth.LE.ScanSettings.Builder!
+Android.Bluetooth.LE.ScanSettings.RssiThreshold.get -> int
+Android.Bluetooth.LE.ScanSettings.ScanType.get -> int
+Android.Bluetooth.LE.ScanType
+Android.Bluetooth.LE.ScanType.Active = 2 -> Android.Bluetooth.LE.ScanType
+Android.Bluetooth.LE.ScanType.Passive = 1 -> Android.Bluetooth.LE.ScanType
+Android.Bluetooth.LE.ScanType.Unknown = 0 -> Android.Bluetooth.LE.ScanType
+Android.Companion.ActionRequest
+Android.Companion.ActionRequest.Action.get -> int
+Android.Companion.ActionRequest.Builder
+Android.Companion.ActionRequest.Builder.Build() -> Android.Companion.ActionRequest!
+Android.Companion.ActionRequest.Builder.Builder(int action, int operation) -> void
+Android.Companion.ActionRequest.DescribeContents() -> int
+Android.Companion.ActionRequest.InterfaceConsts
+Android.Companion.ActionRequest.Operation.get -> int
+Android.Companion.ActionRequest.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Companion.ActionResult
+Android.Companion.ActionResult.Action.get -> int
+Android.Companion.ActionResult.Builder
+Android.Companion.ActionResult.Builder.Build() -> Android.Companion.ActionResult!
+Android.Companion.ActionResult.Builder.Builder(int action, int resultCode) -> void
+Android.Companion.ActionResult.DescribeContents() -> int
+Android.Companion.ActionResult.InterfaceConsts
+Android.Companion.ActionResult.ResultCode.get -> int
+Android.Companion.ActionResult.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Companion.AssociationInfo.DeviceIcon.get -> Android.Graphics.Drawables.Icon?
+Android.Companion.AssociationInfo.ExtraPermissions.get -> System.Collections.Generic.ICollection<string!>!
+Android.Companion.AssociationInfo.IsRemoteAiAgentSupported.get -> bool
+Android.Companion.AssociationRequest.Builder.SetDeviceIcon(Android.Graphics.Drawables.Icon! deviceIcon) -> Android.Companion.AssociationRequest.Builder!
+Android.Companion.AssociationRequest.Builder.SetExtraPermissions(System.Collections.Generic.ICollection<string!>! permissions) -> Android.Companion.AssociationRequest.Builder!
+Android.Companion.AssociationRequest.Builder.SetRemoteAiAgentSupported(bool remoteAiAgentSupported) -> Android.Companion.AssociationRequest.Builder!
+Android.Companion.AssociationRequest.DeviceIcon.get -> Android.Graphics.Drawables.Icon?
+Android.Companion.AssociationRequest.ExtraPermissions.get -> System.Collections.Generic.ICollection<string!>!
+Android.Companion.AssociationRequest.IsRemoteAiAgentSupported.get -> bool
+Android.Companion.CompanionDeviceManager.CreateAndSetDeviceId(int associationId, Android.Companion.DeviceId? deviceId) -> Android.Companion.DeviceId?
+Android.Companion.CompanionDeviceManager.IsSystemDataTransportAttached(int associationId) -> bool
+Android.Companion.CompanionDeviceManager.NotifyActionResult(int associationId, Android.Companion.ActionResult! result) -> void
+Android.Companion.DevicePresenceEventType.EventAssociationRemoved = 6 -> Android.Companion.DevicePresenceEventType
+Android.Companion.DevicePresenceEventType.Nearby = 7 -> Android.Companion.DevicePresenceEventType
+Android.Companion.DevicePresenceEventType.NotNearby = 8 -> Android.Companion.DevicePresenceEventType
+Android.Companion.RequestAction
+Android.Companion.RequestAction.NearbyAdvertising = 1 -> Android.Companion.RequestAction
+Android.Companion.RequestAction.NearbyScanning = 0 -> Android.Companion.RequestAction
+Android.Companion.RequestAction.Transport = 2 -> Android.Companion.RequestAction
+Android.Companion.RequestOperation
+Android.Companion.RequestOperation.Activate = 0 -> Android.Companion.RequestOperation
+Android.Companion.RequestOperation.Deactivate = 1 -> Android.Companion.RequestOperation
+Android.Companion.ResultCode
+Android.Companion.ResultCode.Activated = 0 -> Android.Companion.ResultCode
+Android.Companion.ResultCode.Deactivated = 2 -> Android.Companion.ResultCode
+Android.Companion.ResultCode.FailedToActivate = 1 -> Android.Companion.ResultCode
+Android.Companion.SystemDataSyncFlags.AirplaneMode = 16 -> Android.Companion.SystemDataSyncFlags
+Android.Companion.SystemDataSyncFlags.TaskContinuity = 2 -> Android.Companion.SystemDataSyncFlags
+Android.Companion.SystemDataSyncFlags.UniversalModes = 4 -> Android.Companion.SystemDataSyncFlags
+Android.Content.AttributionSource.Builder.SetNextAttributionSource(Android.Content.AttributionSource! value) -> Android.Content.AttributionSource.Builder!
+Android.Content.Context.UpdateBindingParams
+Android.Content.Context.UpdateBindingParams.Builder
+Android.Content.Context.UpdateBindingParams.Builder.Build() -> Android.Content.Context.UpdateBindingParams!
+Android.Content.Context.UpdateBindingParams.Builder.Builder(Android.Content.IServiceConnection! connection) -> void
+Android.Content.Context.UpdateBindingParams.Builder.Builder(Android.Content.IServiceConnection! connection, Android.Content.Context.BindServiceFlags! flags) -> void
+Android.Content.Context.UpdateBindingParams.Connection.get -> Android.Content.IServiceConnection!
+Android.Content.Context.UpdateBindingParams.Flags.get -> Android.Content.Context.BindServiceFlags!
+Android.Content.Context.UpdateBindingParams.IsRebind.get -> bool
+Android.Content.Context.UpdateBindingParams.IsUnbind.get -> bool
+Android.Content.Context.UpdateBindingParams.SetRebind(Android.Content.Context.BindServiceFlags! flags) -> void
+Android.Content.Context.UpdateBindingParams.SetUnbind() -> void
+Android.Content.PM.PackageInstaller.DeveloperVerificationServiceProvider.get -> Android.Content.ComponentName?
+Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason
+Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason.DeveloperBlocked = 2 -> Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason
+Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason.NetworkUnavailable = 1 -> Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason
+Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason.Unknown = 0 -> Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason
+Android.Content.PM.PermissionInfoFlags.AllowedInPrivateComputeCore = 32 -> Android.Content.PM.PermissionInfoFlags
+Android.Content.PM.RequestedPermission.OnlyForLocationButton = 131072 -> Android.Content.PM.RequestedPermission
+Android.Content.PM.ServiceInfoFlags.NativeService = 32 -> Android.Content.PM.ServiceInfoFlags
+Android.Content.PM.Webapp.WebAppInstallRequest
+Android.Content.PM.Webapp.WebAppInstallRequest.Builder
+Android.Content.PM.Webapp.WebAppInstallRequest.Builder.Build() -> Android.Content.PM.Webapp.WebAppInstallRequest!
+Android.Content.PM.Webapp.WebAppInstallRequest.Builder.Builder(Java.Lang.ICharSequence! title, string! manifestUrl) -> void
+Android.Content.PM.Webapp.WebAppInstallRequest.Builder.Builder(string! title, string! manifestUrl) -> void
+Android.Content.PM.Webapp.WebAppInstallRequest.Title.get -> string?
+Android.Content.PM.Webapp.WebAppInstallRequest.WebAppInstallRequest(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppInstallResultCode.CancelledByUser = 6 -> Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppInstallResultCode.DuplicatedRequest = 4 -> Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppInstallResultCode.InternalError = 2 -> Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppInstallResultCode.InvalidArguments = 5 -> Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppInstallResultCode.NetworkError = 1 -> Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppInstallResultCode.PermissionDenied = 3 -> Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppInstallResultCode.SecurityError = 7 -> Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppInstallResultCode.Success = 0 -> Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppInstallResultCode.Unavailable = 8 -> Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppInstallResultCode.Unknown = 9 -> Android.Content.PM.Webapp.WebAppInstallResultCode
+Android.Content.PM.Webapp.WebAppManager
+Android.Content.PM.Webapp.WebAppManager.Install(Android.Content.PM.Webapp.WebAppInstallRequest! request, Java.Util.Concurrent.IExecutor! executor, Java.Util.Functions.IObjIntConsumer! callback) -> void
+Android.Content.PM.Webapp.WebAppManager.IsAvailable.get -> bool
+Android.Content.PM.Webapp.WebAppManager.Query(Android.Content.PM.Webapp.WebAppQueryRequest! request, Java.Util.Concurrent.IExecutor! executor, Java.Util.Functions.IIntConsumer! callback) -> void
+Android.Content.PM.Webapp.WebAppQueryRequest
+Android.Content.PM.Webapp.WebAppQueryRequest.WebAppQueryRequest(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Content.PM.Webapp.WebAppQueryRequest.WebAppQueryRequest(string! packageName) -> void
+Android.Content.PM.Webapp.WebAppQueryResultCode
+Android.Content.PM.Webapp.WebAppQueryResultCode.Installed = 0 -> Android.Content.PM.Webapp.WebAppQueryResultCode
+Android.Content.PM.Webapp.WebAppQueryResultCode.InternalError = 2 -> Android.Content.PM.Webapp.WebAppQueryResultCode
+Android.Content.PM.Webapp.WebAppQueryResultCode.NotInstalled = 1 -> Android.Content.PM.Webapp.WebAppQueryResultCode
+Android.Content.PM.Webapp.WebAppQueryResultCode.PermissionDenied = 3 -> Android.Content.PM.Webapp.WebAppQueryResultCode
+Android.Content.PM.Webapp.WebAppQueryResultCode.Unavailable = 4 -> Android.Content.PM.Webapp.WebAppQueryResultCode
+Android.Content.PM.Webapp.WebAppQueryResultCode.Unknown = 5 -> Android.Content.PM.Webapp.WebAppQueryResultCode
+Android.Crypto.Hpke.AeadParameterSpec
+Android.Crypto.Hpke.AeadParameterSpec.AeadParameterSpec(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Crypto.Hpke.Hpke
+Android.Crypto.Hpke.Hpke.Hpke(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Crypto.Hpke.KdfParameterSpec
+Android.Crypto.Hpke.KdfParameterSpec.KdfParameterSpec(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Crypto.Hpke.KemParameterSpec
+Android.Crypto.Hpke.KemParameterSpec.KemParameterSpec(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Crypto.Hpke.Message
+Android.Crypto.Hpke.Message.Message(byte[]! encapsulated, byte[]! ciphertext) -> void
+Android.Crypto.Hpke.Message.Message(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Crypto.Hpke.Recipient
+Android.Crypto.Hpke.Recipient.Builder
+Android.Crypto.Hpke.Recipient.Builder.Builder(Android.Crypto.Hpke.Hpke! hpke, byte[]! encapsulated, Java.Security.IPrivateKey! recipientKey) -> void
+Android.Crypto.Hpke.Recipient.Builder.Builder(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Crypto.Hpke.Recipient.Recipient(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Crypto.Hpke.Sender
+Android.Crypto.Hpke.Sender.Builder
+Android.Crypto.Hpke.Sender.Builder.Builder(Android.Crypto.Hpke.Hpke! hpke, Java.Security.IPublicKey! recipientKey) -> void
+Android.Crypto.Hpke.Sender.Builder.Builder(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Crypto.Hpke.Sender.Sender(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.DeviceLock.DeviceIdType.DeviceIdTypeSerialNumber = 2 -> Android.DeviceLock.DeviceIdType
+Android.DeviceLock.DeviceLockManager.ClearDeviceRestrictions(Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.DeviceLock.DeviceLockManager.NotifyKioskSetupFinished(Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.Graphics.Drawables.ShapeType.Arc = 4 -> Android.Graphics.Drawables.ShapeType
+Android.Graphics.ImageDecoder.DefaultProcess -> System.EventHandler<Android.Graphics.ImageDecoder.HeaderDecodedEventArgs!>!
+Android.Graphics.ImageDecoder.DefaultThread -> System.EventHandler<Android.Graphics.ImageDecoder.HeaderDecodedEventArgs!>!
+Android.Graphics.ImageFormatType.Raw14 = 44 -> Android.Graphics.ImageFormatType
+Android.Graphics.Pdf.Component.FreeTextAnnotation
+Android.Graphics.Pdf.Component.FreeTextAnnotation.BackgroundColor.get -> Android.Graphics.Color
+Android.Graphics.Pdf.Component.FreeTextAnnotation.BackgroundColor.set -> void
+Android.Graphics.Pdf.Component.FreeTextAnnotation.Bounds.get -> Android.Graphics.RectF!
+Android.Graphics.Pdf.Component.FreeTextAnnotation.Bounds.set -> void
+Android.Graphics.Pdf.Component.FreeTextAnnotation.FreeTextAnnotation(Android.Graphics.RectF! bounds, string! textContent) -> void
+Android.Graphics.Pdf.Component.FreeTextAnnotation.TextColor.get -> Android.Graphics.Color
+Android.Graphics.Pdf.Component.FreeTextAnnotation.TextColor.set -> void
+Android.Graphics.Pdf.Component.FreeTextAnnotation.TextContent.get -> string!
+Android.Graphics.Pdf.Component.FreeTextAnnotation.TextContent.set -> void
+Android.Graphics.Pdf.Component.HighlightAnnotation
+Android.Graphics.Pdf.Component.HighlightAnnotation.BoundsList.get -> System.Collections.Generic.IList<Android.Graphics.RectF!>!
+Android.Graphics.Pdf.Component.HighlightAnnotation.BoundsList.set -> void
+Android.Graphics.Pdf.Component.HighlightAnnotation.Color.get -> Android.Graphics.Color
+Android.Graphics.Pdf.Component.HighlightAnnotation.Color.set -> void
+Android.Graphics.Pdf.Component.HighlightAnnotation.HighlightAnnotation(System.Collections.Generic.IList<Android.Graphics.RectF!>! boundsList) -> void
+Android.Graphics.Pdf.Component.PdfAnnotation
+Android.Graphics.Pdf.Component.PdfAnnotation.PdfAnnotation(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Graphics.Pdf.Component.PdfAnnotationType
+Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum
+Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum.Freetext = 1 -> Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum
+Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum.Highlight = 2 -> Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum
+Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum.Stamp = 3 -> Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum
+Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum.Unknown = 0 -> Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum
+Android.Graphics.Pdf.Component.PdfPageImageObject
+Android.Graphics.Pdf.Component.PdfPageImageObject.Bitmap.get -> Android.Graphics.Bitmap!
+Android.Graphics.Pdf.Component.PdfPageImageObject.Bitmap.set -> void
+Android.Graphics.Pdf.Component.PdfPageImageObject.PdfPageImageObject(Android.Graphics.Bitmap! bitmap) -> void
+Android.Graphics.Pdf.Component.PdfPageObject
+Android.Graphics.Pdf.Component.PdfPageObject.PdfPageObject(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Graphics.Pdf.Component.PdfPageObjectType
+Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum
+Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum.Image = 3 -> Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum
+Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum.Path = 2 -> Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum
+Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum.Text = 1 -> Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum
+Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum.Unknown = 0 -> Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum
+Android.Graphics.Pdf.Component.PdfPagePathObject
+Android.Graphics.Pdf.Component.PdfPagePathObject.FillColor.get -> Android.Graphics.Color
+Android.Graphics.Pdf.Component.PdfPagePathObject.FillColor.set -> void
+Android.Graphics.Pdf.Component.PdfPagePathObject.PdfPagePathObject(Android.Graphics.Path! path) -> void
+Android.Graphics.Pdf.Component.PdfPagePathObject.RenderMode.get -> int
+Android.Graphics.Pdf.Component.PdfPagePathObject.RenderMode.set -> void
+Android.Graphics.Pdf.Component.PdfPagePathObject.StrokeColor.get -> Android.Graphics.Color
+Android.Graphics.Pdf.Component.PdfPagePathObject.StrokeColor.set -> void
+Android.Graphics.Pdf.Component.PdfPagePathObject.StrokeWidth.get -> float
+Android.Graphics.Pdf.Component.PdfPagePathObject.StrokeWidth.set -> void
+Android.Graphics.Pdf.Component.PdfPagePathObject.ToPath() -> Android.Graphics.Path!
+Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode
+Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode.Fill = 0 -> Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode
+Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode.FillStroke = 2 -> Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode
+Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode.Stroke = 1 -> Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode
+Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode.Unknown = -1 -> Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode
+Android.Graphics.Pdf.Component.PdfPageTextObject
+Android.Graphics.Pdf.Component.PdfPageTextObject.FillColor.get -> Android.Graphics.Color
+Android.Graphics.Pdf.Component.PdfPageTextObject.FillColor.set -> void
+Android.Graphics.Pdf.Component.PdfPageTextObject.Font.get -> Android.Graphics.Pdf.Component.PdfPageTextObjectFont!
+Android.Graphics.Pdf.Component.PdfPageTextObject.FontSize.get -> float
+Android.Graphics.Pdf.Component.PdfPageTextObject.PdfPageTextObject(string! text, Android.Graphics.Pdf.Component.PdfPageTextObjectFont! font, float fontSize) -> void
+Android.Graphics.Pdf.Component.PdfPageTextObject.RenderMode.get -> int
+Android.Graphics.Pdf.Component.PdfPageTextObject.RenderMode.set -> void
+Android.Graphics.Pdf.Component.PdfPageTextObject.StrokeColor.get -> Android.Graphics.Color
+Android.Graphics.Pdf.Component.PdfPageTextObject.StrokeColor.set -> void
+Android.Graphics.Pdf.Component.PdfPageTextObject.StrokeWidth.get -> float
+Android.Graphics.Pdf.Component.PdfPageTextObject.StrokeWidth.set -> void
+Android.Graphics.Pdf.Component.PdfPageTextObject.Text.get -> string!
+Android.Graphics.Pdf.Component.PdfPageTextObject.Text.set -> void
+Android.Graphics.Pdf.Component.PdfPageTextObjectFont
+Android.Graphics.Pdf.Component.PdfPageTextObjectFont.PdfPageTextObjectFont(Android.Graphics.Pdf.Component.PdfPageTextObjectFont! font) -> void
+Android.Graphics.Pdf.Component.PdfPageTextObjectFont.PdfPageTextObjectFont(int fontFamily, bool isBold, bool isItalic) -> void
+Android.Graphics.Pdf.Component.PdfPageTextObjectFont.PdfPageTextObjectFont(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily
+Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily.Courier = 0 -> Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily
+Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily.Helvetica = 1 -> Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily
+Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily.Symbol = 2 -> Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily
+Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily.TimesNewRoman = 3 -> Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily
+Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode
+Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode.Fill = 0 -> Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode
+Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode.FillStroke = 2 -> Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode
+Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode.Stroke = 1 -> Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode
+Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode.Unknown = -1 -> Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode
+Android.Graphics.Pdf.Component.StampAnnotation
+Android.Graphics.Pdf.Component.StampAnnotation.AddObject(Android.Graphics.Pdf.Component.PdfPageObject! pageObject) -> void
+Android.Graphics.Pdf.Component.StampAnnotation.Bounds.get -> Android.Graphics.RectF!
+Android.Graphics.Pdf.Component.StampAnnotation.Bounds.set -> void
+Android.Graphics.Pdf.Component.StampAnnotation.Objects.get -> System.Collections.Generic.IList<Android.Graphics.Pdf.Component.PdfPageObject!>!
+Android.Graphics.Pdf.Component.StampAnnotation.RemoveObject(int index) -> void
+Android.Graphics.Pdf.Component.StampAnnotation.StampAnnotation(Android.Graphics.RectF! bounds) -> void
+Android.Graphics.Pdf.PdfRenderer.Page.AddPageAnnotation(Android.Graphics.Pdf.Component.PdfAnnotation! annotation) -> int
+Android.Graphics.Pdf.PdfRenderer.Page.AddPageObject(Android.Graphics.Pdf.Component.PdfPageObject! pageObject) -> int
+Android.Graphics.Pdf.PdfRenderer.Page.GetTopPageObjectAtPosition(Android.Graphics.PointF! point, int[]! types) -> Android.Util.Pair?
+Android.Graphics.Pdf.PdfRenderer.Page.PageAnnotations.get -> System.Collections.Generic.IList<Android.Util.Pair!>!
+Android.Graphics.Pdf.PdfRenderer.Page.PageObjects.get -> System.Collections.Generic.IList<Android.Util.Pair!>!
+Android.Graphics.Pdf.PdfRenderer.Page.RemovePageAnnotation(int annotationId) -> void
+Android.Graphics.Pdf.PdfRenderer.Page.RemovePageObject(int objectId) -> void
+Android.Graphics.Pdf.PdfRenderer.Page.UpdatePageAnnotation(int annotationId, Android.Graphics.Pdf.Component.PdfAnnotation! annotation) -> bool
+Android.Graphics.Pdf.PdfRenderer.Page.UpdatePageObject(int objectId, Android.Graphics.Pdf.Component.PdfPageObject! pageObject) -> bool
+Android.Graphics.Pdf.PdfRendererPreV.Page.AddPageAnnotation(Android.Graphics.Pdf.Component.PdfAnnotation! annotation) -> int
+Android.Graphics.Pdf.PdfRendererPreV.Page.AddPageObject(Android.Graphics.Pdf.Component.PdfPageObject! pageObject) -> int
+Android.Graphics.Pdf.PdfRendererPreV.Page.GetTopPageObjectAtPosition(Android.Graphics.PointF! point, int[]! types) -> Android.Util.Pair?
+Android.Graphics.Pdf.PdfRendererPreV.Page.PageAnnotations.get -> System.Collections.Generic.IList<Android.Util.Pair!>!
+Android.Graphics.Pdf.PdfRendererPreV.Page.PageObjects.get -> System.Collections.Generic.IList<Android.Util.Pair!>!
+Android.Graphics.Pdf.PdfRendererPreV.Page.RemovePageAnnotation(int annotationId) -> void
+Android.Graphics.Pdf.PdfRendererPreV.Page.RemovePageObject(int objectId) -> void
+Android.Graphics.Pdf.PdfRendererPreV.Page.UpdatePageAnnotation(int annotationId, Android.Graphics.Pdf.Component.PdfAnnotation! annotation) -> bool
+Android.Graphics.Pdf.PdfRendererPreV.Page.UpdatePageObject(int objectId, Android.Graphics.Pdf.Component.PdfPageObject! pageObject) -> bool
+Android.Graphics.Pdf.RenderParams.Builder.SetRenderFormContentMode(int renderFormContentMode) -> Android.Graphics.Pdf.RenderParams.Builder!
+Android.Graphics.Pdf.RenderParams.RenderFormContentMode.get -> int
+Android.Graphics.Pdf.RenderParamsRenderFlag.FlagRenderFreetextAnnotations = 16 -> Android.Graphics.Pdf.RenderParamsRenderFlag
+Android.Graphics.Pdf.RenderParamsRenderFlag.FlagRenderStampAnnotations = 8 -> Android.Graphics.Pdf.RenderParamsRenderFlag
+Android.Graphics.Pdf.RenderParamsRenderFormContentMode
+Android.Graphics.Pdf.RenderParamsRenderFormContentMode.Default = 3 -> Android.Graphics.Pdf.RenderParamsRenderFormContentMode
+Android.Graphics.Pdf.RenderParamsRenderFormContentMode.Disabled = 2 -> Android.Graphics.Pdf.RenderParamsRenderFormContentMode
+Android.Graphics.Pdf.RenderParamsRenderFormContentMode.Enabled = 1 -> Android.Graphics.Pdf.RenderParamsRenderFormContentMode
+Android.Hardware.Biometrics.BiometricManagerAuthenticators.LessThanStrong = 0 -> Android.Hardware.Biometrics.BiometricManagerAuthenticators
+Android.Hardware.Biometrics.BiometricManagerIconType
+Android.Hardware.Biometrics.BiometricManagerIconType.Account = 2 -> Android.Hardware.Biometrics.BiometricManagerIconType
+Android.Hardware.Biometrics.BiometricManagerIconType.Generic = 3 -> Android.Hardware.Biometrics.BiometricManagerIconType
+Android.Hardware.Biometrics.BiometricManagerIconType.Message = 6 -> Android.Hardware.Biometrics.BiometricManagerIconType
+Android.Hardware.Biometrics.BiometricManagerIconType.Password = 0 -> Android.Hardware.Biometrics.BiometricManagerIconType
+Android.Hardware.Biometrics.BiometricManagerIconType.QrCode = 1 -> Android.Hardware.Biometrics.BiometricManagerIconType
+Android.Hardware.Biometrics.BiometricManagerIconType.Reset = 5 -> Android.Hardware.Biometrics.BiometricManagerIconType
+Android.Hardware.Biometrics.BiometricManagerIconType.Setting = 4 -> Android.Hardware.Biometrics.BiometricManagerIconType
+Android.Hardware.Biometrics.BiometricManagerIconType.Supervised = 7 -> Android.Hardware.Biometrics.BiometricManagerIconType
+Android.Hardware.Biometrics.BiometricPrompt.Builder.AddFallbackOption(string! text, int iconType, Java.Util.Concurrent.IExecutor! executor, Android.Content.IDialogInterfaceOnClickListener! listener) -> Android.Hardware.Biometrics.BiometricPrompt.Builder!
+Android.Hardware.Biometrics.BiometricPrompt.CryptoObject.CryptoObject(Javax.Crypto.KeyAgreement! keyAgreement) -> void
+Android.Hardware.Biometrics.BiometricPrompt.CryptoObject.KeyAgreement.get -> Javax.Crypto.KeyAgreement?
+Android.Hardware.Biometrics.FallbackOption
+Android.Hardware.Biometrics.FallbackOption.DescribeContents() -> int
+Android.Hardware.Biometrics.FallbackOption.FallbackOption(Java.Lang.ICharSequence! text, int iconType) -> void
+Android.Hardware.Biometrics.FallbackOption.FallbackOption(string! text, int iconType) -> void
+Android.Hardware.Biometrics.FallbackOption.IconType.get -> int
+Android.Hardware.Biometrics.FallbackOption.InterfaceConsts
+Android.Hardware.Biometrics.FallbackOption.Text.get -> string?
+Android.Hardware.Biometrics.FallbackOption.TextFormatted.get -> Java.Lang.ICharSequence!
+Android.Hardware.Biometrics.FallbackOption.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Hardware.Camera2.CameraExtensionCharacteristics.IsExtensionSupported(int extensionType) -> bool
+Android.Hardware.Camera2.MultiResolutionImageReader.ActiveOutputSurfacesEventArgs
+Android.Hardware.Camera2.MultiResolutionImageReader.ActiveOutputSurfacesEventArgs.ActiveOutputSurfaces.get -> System.Collections.Generic.IList<Android.Views.Surface!>!
+Android.Hardware.Camera2.MultiResolutionImageReader.ActiveOutputSurfacesEventArgs.ActiveOutputSurfacesEventArgs(System.Collections.Generic.IList<Android.Views.Surface!>! activeOutputSurfaces, long timestamp, long frameNumber) -> void
+Android.Hardware.Camera2.MultiResolutionImageReader.ActiveOutputSurfacesEventArgs.FrameNumber.get -> long
+Android.Hardware.Camera2.MultiResolutionImageReader.ActiveOutputSurfacesEventArgs.Timestamp.get -> long
+Android.Hardware.Camera2.MultiResolutionImageReader.Builder
+Android.Hardware.Camera2.MultiResolutionImageReader.Builder.Build() -> Android.Hardware.Camera2.MultiResolutionImageReader!
+Android.Hardware.Camera2.MultiResolutionImageReader.Builder.Builder(System.Collections.Generic.ICollection<Android.Hardware.Camera2.Params.MultiResolutionStreamInfo!>! streams, int format, int maxImages) -> void
+Android.Hardware.Camera2.MultiResolutionImageReader.Builder.SetConcurrentOutputsEnabled(bool enable) -> Android.Hardware.Camera2.MultiResolutionImageReader.Builder!
+Android.Hardware.Camera2.MultiResolutionImageReader.Builder.SetUsage(long usage) -> Android.Hardware.Camera2.MultiResolutionImageReader.Builder!
+Android.Hardware.Camera2.MultiResolutionImageReader.IOnActiveOutputSurfacesListener
+Android.Hardware.Camera2.MultiResolutionImageReader.IOnActiveOutputSurfacesListener.OnActiveOutputSurfaces(System.Collections.Generic.IList<Android.Views.Surface!>! activeOutputSurfaces, long timestamp, long frameNumber) -> void
+Android.Hardware.Camera2.Params.ExtensionSessionConfiguration.SessionWideParams.get -> Android.Hardware.Camera2.CaptureRequest?
+Android.Hardware.Camera2.Params.ExtensionSessionConfiguration.SessionWideParams.set -> void
+Android.Hardware.Camera2.Params.MultiResolutionStreamConfigurationMap.IsConcurrentReadersSupported(int format) -> bool
+Android.Hardware.Camera2.Params.OutputConfiguration.ConfiguredFormat.get -> int
+Android.Hardware.Camera2.Params.OutputConfiguration.ConfiguredSize.get -> Android.Util.Size!
+Android.Hardware.Camera2.Params.OutputConfiguration.MakeDeferredAndRemoveSurfaces() -> Android.Hardware.Camera2.Params.OutputConfiguration!
+Android.Hardware.Camera2.Params.OutputConfiguration.Usage.get -> long
+Android.Hardware.DataSpaceType.DisplayBt2020 = 142999552 -> Android.Hardware.DataSpaceType
+Android.Hardware.Display.DeviceProductInfo.Builder
+Android.Hardware.Display.DeviceProductInfo.Builder.Build() -> Android.Hardware.Display.DeviceProductInfo!
+Android.Hardware.Display.DeviceProductInfo.Builder.Builder(string! manufacturerPnpId, string! productId) -> void
+Android.Hardware.Display.DeviceProductInfo.Builder.SetConnectionToSinkType(int connectionToSinkType) -> Android.Hardware.Display.DeviceProductInfo.Builder!
+Android.Hardware.Display.DeviceProductInfo.Builder.SetEdidStructureMetadata(int edidStructureVersion, int edidStructureRevision) -> Android.Hardware.Display.DeviceProductInfo.Builder!
+Android.Hardware.Display.DeviceProductInfo.Builder.SetManufactureDate(int manufactureWeek, int manufactureYear) -> Android.Hardware.Display.DeviceProductInfo.Builder!
+Android.Hardware.Display.DeviceProductInfo.Builder.SetManufacturerPnpId(string! manufacturerPnpId) -> Android.Hardware.Display.DeviceProductInfo.Builder!
+Android.Hardware.Display.DeviceProductInfo.Builder.SetModelYear(int modelYear) -> Android.Hardware.Display.DeviceProductInfo.Builder!
+Android.Hardware.Display.DeviceProductInfo.Builder.SetName(string? name) -> Android.Hardware.Display.DeviceProductInfo.Builder!
+Android.Hardware.Display.DeviceProductInfo.Builder.SetProductId(string! productId) -> Android.Hardware.Display.DeviceProductInfo.Builder!
+Android.Hardware.Display.DeviceProductInfo.Builder.SetVideoInputType(int videoInputType) -> Android.Hardware.Display.DeviceProductInfo.Builder!
+Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata
+Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata.DescribeContents() -> int
+Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata.InterfaceConsts
+Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata.Revision.get -> int
+Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata.Version.get -> int
+Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Hardware.Display.DeviceProductInfo.GetEdidStructureMetadata() -> Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata?
+Android.Hardware.Display.DeviceProductInfo.VideoInputType.get -> int
+Android.Hardware.Display.DisplayBrightnessUnit
+Android.Hardware.Display.DisplayBrightnessUnit.Percentage = 1 -> Android.Hardware.Display.DisplayBrightnessUnit
+Android.Hardware.Display.DisplayManager.DisplayTopology.get -> Android.Hardware.Display.DisplayTopology?
+Android.Hardware.Display.DisplayManager.GetBrightness(int displayId, int unit) -> float
+Android.Hardware.Display.DisplayManager.RegisterTopologyListener(Java.Util.Concurrent.IExecutor! executor, Java.Util.Functions.IConsumer! listener) -> void
+Android.Hardware.Display.DisplayManager.SetBrightness(int displayId, float value, int unit) -> void
+Android.Hardware.Display.DisplayManager.UnregisterTopologyListener(Java.Util.Functions.IConsumer! listener) -> void
+Android.Hardware.Display.DisplayTopology
+Android.Hardware.Display.DisplayTopology.AbsoluteBounds.get -> Android.Util.SparseArray!
+Android.Hardware.Display.DisplayTopology.DescribeContents() -> int
+Android.Hardware.Display.DisplayTopology.InterfaceConsts
+Android.Hardware.Display.DisplayTopology.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Hardware.Display.VideoInputType
+Android.Hardware.Display.VideoInputType.Analog = 0 -> Android.Hardware.Display.VideoInputType
+Android.Hardware.Display.VideoInputType.Digital = 1 -> Android.Hardware.Display.VideoInputType
+Android.Hardware.Display.VideoInputType.Unknown = -1 -> Android.Hardware.Display.VideoInputType
+Android.Hardware.HardwareBufferFormat.Bgra1010102 = 67 -> Android.Hardware.HardwareBufferFormat
+Android.Hardware.HardwareBufferFormat.Bgrx1010102 = 68 -> Android.Hardware.HardwareBufferFormat
+Android.Hardware.HardwareBufferFormat.R12 = 61 -> Android.Hardware.HardwareBufferFormat
+Android.Hardware.HardwareBufferFormat.R14 = 62 -> Android.Hardware.HardwareBufferFormat
+Android.Hardware.HardwareBufferFormat.Rg1212 = 63 -> Android.Hardware.HardwareBufferFormat
+Android.Hardware.HardwareBufferFormat.Rg1414 = 64 -> Android.Hardware.HardwareBufferFormat
+Android.Hardware.HardwareBufferFormat.Rgba12121212 = 65 -> Android.Hardware.HardwareBufferFormat
+Android.Hardware.HardwareBufferFormat.Rgba14141414 = 66 -> Android.Hardware.HardwareBufferFormat
+Android.Hardware.Lights.ColorSequence
+Android.Hardware.Lights.ColorSequence.Builder
+Android.Hardware.Lights.ColorSequence.Builder.AddControlPoint(long delayMillis, Android.Graphics.Color color) -> Android.Hardware.Lights.ColorSequence.Builder!
+Android.Hardware.Lights.ColorSequence.Builder.AddControlPoints(Android.Hardware.Lights.ColorSequence! sequence) -> Android.Hardware.Lights.ColorSequence.Builder!
+Android.Hardware.Lights.ColorSequence.Builder.AddControlPoints(long[]! delaysMillis, int[]! colors) -> Android.Hardware.Lights.ColorSequence.Builder!
+Android.Hardware.Lights.ColorSequence.Builder.Build() -> Android.Hardware.Lights.ColorSequence!
+Android.Hardware.Lights.ColorSequence.Builder.Builder() -> void
+Android.Hardware.Lights.ColorSequence.Builder.SetInterpolationMode(int interpolationMode) -> Android.Hardware.Lights.ColorSequence.Builder!
+Android.Hardware.Lights.ColorSequence.DescribeContents() -> int
+Android.Hardware.Lights.ColorSequence.DurationMillis.get -> long
+Android.Hardware.Lights.ColorSequence.GetColors() -> int[]!
+Android.Hardware.Lights.ColorSequence.GetDelaysMillis() -> long[]!
+Android.Hardware.Lights.ColorSequence.InterfaceConsts
+Android.Hardware.Lights.ColorSequence.InterpolationMode.get -> int
+Android.Hardware.Lights.ColorSequence.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Hardware.Lights.InterpolationMode
+Android.Hardware.Lights.InterpolationMode.Linear = 1 -> Android.Hardware.Lights.InterpolationMode
+Android.Hardware.Lights.InterpolationMode.None = 0 -> Android.Hardware.Lights.InterpolationMode
+Android.Hardware.Lights.Light.HasAnimationControl.get -> bool
+Android.Hardware.Lights.Light.MinUpdatePeriodMillis.get -> long
+Android.Hardware.Lights.LightCapability.Animation = 4 -> Android.Hardware.Lights.LightCapability
+Android.Hardware.Lights.LightType.Application = 10 -> Android.Hardware.Lights.LightType
+Android.Hardware.Lights.LightsRequest.Builder.SetEffect(Android.Hardware.Lights.MultiLightEffect! effect) -> Android.Hardware.Lights.LightsRequest.Builder!
+Android.Hardware.Lights.LightsRequest.Effect.get -> Android.Hardware.Lights.MultiLightEffect?
+Android.Hardware.Lights.MultiLightEffect
+Android.Hardware.Lights.MultiLightEffect.Builder
+Android.Hardware.Lights.MultiLightEffect.Builder.AddLightSequence(Android.Hardware.Lights.Light! light, Android.Hardware.Lights.ColorSequence! colorSequence) -> Android.Hardware.Lights.MultiLightEffect.Builder!
+Android.Hardware.Lights.MultiLightEffect.Builder.Build() -> Android.Hardware.Lights.MultiLightEffect!
+Android.Hardware.Lights.MultiLightEffect.Builder.Builder() -> void
+Android.Hardware.Lights.MultiLightEffect.Builder.SetIterations(int iterations) -> Android.Hardware.Lights.MultiLightEffect.Builder!
+Android.Hardware.Lights.MultiLightEffect.Builder.SetPreemptive(bool preemptive) -> Android.Hardware.Lights.MultiLightEffect.Builder!
+Android.Hardware.Lights.MultiLightEffect.DescribeContents() -> int
+Android.Hardware.Lights.MultiLightEffect.InterfaceConsts
+Android.Hardware.Lights.MultiLightEffect.IsPreemptive.get -> bool
+Android.Hardware.Lights.MultiLightEffect.Iterations.get -> int
+Android.Hardware.Lights.MultiLightEffect.Sequences.get -> System.Collections.Generic.IDictionary<Java.Lang.Integer!, Android.Hardware.Lights.ColorSequence!>!
+Android.Hardware.Lights.MultiLightEffect.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Hardware.Serial.ISerialPortListener
+Android.Hardware.Serial.ISerialPortListener.OnSerialPortConnected(Android.Hardware.Serial.SerialPort! port) -> void
+Android.Hardware.Serial.ISerialPortListener.OnSerialPortDisconnected(Android.Hardware.Serial.SerialPort! port) -> void
+Android.Hardware.Serial.OpenFlags
+Android.Hardware.Serial.OpenFlags.DataSync = 4096 -> Android.Hardware.Serial.OpenFlags
+Android.Hardware.Serial.OpenFlags.Nonblock = 2048 -> Android.Hardware.Serial.OpenFlags
+Android.Hardware.Serial.OpenFlags.ReadOnly = 0 -> Android.Hardware.Serial.OpenFlags
+Android.Hardware.Serial.OpenFlags.ReadWrite = 2 -> Android.Hardware.Serial.OpenFlags
+Android.Hardware.Serial.OpenFlags.Sync = 1048576 -> Android.Hardware.Serial.OpenFlags
+Android.Hardware.Serial.OpenFlags.WriteOnly = 1 -> Android.Hardware.Serial.OpenFlags
+Android.Hardware.Serial.SerialManager
+Android.Hardware.Serial.SerialManager.Ports.get -> System.Collections.Generic.IList<Android.Hardware.Serial.SerialPort!>!
+Android.Hardware.Serial.SerialManager.RegisterSerialPortListener(Java.Util.Concurrent.IExecutor! executor, Android.Hardware.Serial.ISerialPortListener! listener) -> void
+Android.Hardware.Serial.SerialManager.UnregisterSerialPortListener(Android.Hardware.Serial.ISerialPortListener! listener) -> void
+Android.Hardware.Serial.SerialPort
+Android.Hardware.Serial.SerialPort.Name.get -> string!
+Android.Hardware.Serial.SerialPort.ProductId.get -> int
+Android.Hardware.Serial.SerialPort.RequestOpen(int flags, bool exclusive, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! receiver) -> void
+Android.Hardware.Serial.SerialPort.VendorId.get -> int
+Android.Hardware.Serial.SerialPortConnectedEventArgs
+Android.Hardware.Serial.SerialPortConnectedEventArgs.Port.get -> Android.Hardware.Serial.SerialPort!
+Android.Hardware.Serial.SerialPortConnectedEventArgs.SerialPortConnectedEventArgs(Android.Hardware.Serial.SerialPort! port) -> void
+Android.Hardware.Serial.SerialPortDisconnectedEventArgs
+Android.Hardware.Serial.SerialPortDisconnectedEventArgs.Port.get -> Android.Hardware.Serial.SerialPort!
+Android.Hardware.Serial.SerialPortDisconnectedEventArgs.SerialPortDisconnectedEventArgs(Android.Hardware.Serial.SerialPort! port) -> void
+Android.Hardware.Serial.SerialPortResponse
+Android.Hardware.Serial.SerialPortResponse.FileDescriptor.get -> Android.OS.ParcelFileDescriptor!
+Android.Hardware.Serial.SerialPortResponse.Port.get -> Android.Hardware.Serial.SerialPort!
+Android.Health.Connect.ChangeLog.ChangeLogTokenRequest.Builder.AddMedicalResourceType(int medicalResourceType) -> Android.Health.Connect.ChangeLog.ChangeLogTokenRequest.Builder!
+Android.Health.Connect.ChangeLog.ChangeLogTokenRequest.MedicalResourceTypes.get -> System.Collections.Generic.ICollection<Java.Lang.Integer!>!
+Android.Health.Connect.ChangeLog.ChangeLogsResponse.DeletedLog.DeletedLog(string! deletedRecordId, Java.Time.Instant! deletedTime) -> void
+Android.Health.Connect.ChangeLog.ChangeLogsResponse.DeletedMedicalResource
+Android.Health.Connect.ChangeLog.ChangeLogsResponse.DeletedMedicalResource.DataSourceId.get -> string!
+Android.Health.Connect.ChangeLog.ChangeLogsResponse.DeletedMedicalResource.DeletedMedicalResource(Android.Health.Connect.MedicalResourceId! deletedMedicalResourceId, Java.Time.Instant! deletedTime) -> void
+Android.Health.Connect.ChangeLog.ChangeLogsResponse.DeletedMedicalResource.DeletedMedicalResourceId.get -> Android.Health.Connect.MedicalResourceId!
+Android.Health.Connect.ChangeLog.ChangeLogsResponse.DeletedMedicalResource.DeletedTime.get -> Java.Time.Instant!
+Android.Health.Connect.ChangeLog.ChangeLogsResponse.DeletedMedicalResources.get -> System.Collections.Generic.IList<Android.Health.Connect.ChangeLog.ChangeLogsResponse.DeletedMedicalResource!>!
+Android.Health.Connect.ChangeLog.ChangeLogsResponse.UpsertedMedicalResources.get -> System.Collections.Generic.IList<Android.Health.Connect.DataTypes.MedicalResource!>!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionRecord(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.Build() -> Android.Health.Connect.DataTypes.AlcoholConsumptionRecord!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.Builder(Android.Health.Connect.DataTypes.Metadata! metadata, Java.Time.Instant! startTime, Java.Time.Instant! endTime, int beverageType) -> void
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.Builder(Android.Health.Connect.DataTypes.Metadata! metadata, Java.Time.Instant! time, int beverageType) -> void
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.Builder(Android.Health.Connect.DataTypes.Metadata! metadata, Java.Time.LocalDate! date, int beverageType) -> void
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.ClearEndZoneOffset() -> Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.ClearStartZoneOffset() -> Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.SetAlcoholByVolume(Android.Health.Connect.DataTypes.Units.Percentage? alcoholByVolume) -> Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.SetBeverageType(int beverageType) -> Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.SetEndZoneOffset(Java.Time.ZoneOffset! endZoneOffset) -> Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.SetNotes(Java.Lang.ICharSequence? notes) -> Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.SetNotes(string? notes) -> Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.SetServingVolume(Android.Health.Connect.DataTypes.Units.Volume? servingVolume) -> Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.SetStartZoneOffset(Java.Time.ZoneOffset! startZoneOffset) -> Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder!
+Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Notes.get -> string?
+Android.Health.Connect.DataTypes.CyclingPedalingCadenceRecord.Builder.Builder(Android.Health.Connect.DataTypes.Metadata! metadata, Java.Time.Instant! startTime, Java.Time.Instant! endTime, System.Collections.Generic.IList<Android.Health.Connect.DataTypes.CyclingPedalingCadenceRecord.CyclingPedalingCadenceRecordSample!>! samples) -> void
+Android.Health.Connect.DataTypes.Device.Builder.SetDisplayName(string? displayName) -> Android.Health.Connect.DataTypes.Device.Builder!
+Android.Health.Connect.DataTypes.Device.DisplayName.get -> string?
+Android.Health.Connect.DataTypes.ExerciseSegment.Builder.ClearRateOfPerceivedExertion() -> Android.Health.Connect.DataTypes.ExerciseSegment.Builder!
+Android.Health.Connect.DataTypes.ExerciseSegment.Builder.ClearSetIndex() -> Android.Health.Connect.DataTypes.ExerciseSegment.Builder!
+Android.Health.Connect.DataTypes.ExerciseSegment.Builder.ClearWeight() -> Android.Health.Connect.DataTypes.ExerciseSegment.Builder!
+Android.Health.Connect.DataTypes.ExerciseSegment.Builder.SetRateOfPerceivedExertion(float rateOfPerceivedExertion) -> Android.Health.Connect.DataTypes.ExerciseSegment.Builder!
+Android.Health.Connect.DataTypes.ExerciseSegment.Builder.SetSetIndex(int setIndex) -> Android.Health.Connect.DataTypes.ExerciseSegment.Builder!
+Android.Health.Connect.DataTypes.ExerciseSegment.Builder.SetWeight(Android.Health.Connect.DataTypes.Units.Mass! weight) -> Android.Health.Connect.DataTypes.ExerciseSegment.Builder!
+Android.Health.Connect.DataTypes.ExerciseSegment.HasRateOfPerceivedExertion.get -> bool
+Android.Health.Connect.DataTypes.ExerciseSegment.HasSetIndex.get -> bool
+Android.Health.Connect.DataTypes.ExerciseSegment.RateOfPerceivedExertion.get -> float
+Android.Health.Connect.DataTypes.ExerciseSegment.SetIndex.get -> int
+Android.Health.Connect.DataTypes.ExerciseSegment.Weight.get -> Android.Health.Connect.DataTypes.Units.Mass?
+Android.Health.Connect.DataTypes.ExerciseSessionRecord.Builder.ClearRateOfPerceivedExertion() -> Android.Health.Connect.DataTypes.ExerciseSessionRecord.Builder!
+Android.Health.Connect.DataTypes.ExerciseSessionRecord.Builder.SetRateOfPerceivedExertion(float rateOfPerceivedExertion) -> Android.Health.Connect.DataTypes.ExerciseSessionRecord.Builder!
+Android.Health.Connect.DataTypes.ExerciseSessionRecord.HasRateOfPerceivedExertion.get -> bool
+Android.Health.Connect.DataTypes.ExerciseSessionRecord.RateOfPerceivedExertion.get -> float
+Android.Health.Connect.DataTypes.HealthDeviceType.ConsumerMedicalDevice = 9 -> Android.Health.Connect.DataTypes.HealthDeviceType
+Android.Health.Connect.DataTypes.HealthDeviceType.FitnessEquipment = 13 -> Android.Health.Connect.DataTypes.HealthDeviceType
+Android.Health.Connect.DataTypes.HealthDeviceType.FitnessMachine = 12 -> Android.Health.Connect.DataTypes.HealthDeviceType
+Android.Health.Connect.DataTypes.HealthDeviceType.Glasses = 10 -> Android.Health.Connect.DataTypes.HealthDeviceType
+Android.Health.Connect.DataTypes.HealthDeviceType.Hearable = 11 -> Android.Health.Connect.DataTypes.HealthDeviceType
+Android.Health.Connect.DataTypes.HealthDeviceType.Meter = 15 -> Android.Health.Connect.DataTypes.HealthDeviceType
+Android.Health.Connect.DataTypes.HealthDeviceType.PortableComputer = 14 -> Android.Health.Connect.DataTypes.HealthDeviceType
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder.Build() -> Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord!
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder.Builder(Android.Health.Connect.DataTypes.Metadata! metadata, Java.Time.LocalDate! date, int phase) -> void
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder.ClearDayOfCycle() -> Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder!
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder.ClearStartZoneOffset() -> Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder!
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder.SetDayOfCycle(int dayOfCycle) -> Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder!
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder.SetStartZoneOffset(Java.Time.ZoneOffset! zoneOffset) -> Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder!
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Date.get -> Java.Time.LocalDate!
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.DayOfCycle.get -> int
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.IsDayOfCycleSet.get -> bool
+Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Phase.get -> int
+Android.Health.Connect.DataTypes.SpeedRecord.Builder.Builder(Android.Health.Connect.DataTypes.Metadata! metadata, Java.Time.Instant! startTime, Java.Time.Instant! endTime, System.Collections.Generic.IList<Android.Health.Connect.DataTypes.SpeedRecord.SpeedRecordSample!>! samples) -> void
+Android.Health.Connect.DataTypes.StepsCadenceRecord.Builder.Builder(Android.Health.Connect.DataTypes.Metadata! metadata, Java.Time.Instant! startTime, Java.Time.Instant! endTime, System.Collections.Generic.IList<Android.Health.Connect.DataTypes.StepsCadenceRecord.StepsCadenceRecordSample!>! samples) -> void
+Android.Health.Connect.DataTypes.SymptomRecord
+Android.Health.Connect.DataTypes.SymptomRecord.Builder
+Android.Health.Connect.DataTypes.SymptomRecord.Builder.Build() -> Android.Health.Connect.DataTypes.SymptomRecord!
+Android.Health.Connect.DataTypes.SymptomRecord.Builder.Builder(int symptomType, Java.Time.Instant! startTime, Java.Time.Instant! endTime, Android.Health.Connect.DataTypes.Metadata! metadata) -> void
+Android.Health.Connect.DataTypes.SymptomRecord.Builder.Builder(int symptomType, Java.Time.Instant! time, Android.Health.Connect.DataTypes.Metadata! metadata) -> void
+Android.Health.Connect.DataTypes.SymptomRecord.Builder.Builder(int symptomType, Java.Time.LocalDate! date, Android.Health.Connect.DataTypes.Metadata! metadata) -> void
+Android.Health.Connect.DataTypes.SymptomRecord.Builder.SetCount(int count) -> Android.Health.Connect.DataTypes.SymptomRecord.Builder!
+Android.Health.Connect.DataTypes.SymptomRecord.Builder.SetEndZoneOffset(Java.Time.ZoneOffset! endZoneOffset) -> Android.Health.Connect.DataTypes.SymptomRecord.Builder!
+Android.Health.Connect.DataTypes.SymptomRecord.Builder.SetNotes(string? notes) -> Android.Health.Connect.DataTypes.SymptomRecord.Builder!
+Android.Health.Connect.DataTypes.SymptomRecord.Builder.SetSeverity(int severity) -> Android.Health.Connect.DataTypes.SymptomRecord.Builder!
+Android.Health.Connect.DataTypes.SymptomRecord.Builder.SetStartZoneOffset(Java.Time.ZoneOffset! startZoneOffset) -> Android.Health.Connect.DataTypes.SymptomRecord.Builder!
+Android.Health.Connect.DataTypes.SymptomRecord.Count.get -> int
+Android.Health.Connect.DataTypes.SymptomRecord.Date.get -> Java.Time.LocalDate?
+Android.Health.Connect.DataTypes.SymptomRecord.Notes.get -> string?
+Android.Health.Connect.DataTypes.SymptomRecord.Severity.get -> int
+Android.Health.Connect.DataTypes.SymptomRecord.SymptomType.get -> int
+Android.Health.Connect.DataTypes.SymptomRecord.TemporalType.get -> int
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeAbsinthe = 14 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeBeer = 1 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeBrandy = 15 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeChuhai = 17 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeCider = 9 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeCocktail = 16 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeGin = 4 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeHighball = 18 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeLager = 8 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeMead = 13 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeOther = 0 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeRum = 6 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeSake = 10 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeShochu = 11 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeSoju = 12 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeTequila = 7 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeVodka = 3 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeWhiskey = 5 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeWine = 2 -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType
+Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType.Instant = 0 -> Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType
+Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType.Interval = 1 -> Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType
+Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType.LocalDate = 2 -> Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType
+Android.Health.Connect.Datatypes.MenstrualCyclePhase
+Android.Health.Connect.Datatypes.MenstrualCyclePhase.Follicular = 1 -> Android.Health.Connect.Datatypes.MenstrualCyclePhase
+Android.Health.Connect.Datatypes.MenstrualCyclePhase.Luteal = 2 -> Android.Health.Connect.Datatypes.MenstrualCyclePhase
+Android.Health.Connect.Datatypes.SymptomRecordTemporalType
+Android.Health.Connect.Datatypes.SymptomRecordTemporalType.Instant = 0 -> Android.Health.Connect.Datatypes.SymptomRecordTemporalType
+Android.Health.Connect.Datatypes.SymptomRecordTemporalType.Interval = 1 -> Android.Health.Connect.Datatypes.SymptomRecordTemporalType
+Android.Health.Connect.Datatypes.SymptomRecordTemporalType.LocalDate = 2 -> Android.Health.Connect.Datatypes.SymptomRecordTemporalType
+Android.Health.Connect.Datatypes.SymptomSeverity
+Android.Health.Connect.Datatypes.SymptomSeverity.Mild = 1 -> Android.Health.Connect.Datatypes.SymptomSeverity
+Android.Health.Connect.Datatypes.SymptomSeverity.Moderate = 2 -> Android.Health.Connect.Datatypes.SymptomSeverity
+Android.Health.Connect.Datatypes.SymptomSeverity.Severe = 3 -> Android.Health.Connect.Datatypes.SymptomSeverity
+Android.Health.Connect.Datatypes.SymptomSeverity.Unspecified = 0 -> Android.Health.Connect.Datatypes.SymptomSeverity
+Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.AbdominalPain = 1 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Acne = 2 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.BackPain = 3 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Bloating = 4 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.BrainFog = 5 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.BreastTenderness = 6 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.BrittleNails = 7 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.BurningMouth = 8 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.ChestPain = 9 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.ChestTightness = 10 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Chills = 11 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Constipation = 12 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Cough = 13 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Cramps = 14 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Cravings = 15 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Dehydration = 16 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Diarrhea = 17 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.DifficultySwallowing = 18 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Dizziness = 19 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.DrySkin = 20 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Earaches = 21 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Fatigue = 22 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Fever = 23 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.GeneralizedBodyAche = 24 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.HairLoss = 25 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Headache = 26 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.HeartPalpitations = 28 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Heartburn = 27 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.HotFlashes = 29 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Insomnia = 30 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.JointPain = 31 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.JointStiffness = 32 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.LossOfAppetite = 33 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.LossOfConsciousness = 34 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.LowerBackPain = 35 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.MemoryLapse = 36 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.MoodChange = 37 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.MusclePain = 38 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Nausea = 39 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.NightSweats = 40 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.PelvicPain = 41 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.RapidPoundingOrFlutteringHeartbeat = 42 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.ReducedCapacityForExercise = 43 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.RunnyNose = 44 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.ShortnessOfBreath = 45 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.SkippedHeartbeat = 46 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.SleepChanges = 48 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Sleepiness = 47 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Sneezing = 49 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Snore = 50 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.SoreThroat = 51 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.StomachAche = 52 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.StuffyNose = 53 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.UnexplainedWeightChanges = 54 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Unknown = 0 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.VaginalDryness = 55 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.VaginalItchiness = 56 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Vomiting = 57 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.WaterRetention = 58 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.Datatypes.SymptomType.Wheezing = 59 -> Android.Health.Connect.Datatypes.SymptomType
+Android.Health.Connect.DeviceDataSource
+Android.Health.Connect.DeviceDataSource.DescribeContents() -> int
+Android.Health.Connect.DeviceDataSource.Device.get -> Android.Health.Connect.DataTypes.Device!
+Android.Health.Connect.DeviceDataSource.DeviceDataOrigin.get -> Android.Health.Connect.DataTypes.DataOrigin!
+Android.Health.Connect.DeviceDataSource.DeviceDataSource(Android.Health.Connect.DataTypes.DataOrigin! deviceDataOrigin, Android.Health.Connect.DataTypes.Device! device, System.Collections.Generic.ICollection<Android.Health.Connect.DeviceDataTypeSource!>! dataTypes) -> void
+Android.Health.Connect.DeviceDataSource.DeviceDataTypeSources.get -> System.Collections.Generic.ICollection<Android.Health.Connect.DeviceDataTypeSource!>!
+Android.Health.Connect.DeviceDataSource.InterfaceConsts
+Android.Health.Connect.DeviceDataSource.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Health.Connect.DeviceDataSourceCapabilities
+Android.Health.Connect.DeviceDataSourceCapabilities.RecordTypes.get -> System.Collections.Generic.ICollection<Java.Lang.Class!>!
+Android.Health.Connect.DeviceDataTypeSource
+Android.Health.Connect.DeviceDataTypeSource.DataType.get -> Java.Lang.Class!
+Android.Health.Connect.DeviceDataTypeSource.DescribeContents() -> int
+Android.Health.Connect.DeviceDataTypeSource.InterfaceConsts
+Android.Health.Connect.DeviceDataTypeSource.IsAvailable.get -> bool
+Android.Health.Connect.DeviceDataTypeSource.IsUserEnabled.get -> bool
+Android.Health.Connect.DeviceDataTypeSource.SymptomType.get -> int
+Android.Health.Connect.DeviceDataTypeSource.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Health.Connect.GetDeviceDataSourcesResponse
+Android.Health.Connect.GetDeviceDataSourcesResponse.DescribeContents() -> int
+Android.Health.Connect.GetDeviceDataSourcesResponse.DeviceDataSources.get -> System.Collections.Generic.IList<Android.Health.Connect.DeviceDataSource!>!
+Android.Health.Connect.GetDeviceDataSourcesResponse.GetDeviceDataSourcesResponse(System.Collections.Generic.IList<Android.Health.Connect.DeviceDataSource!>! dataSources) -> void
+Android.Health.Connect.GetDeviceDataSourcesResponse.InterfaceConsts
+Android.Health.Connect.GetDeviceDataSourcesResponse.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Health.Connect.MatchmakingRequest
+Android.Health.Connect.MatchmakingRequest.Builder
+Android.Health.Connect.MatchmakingRequest.Builder.AddRecordType(Java.Lang.Class! recordType) -> Android.Health.Connect.MatchmakingRequest.Builder!
+Android.Health.Connect.MatchmakingRequest.Builder.AddRecordTypes(System.Collections.Generic.ICollection<Java.Lang.Class!>! recordTypes) -> Android.Health.Connect.MatchmakingRequest.Builder!
+Android.Health.Connect.MatchmakingRequest.Builder.Build() -> Android.Health.Connect.MatchmakingRequest!
+Android.Health.Connect.MatchmakingRequest.Builder.Builder() -> void
+Android.Health.Connect.MatchmakingRequest.Builder.SetExcludedDataSources(System.Collections.Generic.ICollection<Android.Health.Connect.DataTypes.DataOrigin!>! dataOrigins) -> Android.Health.Connect.MatchmakingRequest.Builder!
+Android.Health.Connect.MatchmakingRequest.Builder.SetIncludedDataSources(System.Collections.Generic.ICollection<Android.Health.Connect.DataTypes.DataOrigin!>! dataOrigins) -> Android.Health.Connect.MatchmakingRequest.Builder!
+Android.Health.Connect.MatchmakingRequest.DescribeContents() -> int
+Android.Health.Connect.MatchmakingRequest.ExcludedDataSources.get -> System.Collections.Generic.ICollection<Android.Health.Connect.DataTypes.DataOrigin!>!
+Android.Health.Connect.MatchmakingRequest.IncludedDataSources.get -> System.Collections.Generic.ICollection<Android.Health.Connect.DataTypes.DataOrigin!>!
+Android.Health.Connect.MatchmakingRequest.InterfaceConsts
+Android.Health.Connect.MatchmakingRequest.RecordTypes.get -> System.Collections.Generic.ICollection<Java.Lang.Class!>!
+Android.Health.Connect.MatchmakingRequest.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Health.Connect.MatchmakingResponse
+Android.Health.Connect.MatchmakingResponse.Builder
+Android.Health.Connect.MatchmakingResponse.Builder.Build() -> Android.Health.Connect.MatchmakingResponse!
+Android.Health.Connect.MatchmakingResponse.Builder.Builder(bool isMatchmakingPossible) -> void
+Android.Health.Connect.MatchmakingResponse.Builder.SetMatchmakingPossible(bool isMatchmakingPossible) -> Android.Health.Connect.MatchmakingResponse.Builder!
+Android.Health.Connect.MatchmakingResponse.DescribeContents() -> int
+Android.Health.Connect.MatchmakingResponse.InterfaceConsts
+Android.Health.Connect.MatchmakingResponse.IsMatchmakingPossible.get -> bool
+Android.Health.Connect.MatchmakingResponse.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Icu.Lang.UCharacter.IdentifierType
+Android.Icu.Number.SkeletonSyntaxException
+Android.Icu.Number.SkeletonSyntaxException.SkeletonSyntaxException(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Icu.Number.SkeletonSyntaxException.SkeletonSyntaxException(string? message, Java.Lang.ICharSequence? token) -> void
+Android.Icu.Number.SkeletonSyntaxException.SkeletonSyntaxException(string? message, Java.Lang.ICharSequence? token, Java.Lang.Throwable? cause) -> void
+Android.Icu.Number.SkeletonSyntaxException.SkeletonSyntaxException(string? message, string? token) -> void
+Android.Icu.Number.SkeletonSyntaxException.SkeletonSyntaxException(string? message, string? token, Java.Lang.Throwable? cause) -> void
+Android.Icu.Text.DateFormat.Format(Java.Time.Temporal.ITemporal? date) -> string?
+Android.Icu.Text.DateIntervalFormat.Format(Java.Time.Temporal.ITemporal? fromTemporal, Java.Time.Temporal.ITemporal? toTemporal, Java.Lang.StringBuffer? appendTo, Java.Text.FieldPosition? pos) -> Java.Lang.StringBuffer?
+Android.Locations.GnssCapabilities.Builder.SetHasGnssEngineRestartAfterPowerModeChange(bool capable) -> Android.Locations.GnssCapabilities.Builder!
+Android.Locations.GnssCapabilities.HasGnssEngineRestartAfterPowerModeChange.get -> bool
+Android.Locations.GnssStatus.Builder.AddSatellite(int constellationType, int svid, float cn0DbHz, float elevation, float azimuth, bool hasEphemeris, bool hasAlmanac, bool usedInFix, bool hasCarrierFrequency, float carrierFrequency, bool hasBasebandCn0DbHz, float basebandCn0DbHz, bool hasCodeType, string! codeType, bool hasElapsedRealtimeNanos, long elapsedRealtimeNanos, bool hasElapsedRealtimeUncertaintyNanos, double elapsedRealtimeUncertaintyNanos) -> Android.Locations.GnssStatus.Builder!
+Android.Locations.GnssStatus.GetCodeType(int satelliteIndex) -> string!
+Android.Locations.GnssStatus.GetElapsedRealtimeNanos(int satelliteIndex) -> long
+Android.Locations.GnssStatus.GetElapsedRealtimeUncertaintyNanos(int satelliteIndex) -> double
+Android.Locations.GnssStatus.HasCodeType(int satelliteIndex) -> bool
+Android.Locations.GnssStatus.HasElapsedRealtimeNanos(int satelliteIndex) -> bool
+Android.Locations.GnssStatus.HasElapsedRealtimeUncertaintyNanos(int satelliteIndex) -> bool
+Android.Media.AudioDeviceType.TypeBleCentral = 34 -> Android.Media.AudioDeviceType
+Android.Media.AudioDeviceType.TypeBleCentralBroadcast = 35 -> Android.Media.AudioDeviceType
+Android.Media.AudioDeviceType.TypeBleHearingAid = 33 -> Android.Media.AudioDeviceType
+Android.Media.ChannelOut.ThirteenPointZeroMask = 30136348 -> Android.Media.ChannelOut
+Android.Media.FlushFromAccuracy
+Android.Media.FlushFromAccuracy.BestEffort = 0 -> Android.Media.FlushFromAccuracy
+Android.Media.FlushFromAccuracy.Exact = 1 -> Android.Media.FlushFromAccuracy
+Android.Media.FlushWrittenFramesSupport
+Android.Media.FlushWrittenFramesSupport.Supported = 1 -> Android.Media.FlushWrittenFramesSupport
+Android.Media.MediaCodecInfo.EncoderCapabilities.GetSupportedLayeringSchemas() -> string![]!
+Android.Media.MediaCodecProfileType.Hevcprofilemain400 = 8 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Hevcprofilemain444 = 16 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvchightierlevel40 = 64 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvchightierlevel41 = 256 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvchightierlevel50 = 1024 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvchightierlevel51 = 4096 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvchightierlevel52 = 16384 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvchightierlevel60 = 65536 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvchightierlevel61 = 262144 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvchightierlevel62 = 1048576 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvchightierlevel63 = 4194304 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel10 = 1 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel20 = 2 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel21 = 4 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel30 = 8 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel31 = 16 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel40 = 32 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel41 = 128 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel50 = 512 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel51 = 2048 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel52 = 8192 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel60 = 32768 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel61 = 131072 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel62 = 524288 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcmaintierlevel63 = 2097152 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcprofilemain10 = 2 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcprofilemain10hdr10 = 4096 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcprofilemain10hdr10plus = 8192 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcprofilemain10still = 4 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaCodecProfileType.Vvcprofilemain8 = 1 -> Android.Media.MediaCodecProfileType
+Android.Media.MediaRoute2Info.Builder.SetRequiredPermissions(System.Collections.Generic.ICollection<string!>! requiredPermissions) -> Android.Media.MediaRoute2Info.Builder!
+Android.Media.MediaRoute2Info.Builder.SetRequiredPermissions(System.Collections.Generic.IList<System.Collections.Generic.ICollection<string!>!>! requiresOneOf) -> Android.Media.MediaRoute2Info.Builder!
+Android.Media.MediaRoute2Info.Builder.SetVisibilityRestricted(System.Collections.Generic.ICollection<string!>! allowedPackages, bool alsoAllowPrivileged) -> Android.Media.MediaRoute2Info.Builder!
+Android.Media.MediaRoute2Info.ProviderPackageName.get -> string?
+Android.Media.MediaRoute2Info.RequiredPermissions.get -> System.Collections.Generic.IList<System.Collections.Generic.ICollection<string!>!>!
+Android.Media.MediaRouter2.ClearDeviceSuggestions() -> void
+Android.Media.MediaRouter2.DeviceSuggestions.get -> System.Collections.Generic.IDictionary<string!, System.Collections.Generic.IList<Android.Media.SuggestedDeviceInfo!>!>!
+Android.Media.MediaRouter2.IDeviceSuggestionsUpdatesCallback
+Android.Media.MediaRouter2.IDeviceSuggestionsUpdatesCallback.OnSuggestionsCleared(string! suggestingPackageName) -> void
+Android.Media.MediaRouter2.IDeviceSuggestionsUpdatesCallback.OnSuggestionsRequested() -> void
+Android.Media.MediaRouter2.IDeviceSuggestionsUpdatesCallback.OnSuggestionsUpdated(string! suggestingPackageName, System.Collections.Generic.IList<Android.Media.SuggestedDeviceInfo!>! suggestedDeviceInfo) -> void
+Android.Media.MediaRouter2.RegisterDeviceSuggestionsUpdatesCallback(Java.Util.Concurrent.IExecutor! executor, Android.Media.MediaRouter2.IDeviceSuggestionsUpdatesCallback! deviceSuggestionsUpdatesCallback) -> void
+Android.Media.MediaRouter2.SetDeviceSuggestions(System.Collections.Generic.IList<Android.Media.SuggestedDeviceInfo!>! suggestedDeviceInfo) -> void
+Android.Media.MediaRouter2.ShowSystemOutputSwitcher(Android.Media.Session.MediaSession.Token! sessionToken) -> bool
+Android.Media.MediaRouter2.UnregisterDeviceSuggestionsUpdatesCallback(Android.Media.MediaRouter2.IDeviceSuggestionsUpdatesCallback! callback) -> void
+Android.Media.Mode.AssistantConversation = 7 -> Android.Media.Mode
+Android.Media.Projection.AppContentProjectionService
+Android.Media.Projection.AppContentProjectionService.AppContentProjectionService() -> void
+Android.Media.Projection.AppContentProjectionService.AppContentProjectionService(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Media.Projection.AppContentProjectionSession
+Android.Media.Projection.AppContentProjectionSession.AppContentProjectionSession(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Media.Projection.AppContentRequest
+Android.Media.Projection.AppContentRequest.IconSize.get -> Android.Util.Size!
+Android.Media.Projection.AppContentRequest.ProvideContent(System.Collections.Generic.IList<Android.Media.Projection.MediaProjectionAppContent!>! content) -> void
+Android.Media.Projection.AppContentRequest.ThumbnailSize.get -> Android.Util.Size!
+Android.Media.Projection.MediaProjectionAppContent
+Android.Media.Projection.MediaProjectionAppContent.Builder
+Android.Media.Projection.MediaProjectionAppContent.Builder.Build() -> Android.Media.Projection.MediaProjectionAppContent!
+Android.Media.Projection.MediaProjectionAppContent.Builder.Builder(int id) -> void
+Android.Media.Projection.MediaProjectionAppContent.Builder.SetIcon(Android.Graphics.Drawables.Icon! icon) -> Android.Media.Projection.MediaProjectionAppContent.Builder!
+Android.Media.Projection.MediaProjectionAppContent.Builder.SetThumbnail(Android.Graphics.Bitmap! thumbnail) -> Android.Media.Projection.MediaProjectionAppContent.Builder!
+Android.Media.Projection.MediaProjectionAppContent.Builder.SetTitle(Java.Lang.ICharSequence! title) -> Android.Media.Projection.MediaProjectionAppContent.Builder!
+Android.Media.Projection.MediaProjectionAppContent.Builder.SetTitle(string! title) -> Android.Media.Projection.MediaProjectionAppContent.Builder!
+Android.Media.Projection.MediaProjectionAppContent.DescribeContents() -> int
+Android.Media.Projection.MediaProjectionAppContent.Icon.get -> Android.Graphics.Drawables.Icon?
+Android.Media.Projection.MediaProjectionAppContent.Id.get -> int
+Android.Media.Projection.MediaProjectionAppContent.InterfaceConsts
+Android.Media.Projection.MediaProjectionAppContent.Thumbnail.get -> Android.Graphics.Bitmap?
+Android.Media.Projection.MediaProjectionAppContent.Title.get -> string?
+Android.Media.Projection.MediaProjectionAppContent.TitleFormatted.get -> Java.Lang.ICharSequence!
+Android.Media.Projection.MediaProjectionAppContent.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Media.Projection.MediaProjectionConfig.Builder
+Android.Media.Projection.MediaProjectionConfig.Builder.Build() -> Android.Media.Projection.MediaProjectionConfig!
+Android.Media.Projection.MediaProjectionConfig.Builder.Builder() -> void
+Android.Media.Projection.MediaProjectionConfig.Builder.SetAudioRequested(bool isAudioRequested) -> Android.Media.Projection.MediaProjectionConfig.Builder!
+Android.Media.Projection.MediaProjectionConfig.Builder.SetInitiallySelectedSource(int projectionSource) -> Android.Media.Projection.MediaProjectionConfig.Builder!
+Android.Media.Projection.MediaProjectionConfig.Builder.SetOwnAppContentProvided(bool isEnabled) -> Android.Media.Projection.MediaProjectionConfig.Builder!
+Android.Media.Projection.MediaProjectionConfig.Builder.SetRequesterHint(string? requesterHint) -> Android.Media.Projection.MediaProjectionConfig.Builder!
+Android.Media.Projection.MediaProjectionConfig.Builder.SetSourceEnabled(int source, bool enabled) -> Android.Media.Projection.MediaProjectionConfig.Builder!
+Android.Media.Projection.MediaProjectionConfig.InitiallySelectedSource.get -> int
+Android.Media.Projection.MediaProjectionConfig.IsAudioRequested.get -> bool
+Android.Media.Projection.MediaProjectionConfig.IsOwnAppContentProvided.get -> bool
+Android.Media.Projection.MediaProjectionConfig.IsSourceEnabled(int projectionSource) -> bool
+Android.Media.Projection.MediaProjectionConfig.ProjectionSources.get -> int
+Android.Media.Projection.MediaProjectionConfig.RequesterHint.get -> string?
+Android.Media.Projection.MediaProjectionConfig.RequesterHintFormatted.get -> Java.Lang.ICharSequence?
+Android.Media.Projection.MediaProjectionSource
+Android.Media.Projection.MediaProjectionSource.App = 8 -> Android.Media.Projection.MediaProjectionSource
+Android.Media.Projection.MediaProjectionSource.AppContent = 16 -> Android.Media.Projection.MediaProjectionSource
+Android.Media.Projection.MediaProjectionSource.Display = 2 -> Android.Media.Projection.MediaProjectionSource
+Android.Media.Quality.EqualizerBand
+Android.Media.Quality.EqualizerBand.DescribeContents() -> int
+Android.Media.Quality.EqualizerBand.EqualizerBand(int frequencyHz, int gainDb, float qFactor) -> void
+Android.Media.Quality.EqualizerBand.FrequencyHz.get -> int
+Android.Media.Quality.EqualizerBand.GainDb.get -> int
+Android.Media.Quality.EqualizerBand.InterfaceConsts
+Android.Media.Quality.EqualizerBand.QFactor.get -> float
+Android.Media.Quality.EqualizerBand.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Media.Quality.EqualizerCapabilities
+Android.Media.Quality.EqualizerCapabilities.DescribeContents() -> int
+Android.Media.Quality.EqualizerCapabilities.HasAdjustableQ.get -> bool
+Android.Media.Quality.EqualizerCapabilities.InterfaceConsts
+Android.Media.Quality.EqualizerCapabilities.MaxLevelDb.get -> int
+Android.Media.Quality.EqualizerCapabilities.MinLevelDb.get -> int
+Android.Media.Quality.EqualizerCapabilities.SupportedFrequenciesHz.get -> System.Collections.Generic.IList<Java.Lang.Integer!>!
+Android.Media.Quality.EqualizerCapabilities.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Media.Quality.EqualizerSettings
+Android.Media.Quality.EqualizerSettings.Bands.get -> System.Collections.Generic.IList<Android.Media.Quality.EqualizerBand!>!
+Android.Media.Quality.EqualizerSettings.Builder
+Android.Media.Quality.EqualizerSettings.Builder.AddBands(System.Collections.Generic.IList<Android.Media.Quality.EqualizerBand!>! bands) -> Android.Media.Quality.EqualizerSettings.Builder!
+Android.Media.Quality.EqualizerSettings.Builder.Build() -> Android.Media.Quality.EqualizerSettings!
+Android.Media.Quality.EqualizerSettings.Builder.Builder() -> void
+Android.Media.Quality.EqualizerSettings.DescribeContents() -> int
+Android.Media.Quality.EqualizerSettings.InterfaceConsts
+Android.Media.Quality.EqualizerSettings.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Media.Quality.MediaQualityManager.EqualizerCapabilities.get -> Android.Media.Quality.EqualizerCapabilities?
+Android.Media.Quality.MediaQualityManager.SetColorMuteEnabled(bool enable) -> void
+Android.Media.Quality.MediaQualityManager.SetMutedColor(Android.Graphics.Color color) -> void
+Android.Media.Quality.MediaQualityManager.UsesDisplayTechnology(int panelTechnology) -> bool
+Android.Media.Quality.PanelTechnology
+Android.Media.Quality.PanelTechnology.Oled = 0 -> Android.Media.Quality.PanelTechnology
+Android.Media.Quality.PanelTechnology.Unknown = -1 -> Android.Media.Quality.PanelTechnology
+Android.Media.Quality.ParameterCapability.IsMutable.get -> bool
+Android.Media.Quality.PictureProfile.Builder.AddStreamStatusVariant(string! status, Android.OS.PersistableBundle! params) -> Android.Media.Quality.PictureProfile.Builder!
+Android.Media.Quality.PictureProfile.StreamStatusVariants.get -> System.Collections.Generic.IDictionary<string!, Android.OS.PersistableBundle!>!
+Android.Media.RouteListingPreference.Builder.SetMissingPermissionsComponentName(Android.Content.ComponentName? componentName) -> Android.Media.RouteListingPreference.Builder!
+Android.Media.RouteListingPreference.MissingPermissionsComponentName.get -> Android.Content.ComponentName?
+Android.Media.Session.MediaSession.MediaSession(Android.Content.Context! context, string! tag, Android.OS.Bundle? sessionInfo, string! overridePackageName) -> void
+Android.Media.Session.MediaSessionManager.AddOnActiveSessionsForPackageChangedListener(string! packageName, Java.Util.Concurrent.IExecutor! executor, Android.Content.ComponentName? notificationListener, Android.Media.Session.MediaSessionManager.IOnActiveSessionsChangedListener! sessionListener) -> void
+Android.Media.Session.MediaSessionManager.AddOnActiveSessionsForPackageChangedListener(string! packageName, Java.Util.Concurrent.IExecutor! executor, Android.Media.Session.MediaSessionManager.IOnActiveSessionsChangedListener! sessionListener) -> void
+Android.Media.Session.MediaSessionManager.GetActiveSessionsForPackage(string! packageName) -> System.Collections.Generic.IList<Android.Media.Session.MediaSession.Token!>!
+Android.Media.Session.MediaSessionManager.GetActiveSessionsForPackage(string! packageName, Android.Content.ComponentName? notificationListener) -> System.Collections.Generic.IList<Android.Media.Session.MediaSession.Token!>!
+Android.Media.Session.MediaSessionManager.RemoveOnActiveSessionsForPackageChangedListener(Android.Media.Session.MediaSessionManager.IOnActiveSessionsChangedListener! sessionListener) -> void
+Android.Media.Stream.StreamAssistant = 11 -> Android.Media.Stream
+Android.Media.SuggestedDeviceInfo
+Android.Media.SuggestedDeviceInfo.Builder
+Android.Media.SuggestedDeviceInfo.Builder.Build() -> Android.Media.SuggestedDeviceInfo!
+Android.Media.SuggestedDeviceInfo.Builder.Builder(string! deviceDisplayName, string! routeId, int type) -> void
+Android.Media.SuggestedDeviceInfo.Builder.SetExtras(Android.OS.Bundle! extras) -> Android.Media.SuggestedDeviceInfo.Builder!
+Android.Media.SuggestedDeviceInfo.DescribeContents() -> int
+Android.Media.SuggestedDeviceInfo.DeviceDisplayName.get -> string!
+Android.Media.SuggestedDeviceInfo.Extras.get -> Android.OS.Bundle!
+Android.Media.SuggestedDeviceInfo.InterfaceConsts
+Android.Media.SuggestedDeviceInfo.RouteId.get -> string!
+Android.Media.SuggestedDeviceInfo.Type.get -> int
+Android.Media.SuggestedDeviceInfo.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Media.VideoEncoder.Apv = 9 -> Android.Media.VideoEncoder
+Android.Net.Dns.HttpsEndpoint
+Android.Net.Dns.HttpsEndpoint.HttpsEndpoint(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Net.Dns.HttpsRecord
+Android.Net.Dns.HttpsRecord.HttpsRecord(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Net.DnsResolver.DnsResolver(Android.Content.Context! context, Android.OS.Looper? looper) -> void
+Android.Net.DnsResolver.Query(Android.Net.Network? network, string! domain, Android.Net.DnsResolverFlag flags, Java.Util.Concurrent.IExecutor! executor, int httpsTimeoutMillis, Android.OS.CancellationSignal? cancellationSignal, Android.Net.DnsResolver.ICallback! callback) -> void
+Android.Net.DnsResolverType.Https = 65 -> Android.Net.DnsResolverType
+Android.Net.Http.AllProxiesFailedBehavior
+Android.Net.Http.AllProxiesFailedBehavior.AllowDirect = 1 -> Android.Net.Http.AllProxiesFailedBehavior
+Android.Net.Http.AllProxiesFailedBehavior.DisallowDirect = 0 -> Android.Net.Http.AllProxiesFailedBehavior
+Android.Net.Http.HttpProxyScheme
+Android.Net.Http.HttpProxyScheme.Http = 0 -> Android.Net.Http.HttpProxyScheme
+Android.Net.Http.HttpProxyScheme.Https = 1 -> Android.Net.Http.HttpProxyScheme
+Android.Net.Http.OnResponseReceivedAction
+Android.Net.Http.OnResponseReceivedAction.Close = 0 -> Android.Net.Http.OnResponseReceivedAction
+Android.Net.Http.OnResponseReceivedAction.Proceed = 1 -> Android.Net.Http.OnResponseReceivedAction
+Android.Net.Http.Proxy
+Android.Net.Http.Proxy.HttpConnectCallback
+Android.Net.Http.Proxy.IHttpConnectCallback
+Android.Net.Http.Proxy.IHttpConnectCallback.OnBeforeRequest(Android.Net.Http.Proxy.IHttpConnectCallback.Request! request) -> void
+Android.Net.Http.Proxy.IHttpConnectCallback.OnResponseReceived(System.Collections.Generic.IList<Android.Util.Pair!>! p0, int p1) -> int
+Android.Net.Http.Proxy.IHttpConnectCallback.Request
+Android.Net.Http.Proxy.IHttpConnectCallback.Request.Close() -> void
+Android.Net.Http.Proxy.IHttpConnectCallback.Request.Proceed(System.Collections.Generic.IList<Android.Util.Pair!>! extraHeaders) -> void
+Android.Net.Http.ProxyOptions
+Android.Net.NetCapability.PrioritizeUnifiedCommunications = 38 -> Android.Net.NetCapability
+Android.Net.Nsd.DiscoveryRequest.AttributeFilters.get -> System.Collections.Generic.IDictionary<string!, Android.OS.PatternMatcher!>!
+Android.Net.Nsd.DiscoveryRequest.Builder.SetAttributeFilters(System.Collections.Generic.IDictionary<string!, Android.OS.PatternMatcher!>? attributeFilters) -> Android.Net.Nsd.DiscoveryRequest.Builder!
+Android.Net.Nsd.DiscoveryRequest.Builder.SetDisplayNameAttribute(string? attributeKey) -> Android.Net.Nsd.DiscoveryRequest.Builder!
+Android.Net.Nsd.DiscoveryRequest.Builder.SetFlags(long flags) -> Android.Net.Nsd.DiscoveryRequest.Builder!
+Android.Net.Nsd.DiscoveryRequest.Builder.SetFlags(long flags, long mask) -> Android.Net.Nsd.DiscoveryRequest.Builder!
+Android.Net.Nsd.DiscoveryRequest.Builder.SetServiceNameFilter(Android.OS.PatternMatcher? serviceNameFilter) -> Android.Net.Nsd.DiscoveryRequest.Builder!
+Android.Net.Nsd.DiscoveryRequest.DisplayNameAttribute.get -> string?
+Android.Net.Nsd.DiscoveryRequest.Flags.get -> long
+Android.Net.Nsd.DiscoveryRequest.ServiceNameFilter.get -> Android.OS.PatternMatcher?
+Android.Net.Nsd.NsdFailure.PermissionDenied = 7 -> Android.Net.Nsd.NsdFailure
+Android.Net.Nsd.NsdManager.CheckPermissionForService(string! serviceName, string! serviceType, Java.Util.Concurrent.IExecutor! executor, Java.Util.Functions.IIntConsumer! resultReceiver) -> void
+Android.Net.Nsd.NsdManager.IServiceInfoCallback.OnServiceInfoCallbackRegistered() -> void
+Android.Net.Nsd.NsdManager.IServiceInfoCallback.OnServiceLost(Android.Net.Nsd.NsdServiceInfo! serviceInfo) -> void
+Android.Net.Nsd.NsdManager.RegisterService(Android.Net.Nsd.AdvertisingRequest! advertisingRequest, Java.Util.Concurrent.IExecutor! executor, Android.Net.Nsd.NsdManager.IRegistrationListener! listener) -> void
+Android.Net.Nsd.NsdManager.RegisterServiceInfoCallback(Android.Net.Nsd.DiscoveryRequest! discoveryRequest, Java.Util.Concurrent.IExecutor! executor, Android.Net.Nsd.NsdManager.IServiceInfoCallback! listener) -> void
+Android.Net.Nsd.NsdServiceInfo.SetAttribute(string! key, byte[]? value) -> void
+Android.Net.Nsd.PermissionCheckCode
+Android.Net.Nsd.PermissionCheckCode.Denied = 2 -> Android.Net.Nsd.PermissionCheckCode
+Android.Net.Nsd.PermissionCheckCode.Granted = 1 -> Android.Net.Nsd.PermissionCheckCode
+Android.Net.Ssl.EchConfigList
+Android.Net.Ssl.EchConfigList.EchConfigList(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Net.Ssl.EchConfigMismatchException
+Android.Net.Ssl.EchConfigMismatchException.EchConfigMismatchException(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Net.Ssl.EchConfigMismatchException.EchConfigMismatchException(string? message, string? publicName, Android.Net.Ssl.EchConfigList? echRetryConfigList) -> void
+Android.Net.Ssl.InvalidEchDataException
+Android.Net.Ssl.InvalidEchDataException.InvalidEchDataException(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Net.Ssl.InvalidEchDataException.InvalidEchDataException(string? message) -> void
+Android.Net.Wifi.Aware.AwareDataPathRequest
+Android.Net.Wifi.Aware.AwareDataPathRequest.Builder
+Android.Net.Wifi.Aware.AwareDataPathRequest.Builder.Build() -> Android.Net.Wifi.Aware.AwareDataPathRequest!
+Android.Net.Wifi.Aware.AwareDataPathRequest.Builder.Builder() -> void
+Android.Net.Wifi.Aware.AwareDataPathRequest.Builder.SetDataPathSecurityConfig(Android.Net.Wifi.Aware.WifiAwareDataPathSecurityConfig! securityConfig) -> Android.Net.Wifi.Aware.AwareDataPathRequest.Builder!
+Android.Net.Wifi.Aware.AwareDataPathRequest.Builder.SetPort(int port) -> Android.Net.Wifi.Aware.AwareDataPathRequest.Builder!
+Android.Net.Wifi.Aware.AwareDataPathRequest.Builder.SetTransportProtocol(int transportProtocol) -> Android.Net.Wifi.Aware.AwareDataPathRequest.Builder!
+Android.Net.Wifi.Aware.AwareDataPathRequest.DataPathSecurityConfig.get -> Android.Net.Wifi.Aware.WifiAwareDataPathSecurityConfig?
+Android.Net.Wifi.Aware.AwareDataPathRequest.DescribeContents() -> int
+Android.Net.Wifi.Aware.AwareDataPathRequest.InterfaceConsts
+Android.Net.Wifi.Aware.AwareDataPathRequest.Port.get -> int
+Android.Net.Wifi.Aware.AwareDataPathRequest.TransportProtocol.get -> int
+Android.Net.Wifi.Aware.AwareDataPathRequest.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Net.Wifi.Aware.AwarePairingBootstrappingMethods.ServiceManaged = 16384 -> Android.Net.Wifi.Aware.AwarePairingBootstrappingMethods
+Android.Net.Wifi.Aware.AwarePairingBootstrappingMethods.Skipped = 32768 -> Android.Net.Wifi.Aware.AwarePairingBootstrappingMethods
+Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+Android.Net.Wifi.Aware.DataPathConnectionFailureReason.InternalFailure = 5 -> Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+Android.Net.Wifi.Aware.DataPathConnectionFailureReason.NoResource = 1 -> Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+Android.Net.Wifi.Aware.DataPathConnectionFailureReason.PeerNotFound = 2 -> Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+Android.Net.Wifi.Aware.DataPathConnectionFailureReason.RejectByPeer = 3 -> Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+Android.Net.Wifi.Aware.DataPathConnectionFailureReason.TimeOut = 4 -> Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+Android.Net.Wifi.Aware.SubscribeConfig.Builder.SetEgressDistanceMm(int egressDistanceMm) -> Android.Net.Wifi.Aware.SubscribeConfig.Builder!
+Android.Net.Wifi.Aware.SubscribeConfig.Builder.SetIngressDistanceMm(int ingressDistanceMm) -> Android.Net.Wifi.Aware.SubscribeConfig.Builder!
+Android.Net.Wifi.Aware.SubscribeConfig.EgressDistanceMm.get -> int
+Android.Net.Wifi.Aware.SubscribeConfig.IngressDistanceMm.get -> int
+Android.Net.Wifi.MloLink.MaxSupportedRxLinkSpeedMbps.get -> int
+Android.Net.Wifi.MloLink.MaxSupportedTxLinkSpeedMbps.get -> int
+Android.Net.Wifi.P2p.ConnectionRequestType.ConnectionRequestDeferShowPasswordToService = 4 -> Android.Net.Wifi.P2p.ConnectionRequestType
+Android.Net.Wifi.P2p.WifiP2pConfig.Builder.SetPairingDiscoveryChannelFrequencyMhz(int frequencyMhz) -> Android.Net.Wifi.P2p.WifiP2pConfig.Builder!
+Android.Net.Wifi.P2p.WifiP2pConnectionInfo
+Android.Net.Wifi.P2p.WifiP2pConnectionInfo.ChannelWidth.get -> int
+Android.Net.Wifi.P2p.WifiP2pConnectionInfo.DescribeContents() -> int
+Android.Net.Wifi.P2p.WifiP2pConnectionInfo.InterfaceConsts
+Android.Net.Wifi.P2p.WifiP2pConnectionInfo.RxNss.get -> int
+Android.Net.Wifi.P2p.WifiP2pConnectionInfo.TxNss.get -> int
+Android.Net.Wifi.P2p.WifiP2pConnectionInfo.WifiStandard.get -> int
+Android.Net.Wifi.P2p.WifiP2pConnectionInfo.WriteToParcel(Android.OS.Parcel! parcel, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Net.Wifi.P2p.WifiP2pManager.IExternalApproverRequestListener.OnPasswordGenerated(Android.Net.MacAddress! deviceAddress, string! password) -> void
+Android.Net.Wifi.P2p.WifiP2pManager.PasswordGeneratedEventArgs
+Android.Net.Wifi.P2p.WifiP2pManager.PasswordGeneratedEventArgs.DeviceAddress.get -> Android.Net.MacAddress!
+Android.Net.Wifi.P2p.WifiP2pManager.PasswordGeneratedEventArgs.Password.get -> string!
+Android.Net.Wifi.P2p.WifiP2pManager.PasswordGeneratedEventArgs.PasswordGeneratedEventArgs(Android.Net.MacAddress! deviceAddress, string! password) -> void
+Android.Net.Wifi.P2p.WifiP2pPairingBootstrappingConfig.PairingBootstrappingMethod.get -> int
+Android.Net.Wifi.P2p.WifiP2pPairingBootstrappingConfig.PairingBootstrappingPassword.get -> string?
+Android.Net.Wifi.Rtt.PasnConfig.Builder.SetPmk(byte[]! pmk) -> Android.Net.Wifi.Rtt.PasnConfig.Builder!
+Android.Net.Wifi.Rtt.PasnConfig.Builder.SetProximityDetectionSeekerDeviceIdentityKey(byte[]! seekerDevIK) -> Android.Net.Wifi.Rtt.PasnConfig.Builder!
+Android.Net.Wifi.Rtt.PasnConfig.GetPmk() -> byte[]?
+Android.Net.Wifi.Rtt.PasnConfig.GetProximityDetectionSeekerDeviceIdentityKey() -> byte[]?
+Android.Net.Wifi.Rtt.RangingResult.AvailabilityWindowDurationMillis.get -> long
+Android.Net.Wifi.Rtt.RangingResult.Builder.SetAvailabilityWindowDurationMillis(long availabilityWindowDurationMillis) -> Android.Net.Wifi.Rtt.RangingResult.Builder!
+Android.Net.Wifi.Rtt.RangingResult.Builder.SetLmrDelayed(bool isLmrDelayed) -> Android.Net.Wifi.Rtt.RangingResult.Builder!
+Android.Net.Wifi.Rtt.RangingResult.Builder.SetNominalTimeMillis(long nominalTimeMillis) -> Android.Net.Wifi.Rtt.RangingResult.Builder!
+Android.Net.Wifi.Rtt.RangingResult.Builder.SetNumNtbRepetitionsPerMeasurement(int numNtbRepetitionsPerMeasurement) -> Android.Net.Wifi.Rtt.RangingResult.Builder!
+Android.Net.Wifi.Rtt.RangingResult.Builder.SetRetryAfterDurationMillis(int durationMs) -> Android.Net.Wifi.Rtt.RangingResult.Builder!
+Android.Net.Wifi.Rtt.RangingResult.Builder.SetUsdPeerId(int usdPeerId) -> Android.Net.Wifi.Rtt.RangingResult.Builder!
+Android.Net.Wifi.Rtt.RangingResult.IsLmrDelayed.get -> bool
+Android.Net.Wifi.Rtt.RangingResult.NominalTimeMillis.get -> long
+Android.Net.Wifi.Rtt.RangingResult.NumNtbRepetitionsPerMeasurement.get -> int
+Android.Net.Wifi.Rtt.RangingResult.RetryAfterDurationMillis.get -> int
+Android.Net.Wifi.Rtt.RangingResult.UsdPeerId.get -> int
+Android.Net.Wifi.Rtt.RangingStatus.BusyTryLater = 12 -> Android.Net.Wifi.Rtt.RangingStatus
+Android.Net.Wifi.Rtt.ResponderConfig.Builder.Builder(Android.Net.Wifi.Rtt.ResponderConfig! config) -> void
+Android.Net.Wifi.Rtt.ResponderConfig.Builder.SetMacAddress(Android.Net.MacAddress? macAddress) -> Android.Net.Wifi.Rtt.ResponderConfig.Builder!
+Android.Net.Wifi.Rtt.ResponderConfig.Builder.SetPeerHandle(Android.Net.Wifi.Aware.PeerHandle? peerHandle) -> Android.Net.Wifi.Rtt.ResponderConfig.Builder!
+Android.Net.Wifi.Rtt.ResponderConfig.Builder.SetUsdPeerId(int peerId) -> Android.Net.Wifi.Rtt.ResponderConfig.Builder!
+Android.Net.Wifi.Rtt.ResponderConfig.PeerHandle.get -> Android.Net.Wifi.Aware.PeerHandle?
+Android.Net.Wifi.Rtt.ResponderConfig.UsdPeerId.get -> int
+Android.Net.Wifi.SoftApConfiguration.Builder.SetBssid(Android.Net.MacAddress? bssid) -> Android.Net.Wifi.SoftApConfiguration.Builder!
+Android.Net.Wifi.SoftApConfiguration.Builder.SetPassphrase(string? passphrase, int securityType) -> Android.Net.Wifi.SoftApConfiguration.Builder!
+Android.Net.Wifi.SoftApConfiguration.Builder.SetWifiSsid(Android.Net.Wifi.WifiSsid? wifiSsid) -> Android.Net.Wifi.SoftApConfiguration.Builder!
+Android.Net.Wifi.WifiConfiguration.AllowAutojoin.get -> bool
+Android.Net.Wifi.WifiConfiguration.AllowAutojoin.set -> void
+Android.Net.Wifi.WifiConfiguration.Shared.get -> bool
+Android.Net.Wifi.WifiConfiguration.Shared.set -> void
+Android.Nfc.CardEmulators.CardEmulation.GetPollingLoopFiltersForService(Android.Content.ComponentName! service) -> System.Collections.Generic.IList<string!>!
+Android.Nfc.CardEmulators.CardEmulation.GetPollingLoopPatternFiltersForService(Android.Content.ComponentName! service) -> System.Collections.Generic.IList<string!>!
+Android.Nfc.CardEmulators.CardEmulation.INfcEventCallback.OnOffHostAidSelected(string! aid, string! offHostSecureElement) -> void
+Android.Nfc.CardEmulators.CardEmulation.IsDeviceScreenOnRequiredForService(Android.Content.ComponentName! service) -> bool
+Android.Nfc.CardEmulators.CardEmulation.IsDeviceUnlockRequiredForService(Android.Content.ComponentName! service) -> bool
+Android.Nfc.CardEmulators.CardEmulation.SetRequireDeviceScreenOnForService(Android.Content.ComponentName! service, bool enable) -> void
+Android.Nfc.CardEmulators.CardEmulation.SetRequireDeviceUnlockForService(Android.Content.ComponentName! service, bool enable) -> void
+Android.Nfc.CardEmulators.ProtocolAndTechnologyRoute.ProtocolAndTechnologyRouteNdefNfcee = 4 -> Android.Nfc.CardEmulators.ProtocolAndTechnologyRoute
+Android.Nfc.NfcAdapter.AllowOneTransaction() -> void
+Android.Nfc.NfcAdapter.GestureExchangeAid.get -> string?
+Android.Nfc.NfcAdapter.IReaderCallback.OnTagLost(Android.Nfc.Tag! tag) -> void
+Android.Nfc.NfcAdapter.IsExitFramesSupported.get -> bool
+Android.Nfc.NfcAdapter.IsPowerSavingModeEnabled.get -> bool
+Android.Nfc.NfcAdapter.IsPowerSavingModeSupported.get -> bool
+Android.Nfc.NfcAdapter.IsReaderModeAnnotationSupported.get -> bool
+Android.Nfc.NfcAdapter.ResetDiscoveryTechnology(Android.App.Activity? activity) -> void
+Android.Nfc.NfcAdapter.SetDiscoveryTechnology(Android.App.Activity? activity, Android.Nfc.NfcReaderFlags pollTechnology, Android.Nfc.NfcListenFlags listenTechnology) -> void
+Android.Nfc.NfcAdapter.SetPowerSavingMode(bool enabled) -> void
+Android.OS.BackportedFixStatus
+Android.OS.BackportedFixStatus.Fixed = 1 -> Android.OS.BackportedFixStatus
+Android.OS.BackportedFixStatus.NotApplicable = 2 -> Android.OS.BackportedFixStatus
+Android.OS.BackportedFixStatus.NotFixed = 3 -> Android.OS.BackportedFixStatus
+Android.OS.BackportedFixStatus.Unknown = 0 -> Android.OS.BackportedFixStatus
+Android.OS.BuildVersionCodes.CinnamonBun = 37 -> Android.OS.BuildVersionCodes
+Android.OS.BuildVersionCodesFull.Baklava1 = 3600001 -> Android.OS.BuildVersionCodesFull
+Android.OS.BuildVersionCodesFull.CinnamonBun = 3700000 -> Android.OS.BuildVersionCodesFull
+Android.OS.Parcel.Marshall(Java.Nio.ByteBuffer! buffer) -> void
+Android.OS.Parcel.Unmarshall(Java.Nio.ByteBuffer! buffer) -> void
+Android.OS.ProfilingManager.AddAllProfilingTriggers() -> void
+Android.OS.ProfilingManager.RequestRunningSystemTrace(string? tag) -> void
+Android.OS.ProfilingTriggerType.Anomaly = 8 -> Android.OS.ProfilingTriggerType
+Android.OS.ProfilingTriggerType.AppCompat = 11 -> Android.OS.ProfilingTriggerType
+Android.OS.ProfilingTriggerType.ColdStart = 10 -> Android.OS.ProfilingTriggerType
+Android.OS.ProfilingTriggerType.KillExcessiveCpuUsage = 9 -> Android.OS.ProfilingTriggerType
+Android.OS.ProfilingTriggerType.TriggerTypeAppRequestRunningTrace = 3 -> Android.OS.ProfilingTriggerType
+Android.OS.ProfilingTriggerType.TriggerTypeKillForceStop = 4 -> Android.OS.ProfilingTriggerType
+Android.OS.ProfilingTriggerType.TriggerTypeKillRecents = 5 -> Android.OS.ProfilingTriggerType
+Android.OS.ProfilingTriggerType.TriggerTypeKillTaskManager = 6 -> Android.OS.ProfilingTriggerType
+Android.OS.ProfilingTriggerType.TriggerTypeOom = 7 -> Android.OS.ProfilingTriggerType
+Android.OS.Storage.FileManager
+Android.OS.Storage.FileManager.EnqueueOperation(Android.OS.Storage.Operations.FileOperationRequest! request) -> Android.OS.Storage.Operations.FileOperationEnqueueResult!
+Android.OS.Storage.FileManager.FetchResult(string! requestId) -> Android.OS.Storage.Operations.FileOperationResult?
+Android.OS.Storage.FileManager.RegisterCompletionListener(string! requestId) -> void
+Android.OS.Storage.FileManager.UnregisterCompletionListener(string! requestId) -> void
+Android.OS.Storage.Operations.FileOperationEnqueueResult
+Android.OS.Storage.Operations.FileOperationEnqueueResult.DescribeContents() -> int
+Android.OS.Storage.Operations.FileOperationEnqueueResult.ErrorCode.get -> int
+Android.OS.Storage.Operations.FileOperationEnqueueResult.InterfaceConsts
+Android.OS.Storage.Operations.FileOperationEnqueueResult.IsSuccessful.get -> bool
+Android.OS.Storage.Operations.FileOperationEnqueueResult.RequestId.get -> string?
+Android.OS.Storage.Operations.FileOperationEnqueueResult.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.OS.Storage.Operations.FileOperationErrorCode
+Android.OS.Storage.Operations.FileOperationErrorCode.Busy = 1 -> Android.OS.Storage.Operations.FileOperationErrorCode
+Android.OS.Storage.Operations.FileOperationErrorCode.DiskFull = 6 -> Android.OS.Storage.Operations.FileOperationErrorCode
+Android.OS.Storage.Operations.FileOperationErrorCode.InvalidRequest = 2 -> Android.OS.Storage.Operations.FileOperationErrorCode
+Android.OS.Storage.Operations.FileOperationErrorCode.None = -1 -> Android.OS.Storage.Operations.FileOperationErrorCode
+Android.OS.Storage.Operations.FileOperationErrorCode.PermissionDenied = 5 -> Android.OS.Storage.Operations.FileOperationErrorCode
+Android.OS.Storage.Operations.FileOperationErrorCode.Unknown = 0 -> Android.OS.Storage.Operations.FileOperationErrorCode
+Android.OS.Storage.Operations.FileOperationErrorCode.UnsupportedSource = 3 -> Android.OS.Storage.Operations.FileOperationErrorCode
+Android.OS.Storage.Operations.FileOperationErrorCode.UnsupportedTarget = 4 -> Android.OS.Storage.Operations.FileOperationErrorCode
+Android.OS.Storage.Operations.FileOperationMode
+Android.OS.Storage.Operations.FileOperationMode.Copy = 2 -> Android.OS.Storage.Operations.FileOperationMode
+Android.OS.Storage.Operations.FileOperationMode.Move = 1 -> Android.OS.Storage.Operations.FileOperationMode
+Android.OS.Storage.Operations.FileOperationRequest
+Android.OS.Storage.Operations.FileOperationRequest.Builder
+Android.OS.Storage.Operations.FileOperationRequest.Builder.Build() -> Android.OS.Storage.Operations.FileOperationRequest!
+Android.OS.Storage.Operations.FileOperationRequest.Builder.Builder(int mode) -> void
+Android.OS.Storage.Operations.FileOperationRequest.Builder.SetRegisterCompletionListener(bool shouldRegister) -> Android.OS.Storage.Operations.FileOperationRequest.Builder!
+Android.OS.Storage.Operations.FileOperationRequest.Builder.SetSource(Android.OS.Storage.Operations.Sources.OperationSource! source) -> Android.OS.Storage.Operations.FileOperationRequest.Builder!
+Android.OS.Storage.Operations.FileOperationRequest.Builder.SetTarget(Android.OS.Storage.Operations.Targets.OperationTarget! target) -> Android.OS.Storage.Operations.FileOperationRequest.Builder!
+Android.OS.Storage.Operations.FileOperationRequest.DescribeContents() -> int
+Android.OS.Storage.Operations.FileOperationRequest.InterfaceConsts
+Android.OS.Storage.Operations.FileOperationRequest.Mode.get -> int
+Android.OS.Storage.Operations.FileOperationRequest.ShouldRegisterCompletionListener() -> bool
+Android.OS.Storage.Operations.FileOperationRequest.Source.get -> Android.OS.Storage.Operations.Sources.OperationSource!
+Android.OS.Storage.Operations.FileOperationRequest.Target.get -> Android.OS.Storage.Operations.Targets.OperationTarget?
+Android.OS.Storage.Operations.FileOperationRequest.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.OS.Storage.Operations.FileOperationResult
+Android.OS.Storage.Operations.FileOperationResult.DescribeContents() -> int
+Android.OS.Storage.Operations.FileOperationResult.ErrorCode.get -> int
+Android.OS.Storage.Operations.FileOperationResult.ErrorMessage.get -> string?
+Android.OS.Storage.Operations.FileOperationResult.FailedPaths.get -> System.Collections.Generic.IList<string!>!
+Android.OS.Storage.Operations.FileOperationResult.InterfaceConsts
+Android.OS.Storage.Operations.FileOperationResult.RequestId.get -> string!
+Android.OS.Storage.Operations.FileOperationResult.Source.get -> Android.OS.Storage.Operations.Sources.OperationSource!
+Android.OS.Storage.Operations.FileOperationResult.Status.get -> int
+Android.OS.Storage.Operations.FileOperationResult.Target.get -> Android.OS.Storage.Operations.Targets.OperationTarget?
+Android.OS.Storage.Operations.FileOperationResult.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.OS.Storage.Operations.FileOperationStatus
+Android.OS.Storage.Operations.FileOperationStatus.Failed = 4 -> Android.OS.Storage.Operations.FileOperationStatus
+Android.OS.Storage.Operations.FileOperationStatus.Finished = 3 -> Android.OS.Storage.Operations.FileOperationStatus
+Android.OS.Storage.Operations.FileOperationStatus.InProgress = 2 -> Android.OS.Storage.Operations.FileOperationStatus
+Android.OS.Storage.Operations.FileOperationStatus.Queued = 1 -> Android.OS.Storage.Operations.FileOperationStatus
+Android.OS.Storage.Operations.FileOperationStatus.Unknown = 0 -> Android.OS.Storage.Operations.FileOperationStatus
+Android.OS.Storage.Operations.Sources.AppDataFileSource
+Android.OS.Storage.Operations.Sources.AppDataFileSource.AppDataFileSource(Java.IO.File! file) -> void
+Android.OS.Storage.Operations.Sources.AppDataFileSource.File.get -> Java.IO.File!
+Android.OS.Storage.Operations.Sources.OperationSource
+Android.OS.Storage.Operations.Sources.OperationSource.OperationSource(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.OS.Storage.Operations.Targets.OperationTarget
+Android.OS.Storage.Operations.Targets.OperationTarget.OperationTarget(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.OS.Storage.Operations.Targets.PccTarget
+Android.OS.Storage.Operations.Targets.PccTarget.PccTarget() -> void
+Android.OS.Storage.Operations.Targets.PccTarget.PccTarget(string! pathPrefix) -> void
+Android.OS.StrictMode.VmPolicy.Builder.DetectImplicitUriPermissionGrant() -> Android.OS.StrictMode.VmPolicy.Builder!
+Android.OS.StrictMode.VmPolicy.Builder.PermitImplicitUriPermissionGrant() -> Android.OS.StrictMode.VmPolicy.Builder!
+Android.OS.VibrationAttributesUsageType.UsageGestureInput = 98 -> Android.OS.VibrationAttributesUsageType
+Android.OS.Vibrators.HapticFeedbackRequest
+Android.OS.Vibrators.HapticFeedbackRequest.Builder
+Android.OS.Vibrators.HapticFeedbackRequest.Builder.Build() -> Android.OS.Vibrators.HapticFeedbackRequest!
+Android.OS.Vibrators.HapticFeedbackRequest.Builder.Builder(Android.OS.Vibrators.HapticFeedbackRequest! request) -> void
+Android.OS.Vibrators.HapticFeedbackRequest.Builder.Builder(int constant) -> void
+Android.OS.Vibrators.HapticFeedbackRequest.Builder.SetFlags(int flags) -> Android.OS.Vibrators.HapticFeedbackRequest.Builder!
+Android.OS.Vibrators.HapticFeedbackRequest.Builder.SetUsage(int usage) -> Android.OS.Vibrators.HapticFeedbackRequest.Builder!
+Android.OS.Vibrators.HapticFeedbackRequest.FeedbackConstant.get -> int
+Android.OS.Vibrators.HapticFeedbackRequest.Flags.get -> int
+Android.OS.Vibrators.HapticFeedbackRequest.Usage.get -> int
+Android.Print.PrinterInfo.Builder.SetSetupIntent(Android.App.PendingIntent! setupIntent) -> Android.Print.PrinterInfo.Builder!
+Android.Provider.CloudMediaProviderContract.Capabilities.Builder.SetAlbumsAsCategoryEnabled(bool enabled) -> Android.Provider.CloudMediaProviderContract.Capabilities.Builder!
+Android.Provider.CloudMediaProviderContract.Capabilities.IsAlbumsAsCategoryEnabled.get -> bool
+Android.Provider.ContactsContract.Settings.AccountAttributes
+Android.Provider.ContactsPickerSessionContract
+Android.Provider.ContactsPickerSessionContract.Session
+Android.Provider.ContactsPickerSessionContract.Session.InterfaceConsts
+Android.Provider.DocumentContractFlags.SupportsRestore = 131072 -> Android.Provider.DocumentContractFlags
+Android.Provider.DocumentContractFlags.SupportsTrash = 65536 -> Android.Provider.DocumentContractFlags
+Android.Provider.DocumentRootFlags.LimitedFunctionalityWhenOffline = 2097152 -> Android.Provider.DocumentRootFlags
+Android.Provider.DocumentRootFlags.SupportsQueryTrash = 1048576 -> Android.Provider.DocumentRootFlags
+Android.Provider.DocumentSyncStateFlags
+Android.Provider.DocumentSyncStateFlags.AvailableLocally = 1 -> Android.Provider.DocumentSyncStateFlags
+Android.Provider.DocumentSyncStateFlags.DownloadError = 32 -> Android.Provider.DocumentSyncStateFlags
+Android.Provider.DocumentSyncStateFlags.DownloadProgress = 8 -> Android.Provider.DocumentSyncStateFlags
+Android.Provider.DocumentSyncStateFlags.LocalChanges = 2 -> Android.Provider.DocumentSyncStateFlags
+Android.Provider.DocumentSyncStateFlags.UploadError = 16 -> Android.Provider.DocumentSyncStateFlags
+Android.Provider.DocumentSyncStateFlags.UploadProgress = 4 -> Android.Provider.DocumentSyncStateFlags
+Android.Provider.MediaStorePickImagesHighlightType
+Android.Provider.MediaStorePickImagesHighlightType.Collapsed = 0 -> Android.Provider.MediaStorePickImagesHighlightType
+Android.Provider.MediaStorePickImagesHighlightType.Expanded = 1 -> Android.Provider.MediaStorePickImagesHighlightType
+Android.Ranging.AntennaMode
+Android.Ranging.AntennaMode.Directional = 1 -> Android.Ranging.AntennaMode
+Android.Ranging.AntennaMode.Omni = 0 -> Android.Ranging.AntennaMode
+Android.Ranging.Ble.BleSpecificData
+Android.Ranging.Ble.BleSpecificData.DelaySpreadMeters.get -> double
+Android.Ranging.Ble.BleSpecificData.DescribeContents() -> int
+Android.Ranging.Ble.BleSpecificData.InterfaceConsts
+Android.Ranging.Ble.BleSpecificData.RemoteTxPowerDbm.get -> int
+Android.Ranging.Ble.BleSpecificData.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.CoordinateType
+Android.Ranging.CoordinateType.Relative = 1 -> Android.Ranging.CoordinateType
+Android.Ranging.CoordinateType.RelativePlusZElement = 3 -> Android.Ranging.CoordinateType
+Android.Ranging.CoordinateType.RelativeWithZGravityAligned = 4 -> Android.Ranging.CoordinateType
+Android.Ranging.CoordinateType.RelativeWithZGravityAlignedPlusZElement = 5 -> Android.Ranging.CoordinateType
+Android.Ranging.CoordinateType.Unknown = 2147483647 -> Android.Ranging.CoordinateType
+Android.Ranging.CoordinateType.Wgs84 = 0 -> Android.Ranging.CoordinateType
+Android.Ranging.CoordinateType.Wgs84PlusZElement = 2 -> Android.Ranging.CoordinateType
+Android.Ranging.DlTdoaMeasurement
+Android.Ranging.DlTdoaMeasurement.ActiveRangingRoundIndexes.get -> System.Collections.Generic.IList<Java.Lang.Integer!>!
+Android.Ranging.DlTdoaMeasurement.AnchorCfo.get -> float
+Android.Ranging.DlTdoaMeasurement.AnchorLocation
+Android.Ranging.DlTdoaMeasurement.AnchorLocation.CoordinateType.get -> int
+Android.Ranging.DlTdoaMeasurement.AnchorLocation.DescribeContents() -> int
+Android.Ranging.DlTdoaMeasurement.AnchorLocation.GetRawBytes() -> byte[]!
+Android.Ranging.DlTdoaMeasurement.AnchorLocation.InterfaceConsts
+Android.Ranging.DlTdoaMeasurement.AnchorLocation.RelativeLocation.get -> Android.Ranging.DlTdoaMeasurement.RelativeLocation?
+Android.Ranging.DlTdoaMeasurement.AnchorLocation.Wgs84Location.get -> Android.Ranging.DlTdoaMeasurement.Wgs84Location?
+Android.Ranging.DlTdoaMeasurement.AnchorLocation.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.DlTdoaMeasurement.AnchorLocation.ZElementExtension.get -> Android.Ranging.DlTdoaMeasurement.ZElementExtension?
+Android.Ranging.DlTdoaMeasurement.AoaAzimuth.get -> float
+Android.Ranging.DlTdoaMeasurement.AoaAzimuthFom.get -> int
+Android.Ranging.DlTdoaMeasurement.AoaElevation.get -> float
+Android.Ranging.DlTdoaMeasurement.AoaElevationFom.get -> int
+Android.Ranging.DlTdoaMeasurement.BlockIndex.get -> int
+Android.Ranging.DlTdoaMeasurement.Cfo.get -> float
+Android.Ranging.DlTdoaMeasurement.DescribeContents() -> int
+Android.Ranging.DlTdoaMeasurement.GetAnchorLocation() -> Android.Ranging.DlTdoaMeasurement.AnchorLocation?
+Android.Ranging.DlTdoaMeasurement.GetRxTimestamp() -> byte[]!
+Android.Ranging.DlTdoaMeasurement.GetTxTimestamp() -> byte[]!
+Android.Ranging.DlTdoaMeasurement.HasSuperclusterId.get -> bool
+Android.Ranging.DlTdoaMeasurement.InitiatorReplyTime.get -> long
+Android.Ranging.DlTdoaMeasurement.InitiatorResponderTof.get -> int
+Android.Ranging.DlTdoaMeasurement.InterfaceConsts
+Android.Ranging.DlTdoaMeasurement.IsTxTimestampInCommonTimeBase.get -> bool
+Android.Ranging.DlTdoaMeasurement.MeasurementVersion.get -> int
+Android.Ranging.DlTdoaMeasurement.MessageControl.get -> int
+Android.Ranging.DlTdoaMeasurement.MessageType.get -> int
+Android.Ranging.DlTdoaMeasurement.Nlos.get -> int
+Android.Ranging.DlTdoaMeasurement.RelativeLocation
+Android.Ranging.DlTdoaMeasurement.RelativeLocation.DescribeContents() -> int
+Android.Ranging.DlTdoaMeasurement.RelativeLocation.GetX() -> int
+Android.Ranging.DlTdoaMeasurement.RelativeLocation.GetY() -> int
+Android.Ranging.DlTdoaMeasurement.RelativeLocation.GetZ() -> int
+Android.Ranging.DlTdoaMeasurement.RelativeLocation.InterfaceConsts
+Android.Ranging.DlTdoaMeasurement.RelativeLocation.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.DlTdoaMeasurement.ResponderReplyTime.get -> long
+Android.Ranging.DlTdoaMeasurement.RoundIndex.get -> int
+Android.Ranging.DlTdoaMeasurement.Rssi.get -> int
+Android.Ranging.DlTdoaMeasurement.SuperclusterId.get -> int
+Android.Ranging.DlTdoaMeasurement.Wgs84Location
+Android.Ranging.DlTdoaMeasurement.Wgs84Location.Altitude.get -> double
+Android.Ranging.DlTdoaMeasurement.Wgs84Location.DescribeContents() -> int
+Android.Ranging.DlTdoaMeasurement.Wgs84Location.InterfaceConsts
+Android.Ranging.DlTdoaMeasurement.Wgs84Location.Latitude.get -> double
+Android.Ranging.DlTdoaMeasurement.Wgs84Location.Longitude.get -> double
+Android.Ranging.DlTdoaMeasurement.Wgs84Location.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.DlTdoaMeasurement.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.DlTdoaMeasurement.ZElementExtension
+Android.Ranging.DlTdoaMeasurement.ZElementExtension.AnchorFloorNumber.get -> double
+Android.Ranging.DlTdoaMeasurement.ZElementExtension.AnchorHeightAboveFloor.get -> double
+Android.Ranging.DlTdoaMeasurement.ZElementExtension.AnchorHeightAboveFloorRange.get -> Android.Util.Range?
+Android.Ranging.DlTdoaMeasurement.ZElementExtension.AnchorHeightAboveFloorUncertainty.get -> int
+Android.Ranging.DlTdoaMeasurement.ZElementExtension.DescribeContents() -> int
+Android.Ranging.DlTdoaMeasurement.ZElementExtension.ExpectedToMove.get -> int
+Android.Ranging.DlTdoaMeasurement.ZElementExtension.InterfaceConsts
+Android.Ranging.DlTdoaMeasurement.ZElementExtension.IsAnchorFloorNumberOutOfRange.get -> bool
+Android.Ranging.DlTdoaMeasurement.ZElementExtension.IsAnchorHeightAboveFloorOutOfRange.get -> bool
+Android.Ranging.DlTdoaMeasurement.ZElementExtension.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.MessageType
+Android.Ranging.MessageType.FinalDtm = 2 -> Android.Ranging.MessageType
+Android.Ranging.MessageType.PollDtm = 0 -> Android.Ranging.MessageType
+Android.Ranging.MessageType.ResponseDtm = 1 -> Android.Ranging.MessageType
+Android.Ranging.MotionState
+Android.Ranging.MotionState.DescribeContents() -> int
+Android.Ranging.MotionState.GetMotionState() -> int
+Android.Ranging.MotionState.InterfaceConsts
+Android.Ranging.MotionState.MotionState(int motionState) -> void
+Android.Ranging.MotionState.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.MovementExpectation
+Android.Ranging.MovementExpectation.Movable = 1 -> Android.Ranging.MovementExpectation
+Android.Ranging.MovementExpectation.Stationary = 0 -> Android.Ranging.MovementExpectation
+Android.Ranging.MovementExpectation.Unknown = 2 -> Android.Ranging.MovementExpectation
+Android.Ranging.Oob.DeviceHandle.BluetoothDevice.get -> Android.Bluetooth.BluetoothDevice?
+Android.Ranging.Oob.DeviceHandle.Builder.SetBluetoothDevice(Android.Bluetooth.BluetoothDevice! bluetoothDevice) -> Android.Ranging.Oob.DeviceHandle.Builder!
+Android.Ranging.Oob.OobInitiatorRangingConfig.Builder.SetRangingTechnologyFilter(System.Collections.Generic.ICollection<Java.Lang.Integer!>! rangingTechnologies) -> Android.Ranging.Oob.OobInitiatorRangingConfig.Builder!
+Android.Ranging.Oob.OobInitiatorRangingConfig.RangingTechnologyFilter.get -> System.Collections.Generic.ICollection<Java.Lang.Integer!>!
+Android.Ranging.RangingCapabilities.WifiPdRangingCapabilities.get -> Android.Ranging.Wifi.PD.WifiPdRangingCapabilities?
+Android.Ranging.RangingData.DistanceStandardDeviationMeters.get -> double
+Android.Ranging.RangingData.HasDistanceStandardDeviation.get -> bool
+Android.Ranging.RangingData.RangingDataExtras.get -> Android.Ranging.RangingDataExtras?
+Android.Ranging.RangingDataExtras
+Android.Ranging.RangingDataExtras.BleSpecificData.get -> Android.Ranging.Ble.BleSpecificData?
+Android.Ranging.RangingDataExtras.DescribeContents() -> int
+Android.Ranging.RangingDataExtras.InterfaceConsts
+Android.Ranging.RangingDataExtras.UwbSpecificData.get -> Android.Ranging.Uwb.UwbSpecificData?
+Android.Ranging.RangingDataExtras.WifiRttSpecificData.get -> Android.Ranging.Wifi.Rtt.WifiRttSpecificData?
+Android.Ranging.RangingDataExtras.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.RangingDevice.Builder.SetDlTdoaUwbAddress(Android.Ranging.Uwb.UwbAddress! dlTdoaUwbAddress) -> Android.Ranging.RangingDevice.Builder!
+Android.Ranging.RangingDevice.DlTdoaUwbAddress.get -> Android.Ranging.Uwb.UwbAddress?
+Android.Ranging.RangingDeviceRole.DeviceRoleDtTag = 2 -> Android.Ranging.RangingDeviceRole
+Android.Ranging.RangingManagerType.WifiPd = 5 -> Android.Ranging.RangingManagerType
+Android.Ranging.RangingManagerType.WifiStaRtt = 4 -> Android.Ranging.RangingManagerType
+Android.Ranging.RangingMotion
+Android.Ranging.RangingMotion.Large = 3 -> Android.Ranging.RangingMotion
+Android.Ranging.RangingMotion.Moderate = 2 -> Android.Ranging.RangingMotion
+Android.Ranging.RangingMotion.NotDetected = 0 -> Android.Ranging.RangingMotion
+Android.Ranging.RangingMotion.Slight = 1 -> Android.Ranging.RangingMotion
+Android.Ranging.RangingSession.ICallback.OnDlTdoaResults(Android.Ranging.RangingDevice! peer, Android.Ranging.DlTdoaMeasurement! measurement) -> void
+Android.Ranging.RangingSession.ICallback.OnMotionReceived(Android.Ranging.RangingDevice! peer, Android.Ranging.MotionState! motion) -> void
+Android.Ranging.Raw.RawDtTagRangingConfig
+Android.Ranging.Raw.RawDtTagRangingConfig.Builder
+Android.Ranging.Raw.RawDtTagRangingConfig.Builder.Build() -> Android.Ranging.Raw.RawDtTagRangingConfig!
+Android.Ranging.Raw.RawDtTagRangingConfig.Builder.Builder(Android.Ranging.Raw.RawRangingDevice! tagDevice) -> void
+Android.Ranging.Raw.RawDtTagRangingConfig.DtTag.get -> Android.Ranging.Raw.RawRangingDevice!
+Android.Ranging.Raw.RawRangingDevice.Builder.SetDlTdoaRangingParams(Android.Ranging.Uwb.DlTdoaRangingParams! params) -> Android.Ranging.Raw.RawRangingDevice.Builder!
+Android.Ranging.Raw.RawRangingDevice.Builder.SetRttStationRangingParams(Android.Ranging.Wifi.Rtt.RttStationRangingParams! params) -> Android.Ranging.Raw.RawRangingDevice.Builder!
+Android.Ranging.Raw.RawRangingDevice.Builder.SetWifiPdRangingParams(Android.Ranging.Wifi.PD.WifiPdRangingParams! params) -> Android.Ranging.Raw.RawRangingDevice.Builder!
+Android.Ranging.Raw.RawRangingDevice.DlTdoaRangingParams.get -> Android.Ranging.Uwb.DlTdoaRangingParams?
+Android.Ranging.Raw.RawRangingDevice.RangingIntervalValues.get -> System.Collections.Generic.IDictionary<Java.Lang.Integer!, Java.Time.Duration!>!
+Android.Ranging.Raw.RawRangingDevice.RttStationRangingParams.get -> Android.Ranging.Wifi.Rtt.RttStationRangingParams?
+Android.Ranging.Raw.RawRangingDevice.WifiPdRangingParams.get -> Android.Ranging.Wifi.PD.WifiPdRangingParams?
+Android.Ranging.SessionConfig.AntennaMode.get -> int
+Android.Ranging.SessionConfig.Builder.SetAntennaMode(int antennaMode) -> Android.Ranging.SessionConfig.Builder!
+Android.Ranging.Uwb.DlTdoaRangingParams
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder.Build() -> Android.Ranging.Uwb.DlTdoaRangingParams!
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder.Builder(int sessionId) -> void
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder.SetComplexChannel(Android.Ranging.Uwb.UwbComplexChannel! complexChannel) -> Android.Ranging.Uwb.DlTdoaRangingParams.Builder!
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder.SetDeviceAddress(Android.Ranging.Uwb.UwbAddress! deviceAddress) -> Android.Ranging.Uwb.DlTdoaRangingParams.Builder!
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder.SetMeasurementVersion(int measurementVersion) -> Android.Ranging.Uwb.DlTdoaRangingParams.Builder!
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder.SetRangingIntervalMillis(int rangingIntervalMs) -> Android.Ranging.Uwb.DlTdoaRangingParams.Builder!
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder.SetRangingRoundIndexes(byte[]! rangingRoundIndexes) -> Android.Ranging.Uwb.DlTdoaRangingParams.Builder!
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder.SetSessionKeyInfo(byte[]! sessionKeyInfo) -> Android.Ranging.Uwb.DlTdoaRangingParams.Builder!
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder.SetSlotDuration(int slotDuration) -> Android.Ranging.Uwb.DlTdoaRangingParams.Builder!
+Android.Ranging.Uwb.DlTdoaRangingParams.Builder.SetSlotsPerRangingRound(int slotsPerRangingRound) -> Android.Ranging.Uwb.DlTdoaRangingParams.Builder!
+Android.Ranging.Uwb.DlTdoaRangingParams.ComplexChannel.get -> Android.Ranging.Uwb.UwbComplexChannel!
+Android.Ranging.Uwb.DlTdoaRangingParams.DescribeContents() -> int
+Android.Ranging.Uwb.DlTdoaRangingParams.DeviceAddress.get -> Android.Ranging.Uwb.UwbAddress!
+Android.Ranging.Uwb.DlTdoaRangingParams.GetRangingRoundIndexes() -> byte[]?
+Android.Ranging.Uwb.DlTdoaRangingParams.GetSessionKeyInfo() -> byte[]?
+Android.Ranging.Uwb.DlTdoaRangingParams.InterfaceConsts
+Android.Ranging.Uwb.DlTdoaRangingParams.MeasurementVersion.get -> int
+Android.Ranging.Uwb.DlTdoaRangingParams.RangingIntervalMillis.get -> int
+Android.Ranging.Uwb.DlTdoaRangingParams.SessionId.get -> int
+Android.Ranging.Uwb.DlTdoaRangingParams.SlotDuration.get -> int
+Android.Ranging.Uwb.DlTdoaRangingParams.SlotsPerRangingRound.get -> int
+Android.Ranging.Uwb.DlTdoaRangingParams.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.Uwb.LineOfSight
+Android.Ranging.Uwb.LineOfSight.Los = 0 -> Android.Ranging.Uwb.LineOfSight
+Android.Ranging.Uwb.LineOfSight.LosUndetermined = 255 -> Android.Ranging.Uwb.LineOfSight
+Android.Ranging.Uwb.LineOfSight.Nlos = 1 -> Android.Ranging.Uwb.LineOfSight
+Android.Ranging.Uwb.MeasurementVersion
+Android.Ranging.Uwb.MeasurementVersion.Unknown = 2147483647 -> Android.Ranging.Uwb.MeasurementVersion
+Android.Ranging.Uwb.MeasurementVersion.v1 = 1 -> Android.Ranging.Uwb.MeasurementVersion
+Android.Ranging.Uwb.MeasurementVersion.v2 = 2 -> Android.Ranging.Uwb.MeasurementVersion
+Android.Ranging.Uwb.UwbRangingCapabilities.IsDlTdoaSupported.get -> bool
+Android.Ranging.Uwb.UwbRangingCapabilities.SupportedAntennaModes.get -> System.Collections.Generic.IList<Java.Lang.Integer!>!
+Android.Ranging.Uwb.UwbSpecificData
+Android.Ranging.Uwb.UwbSpecificData.DescribeContents() -> int
+Android.Ranging.Uwb.UwbSpecificData.InterfaceConsts
+Android.Ranging.Uwb.UwbSpecificData.NonLineOfSight.get -> int
+Android.Ranging.Uwb.UwbSpecificData.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.DescribeContents() -> int
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.Get80211azNtbMinRangingInterval() -> Java.Time.Duration!
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.Get80211mcMinRangingInterval() -> Java.Time.Duration!
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.InterfaceConsts
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.Is80211azNtbSupported() -> bool
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.Is80211mcSupported() -> bool
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.MaxChannelWidth.get -> int
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.MaxPreamble.get -> int
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.ProximityDetectionMacAddress.get -> Android.Net.MacAddress!
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.SupportedDiscoveryChannelFrequenciesMhz.get -> System.Collections.Generic.ICollection<Java.Lang.Integer!>!
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.SupportedPasnModes.get -> System.Collections.Generic.ICollection<Java.Lang.Integer!>!
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.Technology.get -> int
+Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.Wifi.PD.WifiPdRangingParams
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.Build() -> Android.Ranging.Wifi.PD.WifiPdRangingParams!
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.Builder(Android.Net.MacAddress! peerMacAddress) -> void
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.SetChannelWidth(int channelWidth) -> Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder!
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.SetDeviceIk(byte[]? deviceIk) -> Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder!
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.SetDiscoveryChannelFrequencyMhz(int discoveryChannelFrequencyMhz) -> Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder!
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.SetPasnMode(int pasnMode) -> Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder!
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.SetPassword(string? password) -> Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder!
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.SetPreambleType(int preambleType) -> Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder!
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.SetRangingUpdateRate(int rangingUpdateRate) -> Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder!
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.SetResponder80211azNtbSupported(bool isResponder80211azNtbSupported) -> Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder!
+Android.Ranging.Wifi.PD.WifiPdRangingParams.ChannelWidth.get -> int
+Android.Ranging.Wifi.PD.WifiPdRangingParams.DescribeContents() -> int
+Android.Ranging.Wifi.PD.WifiPdRangingParams.DiscoveryChannelFrequencyMhz.get -> int
+Android.Ranging.Wifi.PD.WifiPdRangingParams.GetDeviceIk() -> byte[]?
+Android.Ranging.Wifi.PD.WifiPdRangingParams.InterfaceConsts
+Android.Ranging.Wifi.PD.WifiPdRangingParams.IsResponder80211azNtbSupported.get -> bool
+Android.Ranging.Wifi.PD.WifiPdRangingParams.PasnMode.get -> int
+Android.Ranging.Wifi.PD.WifiPdRangingParams.Password.get -> string?
+Android.Ranging.Wifi.PD.WifiPdRangingParams.PeerMacAddress.get -> Android.Net.MacAddress!
+Android.Ranging.Wifi.PD.WifiPdRangingParams.PreambleType.get -> int
+Android.Ranging.Wifi.PD.WifiPdRangingParams.RangingUpdateRate.get -> int
+Android.Ranging.Wifi.PD.WifiPdRangingParams.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.Wifi.PD.WifiPdRangingPasnMode
+Android.Ranging.Wifi.PD.WifiPdRangingPasnMode.Authenticated = 1 -> Android.Ranging.Wifi.PD.WifiPdRangingPasnMode
+Android.Ranging.Wifi.PD.WifiPdRangingPasnMode.Unauthenticated = 0 -> Android.Ranging.Wifi.PD.WifiPdRangingPasnMode
+Android.Ranging.Wifi.Rtt.RttStationRangingParams
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.Bssid.get -> string!
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.Builder
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.Builder.Build() -> Android.Ranging.Wifi.Rtt.RttStationRangingParams!
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.Builder.Builder(string! bssid) -> void
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.Builder.SetChannelWidth(int channelWidth) -> Android.Ranging.Wifi.Rtt.RttStationRangingParams.Builder!
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.Builder.SetRangingUpdateRate(int updateRate) -> Android.Ranging.Wifi.Rtt.RttStationRangingParams.Builder!
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.ChannelWidth.get -> int
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.DescribeContents() -> int
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.InterfaceConsts
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.RangingUpdateRate.get -> int
+Android.Ranging.Wifi.Rtt.RttStationRangingParams.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Ranging.Wifi.Rtt.WifiRttSpecificData
+Android.Ranging.Wifi.Rtt.WifiRttSpecificData.DescribeContents() -> int
+Android.Ranging.Wifi.Rtt.WifiRttSpecificData.DistanceStandardDeviationMeters.get -> double
+Android.Ranging.Wifi.Rtt.WifiRttSpecificData.GetLci() -> byte[]!
+Android.Ranging.Wifi.Rtt.WifiRttSpecificData.InterfaceConsts
+Android.Ranging.Wifi.Rtt.WifiRttSpecificData.MeasurementBandwidth.get -> int
+Android.Ranging.Wifi.Rtt.WifiRttSpecificData.MeasurementChannelFrequencyMHz.get -> int
+Android.Ranging.Wifi.Rtt.WifiRttSpecificData.NumAttemptedMeasurements.get -> int
+Android.Ranging.Wifi.Rtt.WifiRttSpecificData.NumSuccessfulMeasurements.get -> int
+Android.Ranging.Wifi.Rtt.WifiRttSpecificData.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Runtime.XmlReaderPullParser.GetNamespace(string? prefix) -> string?
+Android.Runtime.XmlReaderPullParser.GetTextCharacters(int[]? holderForStartAndLength) -> char[]!
+Android.Security.DomainEncryptionMode
+Android.Security.DomainEncryptionMode.Disabled = 1 -> Android.Security.DomainEncryptionMode
+Android.Security.DomainEncryptionMode.Enabled = 3 -> Android.Security.DomainEncryptionMode
+Android.Security.DomainEncryptionMode.Opportunistic = 2 -> Android.Security.DomainEncryptionMode
+Android.Security.DomainEncryptionMode.Unknown = 0 -> Android.Security.DomainEncryptionMode
+Android.Security.KeyStoreExceptionError.ErrorTooManyKeys = 18 -> Android.Security.KeyStoreExceptionError
+Android.Service.Autofill.EventType.ResponseDiscarded = 7 -> Android.Service.Autofill.EventType
+Android.Service.Chooser.ChooserManager
+Android.Service.Chooser.ChooserManager.ChooserManager(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Service.Chooser.ChooserSession
+Android.Service.Chooser.ChooserSession.AddStateListener(Java.Util.Concurrent.IExecutor! executor, Android.Service.Chooser.ChooserSession.IStateListener! listener) -> void
+Android.Service.Chooser.ChooserSession.Bounds.get -> Android.Graphics.Rect?
+Android.Service.Chooser.ChooserSession.BoundsChangedEventArgs
+Android.Service.Chooser.ChooserSession.BoundsChangedEventArgs.Bounds.get -> Android.Graphics.Rect!
+Android.Service.Chooser.ChooserSession.BoundsChangedEventArgs.BoundsChangedEventArgs(Android.Graphics.Rect! bounds) -> void
+Android.Service.Chooser.ChooserSession.EndSession() -> void
+Android.Service.Chooser.ChooserSession.IStateListener
+Android.Service.Chooser.ChooserSession.IStateListener.OnBoundsChanged(Android.Graphics.Rect! bounds) -> void
+Android.Service.Chooser.ChooserSession.IStateListener.OnStateChanged(int state) -> void
+Android.Service.Chooser.ChooserSession.InitialRestingBounds.get -> Android.Graphics.Rect?
+Android.Service.Chooser.ChooserSession.RemoveStateListener(Android.Service.Chooser.ChooserSession.IStateListener! listener) -> void
+Android.Service.Chooser.ChooserSession.SetTargetsEnabled(bool isEnabled) -> void
+Android.Service.Chooser.ChooserSession.State.get -> int
+Android.Service.Chooser.ChooserSession.StateChangedEventArgs
+Android.Service.Chooser.ChooserSession.StateChangedEventArgs.State.get -> int
+Android.Service.Chooser.ChooserSession.StateChangedEventArgs.StateChangedEventArgs(int state) -> void
+Android.Service.Chooser.ChooserSession.Token.get -> Android.Service.Chooser.ChooserSessionToken!
+Android.Service.Chooser.ChooserSession.UpdateIntent(Android.Content.Intent! intent) -> void
+Android.Service.Chooser.ChooserSessionState
+Android.Service.Chooser.ChooserSessionState.Closed = 2 -> Android.Service.Chooser.ChooserSessionState
+Android.Service.Chooser.ChooserSessionState.Initialized = 0 -> Android.Service.Chooser.ChooserSessionState
+Android.Service.Chooser.ChooserSessionState.Started = 1 -> Android.Service.Chooser.ChooserSessionState
+Android.Service.Chooser.ChooserSessionToken
+Android.Service.Chooser.ChooserSessionToken.DescribeContents() -> int
+Android.Service.Chooser.ChooserSessionToken.InterfaceConsts
+Android.Service.Chooser.ChooserSessionToken.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Service.Messaging.AlternativeMessageTransportService
+Android.Service.Messaging.AlternativeMessageTransportService.AlternativeMessageTransportService() -> void
+Android.Service.Messaging.AlternativeMessageTransportService.AlternativeMessageTransportService(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Service.Messaging.UpgradeStatus
+Android.Service.Messaging.UpgradeStatus.Accepted = 1 -> Android.Service.Messaging.UpgradeStatus
+Android.Service.Messaging.UpgradeStatus.Rejected = 2 -> Android.Service.Messaging.UpgradeStatus
+Android.Service.Notification.NotificationCancelReason.ReasonBundleDismissed = 24 -> Android.Service.Notification.NotificationCancelReason
+Android.Service.Notification.NotificationListenerService.DeleteConversationNotificationChannel(string! pkg, Android.OS.UserHandle! user, string! channelId) -> void
+Android.Service.Voice.ShowFlags.ShowWithAssistStructureScreenContent = 256 -> Android.Service.Voice.ShowFlags
+Android.Service.Voice.VoiceInteractionService.SetInvocationEffectEnabled(bool enabled) -> void
+Android.Systems.StructDlInfo
+Android.Systems.StructDlInfo.DliFbase.get -> long
+Android.Systems.StructDlInfo.DliFbase.set -> void
+Android.Systems.StructDlInfo.DliFname.get -> string?
+Android.Systems.StructDlInfo.DliFname.set -> void
+Android.Systems.StructDlInfo.DliSaddr.get -> long
+Android.Systems.StructDlInfo.DliSaddr.set -> void
+Android.Systems.StructDlInfo.DliSname.get -> string?
+Android.Systems.StructDlInfo.DliSname.set -> void
+Android.Systems.StructDlInfo.StructDlInfo(string? dli_fname, long dli_fbase, string? dli_sname, long dli_saddr) -> void
+Android.Telecom.AudioProcessingUseCase
+Android.Telecom.AudioProcessingUseCase.AskToHold = 3 -> Android.Telecom.AudioProcessingUseCase
+Android.Telecom.AudioProcessingUseCase.CallScreening = 2 -> Android.Telecom.AudioProcessingUseCase
+Android.Telecom.AudioProcessingUseCase.Unknown = 0 -> Android.Telecom.AudioProcessingUseCase
+Android.Telecom.AudioProcessingUseCase.Voicemail = 1 -> Android.Telecom.AudioProcessingUseCase
+Android.Telecom.Call.AudioProcessingUseCase.get -> int
+Android.Telecom.Call.Transfer(Android.Net.Uri! targetNumber, bool isConfirmationRequired) -> void
+Android.Telecom.Call.Transfer(Android.Telecom.Call! toCall) -> void
+Android.Telecom.CallAttributes.Builder.SetContactUri(Android.Net.Uri! contactUri) -> Android.Telecom.CallAttributes.Builder!
+Android.Telecom.CallAttributes.Builder.SetIsGroupCall(bool isGroupCall) -> Android.Telecom.CallAttributes.Builder!
+Android.Telecom.CallAttributes.Builder.SetLogExcluded(bool isExcluded) -> Android.Telecom.CallAttributes.Builder!
+Android.Telecom.CallAttributes.ContactUri.get -> Android.Net.Uri?
+Android.Telecom.CallAttributes.IsGroupCall.get -> bool
+Android.Telecom.CallAttributes.IsLogExcluded.get -> bool
+Android.Telecom.CallCapability.PropertyRemotelyHosted = 65536 -> Android.Telecom.CallCapability
+Android.Telecom.CallControl.Answer(int callType, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.Telecom.CallControl.RequestVideoState(int callType, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.Telecom.CallControl.SetContactUri(Android.Net.Uri? uri, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.Telecom.CallControl.SetGroupCallState(bool isGroupCall, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+Android.Telecom.CallRedirectionService.PlaceCallToAlternateNumber(Android.Net.Uri! alternateUri, Android.Telecom.PhoneAccountHandle! targetPhoneAccount, bool confirmFirst) -> void
+Android.Telecom.CallType.Messaging = 3 -> Android.Telecom.CallType
+Android.Telecom.Conference.Conferenceables.get -> System.Collections.Generic.IList<Android.Telecom.Conferenceable!>!
+Android.Telecom.Conference.Conferenceables.set -> void
+Android.Telecom.Connection.AudioProcessingUseCase.get -> int
+Android.Telecom.Connection.SetAudioProcessing(int useCase) -> void
+Android.Telecom.Connection.SetSimulatedRinging() -> void
+Android.Telecom.ConnectionCapability.CapabilityTransfer = 134217728 -> Android.Telecom.ConnectionCapability
+Android.Telecom.ConnectionCapability.CapabilityTransferConsultative = 268435456 -> Android.Telecom.ConnectionCapability
+Android.Telecom.ConnectionService.AddConferenceFromConnection(Android.Telecom.Conference! conference, Android.Telecom.Connection! originalConnection) -> void
+Android.Telecom.ConnectionState.SimulatedRinging = 9 -> Android.Telecom.ConnectionState
+Android.Telecom.ConnectionState.StateAudioProcessing = 8 -> Android.Telecom.ConnectionState
+Android.Telecom.CrsMediaType
+Android.Telecom.CrsMediaType.Audio = 1 -> Android.Telecom.CrsMediaType
+Android.Telecom.CrsMediaType.None = 0 -> Android.Telecom.CrsMediaType
+Android.Telecom.CrsMediaType.Video = 2 -> Android.Telecom.CrsMediaType
+Android.Telecom.PhoneAccountCapability.ChangeRttCallToAudioCall = 1048576 -> Android.Telecom.PhoneAccountCapability
+Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.Background = 168 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.DownlinkStreaming = 163 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.Ims = 1 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.Internet = 8 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.IotDelayTolerant = 161 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.IotNonDelayTolerant = 162 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.LcsUserPlanePositioning = 16 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.LowLatencyLossTolerantUnack = 171 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.MissionCriticalCommunications = 169 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.Mms = 2 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.RealTimeInteractive = 166 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.Supl = 4 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.TimeCriticalCommunications = 170 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.UnifiedCommunications = 167 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.Unknown = 0 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.UplinkStreaming = 164 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.ConnectionCapability.VehicularCommunications = 165 -> Android.Telephony.Data.ConnectionCapability
+Android.Telephony.Data.TrafficDescriptor.Builder.SetConnectionCapability(int connectionCapability) -> Android.Telephony.Data.TrafficDescriptor.Builder!
+Android.Telephony.Data.TrafficDescriptor.ConnectionCapability.get -> int
+Android.Telephony.Ims.ImsRegistrationAttributes.FlagRegistrationTypeEmergency.get -> bool
+Android.Telephony.Ims.ImsRegistrationAttributes.FlagVirtualRegistrationForEmergencyCall.get -> bool
+Android.Telephony.Ims.ImsRegistrationAttributes.PcscfAddress.get -> string?
+Android.Telephony.Ims.RegistrationAttributes.RegistrationTypeEmergency = 2 -> Android.Telephony.Ims.RegistrationAttributes
+Android.Telephony.Ims.RegistrationAttributes.VirtualForAnonymousEmergencyCall = 4 -> Android.Telephony.Ims.RegistrationAttributes
+Android.Telephony.NetworkRegistrationInfoServiceType.EmergencySms = 7 -> Android.Telephony.NetworkRegistrationInfoServiceType
+Android.Telephony.ParsedPhoneNumber
+Android.Telephony.ParsedPhoneNumber.DescribeContents() -> int
+Android.Telephony.ParsedPhoneNumber.ErrorCode.get -> int
+Android.Telephony.ParsedPhoneNumber.GetParsedPhoneNumber() -> string!
+Android.Telephony.ParsedPhoneNumber.InterfaceConsts
+Android.Telephony.ParsedPhoneNumber.IsValidPhoneNumber.get -> bool
+Android.Telephony.ParsedPhoneNumber.ParsedPhoneNumber(string! phoneNumber, int errorCode, bool isValidPhoneNumber) -> void
+Android.Telephony.ParsedPhoneNumber.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Telephony.ParsedPhoneNumberErrorType
+Android.Telephony.ParsedPhoneNumberErrorType.FailedToValidateExtractedPhoneNumer = 1 -> Android.Telephony.ParsedPhoneNumberErrorType
+Android.Telephony.ParsedPhoneNumberErrorType.None = 0 -> Android.Telephony.ParsedPhoneNumberErrorType
+Android.Telephony.ParsedPhoneNumberErrorType.NumberParseException = 2 -> Android.Telephony.ParsedPhoneNumberErrorType
+Android.Telephony.ParsedPhoneNumberErrorType.Unknown = -1 -> Android.Telephony.ParsedPhoneNumberErrorType
+Android.Telephony.PhoneNumberManager
+Android.Telephony.PhoneNumberManager.PhoneNumberManager(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Telephony.PhoneNumberSource.Ts43 = 4 -> Android.Telephony.PhoneNumberSource
+Android.Telephony.Satellite.NtnSignalStrength
+Android.Telephony.Satellite.NtnSignalStrength.DescribeContents() -> int
+Android.Telephony.Satellite.NtnSignalStrength.InterfaceConsts
+Android.Telephony.Satellite.NtnSignalStrength.Level.get -> int
+Android.Telephony.Satellite.NtnSignalStrength.NtnSignalStrength(Android.Telephony.Satellite.NtnSignalStrength? source) -> void
+Android.Telephony.Satellite.NtnSignalStrength.WriteToParcel(Android.OS.Parcel! out, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Telephony.Satellite.NtnSignalStrengthLevel
+Android.Telephony.Satellite.NtnSignalStrengthLevel.Good = 3 -> Android.Telephony.Satellite.NtnSignalStrengthLevel
+Android.Telephony.Satellite.NtnSignalStrengthLevel.Great = 4 -> Android.Telephony.Satellite.NtnSignalStrengthLevel
+Android.Telephony.Satellite.NtnSignalStrengthLevel.Moderate = 2 -> Android.Telephony.Satellite.NtnSignalStrengthLevel
+Android.Telephony.Satellite.NtnSignalStrengthLevel.None = 0 -> Android.Telephony.Satellite.NtnSignalStrengthLevel
+Android.Telephony.Satellite.NtnSignalStrengthLevel.Poor = 1 -> Android.Telephony.Satellite.NtnSignalStrengthLevel
+Android.Telephony.SmsResult.ResultSmsSendFailedAfterMaxRetry = 138 -> Android.Telephony.SmsResult
+Android.Telephony.SubscriptionPlan.DataUsageResetTime.get -> Java.Time.ZonedDateTime?
+Android.Telephony.SubscriptionPlan.Id.get -> int
+Android.Telephony.SubscriptionPlan.Types.get -> System.Collections.Generic.ICollection<Java.Lang.Integer!>!
+Android.Telephony.SubscriptionPlanType
+Android.Telephony.SubscriptionPlanType.Business = 8 -> Android.Telephony.SubscriptionPlanType
+Android.Telephony.SubscriptionPlanType.Cellular = 1 -> Android.Telephony.SubscriptionPlanType
+Android.Telephony.SubscriptionPlanType.DataOnly = 6 -> Android.Telephony.SubscriptionPlanType
+Android.Telephony.SubscriptionPlanType.Family = 7 -> Android.Telephony.SubscriptionPlanType
+Android.Telephony.SubscriptionPlanType.Iot = 3 -> Android.Telephony.SubscriptionPlanType
+Android.Telephony.SubscriptionPlanType.Postpaid = 4 -> Android.Telephony.SubscriptionPlanType
+Android.Telephony.SubscriptionPlanType.Prepaid = 5 -> Android.Telephony.SubscriptionPlanType
+Android.Telephony.SubscriptionPlanType.Roaming = 9 -> Android.Telephony.SubscriptionPlanType
+Android.Telephony.SubscriptionPlanType.Satellite = 2 -> Android.Telephony.SubscriptionPlanType
+Android.Telephony.SubscriptionPlanType.Tethering = 10 -> Android.Telephony.SubscriptionPlanType
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnAvailableServicesChangedEventArgs
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnAvailableServicesChangedEventArgs.AvailableServices.get -> int[]!
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnAvailableServicesChangedEventArgs.CarrierRoamingNtnAvailableServicesChangedEventArgs(int[]! availableServices) -> void
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnEligibleStateChangedEventArgs
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnEligibleStateChangedEventArgs.CarrierRoamingNtnEligibleStateChangedEventArgs(bool eligible) -> void
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnEligibleStateChangedEventArgs.Eligible.get -> bool
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnModeChangedEventArgs
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnModeChangedEventArgs.Active.get -> bool
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnModeChangedEventArgs.CarrierRoamingNtnModeChangedEventArgs(bool active) -> void
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnSignalStrengthChangedEventArgs
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnSignalStrengthChangedEventArgs.CarrierRoamingNtnSignalStrengthChangedEventArgs(Android.Telephony.Satellite.NtnSignalStrength! ntnSignalStrength) -> void
+Android.Telephony.TelephonyCallback.CarrierRoamingNtnSignalStrengthChangedEventArgs.NtnSignalStrength.get -> Android.Telephony.Satellite.NtnSignalStrength!
+Android.Telephony.TelephonyCallback.ICarrierRoamingNtnListener
+Android.Telephony.TelephonyCallback.ICarrierRoamingNtnListener.OnCarrierRoamingNtnAvailableServicesChanged(int[]! availableServices) -> void
+Android.Telephony.TelephonyCallback.ICarrierRoamingNtnListener.OnCarrierRoamingNtnEligibleStateChanged(bool eligible) -> void
+Android.Telephony.TelephonyCallback.ICarrierRoamingNtnListener.OnCarrierRoamingNtnModeChanged(bool active) -> void
+Android.Telephony.TelephonyCallback.ICarrierRoamingNtnListener.OnCarrierRoamingNtnSignalStrengthChanged(Android.Telephony.Satellite.NtnSignalStrength! ntnSignalStrength) -> void
+Android.Telephony.TelephonyManagerTtyMode
+Android.Telephony.TelephonyManagerTtyMode.Full = 1 -> Android.Telephony.TelephonyManagerTtyMode
+Android.Telephony.TelephonyManagerTtyMode.Hco = 2 -> Android.Telephony.TelephonyManagerTtyMode
+Android.Telephony.TelephonyManagerTtyMode.Off = 0 -> Android.Telephony.TelephonyManagerTtyMode
+Android.Telephony.TelephonyManagerTtyMode.Vco = 3 -> Android.Telephony.TelephonyManagerTtyMode
+Android.Text.InputType
+Android.Text.InputTypes.TextFlagEnableTextSuggestionSelected = 2097152 -> Android.Text.InputTypes
+Android.Text.ShowSecretsSetting
+Android.Views.Accessibility.AccessibilityCollectionSortDirection
+Android.Views.Accessibility.AccessibilityCollectionSortDirection.Ascending = 1 -> Android.Views.Accessibility.AccessibilityCollectionSortDirection
+Android.Views.Accessibility.AccessibilityCollectionSortDirection.Descending = 2 -> Android.Views.Accessibility.AccessibilityCollectionSortDirection
+Android.Views.Accessibility.AccessibilityCollectionSortDirection.None = 0 -> Android.Views.Accessibility.AccessibilityCollectionSortDirection
+Android.Views.Accessibility.AccessibilityCollectionSortDirection.Other = 3 -> Android.Views.Accessibility.AccessibilityCollectionSortDirection
+Android.Views.Accessibility.AccessibilityEvent.TextChangeTypes.get -> int
+Android.Views.Accessibility.AccessibilityEvent.TextChangeTypes.set -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.CollectionItemInfo.Builder.SetSortDirection(int sortDirection) -> Android.Views.Accessibility.AccessibilityNodeInfo.CollectionItemInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.CollectionItemInfo.SortDirection.get -> int
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Alpha.get -> float
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.BackgroundColor.get -> Android.Graphics.Color
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.Build() -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.Builder() -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.Builder(Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo! info) -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.ClearAlpha() -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.ClearBackgroundColor() -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.ClearHintTextColor() -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.ClearLayoutSize() -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.ClearLinkTextColor() -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.ClearTextColor() -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.ClearTextSizeInPx() -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.ClearTextSizeUnit() -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.SetAlpha(float alpha) -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.SetBackgroundColor(Android.Graphics.Color color) -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.SetHintTextColor(Android.Graphics.Color color) -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.SetLayoutSize(int width, int height) -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.SetLinkTextColor(Android.Graphics.Color color) -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.SetTextColor(Android.Graphics.Color color) -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.SetTextSizeInPx(float textSizeInPx) -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.SetTextSizeUnit(int textSizeUnit) -> Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder!
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.DescribeContents() -> int
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.HintTextColor.get -> Android.Graphics.Color
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.InterfaceConsts
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.LinkTextColor.get -> Android.Graphics.Color
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.TextColor.get -> Android.Graphics.Color
+Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.WriteToParcel(Android.OS.Parcel! parcel, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo
+Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.DescribeContents() -> int
+Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.InterfaceConsts
+Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathInfo(string! tag) -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.Selection
+Android.Views.Accessibility.AccessibilityNodeInfo.Selection.DescribeContents() -> int
+Android.Views.Accessibility.AccessibilityNodeInfo.Selection.End.get -> Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition!
+Android.Views.Accessibility.AccessibilityNodeInfo.Selection.InterfaceConsts
+Android.Views.Accessibility.AccessibilityNodeInfo.Selection.Selection(Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition! start, Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition! end) -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.Selection.Start.get -> Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition!
+Android.Views.Accessibility.AccessibilityNodeInfo.Selection.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.DescribeContents() -> int
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.InterfaceConsts
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.Node.get -> Android.Views.Accessibility.AccessibilityNodeInfo?
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.Offset.get -> int
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.SelectionPosition(Android.Views.Accessibility.AccessibilityNodeInfo! node, int offset) -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.SelectionPosition(Android.Views.View! view, int offset) -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.SelectionPosition(Android.Views.View! view, int virtualDescendantId, int offset) -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.View.get -> Android.Views.View?
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.VirtualDescendantId.get -> int
+Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo
+Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo.StructuredDataInfo(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Views.Accessibility.AccessibilityWindowInfo.Refresh() -> bool
+Android.Views.Accessibility.ContentChangeTypes.ContentChangeTypeSortDirection = 65536 -> Android.Views.Accessibility.ContentChangeTypes
+Android.Views.Accessibility.TextChangeTypes
+Android.Views.Accessibility.TextChangeTypes.CommittedByIme = 2 -> Android.Views.Accessibility.TextChangeTypes
+Android.Views.Accessibility.TextChangeTypes.ConversionSuggestionSelectedByIme = 4 -> Android.Views.Accessibility.TextChangeTypes
+Android.Views.Accessibility.TextChangeTypes.InComposition = 1 -> Android.Views.Accessibility.TextChangeTypes
+Android.Views.Accessibility.TextChangeTypes.Undefined = 0 -> Android.Views.Accessibility.TextChangeTypes
+Android.Views.Autofill.AutofillNoiseInjectedData
+Android.Views.Autofill.AutofillNoiseInjectedData.DescribeContents() -> int
+Android.Views.Autofill.AutofillNoiseInjectedData.GetNoiseInjectedPayload() -> byte[]!
+Android.Views.Autofill.AutofillNoiseInjectedData.InterfaceConsts
+Android.Views.Autofill.AutofillNoiseInjectedData.RetainedBitMask.get -> sbyte
+Android.Views.Autofill.AutofillNoiseInjectedData.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Views.BlurRegion
+Android.Views.BlurRegion.BlurRegion(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Views.BufferTransform.MirrorHorizontalRotate90 = 5 -> Android.Views.BufferTransform
+Android.Views.BufferTransform.MirrorVerticalRotate90 = 6 -> Android.Views.BufferTransform
+Android.Views.FrameRateVelocityPoint
+Android.Views.FrameRateVelocityPoint.DescribeContents() -> int
+Android.Views.FrameRateVelocityPoint.DpPerSecond.get -> float
+Android.Views.FrameRateVelocityPoint.FramePerSecond.get -> float
+Android.Views.FrameRateVelocityPoint.FrameRateVelocityPoint(float framePerSecond, float dpPerSecond) -> void
+Android.Views.FrameRateVelocityPoint.InterfaceConsts
+Android.Views.FrameRateVelocityPoint.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Views.HdrType.HdrTypeHlgPlus = 6 -> Android.Views.HdrType
+Android.Views.IAttachedSurfaceControl.CreateMirror() -> Android.Views.SurfaceControl!
+Android.Views.IViewParent.RequestChildRectangleOnScreen(Android.Views.View! child, Android.Graphics.Rect! rectangle, bool immediate, int source) -> bool
+Android.Views.InputDevice.AssociatedDisplayId.get -> int
+Android.Views.InputMethods.InputMethodSubtype.InputMethodSubtypeBuilder.SetSubtypeShortLabel(string! subtypeShortLabel) -> Android.Views.InputMethods.InputMethodSubtype.InputMethodSubtypeBuilder!
+Android.Views.InputMethods.InputMethodSubtype.SubtypeShortLabel.get -> string?
+Android.Views.InputMethods.InputMethodSubtype.SubtypeShortLabelFormatted.get -> Java.Lang.ICharSequence!
+Android.Views.InputMethods.TextAttribute.Builder.SetTextSuggestionSelected(bool textSuggestionSelected) -> Android.Views.InputMethods.TextAttribute.Builder!
+Android.Views.InputMethods.TextAttribute.IsTextSuggestionSelected.get -> bool
+Android.Views.Keycode.Accessibility = 338 -> Android.Views.Keycode
+Android.Views.Keycode.ContextualInsert = 340 -> Android.Views.Keycode
+Android.Views.Keycode.ContextualSearch = 339 -> Android.Views.Keycode
+Android.Views.PointerCaptureMode
+Android.Views.PointerCaptureMode.Absolute = 1 -> Android.Views.PointerCaptureMode
+Android.Views.PointerCaptureMode.Relative = 2 -> Android.Views.PointerCaptureMode
+Android.Views.PointerCaptureMode.Uncaptured = 0 -> Android.Views.PointerCaptureMode
+Android.Views.RoundedRectBlurRegion
+Android.Views.RoundedRectBlurRegion.Bounds.get -> Android.Graphics.RectF!
+Android.Views.RoundedRectBlurRegion.Bounds.set -> void
+Android.Views.RoundedRectBlurRegion.GetCornerRadii() -> float[]!
+Android.Views.RoundedRectBlurRegion.RoundedRectBlurRegion() -> void
+Android.Views.RoundedRectBlurRegion.RoundedRectBlurRegion(Android.Graphics.RectF! rect, float[]! cornerRadii, float alpha, float blurRadius) -> void
+Android.Views.RoundedRectBlurRegion.SetCornerRadii(float cornerRadius) -> void
+Android.Views.RoundedRectBlurRegion.SetCornerRadii(float[]! cornerRadii) -> void
+Android.Views.SurfaceControlViewHost.LayoutParams
+Android.Views.SurfaceControlViewHost.LayoutParams.LayoutParams(int width, int height, bool focusable) -> void
+Android.Views.SurfaceControlViewHost.LayoutParams.LayoutParams(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Android.Views.View.ICalledFromWrongThreadListener
+Android.Views.View.ICalledFromWrongThreadListener.OnCalledFromWrongThread() -> void
+Android.Views.ViewRectangleOnScreenRequestSource
+Android.Views.ViewRectangleOnScreenRequestSource.InputFocus = 3 -> Android.Views.ViewRectangleOnScreenRequestSource
+Android.Views.ViewRectangleOnScreenRequestSource.ScrollOnly = 1 -> Android.Views.ViewRectangleOnScreenRequestSource
+Android.Views.ViewRectangleOnScreenRequestSource.TextCursor = 2 -> Android.Views.ViewRectangleOnScreenRequestSource
+Android.Views.ViewRectangleOnScreenRequestSource.Undefined = 0 -> Android.Views.ViewRectangleOnScreenRequestSource
+Android.Views.ViewTreeObserver.DispatchOnScrollChanged() -> void
+Android.Webkit.ChromeFileChooserMode.OpenFolder = 2 -> Android.Webkit.ChromeFileChooserMode
+Android.Webkit.PermissionMode
+Android.Webkit.PermissionMode.Read = 0 -> Android.Webkit.PermissionMode
+Android.Webkit.PermissionMode.ReadWrite = 1 -> Android.Webkit.PermissionMode
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder.Builder(Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo! featureInfo) -> void
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder.SetHighlightAlbumId(string! highlightAlbumId) -> Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder!
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder.SetHighlightSearchMediaTextQuery(string! highlightSearchMediaTextQuery) -> Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder!
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder.SetHighlightType(int highlightType) -> Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder!
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder.SetPickerLaunchedInExpandedState(bool launchedPickerInExpandedState) -> Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder!
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder.SetSelectionParams(Android.Widget.PhotoPicker.PhotoPickerSelectionParams? selectionParams) -> Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder!
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder.SetUiCustomizationParams(Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams? uiCustomizationParams) -> Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.Builder!
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.HighlightAlbumId.get -> string!
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.HighlightSearchMediaTextQuery.get -> string!
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.HighlightType.get -> int
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.IsPickerLaunchedInExpandedState.get -> bool
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.SelectionParams.get -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams?
+Android.Widget.PhotoPicker.EmbeddedPhotoPickerFeatureInfo.UiCustomizationParams.get -> Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams?
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.Build() -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.Builder() -> void
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.ClearMaxMediaItemResolution() -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.ClearMaxMediaItemSize() -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.ClearMaxSelectionBatchSize() -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.ClearMaxVideoDuration() -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.ClearMimeTypes() -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.ClearMinMediaItemResolution() -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.ClearMinVideoDuration() -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.SetMaxMediaItemResolutionInPixels(long maxMediaItemResolutionInPixels) -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.SetMaxMediaItemSizeInBytes(long maxMediaItemSizeInBytes) -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.SetMaxSelectionBatchSizeInBytes(long maxSelectionBatchSizeInBytes) -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.SetMaxVideoDuration(Java.Time.Duration! maxVideoDuration) -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.SetMimeTypes(System.Collections.Generic.IList<string!>! mimeTypes) -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.SetMinMediaItemResolutionInPixels(long minMediaItemResolutionInPixels) -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.SetMinVideoDuration(Java.Time.Duration! minVideoDuration) -> Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.DescribeContents() -> int
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.InterfaceConsts
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.MaxMediaItemResolutionInPixels.get -> long
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.MaxMediaItemSizeInBytes.get -> long
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.MaxSelectionBatchSizeInBytes.get -> long
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.MaxVideoDuration.get -> Java.Time.Duration?
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.MimeTypes.get -> System.Collections.Generic.IList<string!>!
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.MinMediaItemResolutionInPixels.get -> long
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.MinVideoDuration.get -> Java.Time.Duration?
+Android.Widget.PhotoPicker.PhotoPickerSelectionParams.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams
+Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.AspectRatio.get -> int
+Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.Builder
+Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.Builder.Build() -> Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams!
+Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.Builder.Builder() -> void
+Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.Builder.SetAspectRatio(int aspectRatio) -> Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.Builder!
+Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.DescribeContents() -> int
+Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.InterfaceConsts
+Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+Android.Widget.Photopicker.AspectRatio
+Android.Widget.Photopicker.AspectRatio.Portrait916 = 1 -> Android.Widget.Photopicker.AspectRatio
+Android.Widget.Photopicker.AspectRatio.Square11 = 0 -> Android.Widget.Photopicker.AspectRatio
+Android.Widget.Photopicker.AspectRatio.Undefined = -1 -> Android.Widget.Photopicker.AspectRatio
+Java.Interop.IAndroidCallableWrapper
+Java.Interop.IAndroidCallableWrapper.RegisterNatives(Java.Interop.JniType! nativeClass) -> void
+Java.Interop.JavaArrayProxy
+Java.Interop.JavaArrayProxy.JavaArrayProxy() -> void
+Java.Interop.JavaPeerAliasesAttribute
+Java.Interop.JavaPeerAliasesAttribute.Aliases.get -> string![]!
+Java.Interop.JavaPeerAliasesAttribute.JavaPeerAliasesAttribute(params string![]! aliases) -> void
+Java.Interop.JavaPeerContainerFactory
+Java.Interop.JavaPeerContainerFactory.JavaPeerContainerFactory() -> void
+Java.Interop.JavaPeerContainerFactory<T>
+Java.Interop.JavaPeerProxy
+Java.Interop.JavaPeerProxy.InvokerType.get -> System.Type?
+Java.Interop.JavaPeerProxy.JavaPeerProxy(string! jniName, System.Type! targetType, System.Type? invokerType) -> void
+Java.Interop.JavaPeerProxy.JniName.get -> string!
+Java.Interop.JavaPeerProxy.TargetType.get -> System.Type!
+Java.Interop.JavaPeerProxy<T>
+Java.Interop.JavaPeerProxy<T>.JavaPeerProxy(string! jniName, System.Type? invokerType) -> void
+Java.Lang.ICharSequence.GetChars(int srcBegin, int srcEnd, char[]! dst, int dstBegin) -> void
+Java.Lang.IllegalCallerException
+Java.Lang.IllegalCallerException.IllegalCallerException() -> void
+Java.Lang.IllegalCallerException.IllegalCallerException(Java.Lang.Throwable? cause) -> void
+Java.Lang.IllegalCallerException.IllegalCallerException(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Java.Lang.IllegalCallerException.IllegalCallerException(string? message, Java.Lang.Throwable? cause) -> void
+Java.Lang.IllegalCallerException.IllegalCallerException(string? s) -> void
+Java.Lang.String.IndexOf(int ch, int beginIndex, int endIndex) -> int
+Java.Lang.String.IndexOf(string! str, int beginIndex, int endIndex) -> int
+Java.Lang.String.SplitWithDelimiters(string! regex, int limit) -> string![]!
+Java.Lang.StringBuffer.GetChars(int srcBegin, int srcEnd, char[]? dst, int dstBegin) -> void
+Java.Lang.StringBuffer.Repeat(Java.Lang.ICharSequence! cs, int count) -> Java.Lang.StringBuffer!
+Java.Lang.StringBuffer.Repeat(int codePoint, int count) -> Java.Lang.StringBuffer!
+Java.Lang.StringBuffer.Repeat(string! cs, int count) -> Java.Lang.StringBuffer!
+Java.Lang.StringBuilder.GetChars(int srcBegin, int srcEnd, char[]? dst, int dstBegin) -> void
+Java.Lang.StringBuilder.Repeat(Java.Lang.ICharSequence! cs, int count) -> Java.Lang.StringBuilder!
+Java.Lang.StringBuilder.Repeat(int codePoint, int count) -> Java.Lang.StringBuilder!
+Java.Lang.StringBuilder.Repeat(string! cs, int count) -> Java.Lang.StringBuilder!
+Java.Lang.Thread.Join(Java.Time.Duration? duration) -> bool
+Java.Lang.WrongThreadException
+Java.Lang.WrongThreadException.WrongThreadException() -> void
+Java.Lang.WrongThreadException.WrongThreadException(Java.Lang.Throwable? cause) -> void
+Java.Lang.WrongThreadException.WrongThreadException(string? message, Java.Lang.Throwable? cause) -> void
+Java.Lang.WrongThreadException.WrongThreadException(string? s) -> void
+Java.Time.Duration.IsPositive.get -> bool
+Java.Util.Streams.Gatherer
+Java.Util.Streams.Gatherers
+Java.Util.Streams.IGatherer
+Java.Util.Streams.IGatherer.AndThen(Java.Util.Streams.IGatherer? that) -> Java.Util.Streams.IGatherer?
+Java.Util.Streams.IGatherer.Combiner() -> Java.Util.Functions.IBinaryOperator?
+Java.Util.Streams.IGatherer.DefaultCombiner() -> Java.Util.Functions.IBinaryOperator?
+Java.Util.Streams.IGatherer.DefaultFinisher() -> Java.Util.Functions.IBiConsumer?
+Java.Util.Streams.IGatherer.DefaultInitializer() -> Java.Util.Functions.ISupplier?
+Java.Util.Streams.IGatherer.Finisher() -> Java.Util.Functions.IBiConsumer?
+Java.Util.Streams.IGatherer.GetIntegrator() -> Java.Util.Streams.IGatherer.IIntegrator?
+Java.Util.Streams.IGatherer.IDownstream
+Java.Util.Streams.IGatherer.IDownstream.IsRejecting.get -> bool
+Java.Util.Streams.IGatherer.IDownstream.Push(Java.Lang.Object? element) -> bool
+Java.Util.Streams.IGatherer.IIntegrator
+Java.Util.Streams.IGatherer.IIntegrator.IGreedy
+Java.Util.Streams.IGatherer.IIntegrator.Integrate(Java.Lang.Object? state, Java.Lang.Object? element, Java.Util.Streams.IGatherer.IDownstream? downstream) -> bool
+Java.Util.Streams.IGatherer.IIntegrator.Of(Java.Util.Streams.IGatherer.IIntegrator? integrator) -> Java.Util.Streams.IGatherer.IIntegrator?
+Java.Util.Streams.IGatherer.IIntegrator.OfGreedy(Java.Util.Streams.IGatherer.IIntegrator.IGreedy? greedy) -> Java.Util.Streams.IGatherer.IIntegrator.IGreedy?
+Java.Util.Streams.IGatherer.Initializer() -> Java.Util.Functions.ISupplier?
+Java.Util.Streams.IGatherer.Integrator
+Java.Util.Streams.IGatherer.Of(Java.Util.Functions.ISupplier? initializer, Java.Util.Streams.IGatherer.IIntegrator? integrator, Java.Util.Functions.IBinaryOperator? combiner, Java.Util.Functions.IBiConsumer? finisher) -> Java.Util.Streams.IGatherer?
+Java.Util.Streams.IGatherer.Of(Java.Util.Streams.IGatherer.IIntegrator? integrator) -> Java.Util.Streams.IGatherer?
+Java.Util.Streams.IGatherer.Of(Java.Util.Streams.IGatherer.IIntegrator? integrator, Java.Util.Functions.IBiConsumer? finisher) -> Java.Util.Streams.IGatherer?
+Java.Util.Streams.IGatherer.OfSequential(Java.Util.Functions.ISupplier? initializer, Java.Util.Streams.IGatherer.IIntegrator? integrator) -> Java.Util.Streams.IGatherer?
+Java.Util.Streams.IGatherer.OfSequential(Java.Util.Functions.ISupplier? initializer, Java.Util.Streams.IGatherer.IIntegrator? integrator, Java.Util.Functions.IBiConsumer? finisher) -> Java.Util.Streams.IGatherer?
+Java.Util.Streams.IGatherer.OfSequential(Java.Util.Streams.IGatherer.IIntegrator? integrator) -> Java.Util.Streams.IGatherer?
+Java.Util.Streams.IGatherer.OfSequential(Java.Util.Streams.IGatherer.IIntegrator? integrator, Java.Util.Functions.IBiConsumer? finisher) -> Java.Util.Streams.IGatherer?
+Microsoft.Android.Runtime.TrimmableTypeMap
+Org.Apache.Http.Impl.Cookie.BasicClientCookie.SetComment(string? comment) -> void
+Org.Apache.Http.Impl.Cookie.BasicClientCookie.SetDomain(string? domain) -> void
+Org.Apache.Http.Impl.Cookie.BasicClientCookie.SetExpiryDate(Java.Util.Date? date) -> void
+Org.Apache.Http.Impl.Cookie.BasicClientCookie.SetPath(string? path) -> void
+Org.Apache.Http.Impl.Cookie.BasicClientCookie.SetValue(string? value) -> void
 REMOVED Xamarin.Android.Net.AndroidClientHandler
 REMOVED Xamarin.Android.Net.AndroidClientHandler.AndroidClientHandler() -> void
 REMOVED Xamarin.Android.Net.AndroidClientHandler.AssertSelf() -> void
@@ -9,8 +2427,8 @@ REMOVED Xamarin.Android.Net.AndroidClientHandler.PreAuthenticationData.set -> vo
 REMOVED Xamarin.Android.Net.AndroidClientHandler.ProxyAuthenticationRequested.get -> bool
 REMOVED Xamarin.Android.Net.AndroidClientHandler.ReadTimeout.get -> System.TimeSpan
 REMOVED Xamarin.Android.Net.AndroidClientHandler.ReadTimeout.set -> void
-REMOVED Xamarin.Android.Net.AndroidClientHandler.RequestedAuthentication.get -> System.Collections.Generic.IList<Xamarin.Android.Net.AuthenticationData!>?
 REMOVED Xamarin.Android.Net.AndroidClientHandler.RequestNeedsAuthorization.get -> bool
+REMOVED Xamarin.Android.Net.AndroidClientHandler.RequestedAuthentication.get -> System.Collections.Generic.IList<Xamarin.Android.Net.AuthenticationData!>?
 REMOVED Xamarin.Android.Net.AndroidClientHandler.TrustedCerts.get -> System.Collections.Generic.IList<Java.Security.Cert.Certificate!>?
 REMOVED Xamarin.Android.Net.AndroidClientHandler.TrustedCerts.set -> void
 REMOVED override Xamarin.Android.Net.AndroidClientHandler.Dispose(bool disposing) -> void
@@ -23,9 +2441,2268 @@ REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.GetJavaProxy(System.Uri
 REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.GetSSLHostnameVerifier(Javax.Net.Ssl.HttpsURLConnection! connection) -> Javax.Net.Ssl.IHostnameVerifier?
 REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.SetupRequest(System.Net.Http.HttpRequestMessage! request, Java.Net.HttpURLConnection! conn) -> System.Threading.Tasks.Task!
 REMOVED virtual Xamarin.Android.Net.AndroidClientHandler.WriteRequestContentToOutput(System.Net.Http.HttpRequestMessage! request, Java.Net.HttpURLConnection! httpConnection, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-Android.App.ApplicationAttribute.EnableOnBackInvokedCallback.get -> bool
-Android.App.ApplicationAttribute.EnableOnBackInvokedCallback.set -> void
-Java.Interop.BaseExportAttribute
-Java.Interop.JavaArrayProxy
+abstract Android.App.PrivateCompute.DataMigrationToPccService.OnMigrationRequested(Java.Util.Functions.IConsumer! callback) -> void
+abstract Android.App.PrivateCompute.PccService.OnReceiveData(Android.OS.Bundle! data, string! packageName) -> void
+abstract Android.Media.Projection.AppContentProjectionService.OnContentRequest(Android.Media.Projection.AppContentRequest! request) -> void
+abstract Android.Media.Projection.AppContentProjectionService.OnContentRequestCanceled() -> void
+abstract Android.Media.Projection.AppContentProjectionService.OnLoopbackProjectionStarted(Android.Media.Projection.AppContentProjectionSession! session, int contentId) -> bool
+abstract Android.Media.Projection.AppContentProjectionService.OnSessionStopped(Android.Media.Projection.AppContentProjectionSession! session) -> void
+abstract Android.OS.Storage.Operations.Sources.OperationSource.ToString() -> string!
+abstract Android.OS.Storage.Operations.Targets.OperationTarget.ToString() -> string!
+abstract Android.Service.Messaging.AlternativeMessageTransportService.OnMessageUpgradeRequested(Android.Net.Uri! contentUri, Java.Util.Functions.IConsumer! upgradeStatus) -> void
+abstract Android.Views.BlurRegion.Copy() -> Android.Views.BlurRegion!
 abstract Java.Interop.JavaArrayProxy.CreateManagedArray(int length) -> System.Array!
 abstract Java.Interop.JavaArrayProxy.GetArrayTypes() -> System.Type![]!
+abstract Java.Interop.JavaPeerProxy.CreateInstance(nint handle, Android.Runtime.JniHandleOwnership transfer) -> Java.Interop.IJavaPeerable?
+abstract Java.Util.Spliterators.AbstractSpliterator.TryAdvance(Java.Util.Functions.IConsumer? action) -> bool
+const Android.App.ActivityManager.AppTask.WindowingLayerNormalApp = Android.App.ActivityManagerAppTaskWindowingLayer.NormalApp -> Android.App.ActivityManagerAppTaskWindowingLayer
+const Android.App.ActivityManager.AppTask.WindowingLayerPinned = Android.App.ActivityManagerAppTaskWindowingLayer.Pinned -> Android.App.ActivityManagerAppTaskWindowingLayer
+const Android.App.ActivityManager.AppTask.WindowingLayerRequestGranted = Android.App.ActivityManagerAppTaskWindowingLayerResult.Granted -> Android.App.ActivityManagerAppTaskWindowingLayerResult
+const Android.App.ActivityManager.AppTask.WindowingLayerRequestRejected = Android.App.ActivityManagerAppTaskWindowingLayerResult.Rejected -> Android.App.ActivityManagerAppTaskWindowingLayerResult
+const Android.App.ActivityManager.AppTask.WindowingLayerUndefined = Android.App.ActivityManagerAppTaskWindowingLayer.Undefined -> Android.App.ActivityManagerAppTaskWindowingLayer
+const Android.App.Admin.DevicePolicyIdentifiers.CrossProfileWidgetProviderPolicy = "crossProfileWidgetProvider" -> string!
+const Android.App.Admin.DevicePolicyIdentifiers.MemoryTaggingPolicy = "memoryTagging" -> string!
+const Android.App.AnrTypes.AnrTypeAppTriggered = Android.App.AnrType.AppTriggered -> Android.App.AnrType
+const Android.App.AnrTypes.AnrTypeApplicationStart = Android.App.AnrType.ApplicationStart -> Android.App.AnrType
+const Android.App.AnrTypes.AnrTypeBroadcastOfIntent = Android.App.AnrType.BroadcastOfIntent -> Android.App.AnrType
+const Android.App.AnrTypes.AnrTypeContentProviderNotResponding = Android.App.AnrType.ContentProviderNotResponding -> Android.App.AnrType
+const Android.App.AnrTypes.AnrTypeExecuteService = Android.App.AnrType.ExecuteService -> Android.App.AnrType
+const Android.App.AnrTypes.AnrTypeForegroundShortServiceTimeout = Android.App.AnrType.ForegroundShortServiceTimeout -> Android.App.AnrType
+const Android.App.AnrTypes.AnrTypeInputDispatch = Android.App.AnrType.InputDispatch -> Android.App.AnrType
+const Android.App.AnrTypes.AnrTypeInputDispatchNoFocusedWindow = Android.App.AnrType.InputDispatchNoFocusedWindow -> Android.App.AnrType
+const Android.App.AnrTypes.AnrTypeJobServiceStart = Android.App.AnrType.JobServiceStart -> Android.App.AnrType
+const Android.App.AnrTypes.AnrTypeOther = Android.App.AnrType.Other -> Android.App.AnrType
+const Android.App.AnrTypes.AnrTypeStartForegroundService = Android.App.AnrType.StartForegroundService -> Android.App.AnrType
+const Android.App.AnrWarningResult.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AnrWarningResult.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppFunctions.AppFunctionActivityId.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppFunctions.AppFunctionActivityId.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppFunctions.AppFunctionActivityState.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppFunctions.AppFunctionActivityState.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppFunctions.AppFunctionManager.AppFunctionStateDefault = Android.App.AppFunctions.AppFunctionEnabledState.Default -> Android.App.AppFunctions.AppFunctionEnabledState
+const Android.App.AppFunctions.AppFunctionManager.AppFunctionStateDisabled = Android.App.AppFunctions.AppFunctionEnabledState.Disabled -> Android.App.AppFunctions.AppFunctionEnabledState
+const Android.App.AppFunctions.AppFunctionManager.AppFunctionStateEnabled = Android.App.AppFunctions.AppFunctionEnabledState.Enabled -> Android.App.AppFunctions.AppFunctionEnabledState
+const Android.App.AppFunctions.AppFunctionMetadata.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppFunctions.AppFunctionMetadata.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppFunctions.AppFunctionMetadata.PropertyEnabledByDefault = "enabledByDefault" -> string!
+const Android.App.AppFunctions.AppFunctionMetadata.PropertyFunctionId = "id" -> string!
+const Android.App.AppFunctions.AppFunctionMetadata.PropertySchemaCategory = "schemaCategory" -> string!
+const Android.App.AppFunctions.AppFunctionMetadata.PropertySchemaName = "schemaName" -> string!
+const Android.App.AppFunctions.AppFunctionMetadata.PropertySchemaVersion = "schemaVersion" -> string!
+const Android.App.AppFunctions.AppFunctionMetadata.PropertyScope = "scope" -> string!
+const Android.App.AppFunctions.AppFunctionMetadata.PropertyValueScopeActivity = "activity" -> string!
+const Android.App.AppFunctions.AppFunctionMetadata.PropertyValueScopeGlobal = "global" -> string!
+const Android.App.AppFunctions.AppFunctionMetadata.ScopeActivity = Android.App.AppFunctions.AppFunctionMetadataScope.Activity -> Android.App.AppFunctions.AppFunctionMetadataScope
+const Android.App.AppFunctions.AppFunctionMetadata.ScopeGlobal = Android.App.AppFunctions.AppFunctionMetadataScope.Global -> Android.App.AppFunctions.AppFunctionMetadataScope
+const Android.App.AppFunctions.AppFunctionName.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppFunctions.AppFunctionName.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppFunctions.AppFunctionPackageMetadata.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppFunctions.AppFunctionPackageMetadata.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppFunctions.AppFunctionPackageMetadata.PropertyTopLevelDocuments = "topLevelMetadataDocuments" -> string!
+const Android.App.AppFunctions.AppFunctionSchemaMetadata.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppFunctions.AppFunctionSchemaMetadata.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppFunctions.AppFunctionSearchSpec.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppFunctions.AppFunctionSearchSpec.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppFunctions.AppFunctionState.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppFunctions.AppFunctionState.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppFunctions.AppFunctionUriGrant.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppFunctions.AppFunctionUriGrant.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppInteractionAttribution.InteractionTypeOther = Android.App.AppInteractionAttributionInteractionType.Other -> Android.App.AppInteractionAttributionInteractionType
+const Android.App.AppInteractionAttribution.InteractionTypeUserQuery = Android.App.AppInteractionAttributionInteractionType.UserQuery -> Android.App.AppInteractionAttributionInteractionType
+const Android.App.AppInteractionAttribution.InteractionTypeUserScheduled = Android.App.AppInteractionAttributionInteractionType.UserScheduled -> Android.App.AppInteractionAttributionInteractionType
+const Android.App.AppInteractionAttribution.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppInteractionAttribution.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppInteractionContract.InterfaceConsts.Count = "_count" -> string!
+const Android.App.AppInteractionContract.InterfaceConsts.Id = "_id" -> string!
+const Android.App.AppSearch.AppSearchResult.ResultUnavailable = Android.App.AppSearch.AppSearchResultCode.Unavailable -> Android.App.AppSearch.AppSearchResultCode
+const Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppSearch.SearchResult.MatchRange.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppSearch.SearchResult.MatchRange.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppSearch.SearchResult.TextMatchInfo.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.AppSearch.SearchResult.TextMatchInfo.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AppSearch.SetSchemaRequest.PrivateComputeCoreUidAccess = Android.App.AppSearch.SchemaRequestPermissions.PrivateComputeCoreUidAccess -> Android.App.AppSearch.SchemaRequestPermissions
+const Android.App.ApplicationExitInfo.AnrInfo.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.ApplicationExitInfo.AnrInfo.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.AutomaticZenRule.TypeTransit = Android.App.AutomaticZenRuleType.Transit -> Android.App.AutomaticZenRuleType
+const Android.App.Backup.BackupAgent.FlagCrossPlatformDataTransferIos = Android.App.Backup.BackupTransportFlags.CrossPlatformDataTransferIos -> Android.App.Backup.BackupTransportFlags
+const Android.App.HandoffActivityData.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.HandoffActivityData.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.HandoffActivityParams.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.HandoffActivityParams.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.Notification.Action.EmphasisAuto = Android.App.ActionEmphasis.Auto -> Android.App.ActionEmphasis
+const Android.App.Notification.Action.EmphasisPrimary = Android.App.ActionEmphasis.Primary -> Android.App.ActionEmphasis
+const Android.App.Notification.Action.EmphasisSecondary = Android.App.ActionEmphasis.Secondary -> Android.App.ActionEmphasis
+const Android.App.Notification.Action.SemanticActionPause = Android.App.SemanticAction.Pause -> Android.App.SemanticAction
+const Android.App.Notification.Action.SemanticActionPlay = Android.App.SemanticAction.Play -> Android.App.SemanticAction
+const Android.App.Notification.Action.SemanticActionStop = Android.App.SemanticAction.Stop -> Android.App.SemanticAction
+const Android.App.Notification.Action.StyleAuto = Android.App.ActionStyle.Auto -> Android.App.ActionStyle
+const Android.App.Notification.Action.StyleIconAndText = Android.App.ActionStyle.IconAndText -> Android.App.ActionStyle
+const Android.App.Notification.Action.StyleIconOnly = Android.App.ActionStyle.IconOnly -> Android.App.ActionStyle
+const Android.App.Notification.Action.StyleTextOnly = Android.App.ActionStyle.TextOnly -> Android.App.ActionStyle
+const Android.App.Notification.ActionBridgedNotificationPreferences = "android.app.action.BRIDGED_NOTIFICATION_PREFERENCES" -> string!
+const Android.App.Notification.BridgedNotificationMetadata.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.Notification.BridgedNotificationMetadata.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.Notification.ExtraPreferSmallIcon = "android.app.preferSmallIcon" -> string!
+const Android.App.Notification.ExtraRequestPromotedOngoing = "android.requestPromotedOngoing" -> string!
+const Android.App.Notification.Metric.FixedDate.FormatAutomatic = Android.App.FixedDateFormat.Automatic -> Android.App.FixedDateFormat
+const Android.App.Notification.Metric.FixedDate.FormatLongDate = Android.App.FixedDateFormat.LongDate -> Android.App.FixedDateFormat
+const Android.App.Notification.Metric.FixedDate.FormatShortDate = Android.App.FixedDateFormat.ShortDate -> Android.App.FixedDateFormat
+const Android.App.Notification.Metric.TimeDifference.FormatAdaptive = Android.App.TimeDifferenceFormat.Adaptive -> Android.App.TimeDifferenceFormat
+const Android.App.Notification.Metric.TimeDifference.FormatChronometer = Android.App.TimeDifferenceFormat.Chronometer -> Android.App.TimeDifferenceFormat
+const Android.App.Notification.MetricStyle.MetricIndexNone = -1 -> int
+const Android.App.Notification.SemanticStyleCaution = Android.App.NotificationSemanticStyle.Caution -> Android.App.NotificationSemanticStyle
+const Android.App.Notification.SemanticStyleDanger = Android.App.NotificationSemanticStyle.Danger -> Android.App.NotificationSemanticStyle
+const Android.App.Notification.SemanticStyleInfo = Android.App.NotificationSemanticStyle.Info -> Android.App.NotificationSemanticStyle
+const Android.App.Notification.SemanticStyleSafe = Android.App.NotificationSemanticStyle.Safe -> Android.App.NotificationSemanticStyle
+const Android.App.Notification.SemanticStyleUnspecified = Android.App.NotificationSemanticStyle.Unspecified -> Android.App.NotificationSemanticStyle
+const Android.App.PermissionUI.LocationButtonRequest.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.PermissionUI.LocationButtonRequest.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.PermissionUI.LocationButtonSession.TextTypeNearMyPreciseLocation = Android.App.PermissionUI.LocationButtonSessionTextType.NearMyPreciseLocation -> Android.App.PermissionUI.LocationButtonSessionTextType
+const Android.App.PermissionUI.LocationButtonSession.TextTypeNearYourPreciseLocation = Android.App.PermissionUI.LocationButtonSessionTextType.NearYourPreciseLocation -> Android.App.PermissionUI.LocationButtonSessionTextType
+const Android.App.PermissionUI.LocationButtonSession.TextTypeNone = Android.App.PermissionUI.LocationButtonSessionTextType.None -> Android.App.PermissionUI.LocationButtonSessionTextType
+const Android.App.PermissionUI.LocationButtonSession.TextTypePreciseLocation = Android.App.PermissionUI.LocationButtonSessionTextType.PreciseLocation -> Android.App.PermissionUI.LocationButtonSessionTextType
+const Android.App.PermissionUI.LocationButtonSession.TextTypeSharePreciseLocation = Android.App.PermissionUI.LocationButtonSessionTextType.SharePreciseLocation -> Android.App.PermissionUI.LocationButtonSessionTextType
+const Android.App.PermissionUI.LocationButtonSession.TextTypeUsePreciseLocation = Android.App.PermissionUI.LocationButtonSessionTextType.UsePreciseLocation -> Android.App.PermissionUI.LocationButtonSessionTextType
+const Android.App.PrivateCompute.DataMigrationToPccService.MigrationTimeoutMs = 60000 -> long
+const Android.App.PrivateCompute.DataMigrationToPccService.ServiceInterface = "android.app.privatecompute.DataMigrationToPccService" -> string!
+const Android.App.PrivateCompute.MigrationException.ErrorInvocationFailed = Android.App.PrivateCompute.MigrationError.InvocationFailed -> Android.App.PrivateCompute.MigrationError
+const Android.App.PrivateCompute.MigrationException.ErrorTimeout = Android.App.PrivateCompute.MigrationError.Timeout -> Android.App.PrivateCompute.MigrationError
+const Android.App.PrivateCompute.MigrationRequestResult.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.App.PrivateCompute.MigrationRequestResult.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.App.PrivateCompute.MigrationRequestResult.MigrationRequestAccepted = Android.App.PrivateCompute.MigrationStatus.Accepted -> Android.App.PrivateCompute.MigrationStatus
+const Android.App.PrivateCompute.MigrationRequestResult.MigrationRequestRejected = Android.App.PrivateCompute.MigrationStatus.Rejected -> Android.App.PrivateCompute.MigrationStatus
+const Android.App.StatusBarManager.ShowPowerMenuResultDisabled = Android.App.ShowPowerMenuResult.Disabled -> Android.App.ShowPowerMenuResult
+const Android.App.StatusBarManager.ShowPowerMenuResultShowing = Android.App.ShowPowerMenuResult.Showing -> Android.App.ShowPowerMenuResult
+const Android.App.StatusBarManager.ShowPowerMenuResultUnknown = Android.App.ShowPowerMenuResult.Unknown -> Android.App.ShowPowerMenuResult
+const Android.App.VoiceInteractions.VoiceInteractionManager.ReadScreenContextRequestStateGranted = Android.App.VoiceInteractions.ReadScreenContextRequestState.Granted -> Android.App.VoiceInteractions.ReadScreenContextRequestState
+const Android.App.VoiceInteractions.VoiceInteractionManager.ReadScreenContextRequestStateRequestable = Android.App.VoiceInteractions.ReadScreenContextRequestState.Requestable -> Android.App.VoiceInteractions.ReadScreenContextRequestState
+const Android.App.VoiceInteractions.VoiceInteractionManager.ReadScreenContextRequestStateUnrequestable = Android.App.VoiceInteractions.ReadScreenContextRequestState.Unrequestable -> Android.App.VoiceInteractions.ReadScreenContextRequestState
+const Android.Appwidget.AppWidgetEvent.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Appwidget.AppWidgetEvent.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Appwidget.AppWidgetManager.OptionAppwidgetDisplayId = "appWidgetDisplayId" -> string!
+const Android.Bluetooth.BluetoothA2dp.ExtraDisconnectedReason = "android.bluetooth.a2dp.extra.DISCONNECTED_REASON" -> string!
+const Android.Bluetooth.BluetoothA2dp.InterfaceConsts.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.BluetoothCodecType.CodecIdLhdcv5 = 327307049727 -> long
+const Android.Bluetooth.BluetoothCodecType.CodecIdSonyLdac = 2852204031 -> long
+const Android.Bluetooth.BluetoothCsipSetCoordinator.InterfaceConsts.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.BluetoothDevice.BondLossReasonBredrAuthFailure = Android.Bluetooth.BluetoothDeviceBondLossReason.BredrAuthFailure -> Android.Bluetooth.BluetoothDeviceBondLossReason
+const Android.Bluetooth.BluetoothDevice.BondLossReasonBredrIncomingPairing = Android.Bluetooth.BluetoothDeviceBondLossReason.BredrIncomingPairing -> Android.Bluetooth.BluetoothDeviceBondLossReason
+const Android.Bluetooth.BluetoothDevice.BondLossReasonLeEncryptFailure = Android.Bluetooth.BluetoothDeviceBondLossReason.LeEncryptFailure -> Android.Bluetooth.BluetoothDeviceBondLossReason
+const Android.Bluetooth.BluetoothDevice.BondLossReasonLeIncomingPairing = Android.Bluetooth.BluetoothDeviceBondLossReason.LeIncomingPairing -> Android.Bluetooth.BluetoothDeviceBondLossReason
+const Android.Bluetooth.BluetoothDevice.BondLossReasonUnknown = Android.Bluetooth.BluetoothDeviceBondLossReason.Unknown -> Android.Bluetooth.BluetoothDeviceBondLossReason
+const Android.Bluetooth.BluetoothDevice.EncryptionAlgorithmUnknown = Android.Bluetooth.BluetoothDeviceEncryptionAlgorithm.Unknown -> Android.Bluetooth.BluetoothDeviceEncryptionAlgorithm
+const Android.Bluetooth.BluetoothDevice.ExtraBondLossReason = "android.bluetooth.device.extra.BOND_LOSS_REASON" -> string!
+const Android.Bluetooth.BluetoothDevice.ExtraDiscoveryResultType = "android.bluetooth.device.extra.DISCOVERY_RESULT_TYPE" -> string!
+const Android.Bluetooth.BluetoothDevice.ExtraPairingAlgorithm = "android.bluetooth.device.extra.PAIRING_ALGORITHM" -> string!
+const Android.Bluetooth.BluetoothDevice.ExtraPairingContext = "android.bluetooth.device.extra.PAIRING_CONTEXT" -> string!
+const Android.Bluetooth.BluetoothDevice.ExtraUuidLe = "android.bluetooth.device.extra.UUID_LE" -> string!
+const Android.Bluetooth.BluetoothDevice.PairingAlgorithmBredrLegacy = Android.Bluetooth.BluetoothDevicePairingAlgorithm.BredrLegacy -> Android.Bluetooth.BluetoothDevicePairingAlgorithm
+const Android.Bluetooth.BluetoothDevice.PairingAlgorithmBredrSsp = Android.Bluetooth.BluetoothDevicePairingAlgorithm.BredrSsp -> Android.Bluetooth.BluetoothDevicePairingAlgorithm
+const Android.Bluetooth.BluetoothDevice.PairingAlgorithmLeLegacy = Android.Bluetooth.BluetoothDevicePairingAlgorithm.LeLegacy -> Android.Bluetooth.BluetoothDevicePairingAlgorithm
+const Android.Bluetooth.BluetoothDevice.PairingAlgorithmSc = Android.Bluetooth.BluetoothDevicePairingAlgorithm.Sc -> Android.Bluetooth.BluetoothDevicePairingAlgorithm
+const Android.Bluetooth.BluetoothDevice.PairingContextRepairing = 2 -> int
+const Android.Bluetooth.BluetoothDevice.PairingContextUserApprovalRequested = 1 -> int
+const Android.Bluetooth.BluetoothDevice.PairingContextUserParticipationRequested = 0 -> int
+const Android.Bluetooth.BluetoothDevice.PhyLeHdt = Android.Bluetooth.BluetoothPhy.PhyLeHdt -> Android.Bluetooth.BluetoothPhy
+const Android.Bluetooth.BluetoothDevice.PhyLeHdtMask = Android.Bluetooth.BluetoothPhy.PhyLeHdtMask -> Android.Bluetooth.BluetoothPhy
+const Android.Bluetooth.BluetoothGatt.InterfaceConsts.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.BluetoothGatt.SubrateModeBalanced = Android.Bluetooth.GattSubrateMode.Balanced -> Android.Bluetooth.GattSubrateMode
+const Android.Bluetooth.BluetoothGatt.SubrateModeHigh = Android.Bluetooth.GattSubrateMode.High -> Android.Bluetooth.GattSubrateMode
+const Android.Bluetooth.BluetoothGatt.SubrateModeLow = Android.Bluetooth.GattSubrateMode.Low -> Android.Bluetooth.GattSubrateMode
+const Android.Bluetooth.BluetoothGatt.SubrateModeNotUpdated = Android.Bluetooth.GattSubrateMode.NotUpdated -> Android.Bluetooth.GattSubrateMode
+const Android.Bluetooth.BluetoothGatt.SubrateModeOff = Android.Bluetooth.GattSubrateMode.Off -> Android.Bluetooth.GattSubrateMode
+const Android.Bluetooth.BluetoothGatt.SubrateModeSystemUpdate = Android.Bluetooth.GattSubrateMode.SystemUpdate -> Android.Bluetooth.GattSubrateMode
+const Android.Bluetooth.BluetoothGattServer.InterfaceConsts.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.BluetoothHeadset.ExtraDisconnectedReason = "android.bluetooth.headset.extra.DISCONNECTED_REASON" -> string!
+const Android.Bluetooth.BluetoothHeadset.InterfaceConsts.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.BluetoothHealth.InterfaceConsts.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.BluetoothHearingAid.InterfaceConsts.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.BluetoothHidDevice.InterfaceConsts.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.BluetoothLeAudio.InterfaceConsts.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.BluetoothLeAudioCodecConfig.SourceCodecTypeOpusHiRes = Android.Bluetooth.BluetoothLeSourceCodecType.OpusHiRes -> Android.Bluetooth.BluetoothLeSourceCodecType
+const Android.Bluetooth.BluetoothLeAudioCodecConfig.SourceCodecTypeVendorSpecific = Android.Bluetooth.BluetoothLeSourceCodecType.VendorSpecific -> Android.Bluetooth.BluetoothLeSourceCodecType
+const Android.Bluetooth.BluetoothProfile.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.BluetoothStatusCodes.ErrorAvdtpDiscoveryFailed = Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorAvdtpDiscoveryFailed -> Android.Bluetooth.CurrentBluetoothStatusCodes
+const Android.Bluetooth.BluetoothStatusCodes.ErrorInsufficientResources = Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorInsufficientResources -> Android.Bluetooth.CurrentBluetoothStatusCodes
+const Android.Bluetooth.BluetoothStatusCodes.ErrorRfcommConnectionFailed = Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorRfcommConnectionFailed -> Android.Bluetooth.CurrentBluetoothStatusCodes
+const Android.Bluetooth.BluetoothStatusCodes.ErrorRoleSwitchFailed = Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorRoleSwitchFailed -> Android.Bluetooth.CurrentBluetoothStatusCodes
+const Android.Bluetooth.BluetoothStatusCodes.ErrorSdpDiscoveryFailed = Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorSdpDiscoveryFailed -> Android.Bluetooth.CurrentBluetoothStatusCodes
+const Android.Bluetooth.BluetoothStatusCodes.ErrorStreamConnectionFailed = Android.Bluetooth.CurrentBluetoothStatusCodes.ErrorStreamConnectionFailed -> Android.Bluetooth.CurrentBluetoothStatusCodes
+const Android.Bluetooth.IBluetoothProfile.ExtraProfile = "android.bluetooth.profile.extra.PROFILE" -> string!
+const Android.Bluetooth.LE.AdvertisingSetParameters.TxPowerMaxAvailable = Android.Bluetooth.LE.AdvertiseTxPower.MaxAvailable -> Android.Bluetooth.LE.AdvertiseTxPower
+const Android.Bluetooth.LE.ScanSettings.ScanTypeActive = Android.Bluetooth.LE.ScanType.Active -> Android.Bluetooth.LE.ScanType
+const Android.Bluetooth.LE.ScanSettings.ScanTypePassive = Android.Bluetooth.LE.ScanType.Passive -> Android.Bluetooth.LE.ScanType
+const Android.Bluetooth.LE.ScanSettings.ScanTypeUnknown = Android.Bluetooth.LE.ScanType.Unknown -> Android.Bluetooth.LE.ScanType
+const Android.Companion.ActionRequest.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Companion.ActionRequest.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Companion.ActionRequest.OpActivate = Android.Companion.RequestOperation.Activate -> Android.Companion.RequestOperation
+const Android.Companion.ActionRequest.OpDeactivate = Android.Companion.RequestOperation.Deactivate -> Android.Companion.RequestOperation
+const Android.Companion.ActionRequest.RequestNearbyAdvertising = Android.Companion.RequestAction.NearbyAdvertising -> Android.Companion.RequestAction
+const Android.Companion.ActionRequest.RequestNearbyScanning = Android.Companion.RequestAction.NearbyScanning -> Android.Companion.RequestAction
+const Android.Companion.ActionRequest.RequestTransport = Android.Companion.RequestAction.Transport -> Android.Companion.RequestAction
+const Android.Companion.ActionResult.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Companion.ActionResult.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Companion.ActionResult.ResultActivated = Android.Companion.ResultCode.Activated -> Android.Companion.ResultCode
+const Android.Companion.ActionResult.ResultDeactivated = Android.Companion.ResultCode.Deactivated -> Android.Companion.ResultCode
+const Android.Companion.ActionResult.ResultFailedToActivate = Android.Companion.ResultCode.FailedToActivate -> Android.Companion.ResultCode
+const Android.Companion.AssociationRequest.DeviceProfileFitnessTracker = "android.app.role.COMPANION_DEVICE_FITNESS_TRACKER" -> string!
+const Android.Companion.AssociationRequest.DeviceProfileMedical = "android.app.role.COMPANION_DEVICE_MEDICAL" -> string!
+const Android.Companion.AssociationRequest.PermissionGroupNearby = "NEARBY_DEVICES" -> string!
+const Android.Companion.CompanionDeviceManager.FlagAirplaneMode = Android.Companion.SystemDataSyncFlags.AirplaneMode -> Android.Companion.SystemDataSyncFlags
+const Android.Companion.CompanionDeviceManager.FlagTaskContinuity = Android.Companion.SystemDataSyncFlags.TaskContinuity -> Android.Companion.SystemDataSyncFlags
+const Android.Companion.CompanionDeviceManager.FlagUniversalModes = Android.Companion.SystemDataSyncFlags.UniversalModes -> Android.Companion.SystemDataSyncFlags
+const Android.Companion.DevicePresenceEvent.EventAssociationRemoved = Android.Companion.DevicePresenceEventType.EventAssociationRemoved -> Android.Companion.DevicePresenceEventType
+const Android.Companion.DevicePresenceEvent.EventSelfManagedNearby = Android.Companion.DevicePresenceEventType.Nearby -> Android.Companion.DevicePresenceEventType
+const Android.Companion.DevicePresenceEvent.EventSelfManagedNotNearby = Android.Companion.DevicePresenceEventType.NotNearby -> Android.Companion.DevicePresenceEventType
+const Android.Content.Context.AutofillService = "autofill" -> string!
+const Android.Content.Context.ChooserService = "chooser" -> string!
+const Android.Content.Context.FileService = "file" -> string!
+const Android.Content.Context.NpuService = "npu" -> string!
+const Android.Content.Context.PccSandboxService = "pcc_sandbox" -> string!
+const Android.Content.Context.SerialService = "serial" -> string!
+const Android.Content.Context.TelephonyPhoneNumberService = "telephony_phone_number" -> string!
+const Android.Content.Context.WebAppService = "web_app" -> string!
+const Android.Content.Intent.ActionOpenEyeDropper = "android.intent.action.OPEN_EYE_DROPPER" -> string!
+const Android.Content.Intent.ActionStopVoiceCommand = "android.intent.action.STOP_VOICE_COMMAND" -> string!
+const Android.Content.Intent.ActionTimezoneOffsetChanged = "android.intent.action.TIMEZONE_OFFSET_CHANGED" -> string!
+const Android.Content.Intent.ExtraAssistDisplayId = "android.intent.extra.ASSIST_DISPLAY_ID" -> string!
+const Android.Content.Intent.ExtraColor = "android.intent.extra.COLOR" -> string!
+const Android.Content.Intent.ExtraNewTimezoneOffset = "android.intent.extra.NEW_TIMEZONE_OFFSET" -> string!
+const Android.Content.Intent.ExtraOldTimezoneOffset = "android.intent.extra.OLD_TIMEZONE_OFFSET" -> string!
+const Android.Content.Intent.ExtraUseSystemContactsPicker = "android.intent.extra.USE_SYSTEM_CONTACTS_PICKER" -> string!
+const Android.Content.PM.PackageInfo.RequestedPermissionOnlyForLocationButton = Android.Content.PM.RequestedPermission.OnlyForLocationButton -> Android.Content.PM.RequestedPermission
+const Android.Content.PM.PackageInstaller.DeveloperVerificationFailedReasonDeveloperBlocked = Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason.DeveloperBlocked -> Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason
+const Android.Content.PM.PackageInstaller.DeveloperVerificationFailedReasonNetworkUnavailable = Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason.NetworkUnavailable -> Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason
+const Android.Content.PM.PackageInstaller.DeveloperVerificationFailedReasonUnknown = Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason.Unknown -> Android.Content.PM.PackageInstallerDeveloperVerificationFailedReason
+const Android.Content.PM.PackageInstaller.ExtraDeveloperVerificationExtensionResponse = "android.content.pm.extra.DEVELOPER_VERIFICATION_EXTENSION_RESPONSE" -> string!
+const Android.Content.PM.PackageInstaller.ExtraDeveloperVerificationFailureReason = "android.content.pm.extra.DEVELOPER_VERIFICATION_FAILURE_REASON" -> string!
+const Android.Content.PM.PackageInstaller.ExtraDeveloperVerificationLitePerformed = "android.content.pm.extra.DEVELOPER_VERIFICATION_LITE_PERFORMED" -> string!
+const Android.Content.PM.PackageManager.FeatureDeviceIdAttestation = "android.software.device_id_attestation" -> string!
+const Android.Content.PM.PackageManager.FeatureNeuralProcessingUnit = "android.hardware.npu" -> string!
+const Android.Content.PM.PackageManager.PropertyNativeServiceFunctionName = "android.app.PROPERTY_NATIVE_SERVICE_FUNCTION_NAME" -> string!
+const Android.Content.PM.PackageManager.PropertyNativeServiceLibraryName = "android.app.PROPERTY_NATIVE_SERVICE_LIBRARY_NAME" -> string!
+const Android.Content.PM.PermissionInfo.FlagAllowedInPrivateComputeCore = Android.Content.PM.PermissionInfoFlags.AllowedInPrivateComputeCore -> Android.Content.PM.PermissionInfoFlags
+const Android.Content.PM.ServiceInfo.FlagNativeService = Android.Content.PM.ServiceInfoFlags.NativeService -> Android.Content.PM.ServiceInfoFlags
+const Android.Content.PM.Webapp.WebAppInstallRequest.ResultCancelledByUser = Android.Content.PM.Webapp.WebAppInstallResultCode.CancelledByUser -> Android.Content.PM.Webapp.WebAppInstallResultCode
+const Android.Content.PM.Webapp.WebAppInstallRequest.ResultDuplicatedRequest = Android.Content.PM.Webapp.WebAppInstallResultCode.DuplicatedRequest -> Android.Content.PM.Webapp.WebAppInstallResultCode
+const Android.Content.PM.Webapp.WebAppInstallRequest.ResultInternalError = Android.Content.PM.Webapp.WebAppInstallResultCode.InternalError -> Android.Content.PM.Webapp.WebAppInstallResultCode
+const Android.Content.PM.Webapp.WebAppInstallRequest.ResultInvalidArguments = Android.Content.PM.Webapp.WebAppInstallResultCode.InvalidArguments -> Android.Content.PM.Webapp.WebAppInstallResultCode
+const Android.Content.PM.Webapp.WebAppInstallRequest.ResultNetworkError = Android.Content.PM.Webapp.WebAppInstallResultCode.NetworkError -> Android.Content.PM.Webapp.WebAppInstallResultCode
+const Android.Content.PM.Webapp.WebAppInstallRequest.ResultPermissionDenied = Android.Content.PM.Webapp.WebAppInstallResultCode.PermissionDenied -> Android.Content.PM.Webapp.WebAppInstallResultCode
+const Android.Content.PM.Webapp.WebAppInstallRequest.ResultSecurityError = Android.Content.PM.Webapp.WebAppInstallResultCode.SecurityError -> Android.Content.PM.Webapp.WebAppInstallResultCode
+const Android.Content.PM.Webapp.WebAppInstallRequest.ResultSuccess = Android.Content.PM.Webapp.WebAppInstallResultCode.Success -> Android.Content.PM.Webapp.WebAppInstallResultCode
+const Android.Content.PM.Webapp.WebAppInstallRequest.ResultUnavailable = Android.Content.PM.Webapp.WebAppInstallResultCode.Unavailable -> Android.Content.PM.Webapp.WebAppInstallResultCode
+const Android.Content.PM.Webapp.WebAppInstallRequest.ResultUnknown = Android.Content.PM.Webapp.WebAppInstallResultCode.Unknown -> Android.Content.PM.Webapp.WebAppInstallResultCode
+const Android.Content.PM.Webapp.WebAppQueryRequest.ResultInstalled = Android.Content.PM.Webapp.WebAppQueryResultCode.Installed -> Android.Content.PM.Webapp.WebAppQueryResultCode
+const Android.Content.PM.Webapp.WebAppQueryRequest.ResultInternalError = Android.Content.PM.Webapp.WebAppQueryResultCode.InternalError -> Android.Content.PM.Webapp.WebAppQueryResultCode
+const Android.Content.PM.Webapp.WebAppQueryRequest.ResultNotInstalled = Android.Content.PM.Webapp.WebAppQueryResultCode.NotInstalled -> Android.Content.PM.Webapp.WebAppQueryResultCode
+const Android.Content.PM.Webapp.WebAppQueryRequest.ResultPermissionDenied = Android.Content.PM.Webapp.WebAppQueryResultCode.PermissionDenied -> Android.Content.PM.Webapp.WebAppQueryResultCode
+const Android.Content.PM.Webapp.WebAppQueryRequest.ResultUnavailable = Android.Content.PM.Webapp.WebAppQueryResultCode.Unavailable -> Android.Content.PM.Webapp.WebAppQueryResultCode
+const Android.Content.PM.Webapp.WebAppQueryRequest.ResultUnknown = Android.Content.PM.Webapp.WebAppQueryResultCode.Unknown -> Android.Content.PM.Webapp.WebAppQueryResultCode
+const Android.DeviceLock.DeviceId.DeviceIdTypeSerialNumber = Android.DeviceLock.DeviceIdType.DeviceIdTypeSerialNumber -> Android.DeviceLock.DeviceIdType
+const Android.DeviceLock.DeviceLockManager.ExtraDeviceLockVersion = "android.devicelock.extra.DEVICE_LOCK_VERSION" -> string!
+const Android.Graphics.Drawables.GradientDrawable.Arc = Android.Graphics.Drawables.ShapeType.Arc -> Android.Graphics.Drawables.ShapeType
+const Android.Graphics.ImageFormat.Raw14 = Android.Graphics.ImageFormatType.Raw14 -> Android.Graphics.ImageFormatType
+const Android.Graphics.Pdf.Component.PdfAnnotationType.Freetext = Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum.Freetext -> Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum
+const Android.Graphics.Pdf.Component.PdfAnnotationType.Highlight = Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum.Highlight -> Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum
+const Android.Graphics.Pdf.Component.PdfAnnotationType.Stamp = Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum.Stamp -> Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum
+const Android.Graphics.Pdf.Component.PdfAnnotationType.Unknown = Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum.Unknown -> Android.Graphics.Pdf.Component.PdfAnnotationTypeEnum
+const Android.Graphics.Pdf.Component.PdfPageObjectType.Image = Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum.Image -> Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum
+const Android.Graphics.Pdf.Component.PdfPageObjectType.Path = Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum.Path -> Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum
+const Android.Graphics.Pdf.Component.PdfPageObjectType.Text = Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum.Text -> Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum
+const Android.Graphics.Pdf.Component.PdfPageObjectType.Unknown = Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum.Unknown -> Android.Graphics.Pdf.Component.PdfPageObjectTypeEnum
+const Android.Graphics.Pdf.Component.PdfPagePathObject.RenderModeFill = Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode.Fill -> Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode
+const Android.Graphics.Pdf.Component.PdfPagePathObject.RenderModeFillStroke = Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode.FillStroke -> Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode
+const Android.Graphics.Pdf.Component.PdfPagePathObject.RenderModeStroke = Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode.Stroke -> Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode
+const Android.Graphics.Pdf.Component.PdfPagePathObject.RenderModeUnknown = Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode.Unknown -> Android.Graphics.Pdf.Component.PdfPagePathObjectRenderMode
+const Android.Graphics.Pdf.Component.PdfPageTextObject.RenderModeFill = Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode.Fill -> Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode
+const Android.Graphics.Pdf.Component.PdfPageTextObject.RenderModeFillStroke = Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode.FillStroke -> Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode
+const Android.Graphics.Pdf.Component.PdfPageTextObject.RenderModeStroke = Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode.Stroke -> Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode
+const Android.Graphics.Pdf.Component.PdfPageTextObject.RenderModeUnknown = Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode.Unknown -> Android.Graphics.Pdf.Component.PdfPageTextObjectRenderMode
+const Android.Graphics.Pdf.Component.PdfPageTextObjectFont.FontFamilyCourier = Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily.Courier -> Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily
+const Android.Graphics.Pdf.Component.PdfPageTextObjectFont.FontFamilyHelvetica = Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily.Helvetica -> Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily
+const Android.Graphics.Pdf.Component.PdfPageTextObjectFont.FontFamilySymbol = Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily.Symbol -> Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily
+const Android.Graphics.Pdf.Component.PdfPageTextObjectFont.FontFamilyTimesNewRoman = Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily.TimesNewRoman -> Android.Graphics.Pdf.Component.PdfPageTextObjectFontFamily
+const Android.Graphics.Pdf.RenderParams.FlagRenderFreetextAnnotations = Android.Graphics.Pdf.RenderParamsRenderFlag.FlagRenderFreetextAnnotations -> Android.Graphics.Pdf.RenderParamsRenderFlag
+const Android.Graphics.Pdf.RenderParams.FlagRenderStampAnnotations = Android.Graphics.Pdf.RenderParamsRenderFlag.FlagRenderStampAnnotations -> Android.Graphics.Pdf.RenderParamsRenderFlag
+const Android.Graphics.Pdf.RenderParams.RenderFormContentDefault = Android.Graphics.Pdf.RenderParamsRenderFormContentMode.Default -> Android.Graphics.Pdf.RenderParamsRenderFormContentMode
+const Android.Graphics.Pdf.RenderParams.RenderFormContentDisabled = Android.Graphics.Pdf.RenderParamsRenderFormContentMode.Disabled -> Android.Graphics.Pdf.RenderParamsRenderFormContentMode
+const Android.Graphics.Pdf.RenderParams.RenderFormContentEnabled = Android.Graphics.Pdf.RenderParamsRenderFormContentMode.Enabled -> Android.Graphics.Pdf.RenderParamsRenderFormContentMode
+const Android.Hardware.Biometrics.BiometricManager.IconTypeAccount = Android.Hardware.Biometrics.BiometricManagerIconType.Account -> Android.Hardware.Biometrics.BiometricManagerIconType
+const Android.Hardware.Biometrics.BiometricManager.IconTypeGeneric = Android.Hardware.Biometrics.BiometricManagerIconType.Generic -> Android.Hardware.Biometrics.BiometricManagerIconType
+const Android.Hardware.Biometrics.BiometricManager.IconTypeMessage = Android.Hardware.Biometrics.BiometricManagerIconType.Message -> Android.Hardware.Biometrics.BiometricManagerIconType
+const Android.Hardware.Biometrics.BiometricManager.IconTypePassword = Android.Hardware.Biometrics.BiometricManagerIconType.Password -> Android.Hardware.Biometrics.BiometricManagerIconType
+const Android.Hardware.Biometrics.BiometricManager.IconTypeQrCode = Android.Hardware.Biometrics.BiometricManagerIconType.QrCode -> Android.Hardware.Biometrics.BiometricManagerIconType
+const Android.Hardware.Biometrics.BiometricManager.IconTypeReset = Android.Hardware.Biometrics.BiometricManagerIconType.Reset -> Android.Hardware.Biometrics.BiometricManagerIconType
+const Android.Hardware.Biometrics.BiometricManager.IconTypeSetting = Android.Hardware.Biometrics.BiometricManagerIconType.Setting -> Android.Hardware.Biometrics.BiometricManagerIconType
+const Android.Hardware.Biometrics.BiometricManager.IconTypeSupervised = Android.Hardware.Biometrics.BiometricManagerIconType.Supervised -> Android.Hardware.Biometrics.BiometricManagerIconType
+const Android.Hardware.Biometrics.FallbackOption.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Hardware.Biometrics.FallbackOption.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Hardware.Camera2.CameraMetadata.InfoDeviceTypeBuiltIn = 0 -> int
+const Android.Hardware.Camera2.CameraMetadata.InfoDeviceTypeExternal = 1 -> int
+const Android.Hardware.Camera2.CameraMetadata.InfoDeviceTypeUnknown = 3 -> int
+const Android.Hardware.Camera2.CameraMetadata.InfoDeviceTypeVirtual = 2 -> int
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.DolbyVision10bHdrOemPoSmpte209450 = 1048576 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.DolbyVision10bHdrOemSmpte209450 = 524288 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.DolbyVision10bHdrRefPoSmpte209450 = 262144 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.DolbyVision10bHdrRefSmpte209450 = 131072 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.DolbyVision8bHdrOemPoSmpte209450 = 16777216 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.DolbyVision8bHdrOemSmpte209450 = 8388608 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.DolbyVision8bHdrRefPoSmpte209450 = 4194304 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.DolbyVision8bHdrRefSmpte209450 = 2097152 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.Hdr10PlusSmpte209450 = 65536 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.Hdr10Smpte209450 = 32768 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.Hlg10Smpte209450 = 16384 -> long
+const Android.Hardware.Camera2.Params.DynamicRangeProfiles.StandardSmpte209450 = 8192 -> long
+const Android.Hardware.DataSpace.DataspaceDisplayBt2020 = Android.Hardware.DataSpaceType.DisplayBt2020 -> Android.Hardware.DataSpaceType
+const Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Hardware.Display.DeviceProductInfo.VideoInputTypeAnalog = Android.Hardware.Display.VideoInputType.Analog -> Android.Hardware.Display.VideoInputType
+const Android.Hardware.Display.DeviceProductInfo.VideoInputTypeDigital = Android.Hardware.Display.VideoInputType.Digital -> Android.Hardware.Display.VideoInputType
+const Android.Hardware.Display.DeviceProductInfo.VideoInputTypeUnknown = Android.Hardware.Display.VideoInputType.Unknown -> Android.Hardware.Display.VideoInputType
+const Android.Hardware.Display.DisplayManager.BrightnessUnitPercentage = Android.Hardware.Display.DisplayBrightnessUnit.Percentage -> Android.Hardware.Display.DisplayBrightnessUnit
+const Android.Hardware.Display.DisplayManager.DisplayCategoryBuiltInDisplays = "android.hardware.display.category.BUILT_IN_DISPLAYS" -> string!
+const Android.Hardware.Display.DisplayManager.EventTypeDisplayBrightness = 32 -> long
+const Android.Hardware.Display.DisplayTopology.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Hardware.Display.DisplayTopology.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Hardware.HardwareBuffer.Bgra1010102 = Android.Hardware.HardwareBufferFormat.Bgra1010102 -> Android.Hardware.HardwareBufferFormat
+const Android.Hardware.HardwareBuffer.Bgrx1010102 = Android.Hardware.HardwareBufferFormat.Bgrx1010102 -> Android.Hardware.HardwareBufferFormat
+const Android.Hardware.HardwareBuffer.R12 = Android.Hardware.HardwareBufferFormat.R12 -> Android.Hardware.HardwareBufferFormat
+const Android.Hardware.HardwareBuffer.R14 = Android.Hardware.HardwareBufferFormat.R14 -> Android.Hardware.HardwareBufferFormat
+const Android.Hardware.HardwareBuffer.Rg1212 = Android.Hardware.HardwareBufferFormat.Rg1212 -> Android.Hardware.HardwareBufferFormat
+const Android.Hardware.HardwareBuffer.Rg1414 = Android.Hardware.HardwareBufferFormat.Rg1414 -> Android.Hardware.HardwareBufferFormat
+const Android.Hardware.HardwareBuffer.Rgba12121212 = Android.Hardware.HardwareBufferFormat.Rgba12121212 -> Android.Hardware.HardwareBufferFormat
+const Android.Hardware.HardwareBuffer.Rgba14141414 = Android.Hardware.HardwareBufferFormat.Rgba14141414 -> Android.Hardware.HardwareBufferFormat
+const Android.Hardware.Lights.ColorSequence.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Hardware.Lights.ColorSequence.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Hardware.Lights.ColorSequence.InterpolationModeLinear = Android.Hardware.Lights.InterpolationMode.Linear -> Android.Hardware.Lights.InterpolationMode
+const Android.Hardware.Lights.ColorSequence.InterpolationModeNone = Android.Hardware.Lights.InterpolationMode.None -> Android.Hardware.Lights.InterpolationMode
+const Android.Hardware.Lights.Light.LightCapabilityAnimation = Android.Hardware.Lights.LightCapability.Animation -> Android.Hardware.Lights.LightCapability
+const Android.Hardware.Lights.Light.LightTypeApplication = Android.Hardware.Lights.LightType.Application -> Android.Hardware.Lights.LightType
+const Android.Hardware.Lights.MultiLightEffect.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Hardware.Lights.MultiLightEffect.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Hardware.Serial.SerialPort.InvalidId = -1 -> int
+const Android.Hardware.Serial.SerialPort.OpenFlagDataSync = Android.Hardware.Serial.OpenFlags.DataSync -> Android.Hardware.Serial.OpenFlags
+const Android.Hardware.Serial.SerialPort.OpenFlagNonblock = Android.Hardware.Serial.OpenFlags.Nonblock -> Android.Hardware.Serial.OpenFlags
+const Android.Hardware.Serial.SerialPort.OpenFlagReadOnly = Android.Hardware.Serial.OpenFlags.ReadOnly -> Android.Hardware.Serial.OpenFlags
+const Android.Hardware.Serial.SerialPort.OpenFlagReadWrite = Android.Hardware.Serial.OpenFlags.ReadWrite -> Android.Hardware.Serial.OpenFlags
+const Android.Hardware.Serial.SerialPort.OpenFlagSync = Android.Hardware.Serial.OpenFlags.Sync -> Android.Hardware.Serial.OpenFlags
+const Android.Hardware.Serial.SerialPort.OpenFlagWriteOnly = Android.Hardware.Serial.OpenFlags.WriteOnly -> Android.Hardware.Serial.OpenFlags
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeAbsinthe = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeAbsinthe -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeBeer = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeBeer -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeBrandy = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeBrandy -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeChuhai = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeChuhai -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeCider = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeCider -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeCocktail = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeCocktail -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeGin = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeGin -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeHighball = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeHighball -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeLager = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeLager -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeMead = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeMead -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeOther = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeOther -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeRum = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeRum -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeSake = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeSake -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeShochu = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeShochu -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeSoju = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeSoju -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeTequila = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeTequila -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeVodka = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeVodka -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeWhiskey = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeWhiskey -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholConsumptionBeverageTypeWine = Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType.AlcoholConsumptionBeverageTypeWine -> Android.Health.Connect.Datatypes.AlcoholConsumptionBeverageType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.RecordTemporalTypeInstant = Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType.Instant -> Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.RecordTemporalTypeInterval = Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType.Interval -> Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType
+const Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.RecordTemporalTypeLocalDate = Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType.LocalDate -> Android.Health.Connect.Datatypes.AlcoholConsumptionTemporalType
+const Android.Health.Connect.DataTypes.Device.DeviceTypeConsumerMedicalDevice = Android.Health.Connect.DataTypes.HealthDeviceType.ConsumerMedicalDevice -> Android.Health.Connect.DataTypes.HealthDeviceType
+const Android.Health.Connect.DataTypes.Device.DeviceTypeFitnessEquipment = Android.Health.Connect.DataTypes.HealthDeviceType.FitnessEquipment -> Android.Health.Connect.DataTypes.HealthDeviceType
+const Android.Health.Connect.DataTypes.Device.DeviceTypeFitnessMachine = Android.Health.Connect.DataTypes.HealthDeviceType.FitnessMachine -> Android.Health.Connect.DataTypes.HealthDeviceType
+const Android.Health.Connect.DataTypes.Device.DeviceTypeGlasses = Android.Health.Connect.DataTypes.HealthDeviceType.Glasses -> Android.Health.Connect.DataTypes.HealthDeviceType
+const Android.Health.Connect.DataTypes.Device.DeviceTypeHearable = Android.Health.Connect.DataTypes.HealthDeviceType.Hearable -> Android.Health.Connect.DataTypes.HealthDeviceType
+const Android.Health.Connect.DataTypes.Device.DeviceTypeMeter = Android.Health.Connect.DataTypes.HealthDeviceType.Meter -> Android.Health.Connect.DataTypes.HealthDeviceType
+const Android.Health.Connect.DataTypes.Device.DeviceTypePortableComputer = Android.Health.Connect.DataTypes.HealthDeviceType.PortableComputer -> Android.Health.Connect.DataTypes.HealthDeviceType
+const Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.PhaseFollicular = Android.Health.Connect.Datatypes.MenstrualCyclePhase.Follicular -> Android.Health.Connect.Datatypes.MenstrualCyclePhase
+const Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.PhaseLuteal = Android.Health.Connect.Datatypes.MenstrualCyclePhase.Luteal -> Android.Health.Connect.Datatypes.MenstrualCyclePhase
+const Android.Health.Connect.DataTypes.SymptomRecord.RecordTemporalTypeInstant = Android.Health.Connect.Datatypes.SymptomRecordTemporalType.Instant -> Android.Health.Connect.Datatypes.SymptomRecordTemporalType
+const Android.Health.Connect.DataTypes.SymptomRecord.RecordTemporalTypeInterval = Android.Health.Connect.Datatypes.SymptomRecordTemporalType.Interval -> Android.Health.Connect.Datatypes.SymptomRecordTemporalType
+const Android.Health.Connect.DataTypes.SymptomRecord.RecordTemporalTypeLocalDate = Android.Health.Connect.Datatypes.SymptomRecordTemporalType.LocalDate -> Android.Health.Connect.Datatypes.SymptomRecordTemporalType
+const Android.Health.Connect.DataTypes.SymptomRecord.SeverityMild = Android.Health.Connect.Datatypes.SymptomSeverity.Mild -> Android.Health.Connect.Datatypes.SymptomSeverity
+const Android.Health.Connect.DataTypes.SymptomRecord.SeverityModerate = Android.Health.Connect.Datatypes.SymptomSeverity.Moderate -> Android.Health.Connect.Datatypes.SymptomSeverity
+const Android.Health.Connect.DataTypes.SymptomRecord.SeveritySevere = Android.Health.Connect.Datatypes.SymptomSeverity.Severe -> Android.Health.Connect.Datatypes.SymptomSeverity
+const Android.Health.Connect.DataTypes.SymptomRecord.SeverityUnspecified = Android.Health.Connect.Datatypes.SymptomSeverity.Unspecified -> Android.Health.Connect.Datatypes.SymptomSeverity
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeAbdominalPain = Android.Health.Connect.Datatypes.SymptomType.AbdominalPain -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeAcne = Android.Health.Connect.Datatypes.SymptomType.Acne -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeBackPain = Android.Health.Connect.Datatypes.SymptomType.BackPain -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeBloating = Android.Health.Connect.Datatypes.SymptomType.Bloating -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeBrainFog = Android.Health.Connect.Datatypes.SymptomType.BrainFog -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeBreastTenderness = Android.Health.Connect.Datatypes.SymptomType.BreastTenderness -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeBrittleNails = Android.Health.Connect.Datatypes.SymptomType.BrittleNails -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeBurningMouth = Android.Health.Connect.Datatypes.SymptomType.BurningMouth -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeChestPain = Android.Health.Connect.Datatypes.SymptomType.ChestPain -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeChestTightness = Android.Health.Connect.Datatypes.SymptomType.ChestTightness -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeChills = Android.Health.Connect.Datatypes.SymptomType.Chills -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeConstipation = Android.Health.Connect.Datatypes.SymptomType.Constipation -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeCough = Android.Health.Connect.Datatypes.SymptomType.Cough -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeCramps = Android.Health.Connect.Datatypes.SymptomType.Cramps -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeCravings = Android.Health.Connect.Datatypes.SymptomType.Cravings -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeDehydration = Android.Health.Connect.Datatypes.SymptomType.Dehydration -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeDiarrhea = Android.Health.Connect.Datatypes.SymptomType.Diarrhea -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeDifficultySwallowing = Android.Health.Connect.Datatypes.SymptomType.DifficultySwallowing -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeDizziness = Android.Health.Connect.Datatypes.SymptomType.Dizziness -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeDrySkin = Android.Health.Connect.Datatypes.SymptomType.DrySkin -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeEaraches = Android.Health.Connect.Datatypes.SymptomType.Earaches -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeFatigue = Android.Health.Connect.Datatypes.SymptomType.Fatigue -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeFever = Android.Health.Connect.Datatypes.SymptomType.Fever -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeGeneralizedBodyAche = Android.Health.Connect.Datatypes.SymptomType.GeneralizedBodyAche -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeHairLoss = Android.Health.Connect.Datatypes.SymptomType.HairLoss -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeHeadache = Android.Health.Connect.Datatypes.SymptomType.Headache -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeHeartPalpitations = Android.Health.Connect.Datatypes.SymptomType.HeartPalpitations -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeHeartburn = Android.Health.Connect.Datatypes.SymptomType.Heartburn -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeHotFlashes = Android.Health.Connect.Datatypes.SymptomType.HotFlashes -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeInsomnia = Android.Health.Connect.Datatypes.SymptomType.Insomnia -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeJointPain = Android.Health.Connect.Datatypes.SymptomType.JointPain -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeJointStiffness = Android.Health.Connect.Datatypes.SymptomType.JointStiffness -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeLossOfAppetite = Android.Health.Connect.Datatypes.SymptomType.LossOfAppetite -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeLossOfConsciousness = Android.Health.Connect.Datatypes.SymptomType.LossOfConsciousness -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeLowerBackPain = Android.Health.Connect.Datatypes.SymptomType.LowerBackPain -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeMemoryLapse = Android.Health.Connect.Datatypes.SymptomType.MemoryLapse -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeMoodChange = Android.Health.Connect.Datatypes.SymptomType.MoodChange -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeMusclePain = Android.Health.Connect.Datatypes.SymptomType.MusclePain -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeNausea = Android.Health.Connect.Datatypes.SymptomType.Nausea -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeNightSweats = Android.Health.Connect.Datatypes.SymptomType.NightSweats -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypePelvicPain = Android.Health.Connect.Datatypes.SymptomType.PelvicPain -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeRapidPoundingOrFlutteringHeartbeat = Android.Health.Connect.Datatypes.SymptomType.RapidPoundingOrFlutteringHeartbeat -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeReducedCapacityForExercise = Android.Health.Connect.Datatypes.SymptomType.ReducedCapacityForExercise -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeRunnyNose = Android.Health.Connect.Datatypes.SymptomType.RunnyNose -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeShortnessOfBreath = Android.Health.Connect.Datatypes.SymptomType.ShortnessOfBreath -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeSkippedHeartbeat = Android.Health.Connect.Datatypes.SymptomType.SkippedHeartbeat -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeSleepChanges = Android.Health.Connect.Datatypes.SymptomType.SleepChanges -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeSleepiness = Android.Health.Connect.Datatypes.SymptomType.Sleepiness -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeSneezing = Android.Health.Connect.Datatypes.SymptomType.Sneezing -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeSnore = Android.Health.Connect.Datatypes.SymptomType.Snore -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeSoreThroat = Android.Health.Connect.Datatypes.SymptomType.SoreThroat -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeStomachAche = Android.Health.Connect.Datatypes.SymptomType.StomachAche -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeStuffyNose = Android.Health.Connect.Datatypes.SymptomType.StuffyNose -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeUnexplainedWeightChanges = Android.Health.Connect.Datatypes.SymptomType.UnexplainedWeightChanges -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeUnknown = Android.Health.Connect.Datatypes.SymptomType.Unknown -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeVaginalDryness = Android.Health.Connect.Datatypes.SymptomType.VaginalDryness -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeVaginalItchiness = Android.Health.Connect.Datatypes.SymptomType.VaginalItchiness -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeVomiting = Android.Health.Connect.Datatypes.SymptomType.Vomiting -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeWaterRetention = Android.Health.Connect.Datatypes.SymptomType.WaterRetention -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DataTypes.SymptomRecord.SymptomTypeWheezing = Android.Health.Connect.Datatypes.SymptomType.Wheezing -> Android.Health.Connect.Datatypes.SymptomType
+const Android.Health.Connect.DeviceDataSource.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Health.Connect.DeviceDataSource.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Health.Connect.DeviceDataTypeSource.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Health.Connect.DeviceDataTypeSource.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Health.Connect.GetDeviceDataSourcesResponse.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Health.Connect.GetDeviceDataSourcesResponse.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Health.Connect.HealthConnectManager.ActionShowOnboarding = "android.health.connect.action.SHOW_ONBOARDING" -> string!
+const Android.Health.Connect.HealthPermissions.ReadAlcoholConsumption = "android.permission.health.READ_ALCOHOL_CONSUMPTION" -> string!
+const Android.Health.Connect.HealthPermissions.ReadMenstrualCyclePhase = "android.permission.health.READ_MENSTRUAL_CYCLE_PHASE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomAbdominalPain = "android.permission.health.READ_SYMPTOM_ABDOMINAL_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomAcne = "android.permission.health.READ_SYMPTOM_ACNE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomBackPain = "android.permission.health.READ_SYMPTOM_BACK_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomBloating = "android.permission.health.READ_SYMPTOM_BLOATING" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomBrainFog = "android.permission.health.READ_SYMPTOM_BRAIN_FOG" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomBreastTenderness = "android.permission.health.READ_SYMPTOM_BREAST_TENDERNESS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomBrittleNails = "android.permission.health.READ_SYMPTOM_BRITTLE_NAILS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomBurningMouth = "android.permission.health.READ_SYMPTOM_BURNING_MOUTH" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomChestPain = "android.permission.health.READ_SYMPTOM_CHEST_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomChestTightness = "android.permission.health.READ_SYMPTOM_CHEST_TIGHTNESS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomChills = "android.permission.health.READ_SYMPTOM_CHILLS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomConstipation = "android.permission.health.READ_SYMPTOM_CONSTIPATION" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomCough = "android.permission.health.READ_SYMPTOM_COUGH" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomCramps = "android.permission.health.READ_SYMPTOM_CRAMPS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomCravings = "android.permission.health.READ_SYMPTOM_CRAVINGS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomDehydration = "android.permission.health.READ_SYMPTOM_DEHYDRATION" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomDiarrhea = "android.permission.health.READ_SYMPTOM_DIARRHEA" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomDifficultySwallowing = "android.permission.health.READ_SYMPTOM_DIFFICULTY_SWALLOWING" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomDizziness = "android.permission.health.READ_SYMPTOM_DIZZINESS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomDrySkin = "android.permission.health.READ_SYMPTOM_DRY_SKIN" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomEaraches = "android.permission.health.READ_SYMPTOM_EARACHES" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomFatigue = "android.permission.health.READ_SYMPTOM_FATIGUE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomFever = "android.permission.health.READ_SYMPTOM_FEVER" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomGeneralizedBodyAche = "android.permission.health.READ_SYMPTOM_GENERALIZED_BODY_ACHE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomHairLoss = "android.permission.health.READ_SYMPTOM_HAIR_LOSS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomHeadache = "android.permission.health.READ_SYMPTOM_HEADACHE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomHeartPalpitations = "android.permission.health.READ_SYMPTOM_HEART_PALPITATIONS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomHeartburn = "android.permission.health.READ_SYMPTOM_HEARTBURN" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomHotFlashes = "android.permission.health.READ_SYMPTOM_HOT_FLASHES" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomInsomnia = "android.permission.health.READ_SYMPTOM_INSOMNIA" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomJointPain = "android.permission.health.READ_SYMPTOM_JOINT_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomJointStiffness = "android.permission.health.READ_SYMPTOM_JOINT_STIFFNESS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomLossOfAppetite = "android.permission.health.READ_SYMPTOM_LOSS_OF_APPETITE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomLossOfConsciousness = "android.permission.health.READ_SYMPTOM_LOSS_OF_CONSCIOUSNESS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomLowerBackPain = "android.permission.health.READ_SYMPTOM_LOWER_BACK_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomMemoryLapse = "android.permission.health.READ_SYMPTOM_MEMORY_LAPSE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomMoodChange = "android.permission.health.READ_SYMPTOM_MOOD_CHANGE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomMusclePain = "android.permission.health.READ_SYMPTOM_MUSCLE_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomNausea = "android.permission.health.READ_SYMPTOM_NAUSEA" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomNightSweats = "android.permission.health.READ_SYMPTOM_NIGHT_SWEATS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomPelvicPain = "android.permission.health.READ_SYMPTOM_PELVIC_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomRapidPoundingOrFlutteringHeartbeat = "android.permission.health.READ_SYMPTOM_RAPID_POUNDING_OR_FLUTTERING_HEARTBEAT" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomReducedCapacityForExercise = "android.permission.health.READ_SYMPTOM_REDUCED_CAPACITY_FOR_EXERCISE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomRunnyNose = "android.permission.health.READ_SYMPTOM_RUNNY_NOSE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomShortnessOfBreath = "android.permission.health.READ_SYMPTOM_SHORTNESS_OF_BREATH" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomSkippedHeartbeat = "android.permission.health.READ_SYMPTOM_SKIPPED_HEARTBEAT" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomSleepChanges = "android.permission.health.READ_SYMPTOM_SLEEP_CHANGES" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomSleepiness = "android.permission.health.READ_SYMPTOM_SLEEPINESS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomSneezing = "android.permission.health.READ_SYMPTOM_SNEEZING" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomSnore = "android.permission.health.READ_SYMPTOM_SNORE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomSoreThroat = "android.permission.health.READ_SYMPTOM_SORE_THROAT" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomStomachAche = "android.permission.health.READ_SYMPTOM_STOMACH_ACHE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomStuffyNose = "android.permission.health.READ_SYMPTOM_STUFFY_NOSE" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomUnexplainedWeightChanges = "android.permission.health.READ_SYMPTOM_UNEXPLAINED_WEIGHT_CHANGES" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomVaginalDryness = "android.permission.health.READ_SYMPTOM_VAGINAL_DRYNESS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomVaginalItchiness = "android.permission.health.READ_SYMPTOM_VAGINAL_ITCHINESS" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomVomiting = "android.permission.health.READ_SYMPTOM_VOMITING" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomWaterRetention = "android.permission.health.READ_SYMPTOM_WATER_RETENTION" -> string!
+const Android.Health.Connect.HealthPermissions.ReadSymptomWheezing = "android.permission.health.READ_SYMPTOM_WHEEZING" -> string!
+const Android.Health.Connect.HealthPermissions.StartOnboarding = "android.permission.health.START_ONBOARDING" -> string!
+const Android.Health.Connect.HealthPermissions.WriteAlcoholConsumption = "android.permission.health.WRITE_ALCOHOL_CONSUMPTION" -> string!
+const Android.Health.Connect.HealthPermissions.WriteMenstrualCyclePhase = "android.permission.health.WRITE_MENSTRUAL_CYCLE_PHASE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomAbdominalPain = "android.permission.health.WRITE_SYMPTOM_ABDOMINAL_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomAcne = "android.permission.health.WRITE_SYMPTOM_ACNE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomBackPain = "android.permission.health.WRITE_SYMPTOM_BACK_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomBloating = "android.permission.health.WRITE_SYMPTOM_BLOATING" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomBrainFog = "android.permission.health.WRITE_SYMPTOM_BRAIN_FOG" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomBreastTenderness = "android.permission.health.WRITE_SYMPTOM_BREAST_TENDERNESS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomBrittleNails = "android.permission.health.WRITE_SYMPTOM_BRITTLE_NAILS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomBurningMouth = "android.permission.health.WRITE_SYMPTOM_BURNING_MOUTH" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomChestPain = "android.permission.health.WRITE_SYMPTOM_CHEST_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomChestTightness = "android.permission.health.WRITE_SYMPTOM_CHEST_TIGHTNESS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomChills = "android.permission.health.WRITE_SYMPTOM_CHILLS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomConstipation = "android.permission.health.WRITE_SYMPTOM_CONSTIPATION" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomCough = "android.permission.health.WRITE_SYMPTOM_COUGH" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomCramps = "android.permission.health.WRITE_SYMPTOM_CRAMPS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomCravings = "android.permission.health.WRITE_SYMPTOM_CRAVINGS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomDehydration = "android.permission.health.WRITE_SYMPTOM_DEHYDRATION" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomDiarrhea = "android.permission.health.WRITE_SYMPTOM_DIARRHEA" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomDifficultySwallowing = "android.permission.health.WRITE_SYMPTOM_DIFFICULTY_SWALLOWING" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomDizziness = "android.permission.health.WRITE_SYMPTOM_DIZZINESS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomDrySkin = "android.permission.health.WRITE_SYMPTOM_DRY_SKIN" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomEaraches = "android.permission.health.WRITE_SYMPTOM_EARACHES" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomFatigue = "android.permission.health.WRITE_SYMPTOM_FATIGUE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomFever = "android.permission.health.WRITE_SYMPTOM_FEVER" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomGeneralizedBodyAche = "android.permission.health.WRITE_SYMPTOM_GENERALIZED_BODY_ACHE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomHairLoss = "android.permission.health.WRITE_SYMPTOM_HAIR_LOSS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomHeadache = "android.permission.health.WRITE_SYMPTOM_HEADACHE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomHeartPalpitations = "android.permission.health.WRITE_SYMPTOM_HEART_PALPITATIONS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomHeartburn = "android.permission.health.WRITE_SYMPTOM_HEARTBURN" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomHotFlashes = "android.permission.health.WRITE_SYMPTOM_HOT_FLASHES" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomInsomnia = "android.permission.health.WRITE_SYMPTOM_INSOMNIA" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomJointPain = "android.permission.health.WRITE_SYMPTOM_JOINT_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomJointStiffness = "android.permission.health.WRITE_SYMPTOM_JOINT_STIFFNESS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomLossOfAppetite = "android.permission.health.WRITE_SYMPTOM_LOSS_OF_APPETITE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomLossOfConsciousness = "android.permission.health.WRITE_SYMPTOM_LOSS_OF_CONSCIOUSNESS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomLowerBackPain = "android.permission.health.WRITE_SYMPTOM_LOWER_BACK_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomMemoryLapse = "android.permission.health.WRITE_SYMPTOM_MEMORY_LAPSE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomMoodChange = "android.permission.health.WRITE_SYMPTOM_MOOD_CHANGE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomMusclePain = "android.permission.health.WRITE_SYMPTOM_MUSCLE_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomNausea = "android.permission.health.WRITE_SYMPTOM_NAUSEA" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomNightSweats = "android.permission.health.WRITE_SYMPTOM_NIGHT_SWEATS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomPelvicPain = "android.permission.health.WRITE_SYMPTOM_PELVIC_PAIN" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomRapidPoundingOrFlutteringHeartbeat = "android.permission.health.WRITE_SYMPTOM_RAPID_POUNDING_OR_FLUTTERING_HEARTBEAT" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomReducedCapacityForExercise = "android.permission.health.WRITE_SYMPTOM_REDUCED_CAPACITY_FOR_EXERCISE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomRunnyNose = "android.permission.health.WRITE_SYMPTOM_RUNNY_NOSE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomShortnessOfBreath = "android.permission.health.WRITE_SYMPTOM_SHORTNESS_OF_BREATH" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomSkippedHeartbeat = "android.permission.health.WRITE_SYMPTOM_SKIPPED_HEARTBEAT" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomSleepChanges = "android.permission.health.WRITE_SYMPTOM_SLEEP_CHANGES" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomSleepiness = "android.permission.health.WRITE_SYMPTOM_SLEEPINESS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomSneezing = "android.permission.health.WRITE_SYMPTOM_SNEEZING" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomSnore = "android.permission.health.WRITE_SYMPTOM_SNORE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomSoreThroat = "android.permission.health.WRITE_SYMPTOM_SORE_THROAT" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomStomachAche = "android.permission.health.WRITE_SYMPTOM_STOMACH_ACHE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomStuffyNose = "android.permission.health.WRITE_SYMPTOM_STUFFY_NOSE" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomUnexplainedWeightChanges = "android.permission.health.WRITE_SYMPTOM_UNEXPLAINED_WEIGHT_CHANGES" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomVaginalDryness = "android.permission.health.WRITE_SYMPTOM_VAGINAL_DRYNESS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomVaginalItchiness = "android.permission.health.WRITE_SYMPTOM_VAGINAL_ITCHINESS" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomVomiting = "android.permission.health.WRITE_SYMPTOM_VOMITING" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomWaterRetention = "android.permission.health.WRITE_SYMPTOM_WATER_RETENTION" -> string!
+const Android.Health.Connect.HealthPermissions.WriteSymptomWheezing = "android.permission.health.WRITE_SYMPTOM_WHEEZING" -> string!
+const Android.Health.Connect.MatchmakingRequest.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Health.Connect.MatchmakingRequest.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Health.Connect.MatchmakingResponse.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Health.Connect.MatchmakingResponse.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Icu.Lang.IUProperty.IdentifierStatus = 4121 -> int
+const Android.Icu.Lang.IUProperty.IdentifierType = 28673 -> int
+const Android.Icu.Lang.IUProperty.IndicConjunctBreak = 4122 -> int
+const Android.Icu.Lang.IUProperty.ModifierCombiningMark = 75 -> int
+const Android.Icu.Lang.UCharacter.IJoiningGroup.ThinNoon = 105 -> int
+const Android.Icu.Lang.UCharacter.ILineBreak.UnambiguousHyphen = 48 -> int
+const Android.Icu.Lang.UCharacter.JoiningGroup.ThinNoon = 105 -> int
+const Android.Icu.Lang.UCharacter.LineBreak.UnambiguousHyphen = 48 -> int
+const Android.Icu.Lang.UCharacter.UnicodeBlock.BeriaErfeId = 339 -> int
+const Android.Icu.Lang.UCharacter.UnicodeBlock.CjkUnifiedIdeographsExtensionJId = 340 -> int
+const Android.Icu.Lang.UCharacter.UnicodeBlock.MiscellaneousSymbolsSupplementId = 341 -> int
+const Android.Icu.Lang.UCharacter.UnicodeBlock.SharadaSupplementId = 342 -> int
+const Android.Icu.Lang.UCharacter.UnicodeBlock.SideticId = 343 -> int
+const Android.Icu.Lang.UCharacter.UnicodeBlock.TaiYoId = 344 -> int
+const Android.Icu.Lang.UCharacter.UnicodeBlock.TangutComponentsSupplementId = 345 -> int
+const Android.Icu.Lang.UCharacter.UnicodeBlock.TolongSikiId = 346 -> int
+const Android.Icu.Lang.UProperty.IdentifierStatus = 4121 -> int
+const Android.Icu.Lang.UProperty.IdentifierType = 28673 -> int
+const Android.Icu.Lang.UProperty.IndicConjunctBreak = 4122 -> int
+const Android.Icu.Lang.UProperty.ModifierCombiningMark = 75 -> int
+const Android.Icu.Lang.UScript.BeriaErfe = 208 -> int
+const Android.Icu.Lang.UScript.Sidetic = 209 -> int
+const Android.Icu.Lang.UScript.TaiYo = 210 -> int
+const Android.Icu.Lang.UScript.TolongSiki = 211 -> int
+const Android.Icu.Lang.UScript.TraditionalHanWithLatin = 212 -> int
+const Android.Locations.GnssMeasurement.CodeTypeA = "A" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeB = "B" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeC = "C" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeD = "D" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeE = "E" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeI = "I" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeL = "L" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeM = "M" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeN = "N" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeP = "P" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeQ = "Q" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeS = "S" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeUnknown = "UNKNOWN" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeW = "W" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeX = "X" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeY = "Y" -> string!
+const Android.Locations.GnssMeasurement.CodeTypeZ = "Z" -> string!
+const Android.Manifest.Permission.AccessBiometricSensorStrengths = "android.permission.ACCESS_BIOMETRIC_SENSOR_STRENGTHS" -> string!
+const Android.Manifest.Permission.AccessLauncherData = "android.permission.ACCESS_LAUNCHER_DATA" -> string!
+const Android.Manifest.Permission.AccessLocalNetwork = "android.permission.ACCESS_LOCAL_NETWORK" -> string!
+const Android.Manifest.Permission.BindAlternativeMessageTransportService = "android.permission.BIND_ALTERNATIVE_MESSAGE_TRANSPORT_SERVICE" -> string!
+const Android.Manifest.Permission.BindDataMigrationForPrivatecompute = "android.permission.BIND_DATA_MIGRATION_FOR_PRIVATECOMPUTE" -> string!
+const Android.Manifest.Permission.CaptureKeyboard = "android.permission.CAPTURE_KEYBOARD" -> string!
+const Android.Manifest.Permission.OverrideMediaSessionOwner = "android.permission.OVERRIDE_MEDIA_SESSION_OWNER" -> string!
+const Android.Manifest.Permission.PostPromotedNotifications = "android.permission.POST_PROMOTED_NOTIFICATIONS" -> string!
+const Android.Manifest.Permission.ProvidePrivateComputeServices = "android.permission.PROVIDE_PRIVATE_COMPUTE_SERVICES" -> string!
+const Android.Manifest.Permission.ReadAssistStructureScreenContent = "android.permission.READ_ASSIST_STRUCTURE_SCREEN_CONTENT" -> string!
+const Android.Manifest.Permission.ReceiveSensitiveNotifications = "android.permission.RECEIVE_SENSITIVE_NOTIFICATIONS" -> string!
+const Android.Manifest.Permission.RepositionSelfWindows = "android.permission.REPOSITION_SELF_WINDOWS" -> string!
+const Android.Manifest.Permission.RequestCompanionProfileMedical = "android.permission.REQUEST_COMPANION_PROFILE_MEDICAL" -> string!
+const Android.Manifest.Permission.ShowPowerMenu = "android.permission.SHOW_POWER_MENU" -> string!
+const Android.Manifest.Permission.ShowPowerMenuPrivileged = "android.permission.SHOW_POWER_MENU_PRIVILEGED" -> string!
+const Android.Manifest.Permission.UseLocationButton = "android.permission.USE_LOCATION_BUTTON" -> string!
+const Android.Manifest.Permission.UseLoopbackInterface = "android.permission.USE_LOOPBACK_INTERFACE" -> string!
+const Android.Manifest.Permission.UsePinnedWindowingLayer = "android.permission.USE_PINNED_WINDOWING_LAYER" -> string!
+const Android.Media.AudioDeviceInfo.TypeBleCentral = Android.Media.AudioDeviceType.TypeBleCentral -> Android.Media.AudioDeviceType
+const Android.Media.AudioDeviceInfo.TypeBleCentralBroadcast = Android.Media.AudioDeviceType.TypeBleCentralBroadcast -> Android.Media.AudioDeviceType
+const Android.Media.AudioDeviceInfo.TypeBleHearingAid = Android.Media.AudioDeviceType.TypeBleHearingAid -> Android.Media.AudioDeviceType
+const Android.Media.AudioFormat.ChannelAcnHorizontal = 512 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder0 = 1 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder0Hrz = 513 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder1 = 4 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder10 = 121 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder10Hrz = 533 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder11 = 144 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder11Hrz = 535 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder12 = 169 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder12Hrz = 537 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder13 = 196 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder13Hrz = 539 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder14 = 225 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder14Hrz = 541 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder1Hrz = 515 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder2 = 9 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder2Hrz = 517 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder3 = 16 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder3Hrz = 519 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder4 = 25 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder4Hrz = 521 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder5 = 36 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder5Hrz = 523 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder6 = 49 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder6Hrz = 525 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder7 = 64 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder7Hrz = 527 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder8 = 81 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder8Hrz = 529 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder9 = 100 -> int
+const Android.Media.AudioFormat.ChannelAcnOrder9Hrz = 531 -> int
+const Android.Media.AudioFormat.ChannelOut13point0 = Android.Media.ChannelOut.ThirteenPointZeroMask -> Android.Media.ChannelOut
+const Android.Media.AudioManager.ModeAssistantConversation = Android.Media.Mode.AssistantConversation -> Android.Media.Mode
+const Android.Media.AudioManager.StreamAssistant = Android.Media.Stream.StreamAssistant -> Android.Media.Stream
+const Android.Media.AudioTrack.FlushFromAccuracyBestEffort = Android.Media.FlushFromAccuracy.BestEffort -> Android.Media.FlushFromAccuracy
+const Android.Media.AudioTrack.FlushFromAccuracyExact = Android.Media.FlushFromAccuracy.Exact -> Android.Media.FlushFromAccuracy
+const Android.Media.AudioTrack.FlushWrittenFramesSupported = Android.Media.FlushWrittenFramesSupport.Supported -> Android.Media.FlushWrittenFramesSupport
+const Android.Media.MediaCodecInfo.CodecProfileLevel.HEVCProfileMain400 = Android.Media.MediaCodecProfileType.Avcprofilehigh -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.HEVCProfileMain444 = Android.Media.MediaCodecProfileType.Avcprofilehigh10 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VP9Profile2HDR10Plus = Android.Media.MediaCodecProfileType.Mpeg4profileadvancedscalable -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCHighTierLevel40 = Android.Media.MediaCodecProfileType.Avcprofilehigh444 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCHighTierLevel41 = Android.Media.MediaCodecProfileType.Dolbyvisionprofiledvhest -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCHighTierLevel50 = Android.Media.MediaCodecProfileType.Dolbyvisionprofiledvav110 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCHighTierLevel51 = Android.Media.MediaCodecProfileType.Apvprofile42210hdr10 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCHighTierLevel52 = Android.Media.MediaCodecProfileType.Mpeg4profileadvancedscalable -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCHighTierLevel60 = Android.Media.MediaCodecProfileType.Avcprofileconstrainedbaseline -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCHighTierLevel61 = Android.Media.MediaCodecProfileType.Vvchightierlevel61 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCHighTierLevel62 = Android.Media.MediaCodecProfileType.Vvchightierlevel62 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCHighTierLevel63 = Android.Media.MediaCodecProfileType.Vvchightierlevel63 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel10 = Android.Media.MediaCodecProfileType.Aacobjectmain -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel20 = Android.Media.MediaCodecProfileType.Aacobjectlc -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel21 = Android.Media.MediaCodecProfileType.Aacobjectltp -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel30 = Android.Media.MediaCodecProfileType.Avcprofilehigh -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel31 = Android.Media.MediaCodecProfileType.Avcprofilehigh10 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel40 = Android.Media.MediaCodecProfileType.Avcprofilehigh422 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel41 = Android.Media.MediaCodecProfileType.Dolbyvisionprofiledvhedtb -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel50 = Android.Media.MediaCodecProfileType.Dolbyvisionprofiledvavse -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel51 = Android.Media.MediaCodecProfileType.Mpeg4profilecorescalable -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel52 = Android.Media.MediaCodecProfileType.Apvprofile42210hdr10plus -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel60 = Android.Media.MediaCodecProfileType.Mpeg4profileadvancedsimple -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel61 = Android.Media.MediaCodecProfileType.Vvcmaintierlevel61 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel62 = Android.Media.MediaCodecProfileType.Avcprofileconstrainedhigh -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCMainTierLevel63 = Android.Media.MediaCodecProfileType.Vvcmaintierlevel63 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCProfileMain10 = Android.Media.MediaCodecProfileType.Aacobjectlc -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCProfileMain10HDR10 = Android.Media.MediaCodecProfileType.Apvprofile42210hdr10 -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCProfileMain10HDR10Plus = Android.Media.MediaCodecProfileType.Apvprofile42210hdr10plus -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCProfileMain10Still = Android.Media.MediaCodecProfileType.Aacobjectltp -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaCodecInfo.CodecProfileLevel.VVCProfileMain8 = Android.Media.MediaCodecProfileType.Aacobjectmain -> Android.Media.MediaCodecProfileType
+const Android.Media.MediaFormat.KeyAudioPresentationId = "audio-presentation-id" -> string!
+const Android.Media.MediaFormat.KeyHdrSt209450Info = "hdr-st2094-50-info" -> string!
+const Android.Media.MediaFormat.KeyNumSlots = "num-slots" -> string!
+const Android.Media.MediaFormat.KeyTemporalLayerId = "temporal-layer-id" -> string!
+const Android.Media.MediaFormat.KeyVideoBitrateLayering = "video-bitrate-layering" -> string!
+const Android.Media.MediaFormat.MimetypeVideoVvc = "video/vvc" -> string!
+const Android.Media.MediaRecorder.VideoEncoder.Apv = Android.Media.VideoEncoder.Apv -> Android.Media.VideoEncoder
+const Android.Media.Projection.AppContentProjectionService.ServiceInterface = "android.media.projection.AppContentProjectionService" -> string!
+const Android.Media.Projection.MediaProjectionAppContent.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Media.Projection.MediaProjectionAppContent.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Media.Projection.MediaProjectionConfig.ProjectionSourceApp = Android.Media.Projection.MediaProjectionSource.App -> Android.Media.Projection.MediaProjectionSource
+const Android.Media.Projection.MediaProjectionConfig.ProjectionSourceAppContent = Android.Media.Projection.MediaProjectionSource.AppContent -> Android.Media.Projection.MediaProjectionSource
+const Android.Media.Projection.MediaProjectionConfig.ProjectionSourceDisplay = Android.Media.Projection.MediaProjectionSource.Display -> Android.Media.Projection.MediaProjectionSource
+const Android.Media.Quality.EqualizerBand.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Media.Quality.EqualizerBand.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Media.Quality.EqualizerCapabilities.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Media.Quality.EqualizerCapabilities.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Media.Quality.EqualizerSettings.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Media.Quality.EqualizerSettings.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Media.Quality.MediaQualityContract.ColorSpaceAdobeRgb = "ADOBE_RGB" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorSpaceAuto = "AUTO" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorSpaceBt2020 = "BT2020" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorSpaceDci = "DCI" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorSpaceOff = "OFF" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorSpaceOn = "ON" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorSpaceSRgbBt709 = "S_RGB_BT_709" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorSpaceUnknown = "UNKNOWN" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempCool = "color_temp_cool" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempCoolHdr10plus = "color_temp_cool_hdr10plus" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempFmmhdr = "color_temp_fmmhdr" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempFmmsdr = "color_temp_fmmsdr" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempStandard = "color_temp_standard" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempStandardHdr10plus = "color_temp_standard_hdr10plus" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempUnknown = "color_temp_unknown" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempUser = "color_temp_user" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempUserHdr10plus = "color_temp_user_hdr10plus" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempWarm = "color_temp_warm" -> string!
+const Android.Media.Quality.MediaQualityContract.ColorTempWarmHdr10plus = "color_temp_warm_hdr10plus" -> string!
+const Android.Media.Quality.MediaQualityContract.DigitalOutputModeAuto = "AUTO" -> string!
+const Android.Media.Quality.MediaQualityContract.DigitalOutputModeBypass = "BYPASS" -> string!
+const Android.Media.Quality.MediaQualityContract.DigitalOutputModeDolbyDigital = "DolbyDigital" -> string!
+const Android.Media.Quality.MediaQualityContract.DigitalOutputModeDolbyDigitalPlus = "DolbyDigitalPlus" -> string!
+const Android.Media.Quality.MediaQualityContract.DigitalOutputModeDolbyMat = "DolbyMat" -> string!
+const Android.Media.Quality.MediaQualityContract.DigitalOutputModePcm = "PCM" -> string!
+const Android.Media.Quality.MediaQualityContract.DigitalOutputModeUnknown = "UNKNOWN" -> string!
+const Android.Media.Quality.MediaQualityContract.DolbySoundModeGame = "GAME" -> string!
+const Android.Media.Quality.MediaQualityContract.DolbySoundModeMovie = "MOVIE" -> string!
+const Android.Media.Quality.MediaQualityContract.DolbySoundModeMusic = "MUSIC" -> string!
+const Android.Media.Quality.MediaQualityContract.DolbySoundModeNews = "NEWS" -> string!
+const Android.Media.Quality.MediaQualityContract.DolbySoundModeStadium = "STADIUM" -> string!
+const Android.Media.Quality.MediaQualityContract.DolbySoundModeStandard = "STANDARD" -> string!
+const Android.Media.Quality.MediaQualityContract.DolbySoundModeUnknown = "UNKNOWN" -> string!
+const Android.Media.Quality.MediaQualityContract.DolbySoundModeUser = "USER" -> string!
+const Android.Media.Quality.MediaQualityContract.DownMixModeStereo = "STEREO" -> string!
+const Android.Media.Quality.MediaQualityContract.DownMixModeSurround = "SURROUND" -> string!
+const Android.Media.Quality.MediaQualityContract.DownMixModeUnknown = "UNKNOWN" -> string!
+const Android.Media.Quality.MediaQualityContract.ExtraPictureQualityEventTypeFrameChange = "android.media.quality.extra.PICTURE_QUALITY_EVENT_TYPE_FRAME_CHANGE" -> string!
+const Android.Media.Quality.MediaQualityContract.GammaBright = "BRIGHT" -> string!
+const Android.Media.Quality.MediaQualityContract.GammaDark = "DARK" -> string!
+const Android.Media.Quality.MediaQualityContract.GammaMiddle = "MIDDLE" -> string!
+const Android.Media.Quality.MediaQualityContract.GammaUnknown = "UNKNOWN" -> string!
+const Android.Media.Quality.MediaQualityContract.HdmirgbRangeAuto = "AUTO" -> string!
+const Android.Media.Quality.MediaQualityContract.HdmirgbRangeFull = "FULL" -> string!
+const Android.Media.Quality.MediaQualityContract.HdmirgbRangeLimited = "LIMITED" -> string!
+const Android.Media.Quality.MediaQualityContract.HdmirgbRangeUnknown = "UNKNOWN" -> string!
+const Android.Media.Quality.MediaQualityContract.LevelRangeAuto = "AUTO" -> string!
+const Android.Media.Quality.MediaQualityContract.LevelRangeFull = "FULL" -> string!
+const Android.Media.Quality.MediaQualityContract.LevelRangeLimited = "LIMITED" -> string!
+const Android.Media.Quality.MediaQualityContract.LevelRangeUnknown = "UNKNOWN" -> string!
+const Android.Media.Quality.MediaQualityContract.LevelUnknown = "level_unknown" -> string!
+const Android.Media.Quality.MediaQualityContract.LevelUser = "level_user" -> string!
+const Android.Media.Quality.MediaQualityContract.PanelTechnologyOled = Android.Media.Quality.PanelTechnology.Oled -> Android.Media.Quality.PanelTechnology
+const Android.Media.Quality.MediaQualityContract.PanelTechnologyUnknown = Android.Media.Quality.PanelTechnology.Unknown -> Android.Media.Quality.PanelTechnology
+const Android.Media.Quality.MediaQualityContract.PictureQuality.Parameter3dMode = "3d_mode" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.Parameter3dTo2d = "3d_to_2d" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterBlackStretch = "black_stretch" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorSpace = "color_space" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTemperatureBlueGain = "color_temperature_blue_gain" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTemperatureBlueOffset = "color_temperature_blue_offset" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTemperatureGreenGain = "color_temperature_green_gain" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTemperatureGreenOffset = "color_temperature_green_offset" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTemperatureRedGain = "color_temperature_red_gain" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTemperatureRedOffset = "color_temperature_red_offset" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerHueBlue = "color_tuner_hue_blue" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerHueCyan = "color_tuner_hue_cyan" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerHueFlesh = "color_tuner_hue_flesh" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerHueGreen = "color_tuner_hue_green" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerHueMagenta = "color_tuner_hue_magenta" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerHueRed = "color_tuner_hue_red" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerHueYellow = "color_tuner_hue_yellow" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerLuminanceBlue = "color_tuner_luminance_blue" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerLuminanceCyan = "color_tuner_luminance_cyan" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerLuminanceFlesh = "color_tuner_luminance_flesh" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerLuminanceGreen = "color_tuner_luminance_green" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerLuminanceMagenta = "color_tuner_luminance_magenta" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerLuminanceRed = "color_tuner_luminance_red" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerLuminanceYellow = "color_tuner_luminance_yellow" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerSaturationBlue = "color_tuner_saturation_blue" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerSaturationCyan = "color_tuner_saturation_cyan" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerSaturationFlesh = "color_tuner_saturation_flesh" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerSaturationGreen = "color_tuner_saturation_green" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerSaturationMagenta = "color_tuner_saturation_magenta" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerSaturationRed = "color_tuner_saturation_red" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerSaturationYellow = "color_tuner_saturation_yellow" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterColorTunerSwitch = "color_tuner_switch" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterCvrr = "cvrr" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterElevenPointBlue = "eleven_point_blue" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterElevenPointGreen = "eleven_point_green" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterElevenPointRed = "eleven_point_red" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterGamma = "gamma" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterGamutMapping = "gamut_mapping" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterHdmiRgbRange = "hdmi_rgb_range" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterLdMode = "ld_mode" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterLevelRange = "level_range" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterLowBlueLight = "low_blue_light" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterLowLatency = "low_latency" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterMemcDeblur = "memc_deblur" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterMemcDejudder = "memc_dejudder" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterMemcEffect = "memc_effect" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterOriginalFramerate = "original_framerate" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterOsdBlueGain = "osd_blue_gain" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterOsdBlueOffset = "osd_blue_offset" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterOsdContrast = "osd_contrast" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterOsdGreenGain = "osd_green_gain" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterOsdGreenOffset = "osd_green_offset" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterOsdHue = "osd_hue" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterOsdRedGain = "osd_red_gain" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterOsdRedOffset = "osd_red_offset" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterOsdSaturation = "osd_saturation" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterPanelInitMaxLuminceNits = "panel_init_max_lumince_nits" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterPanelInitMaxLuminceValid = "panel_init_max_lumince_valid" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterPcMode = "pc_mode" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQuality.ParameterVrr = "vrr" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQualityEventTypeBbdResult = "BBD_RESULT" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQualityEventTypeCapturepointInfoChange = "CAPTUREPOINT_INFO_CHANGE" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQualityEventTypeDolbyApoChange = "DOLBY_APO_CHANGE" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQualityEventTypeDolbyIqChange = "DOLBY_IQ_CHANGE" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQualityEventTypeNone = "NONE" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQualityEventTypeUnknown = "UNKNOWN" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQualityEventTypeVideoDelayChange = "VIDEO_DELAY_CHANGE" -> string!
+const Android.Media.Quality.MediaQualityContract.PictureQualityEventTypeVideopathChange = "VIDEOPATH_CHANGE" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterAdHeadphoneEnable = "ad_headphone_enable" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterAdSpeakerEnable = "ad_speaker_enable" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterAdVolume = "ad_volume" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterBalanceBluetooth = "balance_bluetooth" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterBalanceHeadphones = "balance_headphones" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterBalanceSpeaker = "balance_speaker" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterBtLatencyUs = "bt_latency_us" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterDolbyAudioProcessing = "dolby_audio_processing" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterDtsVirtualX = "dts_virtual_x" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterEqualizerSettings = "equalizer_settings" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterHiResAudio = "hi_res_audio" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterPanFadeEnable = "pan_fade_enable" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundQuality.ParameterSoundStyle = "sound_style" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundStyleAuto = "AUTO" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundStyleMovie = "MOVIE" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundStyleMusic = "MUSIC" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundStyleNews = "NEWS" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundStyleSports = "SPORTS" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundStyleStandard = "STANDARD" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundStyleUnknown = "UNKNOWN" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundStyleUser = "USER" -> string!
+const Android.Media.Quality.MediaQualityContract.SoundStyleVivid = "VIVID" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusDolbyVision = "DOLBYVISION" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusFmmDolby = "FMMDOLBY" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusFmmHdr10 = "FMMHDR10" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusFmmHdr10Plus = "FMMHDR10PLUS" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusFmmHdrVivid = "FMMHDRVIVID" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusFmmHlg = "FMMHLG" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusFmmSdr = "FMMSDR" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusFmmTch = "FMMTCH" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusHdr10 = "HDR10" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusHdr10Plus = "HDR10PLUS" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusHdrVivid = "HDRVIVID" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusHlg = "HLG" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusImaxHdr10 = "IMAXHDR10" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusImaxHdr10Plus = "IMAXHDR10PLUS" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusImaxSdr = "IMAXSDR" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusSdr = "SDR" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusTch = "TCH" -> string!
+const Android.Media.Quality.MediaQualityContract.StreamStatusUnknown = "UNKNOWN" -> string!
+const Android.Media.Quality.MediaQualityContract.ThreeDModeFramePacking = "frame_packing" -> string!
+const Android.Media.Quality.MediaQualityContract.ThreeDModeOff = "off" -> string!
+const Android.Media.Quality.MediaQualityContract.ThreeDModeSideBySide = "side_by_side" -> string!
+const Android.Media.Quality.MediaQualityContract.ThreeDModeTopAndBottom = "top_and_bottom" -> string!
+const Android.Media.Quality.MediaQualityContract.ThreeDModeUnknown = "unknown" -> string!
+const Android.Media.Quality.PictureProfile.NameDefault = "default" -> string!
+const Android.Media.Quality.PictureProfile.NameEnergySaving = "energy_saving" -> string!
+const Android.Media.Quality.PictureProfile.NameGame = "game" -> string!
+const Android.Media.Quality.PictureProfile.NameMovie = "movie" -> string!
+const Android.Media.Quality.PictureProfile.NameSports = "sports" -> string!
+const Android.Media.Quality.PictureProfile.NameStandard = "standard" -> string!
+const Android.Media.Quality.PictureProfile.NameUnknown = "unknown" -> string!
+const Android.Media.Quality.PictureProfile.NameUser = "user" -> string!
+const Android.Media.Quality.PictureProfile.NameVivid = "vivid" -> string!
+const Android.Media.Quality.SoundProfile.NameDefault = "default" -> string!
+const Android.Media.Quality.SoundProfile.NameMovie = "movie" -> string!
+const Android.Media.Quality.SoundProfile.NameMusic = "music" -> string!
+const Android.Media.Quality.SoundProfile.NameNews = "news" -> string!
+const Android.Media.Quality.SoundProfile.NameSports = "sports" -> string!
+const Android.Media.Quality.SoundProfile.NameStandard = "standard" -> string!
+const Android.Media.Quality.SoundProfile.NameUser = "user" -> string!
+const Android.Media.Quality.SoundProfile.NameVivid = "vivid" -> string!
+const Android.Media.RouteListingPreference.ActionResolveMissingPermissions = "android.media.action.RESOLVE_MISSING_PERMISSIONS" -> string!
+const Android.Media.RouteListingPreference.ExtraMissingPermissions = "android.media.extra.MISSING_PERMISSIONS" -> string!
+const Android.Media.SuggestedDeviceInfo.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Media.SuggestedDeviceInfo.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Net.Dns.HttpsRecord.DefaultAlpnId = "http/1.1" -> string!
+const Android.Net.DnsResolver.HttpsQueryWaitAuto = -1 -> int
+const Android.Net.DnsResolver.HttpsQueryWaitNone = 0 -> int
+const Android.Net.DnsResolver.HttpsQueryWaitUntilTimeout = -2 -> int
+const Android.Net.DnsResolver.TypeHttps = Android.Net.DnsResolverType.Https -> Android.Net.DnsResolverType
+const Android.Net.Http.Proxy.HttpConnectCallback.ResponseActionClose = Android.Net.Http.OnResponseReceivedAction.Close -> Android.Net.Http.OnResponseReceivedAction
+const Android.Net.Http.Proxy.HttpConnectCallback.ResponseActionProceed = Android.Net.Http.OnResponseReceivedAction.Proceed -> Android.Net.Http.OnResponseReceivedAction
+const Android.Net.Http.Proxy.SchemeHttp = Android.Net.Http.HttpProxyScheme.Http -> Android.Net.Http.HttpProxyScheme
+const Android.Net.Http.Proxy.SchemeHttps = Android.Net.Http.HttpProxyScheme.Https -> Android.Net.Http.HttpProxyScheme
+const Android.Net.Http.ProxyOptions.AllProxiesFailedBehaviorAllowDirect = Android.Net.Http.AllProxiesFailedBehavior.AllowDirect -> Android.Net.Http.AllProxiesFailedBehavior
+const Android.Net.Http.ProxyOptions.AllProxiesFailedBehaviorDisallowDirect = Android.Net.Http.AllProxiesFailedBehavior.DisallowDirect -> Android.Net.Http.AllProxiesFailedBehavior
+const Android.Net.NetworkCapabilities.NetCapabilityPrioritizeUnifiedCommunications = Android.Net.NetCapability.PrioritizeUnifiedCommunications -> Android.Net.NetCapability
+const Android.Net.Nsd.DiscoveryRequest.FlagNoPicker = 1 -> long
+const Android.Net.Nsd.DiscoveryRequest.FlagShowPicker = 2 -> long
+const Android.Net.Nsd.DiscoveryRequest.FlagUserApprovedOnly = 4 -> long
+const Android.Net.Nsd.NsdManager.FailurePermissionDenied = Android.Net.Nsd.NsdFailure.PermissionDenied -> Android.Net.Nsd.NsdFailure
+const Android.Net.Nsd.NsdManager.ServicePermissionDenied = Android.Net.Nsd.PermissionCheckCode.Denied -> Android.Net.Nsd.PermissionCheckCode
+const Android.Net.Nsd.NsdManager.ServicePermissionGranted = Android.Net.Nsd.PermissionCheckCode.Granted -> Android.Net.Nsd.PermissionCheckCode
+const Android.Net.Wifi.Aware.AwareDataPathRequest.DataPathConnectionFailureReasonInternalFailure = Android.Net.Wifi.Aware.DataPathConnectionFailureReason.InternalFailure -> Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+const Android.Net.Wifi.Aware.AwareDataPathRequest.DataPathConnectionFailureReasonNoResource = Android.Net.Wifi.Aware.DataPathConnectionFailureReason.NoResource -> Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+const Android.Net.Wifi.Aware.AwareDataPathRequest.DataPathConnectionFailureReasonPeerNotFound = Android.Net.Wifi.Aware.DataPathConnectionFailureReason.PeerNotFound -> Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+const Android.Net.Wifi.Aware.AwareDataPathRequest.DataPathConnectionFailureReasonRejectByPeer = Android.Net.Wifi.Aware.DataPathConnectionFailureReason.RejectByPeer -> Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+const Android.Net.Wifi.Aware.AwareDataPathRequest.DataPathConnectionFailureReasonTimeOut = Android.Net.Wifi.Aware.DataPathConnectionFailureReason.TimeOut -> Android.Net.Wifi.Aware.DataPathConnectionFailureReason
+const Android.Net.Wifi.Aware.AwareDataPathRequest.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Net.Wifi.Aware.AwareDataPathRequest.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Net.Wifi.Aware.AwarePairingConfig.PairingBootstrappingServiceManaged = Android.Net.Wifi.Aware.AwarePairingBootstrappingMethods.ServiceManaged -> Android.Net.Wifi.Aware.AwarePairingBootstrappingMethods
+const Android.Net.Wifi.Aware.AwarePairingConfig.PairingBootstrappingSkipped = Android.Net.Wifi.Aware.AwarePairingBootstrappingMethods.Skipped -> Android.Net.Wifi.Aware.AwarePairingBootstrappingMethods
+const Android.Net.Wifi.P2p.WifiP2pConnectionInfo.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Net.Wifi.P2p.WifiP2pConnectionInfo.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Net.Wifi.P2p.WifiP2pConnectionInfo.Unspecified = 0 -> int
+const Android.Net.Wifi.P2p.WifiP2pManager.ConnectionRequestDeferShowPasswordToService = Android.Net.Wifi.P2p.ConnectionRequestType.ConnectionRequestDeferShowPasswordToService -> Android.Net.Wifi.P2p.ConnectionRequestType
+const Android.Net.Wifi.Rtt.RangingResult.StatusBusyTryLater = Android.Net.Wifi.Rtt.RangingStatus.BusyTryLater -> Android.Net.Wifi.Rtt.RangingStatus
+const Android.Nfc.CardEmulators.CardEmulation.ProtocolAndTechnologyRouteNdefNfcee = Android.Nfc.CardEmulators.ProtocolAndTechnologyRoute.ProtocolAndTechnologyRouteNdefNfcee -> Android.Nfc.CardEmulators.ProtocolAndTechnologyRoute
+const Android.Nfc.NfcAdapter.ExtraReaderTechAPollingLoopAnnotation = "android.nfc.extra.READER_TECH_A_POLLING_LOOP_ANNOTATION" -> string!
+const Android.OS.Build.BackportedFixStatusFixed = Android.OS.BackportedFixStatus.Fixed -> Android.OS.BackportedFixStatus
+const Android.OS.Build.BackportedFixStatusNotApplicable = Android.OS.BackportedFixStatus.NotApplicable -> Android.OS.BackportedFixStatus
+const Android.OS.Build.BackportedFixStatusNotFixed = Android.OS.BackportedFixStatus.NotFixed -> Android.OS.BackportedFixStatus
+const Android.OS.Build.BackportedFixStatusUnknown = Android.OS.BackportedFixStatus.Unknown -> Android.OS.BackportedFixStatus
+const Android.OS.Build.VERSION_CODES.CinnamonBun = Android.OS.BuildVersionCodes.CinnamonBun -> Android.OS.BuildVersionCodes
+const Android.OS.Build.VERSION_CODES_FULL.Baklava1 = Android.OS.BuildVersionCodesFull.Baklava1 -> Android.OS.BuildVersionCodesFull
+const Android.OS.Build.VERSION_CODES_FULL.CinnamonBun = Android.OS.BuildVersionCodesFull.CinnamonBun -> Android.OS.BuildVersionCodesFull
+const Android.OS.ProfilingTrigger.TriggerTypeAnomaly = Android.OS.ProfilingTriggerType.Anomaly -> Android.OS.ProfilingTriggerType
+const Android.OS.ProfilingTrigger.TriggerTypeAppCompat = Android.OS.ProfilingTriggerType.AppCompat -> Android.OS.ProfilingTriggerType
+const Android.OS.ProfilingTrigger.TriggerTypeAppRequestRunningTrace = Android.OS.ProfilingTriggerType.TriggerTypeAppRequestRunningTrace -> Android.OS.ProfilingTriggerType
+const Android.OS.ProfilingTrigger.TriggerTypeColdStart = Android.OS.ProfilingTriggerType.ColdStart -> Android.OS.ProfilingTriggerType
+const Android.OS.ProfilingTrigger.TriggerTypeKillExcessiveCpuUsage = Android.OS.ProfilingTriggerType.KillExcessiveCpuUsage -> Android.OS.ProfilingTriggerType
+const Android.OS.ProfilingTrigger.TriggerTypeKillForceStop = Android.OS.ProfilingTriggerType.TriggerTypeKillForceStop -> Android.OS.ProfilingTriggerType
+const Android.OS.ProfilingTrigger.TriggerTypeKillRecents = Android.OS.ProfilingTriggerType.TriggerTypeKillRecents -> Android.OS.ProfilingTriggerType
+const Android.OS.ProfilingTrigger.TriggerTypeKillTaskManager = Android.OS.ProfilingTriggerType.TriggerTypeKillTaskManager -> Android.OS.ProfilingTriggerType
+const Android.OS.ProfilingTrigger.TriggerTypeOom = Android.OS.ProfilingTriggerType.TriggerTypeOom -> Android.OS.ProfilingTriggerType
+const Android.OS.SecurityStateManager.KeySystemSupplementalPatches = "system_supplemental_security_patches" -> string!
+const Android.OS.SecurityStateManager.KeyVendorSupplementalPatches = "vendor_supplemental_security_patches" -> string!
+const Android.OS.Storage.FileManager.ActionFileOperationCompleted = "android.os.storage.action.FILE_OPERATION_COMPLETED" -> string!
+const Android.OS.Storage.FileManager.ExtraRequestId = "android.os.storage.extra.REQUEST_ID" -> string!
+const Android.OS.Storage.FileManager.ExtraResult = "android.os.storage.extra.RESULT" -> string!
+const Android.OS.Storage.Operations.FileOperationEnqueueResult.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.OS.Storage.Operations.FileOperationEnqueueResult.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.OS.Storage.Operations.FileOperationRequest.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.OS.Storage.Operations.FileOperationRequest.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.OS.Storage.Operations.FileOperationRequest.OperationCopy = Android.OS.Storage.Operations.FileOperationMode.Copy -> Android.OS.Storage.Operations.FileOperationMode
+const Android.OS.Storage.Operations.FileOperationRequest.OperationMove = Android.OS.Storage.Operations.FileOperationMode.Move -> Android.OS.Storage.Operations.FileOperationMode
+const Android.OS.Storage.Operations.FileOperationResult.ErrorBusy = Android.OS.Storage.Operations.FileOperationErrorCode.Busy -> Android.OS.Storage.Operations.FileOperationErrorCode
+const Android.OS.Storage.Operations.FileOperationResult.ErrorDiskFull = Android.OS.Storage.Operations.FileOperationErrorCode.DiskFull -> Android.OS.Storage.Operations.FileOperationErrorCode
+const Android.OS.Storage.Operations.FileOperationResult.ErrorInvalidRequest = Android.OS.Storage.Operations.FileOperationErrorCode.InvalidRequest -> Android.OS.Storage.Operations.FileOperationErrorCode
+const Android.OS.Storage.Operations.FileOperationResult.ErrorNone = Android.OS.Storage.Operations.FileOperationErrorCode.None -> Android.OS.Storage.Operations.FileOperationErrorCode
+const Android.OS.Storage.Operations.FileOperationResult.ErrorPermissionDenied = Android.OS.Storage.Operations.FileOperationErrorCode.PermissionDenied -> Android.OS.Storage.Operations.FileOperationErrorCode
+const Android.OS.Storage.Operations.FileOperationResult.ErrorUnknown = Android.OS.Storage.Operations.FileOperationErrorCode.Unknown -> Android.OS.Storage.Operations.FileOperationErrorCode
+const Android.OS.Storage.Operations.FileOperationResult.ErrorUnsupportedSource = Android.OS.Storage.Operations.FileOperationErrorCode.UnsupportedSource -> Android.OS.Storage.Operations.FileOperationErrorCode
+const Android.OS.Storage.Operations.FileOperationResult.ErrorUnsupportedTarget = Android.OS.Storage.Operations.FileOperationErrorCode.UnsupportedTarget -> Android.OS.Storage.Operations.FileOperationErrorCode
+const Android.OS.Storage.Operations.FileOperationResult.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.OS.Storage.Operations.FileOperationResult.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.OS.Storage.Operations.FileOperationResult.StatusFailed = Android.OS.Storage.Operations.FileOperationStatus.Failed -> Android.OS.Storage.Operations.FileOperationStatus
+const Android.OS.Storage.Operations.FileOperationResult.StatusFinished = Android.OS.Storage.Operations.FileOperationStatus.Finished -> Android.OS.Storage.Operations.FileOperationStatus
+const Android.OS.Storage.Operations.FileOperationResult.StatusInProgress = Android.OS.Storage.Operations.FileOperationStatus.InProgress -> Android.OS.Storage.Operations.FileOperationStatus
+const Android.OS.Storage.Operations.FileOperationResult.StatusQueued = Android.OS.Storage.Operations.FileOperationStatus.Queued -> Android.OS.Storage.Operations.FileOperationStatus
+const Android.OS.Storage.Operations.FileOperationResult.StatusUnknown = Android.OS.Storage.Operations.FileOperationStatus.Unknown -> Android.OS.Storage.Operations.FileOperationStatus
+const Android.OS.UserManager.DisallowTaskContinuityHandoff = "no_task_continuity_handoff" -> string!
+const Android.OS.VibrationAttributes.UsageGestureInput = Android.OS.VibrationAttributesUsageType.UsageGestureInput -> Android.OS.VibrationAttributesUsageType
+const Android.Provider.CallLog.Calls.FeaturesGroupCall = 512 -> int
+const Android.Provider.CallLog.Calls.FeaturesHdPlusCall = 128 -> int
+const Android.Provider.CallLog.Calls.FeaturesVonr = 256 -> int
+const Android.Provider.CallLog.Calls.IncludeVoipCallsParamKey = "include_voip_calls" -> string!
+const Android.Provider.CallLog.Calls.PreferredDisplayName = "preferred_display_name" -> string!
+const Android.Provider.CallLog.Calls.Uuid = "uuid" -> string!
+const Android.Provider.CloudMediaProviderContract.MediaCategoryTypeUserAlbums = "com.android.providers.media.MEDIA_CATEGORY_TYPE_USER_ALBUMS" -> string!
+const Android.Provider.ContactsContract.Settings.AccountAttributes.AttributeDataOriginCloud = 4 -> long
+const Android.Provider.ContactsContract.Settings.AccountAttributes.AttributeDataOriginLocal = 1 -> long
+const Android.Provider.ContactsContract.Settings.AccountAttributes.AttributeDataOriginSim = 2 -> long
+const Android.Provider.ContactsContract.Settings.AccountAttributes.AttributeDataTypeCustomDeclared = 32 -> long
+const Android.Provider.ContactsContract.Settings.AccountAttributes.AttributeSyncModeDownSync = 16 -> long
+const Android.Provider.ContactsContract.Settings.AccountAttributes.AttributeSyncModeUpSync = 8 -> long
+const Android.Provider.ContactsPickerSessionContract.ActionPickContacts = "android.provider.action.PICK_CONTACTS" -> string!
+const Android.Provider.ContactsPickerSessionContract.Authority = "com.android.contacts.picker.sessions" -> string!
+const Android.Provider.ContactsPickerSessionContract.ExtraPickContactsMatchAllDataFields = "android.provider.extra.PICK_CONTACTS_MATCH_ALL_DATA_FIELDS" -> string!
+const Android.Provider.ContactsPickerSessionContract.ExtraPickContactsRequestedDataFields = "android.provider.extra.PICK_CONTACTS_REQUESTED_DATA_FIELDS" -> string!
+const Android.Provider.ContactsPickerSessionContract.ExtraPickContactsSelectionLimit = "android.provider.extra.PICK_CONTACTS_SELECTION_LIMIT" -> string!
+const Android.Provider.ContactsPickerSessionContract.Session.ContentType = "vnd.android.cursor.dir/data" -> string!
+const Android.Provider.ContactsPickerSessionContract.Session.InterfaceConsts.Count = "_count" -> string!
+const Android.Provider.ContactsPickerSessionContract.Session.InterfaceConsts.Id = "_id" -> string!
+const Android.Provider.DocumentsContract.CategoryApprovedDocumentHandler = "android.provider.category.APPROVED_DOCUMENT_HANDLER" -> string!
+const Android.Provider.DocumentsContract.Document.ColumnContentSyncStateFlags = "content_sync_state_flags" -> string!
+const Android.Provider.DocumentsContract.Document.ColumnOriginalRelativePath = "original_relative_path" -> string!
+const Android.Provider.DocumentsContract.Document.FlagSupportsRestore = Android.Provider.DocumentContractFlags.SupportsRestore -> Android.Provider.DocumentContractFlags
+const Android.Provider.DocumentsContract.Document.FlagSupportsTrash = Android.Provider.DocumentContractFlags.SupportsTrash -> Android.Provider.DocumentContractFlags
+const Android.Provider.DocumentsContract.Document.SyncStateFlagAvailableLocally = Android.Provider.DocumentSyncStateFlags.AvailableLocally -> Android.Provider.DocumentSyncStateFlags
+const Android.Provider.DocumentsContract.Document.SyncStateFlagDownloadError = Android.Provider.DocumentSyncStateFlags.DownloadError -> Android.Provider.DocumentSyncStateFlags
+const Android.Provider.DocumentsContract.Document.SyncStateFlagDownloadProgress = Android.Provider.DocumentSyncStateFlags.DownloadProgress -> Android.Provider.DocumentSyncStateFlags
+const Android.Provider.DocumentsContract.Document.SyncStateFlagLocalChanges = Android.Provider.DocumentSyncStateFlags.LocalChanges -> Android.Provider.DocumentSyncStateFlags
+const Android.Provider.DocumentsContract.Document.SyncStateFlagUploadError = Android.Provider.DocumentSyncStateFlags.UploadError -> Android.Provider.DocumentSyncStateFlags
+const Android.Provider.DocumentsContract.Document.SyncStateFlagUploadProgress = Android.Provider.DocumentSyncStateFlags.UploadProgress -> Android.Provider.DocumentSyncStateFlags
+const Android.Provider.DocumentsContract.Root.FlagLimitedFunctionalityWhenOffline = Android.Provider.DocumentRootFlags.LimitedFunctionalityWhenOffline -> Android.Provider.DocumentRootFlags
+const Android.Provider.DocumentsContract.Root.FlagSupportsQueryTrash = Android.Provider.DocumentRootFlags.SupportsQueryTrash -> Android.Provider.DocumentRootFlags
+const Android.Provider.MediaStore.ExtraPickImagesHighlightAlbum = "android.provider.extra.PICK_IMAGES_HIGHLIGHT_ALBUM" -> string!
+const Android.Provider.MediaStore.ExtraPickImagesHighlightSearchResults = "android.provider.extra.PICK_IMAGES_HIGHLIGHT_SEARCH_RESULTS" -> string!
+const Android.Provider.MediaStore.ExtraPickImagesSelectionParams = "android.provider.extra.PICK_IMAGES_SELECTION_PARAMS" -> string!
+const Android.Provider.MediaStore.ExtraPickImagesUiCustomizationParams = "android.provider.extra.PICK_IMAGES_UI_CUSTOMIZATION_PARAMS" -> string!
+const Android.Provider.MediaStore.Files.FileColumns.SpecialFormat = "_special_format" -> string!
+const Android.Provider.MediaStore.Files.FileColumns.SpecialFormatAnimatedWebp = 3 -> int
+const Android.Provider.MediaStore.Files.FileColumns.SpecialFormatGif = 1 -> int
+const Android.Provider.MediaStore.Files.FileColumns.SpecialFormatMotionPhoto = 2 -> int
+const Android.Provider.MediaStore.Files.FileColumns.SpecialFormatNone = 0 -> int
+const Android.Provider.MediaStore.Files.IFileColumns.SpecialFormat = "_special_format" -> string!
+const Android.Provider.MediaStore.Files.IFileColumns.SpecialFormatAnimatedWebp = 3 -> int
+const Android.Provider.MediaStore.Files.IFileColumns.SpecialFormatGif = 1 -> int
+const Android.Provider.MediaStore.Files.IFileColumns.SpecialFormatMotionPhoto = 2 -> int
+const Android.Provider.MediaStore.Files.IFileColumns.SpecialFormatNone = 0 -> int
+const Android.Provider.MediaStore.KeyPickImagesHighlightAlbumId = "android.provider.media.key.PICK_IMAGES_HIGHLIGHT_MEDIA_ALBUM_ID" -> string!
+const Android.Provider.MediaStore.KeyPickImagesHighlightSearchTextQuery = "android.provider.media.key.PICK_IMAGES_HIGHLIGHT_SEARCH_TEXT_QUERY" -> string!
+const Android.Provider.MediaStore.KeyPickImagesHighlightType = "android.provider.media.key.PICK_IMAGES_HIGHLIGHT_TYPE" -> string!
+const Android.Provider.MediaStore.PickImagesHighlightAlbumCamera = "android.provider.media.PICK_IMAGES_HIGHLIGHT_ALBUM_CAMERA" -> string!
+const Android.Provider.MediaStore.PickImagesHighlightAlbumDownloads = "android.provider.media.PICK_IMAGES_HIGHLIGHT_ALBUM_DOWNLOADS" -> string!
+const Android.Provider.MediaStore.PickImagesHighlightAlbumFavorites = "android.provider.media.PICK_IMAGES_HIGHLIGHT_ALBUM_FAVORITES" -> string!
+const Android.Provider.MediaStore.PickImagesHighlightAlbumScreenshots = "android.provider.media.PICK_IMAGES_HIGHLIGHT_ALBUM_SCREENSHOTS" -> string!
+const Android.Provider.MediaStore.PickImagesHighlightAlbumVideos = "android.provider.media.PICK_IMAGES_HIGHLIGHT_ALBUM_VIDEOS" -> string!
+const Android.Provider.MediaStore.PickImagesHighlightTypeCollapsed = Android.Provider.MediaStorePickImagesHighlightType.Collapsed -> Android.Provider.MediaStorePickImagesHighlightType
+const Android.Provider.MediaStore.PickImagesHighlightTypeExpanded = Android.Provider.MediaStorePickImagesHighlightType.Expanded -> Android.Provider.MediaStorePickImagesHighlightType
+const Android.Provider.Settings.ActionSupervisionSettings = "android.settings.SUPERVISION_SETTINGS" -> string!
+const Android.Provider.Settings.ActionSystemUpdateSettings = "android.settings.SYSTEM_UPDATE_SETTINGS" -> string!
+const Android.Provider.Settings.ActionVpnAppExclusionSettings = "android.settings.VPN_APP_EXCLUSION_SETTINGS" -> string!
+const Android.Provider.Telephony.ITextBasedSmsColumns.TransactionId = "tr_id" -> string!
+const Android.Provider.Telephony.Sms.Conversations.InterfaceConsts.TransactionId = "tr_id" -> string!
+const Android.Provider.Telephony.Sms.Draft.InterfaceConsts.TransactionId = "tr_id" -> string!
+const Android.Provider.Telephony.Sms.Inbox.InterfaceConsts.TransactionId = "tr_id" -> string!
+const Android.Provider.Telephony.Sms.InterfaceConsts.TransactionId = "tr_id" -> string!
+const Android.Provider.Telephony.Sms.Outbox.InterfaceConsts.TransactionId = "tr_id" -> string!
+const Android.Provider.Telephony.Sms.Sent.InterfaceConsts.TransactionId = "tr_id" -> string!
+const Android.Provider.Telephony.TextBasedSmsColumns.TransactionId = "tr_id" -> string!
+const Android.Ranging.Ble.BleSpecificData.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.Ble.BleSpecificData.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.Ble.BleSpecificData.InvalidTxPowerDbm = 127 -> int
+const Android.Ranging.DlTdoaMeasurement.AnchorLocation.CoordinateRelative = Android.Ranging.CoordinateType.Relative -> Android.Ranging.CoordinateType
+const Android.Ranging.DlTdoaMeasurement.AnchorLocation.CoordinateRelativePlusZElement = Android.Ranging.CoordinateType.RelativePlusZElement -> Android.Ranging.CoordinateType
+const Android.Ranging.DlTdoaMeasurement.AnchorLocation.CoordinateRelativeWithZGravityAligned = Android.Ranging.CoordinateType.RelativeWithZGravityAligned -> Android.Ranging.CoordinateType
+const Android.Ranging.DlTdoaMeasurement.AnchorLocation.CoordinateRelativeWithZGravityAlignedPlusZElement = Android.Ranging.CoordinateType.RelativeWithZGravityAlignedPlusZElement -> Android.Ranging.CoordinateType
+const Android.Ranging.DlTdoaMeasurement.AnchorLocation.CoordinateUnknown = Android.Ranging.CoordinateType.Unknown -> Android.Ranging.CoordinateType
+const Android.Ranging.DlTdoaMeasurement.AnchorLocation.CoordinateWgs84 = Android.Ranging.CoordinateType.Wgs84 -> Android.Ranging.CoordinateType
+const Android.Ranging.DlTdoaMeasurement.AnchorLocation.CoordinateWgs84PlusZElement = Android.Ranging.CoordinateType.Wgs84PlusZElement -> Android.Ranging.CoordinateType
+const Android.Ranging.DlTdoaMeasurement.AnchorLocation.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.DlTdoaMeasurement.AnchorLocation.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.DlTdoaMeasurement.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.DlTdoaMeasurement.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.DlTdoaMeasurement.MessageTypeFinalDtm = Android.Ranging.MessageType.FinalDtm -> Android.Ranging.MessageType
+const Android.Ranging.DlTdoaMeasurement.MessageTypePollDtm = Android.Ranging.MessageType.PollDtm -> Android.Ranging.MessageType
+const Android.Ranging.DlTdoaMeasurement.MessageTypeResponseDtm = Android.Ranging.MessageType.ResponseDtm -> Android.Ranging.MessageType
+const Android.Ranging.DlTdoaMeasurement.RelativeLocation.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.DlTdoaMeasurement.RelativeLocation.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.DlTdoaMeasurement.Wgs84Location.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.DlTdoaMeasurement.Wgs84Location.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.DlTdoaMeasurement.ZElementExtension.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.DlTdoaMeasurement.ZElementExtension.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.DlTdoaMeasurement.ZElementExtension.MovementExpectationMovable = Android.Ranging.MovementExpectation.Movable -> Android.Ranging.MovementExpectation
+const Android.Ranging.DlTdoaMeasurement.ZElementExtension.MovementExpectationStationary = Android.Ranging.MovementExpectation.Stationary -> Android.Ranging.MovementExpectation
+const Android.Ranging.DlTdoaMeasurement.ZElementExtension.MovementExpectationUnknown = Android.Ranging.MovementExpectation.Unknown -> Android.Ranging.MovementExpectation
+const Android.Ranging.MotionState.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.MotionState.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.MotionState.MotionLarge = Android.Ranging.RangingMotion.Large -> Android.Ranging.RangingMotion
+const Android.Ranging.MotionState.MotionModerate = Android.Ranging.RangingMotion.Moderate -> Android.Ranging.RangingMotion
+const Android.Ranging.MotionState.MotionNotDetected = Android.Ranging.RangingMotion.NotDetected -> Android.Ranging.RangingMotion
+const Android.Ranging.MotionState.MotionSlight = Android.Ranging.RangingMotion.Slight -> Android.Ranging.RangingMotion
+const Android.Ranging.RangingDataExtras.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.RangingDataExtras.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.RangingManager.WifiPd = Android.Ranging.RangingManagerType.WifiPd -> Android.Ranging.RangingManagerType
+const Android.Ranging.RangingManager.WifiStaRtt = Android.Ranging.RangingManagerType.WifiStaRtt -> Android.Ranging.RangingManagerType
+const Android.Ranging.RangingPreference.DeviceRoleDtTag = Android.Ranging.RangingDeviceRole.DeviceRoleDtTag -> Android.Ranging.RangingDeviceRole
+const Android.Ranging.SessionConfig.AntennaModeDirectional = Android.Ranging.AntennaMode.Directional -> Android.Ranging.AntennaMode
+const Android.Ranging.SessionConfig.AntennaModeOmni = Android.Ranging.AntennaMode.Omni -> Android.Ranging.AntennaMode
+const Android.Ranging.Uwb.DlTdoaRangingParams.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.Uwb.DlTdoaRangingParams.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.Uwb.DlTdoaRangingParams.MeasurementVersion1 = Android.Ranging.Uwb.MeasurementVersion.v1 -> Android.Ranging.Uwb.MeasurementVersion
+const Android.Ranging.Uwb.DlTdoaRangingParams.MeasurementVersion2 = Android.Ranging.Uwb.MeasurementVersion.v2 -> Android.Ranging.Uwb.MeasurementVersion
+const Android.Ranging.Uwb.DlTdoaRangingParams.MeasurementVersionUnknown = Android.Ranging.Uwb.MeasurementVersion.Unknown -> Android.Ranging.Uwb.MeasurementVersion
+const Android.Ranging.Uwb.UwbSpecificData.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.Uwb.UwbSpecificData.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.Uwb.UwbSpecificData.Los = Android.Ranging.Uwb.LineOfSight.Los -> Android.Ranging.Uwb.LineOfSight
+const Android.Ranging.Uwb.UwbSpecificData.LosUndetermined = Android.Ranging.Uwb.LineOfSight.LosUndetermined -> Android.Ranging.Uwb.LineOfSight
+const Android.Ranging.Uwb.UwbSpecificData.Nlos = Android.Ranging.Uwb.LineOfSight.Nlos -> Android.Ranging.Uwb.LineOfSight
+const Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.AuthenticatedPasnMode = Android.Ranging.Wifi.PD.WifiPdRangingPasnMode.Authenticated -> Android.Ranging.Wifi.PD.WifiPdRangingPasnMode
+const Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.UnauthenticatedPasnMode = Android.Ranging.Wifi.PD.WifiPdRangingPasnMode.Unauthenticated -> Android.Ranging.Wifi.PD.WifiPdRangingPasnMode
+const Android.Ranging.Wifi.PD.WifiPdRangingParams.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.Wifi.PD.WifiPdRangingParams.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.Wifi.Rtt.RttStationRangingParams.ChannelWidthDefault = 255 -> int
+const Android.Ranging.Wifi.Rtt.RttStationRangingParams.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.Wifi.Rtt.RttStationRangingParams.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Ranging.Wifi.Rtt.WifiRttSpecificData.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Ranging.Wifi.Rtt.WifiRttSpecificData.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Resource.Attribute.BackupAgentProcess = 16844470 -> int
+const Android.Resource.Attribute.NativeService = 16844462 -> int
+const Android.Resource.Attribute.PrivateComputeCore = 16844469 -> int
+const Android.Resource.Attribute.ShortLabel = 16844468 -> int
+const Android.Resource.Attribute.UsesAssistData = 16844465 -> int
+const Android.Resource.Attribute.UsesAssistScreenshots = 16844466 -> int
+const Android.Resource.Attribute.UsesAssistStructureScreenContent = 16844467 -> int
+const Android.Resource.Attribute.ZygotePreloadNativeFunc = 16844464 -> int
+const Android.Resource.Attribute.ZygotePreloadNativeLib = 16844463 -> int
+const Android.Resource.Color.SystemInverseOnSurfaceDark = 17170648 -> int
+const Android.Resource.Color.SystemInverseOnSurfaceLight = 17170642 -> int
+const Android.Resource.Color.SystemInversePrimaryDark = 17170649 -> int
+const Android.Resource.Color.SystemInversePrimaryLight = 17170643 -> int
+const Android.Resource.Color.SystemInverseSurfaceDark = 17170650 -> int
+const Android.Resource.Color.SystemInverseSurfaceLight = 17170644 -> int
+const Android.Resource.Color.SystemScrimDark = 17170651 -> int
+const Android.Resource.Color.SystemScrimLight = 17170645 -> int
+const Android.Resource.Color.SystemShadowDark = 17170652 -> int
+const Android.Resource.Color.SystemShadowLight = 17170646 -> int
+const Android.Resource.Color.SystemSurfaceTintDark = 17170653 -> int
+const Android.Resource.Color.SystemSurfaceTintLight = 17170647 -> int
+const Android.Resource.Dimension.ConfigMotionExpressiveDefaultEffectDamping = 17104916 -> int
+const Android.Resource.Dimension.ConfigMotionExpressiveDefaultSpatialDamping = 17104915 -> int
+const Android.Resource.Dimension.ConfigMotionExpressiveFastEffectDamping = 17104914 -> int
+const Android.Resource.Dimension.ConfigMotionExpressiveFastSpatialDamping = 17104913 -> int
+const Android.Resource.Dimension.ConfigMotionExpressiveSlowEffectDamping = 17104918 -> int
+const Android.Resource.Dimension.ConfigMotionExpressiveSlowSpatialDamping = 17104917 -> int
+const Android.Resource.Dimension.ConfigMotionStandardDefaultEffectDamping = 17104910 -> int
+const Android.Resource.Dimension.ConfigMotionStandardDefaultSpatialDamping = 17104909 -> int
+const Android.Resource.Dimension.ConfigMotionStandardFastEffectDamping = 17104908 -> int
+const Android.Resource.Dimension.ConfigMotionStandardFastSpatialDamping = 17104907 -> int
+const Android.Resource.Dimension.ConfigMotionStandardSlowEffectDamping = 17104912 -> int
+const Android.Resource.Dimension.ConfigMotionStandardSlowSpatialDamping = 17104911 -> int
+const Android.Resource.Dimension.ConfigShapeCornerRadiusLarge = 17104922 -> int
+const Android.Resource.Dimension.ConfigShapeCornerRadiusMedium = 17104921 -> int
+const Android.Resource.Dimension.ConfigShapeCornerRadiusSmall = 17104920 -> int
+const Android.Resource.Dimension.ConfigShapeCornerRadiusXlarge = 17104923 -> int
+const Android.Resource.Dimension.ConfigShapeCornerRadiusXsmall = 17104919 -> int
+const Android.Resource.Id.AccessibilityActionSetExtendedSelection = 16908383 -> int
+const Android.Resource.Integer.ConfigMotionExpressiveDefaultEffectStiffness = 17694733 -> int
+const Android.Resource.Integer.ConfigMotionExpressiveDefaultSpatialStiffness = 17694732 -> int
+const Android.Resource.Integer.ConfigMotionExpressiveFastEffectStiffness = 17694731 -> int
+const Android.Resource.Integer.ConfigMotionExpressiveFastSpatialStiffness = 17694730 -> int
+const Android.Resource.Integer.ConfigMotionExpressiveSlowEffectStiffness = 17694735 -> int
+const Android.Resource.Integer.ConfigMotionExpressiveSlowSpatialStiffness = 17694734 -> int
+const Android.Resource.Integer.ConfigMotionStandardDefaultEffectStiffness = 17694727 -> int
+const Android.Resource.Integer.ConfigMotionStandardDefaultSpatialStiffness = 17694726 -> int
+const Android.Resource.Integer.ConfigMotionStandardFastEffectStiffness = 17694725 -> int
+const Android.Resource.Integer.ConfigMotionStandardFastSpatialStiffness = 17694724 -> int
+const Android.Resource.Integer.ConfigMotionStandardSlowEffectStiffness = 17694729 -> int
+const Android.Resource.Integer.ConfigMotionStandardSlowSpatialStiffness = 17694728 -> int
+const Android.Security.KeyStoreException.ErrorTooManyKeys = Android.Security.KeyStoreExceptionError.ErrorTooManyKeys -> Android.Security.KeyStoreExceptionError
+const Android.Security.Keystore.KeyProperties.KeyAlgorithmMlDsa = "ML-DSA" -> string!
+const Android.Security.Keystore.KeyProperties.KeyAlgorithmMlDsa65 = "ML-DSA-65" -> string!
+const Android.Security.Keystore.KeyProperties.KeyAlgorithmMlDsa87 = "ML-DSA-87" -> string!
+const Android.Security.NetworkSecurityPolicy.DomainEncryptionModeDisabled = Android.Security.DomainEncryptionMode.Disabled -> Android.Security.DomainEncryptionMode
+const Android.Security.NetworkSecurityPolicy.DomainEncryptionModeEnabled = Android.Security.DomainEncryptionMode.Enabled -> Android.Security.DomainEncryptionMode
+const Android.Security.NetworkSecurityPolicy.DomainEncryptionModeOpportunistic = Android.Security.DomainEncryptionMode.Opportunistic -> Android.Security.DomainEncryptionMode
+const Android.Security.NetworkSecurityPolicy.DomainEncryptionModeUnknown = Android.Security.DomainEncryptionMode.Unknown -> Android.Security.DomainEncryptionMode
+const Android.Service.Autofill.FillEventHistory.Event.TypeResponseDiscarded = Android.Service.Autofill.EventType.ResponseDiscarded -> Android.Service.Autofill.EventType
+const Android.Service.Chooser.ChooserSession.StateClosed = Android.Service.Chooser.ChooserSessionState.Closed -> Android.Service.Chooser.ChooserSessionState
+const Android.Service.Chooser.ChooserSession.StateInitialized = Android.Service.Chooser.ChooserSessionState.Initialized -> Android.Service.Chooser.ChooserSessionState
+const Android.Service.Chooser.ChooserSession.StateStarted = Android.Service.Chooser.ChooserSessionState.Started -> Android.Service.Chooser.ChooserSessionState
+const Android.Service.Chooser.ChooserSessionToken.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Service.Chooser.ChooserSessionToken.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Service.Messaging.AlternativeMessageTransportService.ServiceInterface = "android.service.messaging.AlternativeMessageTransportService" -> string!
+const Android.Service.Messaging.AlternativeMessageTransportService.UpgradeStatusAccepted = Android.Service.Messaging.UpgradeStatus.Accepted -> Android.Service.Messaging.UpgradeStatus
+const Android.Service.Messaging.AlternativeMessageTransportService.UpgradeStatusRejected = Android.Service.Messaging.UpgradeStatus.Rejected -> Android.Service.Messaging.UpgradeStatus
+const Android.Service.Notification.NotificationListenerService.ReasonBundleDismissed = Android.Service.Notification.NotificationCancelReason.ReasonBundleDismissed -> Android.Service.Notification.NotificationCancelReason
+const Android.Service.QuickSettings.TileService.CategoryAccessibility = "android.service.quicksettings.CATEGORY_ACCESSIBILITY" -> string!
+const Android.Service.QuickSettings.TileService.CategoryConnectivity = "android.service.quicksettings.CATEGORY_CONNECTIVITY" -> string!
+const Android.Service.QuickSettings.TileService.CategoryDisplay = "android.service.quicksettings.CATEGORY_DISPLAY" -> string!
+const Android.Service.QuickSettings.TileService.CategoryPrivacy = "android.service.quicksettings.CATEGORY_PRIVACY" -> string!
+const Android.Service.QuickSettings.TileService.CategoryUtilities = "android.service.quicksettings.CATEGORY_UTILITIES" -> string!
+const Android.Service.QuickSettings.TileService.MetaDataTileCategory = "android.service.quicksettings.TILE_CATEGORY" -> string!
+const Android.Service.Voice.VoiceInteractionSession.ShowWithAssistStructureScreenContent = Android.Service.Voice.ShowFlags.ShowWithAssistStructureScreenContent -> Android.Service.Voice.ShowFlags
+const Android.Telecom.Call.AudioProcessingUseCaseAskToHold = Android.Telecom.AudioProcessingUseCase.AskToHold -> Android.Telecom.AudioProcessingUseCase
+const Android.Telecom.Call.AudioProcessingUseCaseCallScreening = Android.Telecom.AudioProcessingUseCase.CallScreening -> Android.Telecom.AudioProcessingUseCase
+const Android.Telecom.Call.AudioProcessingUseCaseUnknown = Android.Telecom.AudioProcessingUseCase.Unknown -> Android.Telecom.AudioProcessingUseCase
+const Android.Telecom.Call.AudioProcessingUseCaseVoicemail = Android.Telecom.AudioProcessingUseCase.Voicemail -> Android.Telecom.AudioProcessingUseCase
+const Android.Telecom.Call.CrsMediaTypeAudio = Android.Telecom.CrsMediaType.Audio -> Android.Telecom.CrsMediaType
+const Android.Telecom.Call.CrsMediaTypeNone = Android.Telecom.CrsMediaType.None -> Android.Telecom.CrsMediaType
+const Android.Telecom.Call.CrsMediaTypeVideo = Android.Telecom.CrsMediaType.Video -> Android.Telecom.CrsMediaType
+const Android.Telecom.Call.Details.PropertyRemotelyHosted = Android.Telecom.CallCapability.PropertyRemotelyHosted -> Android.Telecom.CallCapability
+const Android.Telecom.Call.EventPhoneAccountChanged = "android.telecom.event.PHONE_ACCOUNT_CHANGED" -> string!
+const Android.Telecom.Call.ExtraCrsAudioMode = "android.telecom.extra.CRS_AUDIO_MODE" -> string!
+const Android.Telecom.Call.ExtraCrsMediaType = "android.telecom.extra.CRS_MEDIA_TYPE" -> string!
+const Android.Telecom.Call.ExtraIsUsingUnidirectionalVideoService = "android.telecom.extra.IS_USING_UNIDIRECTIONAL_VIDEO_SERVICE" -> string!
+const Android.Telecom.Call.ExtraIsUsingVideoRingback = "android.telecom.extra.IS_USING_VIDEO_RINGBACK" -> string!
+const Android.Telecom.CallAttributes.Messaging = Android.Telecom.CallType.Messaging -> Android.Telecom.CallType
+const Android.Telecom.Connection.CapabilityTransfer = Android.Telecom.ConnectionCapability.CapabilityTransfer -> Android.Telecom.ConnectionCapability
+const Android.Telecom.Connection.CapabilityTransferConsultative = Android.Telecom.ConnectionCapability.CapabilityTransferConsultative -> Android.Telecom.ConnectionCapability
+const Android.Telecom.Connection.EventCallResumeFailed = "android.telecom.event.CALL_RESUME_FAILED" -> string!
+const Android.Telecom.Connection.EventDisconnectFailed = "android.telecom.event.DISCONNECT_FAILED" -> string!
+const Android.Telecom.Connection.StateAudioProcessing = Android.Telecom.ConnectionState.StateAudioProcessing -> Android.Telecom.ConnectionState
+const Android.Telecom.Connection.StateSimulatedRinging = Android.Telecom.ConnectionState.SimulatedRinging -> Android.Telecom.ConnectionState
+const Android.Telecom.PhoneAccount.CapabilityChangeRttCallToAudioCall = Android.Telecom.PhoneAccountCapability.ChangeRttCallToAudioCall -> Android.Telecom.PhoneAccountCapability
+const Android.Telecom.PhoneAccount.LowBatteryAlertDisabled = -1 -> int
+const Android.Telecom.TelecomManager.ActionCallBack = "android.telecom.action.CALL_BACK" -> string!
+const Android.Telecom.TelecomManager.ActionConfigureCallLogIntegration = "android.telecom.action.CONFIGURE_CALL_LOG_INTEGRATION" -> string!
+const Android.Telecom.TelecomManager.ActionVoipCallLogPreference = "android.telecom.action.VOIP_CALL_LOG_PREFERENCE" -> string!
+const Android.Telecom.TelecomManager.ExtraCallType = "android.telecom.extra.CALL_TYPE" -> string!
+const Android.Telecom.TelecomManager.ExtraUuid = "android.telecom.extra.UUID" -> string!
+const Android.Telecom.TelecomManager.ExtraVoipCallLogPreferenceStatus = "android.telecom.extra.VOIP_CALL_LOG_PREFERENCE_STATUS" -> string!
+const Android.Telephony.CarrierConfigManager.CarrierRoamingNtnConnectAutomatic = 0 -> int
+const Android.Telephony.CarrierConfigManager.CarrierRoamingNtnConnectHybrid = 2 -> int
+const Android.Telephony.CarrierConfigManager.CarrierRoamingNtnConnectManual = 1 -> int
+const Android.Telephony.CarrierConfigManager.KeyAllowHoldInRttCallBool = "allow_hold_in_rtt_call_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeyAutoUnholdOnRemoteDisconnectBool = "auto_unhold_on_remote_disconnect_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeyAvoidBadWifiBool = "avoid_bad_wifi_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeyCarrierRoamingNtnConnectTypeInt = "carrier_roaming_ntn_connect_type_int" -> string!
+const Android.Telephony.CarrierConfigManager.KeyCarrierRoamingSatelliteDefaultServicesIntArray = "carrier_roaming_satellite_default_services_int_array" -> string!
+const Android.Telephony.CarrierConfigManager.KeyCarrierRoamingSatelliteT911ToEsosHandoverSupportedBool = "carrier_roaming_satellite_t911_to_esos_handover_supported_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeyCarrierSupportedSatelliteNotificationHysteresisSecInt = "carrier_supported_satellite_notification_hysteresis_sec_int" -> string!
+const Android.Telephony.CarrierConfigManager.KeyDisableDunApnWhileRoamingWithPresetApnBool = "disable_dun_apn_while_roaming_with_preset_apn_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeyDisallowAddingApnStringArray = "disallow_adding_apn_string_array" -> string!
+const Android.Telephony.CarrierConfigManager.KeyEmergencyCallToSatelliteT911HandoverTimeoutMillisInt = "emergency_call_to_satellite_t911_handover_timeout_millis_int" -> string!
+const Android.Telephony.CarrierConfigManager.KeyEmergencyMessagingSupportedBool = "emergency_messaging_supported_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeyIsPrivateNetworkBool = "is_private_network_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeyLogCallsAnsweredElsewhereBool = "log_calls_answered_elsewhere_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeyLowBatteryAlertIntervalInt = "low_battery_alert_interval_int" -> string!
+const Android.Telephony.CarrierConfigManager.KeyLowBatteryAlertThresholdInt = "low_battery_alert_threshold_int" -> string!
+const Android.Telephony.CarrierConfigManager.KeyMmsMaxNtnPayloadSizeBytesInt = "mms_max_ntn_payload_size_bytes_int" -> string!
+const Android.Telephony.CarrierConfigManager.KeyNtn5gNrSsrsrpThresholdsIntArray = "ntn_5g_nr_ssrsrp_thresholds_int_array" -> string!
+const Android.Telephony.CarrierConfigManager.KeyNtn5gNrSsrsrqThresholdsIntArray = "ntn_5g_nr_ssrsrq_thresholds_int_array" -> string!
+const Android.Telephony.CarrierConfigManager.KeyNtn5gNrSssinrThresholdsIntArray = "ntn_5g_nr_sssinr_thresholds_int_array" -> string!
+const Android.Telephony.CarrierConfigManager.KeyOppAutoDataSwitchPolicyInt = "opp_auto_data_switch_policy_int" -> string!
+const Android.Telephony.CarrierConfigManager.KeyOverrideWfcRoamingModeWhileUsingNtnBool = "override_wfc_roaming_mode_while_using_ntn_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeyRegionalSatelliteEarfcnBundle = "regional_satellite_earfcn_bundle" -> string!
+const Android.Telephony.CarrierConfigManager.KeyRemoveSatellitePlmnInManualNetworkScanBool = "remove_satellite_plmn_in_manual_network_scan_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteConfigsPerPlmnBundle = "satellite_configs_per_plmn_bundle" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteConnectedNotificationThrottleMillisInt = "satellite_connected_notification_throttle_millis_int" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteDataSupportModeInt = "satellite_data_support_mode_int" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteDisplayNameString = "satellite_display_name_string" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteEntitlementAppNameString = "satellite_entitlement_app_name_string" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteIgnoreDataRoamingSettingBool = "satellite_ignore_data_roaming_setting_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteInformationRedirectUrlString = "satellite_information_redirect_url_string" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteNiddApnNameString = "satellite_nidd_apn_name_string" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteRoamingTurnOffSessionForEmergencyCallBool = "satellite_roaming_turn_off_session_for_emergency_call_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteSosMaxDatagramSizeBytesInt = "satellite_sos_max_datagram_size_bytes_int" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteSupportedDisasterPlmnStringArray = "satellite_supported_disaster_plmn_string_array" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteSupportedEmergencyPlmnStringArray = "satellite_supported_emergency_plmn_string_array" -> string!
+const Android.Telephony.CarrierConfigManager.KeySatelliteSupportedMsgAppsStringArray = "satellite_supported_msg_apps_string_array" -> string!
+const Android.Telephony.CarrierConfigManager.KeyShowAvoidBadWifiToggleBool = "show_avoid_bad_wifi_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeySupportMultiPartyAnchorConferenceBool = "support_multi_anchor_conf_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeySupportPhoneNumberSourceTs43Bool = "support_phone_number_source_ts43_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeySupportsCustomizedRingingSignalBool = "supports_customized_ringing_signal_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeySupportsUnidirectionalVideoServiceBool = "supports_unidirectional_video_service_bool" -> string!
+const Android.Telephony.CarrierConfigManager.KeySupportsVideoRingbackBool = "supports_video_back_tone_bool" -> string!
+const Android.Telephony.CarrierConfigManager.OppAutoDataSwitchPolicyDisabled = 0 -> int
+const Android.Telephony.CarrierConfigManager.OppAutoDataSwitchPolicyFollowSystem = 2147483647 -> int
+const Android.Telephony.CarrierConfigManager.OppAutoDataSwitchPolicyForAvailability = 1 -> int
+const Android.Telephony.CarrierConfigManager.OppAutoDataSwitchPolicyForPerformance = 3 -> int
+const Android.Telephony.CarrierConfigManager.SatelliteDataSupportAll = 2 -> int
+const Android.Telephony.CarrierConfigManager.SatelliteDataSupportBandwidthConstrained = 1 -> int
+const Android.Telephony.CarrierConfigManager.SatelliteDataSupportOnlyRestricted = 0 -> int
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityBackground = Android.Telephony.Data.ConnectionCapability.Background -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityDownlinkStreaming = Android.Telephony.Data.ConnectionCapability.DownlinkStreaming -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityIms = Android.Telephony.Data.ConnectionCapability.Ims -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityInternet = Android.Telephony.Data.ConnectionCapability.Internet -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityIotDelayTolerant = Android.Telephony.Data.ConnectionCapability.IotDelayTolerant -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityIotNonDelayTolerant = Android.Telephony.Data.ConnectionCapability.IotNonDelayTolerant -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityLcsUserPlanePositioning = Android.Telephony.Data.ConnectionCapability.LcsUserPlanePositioning -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityLowLatencyLossTolerantUnack = Android.Telephony.Data.ConnectionCapability.LowLatencyLossTolerantUnack -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityMissionCriticalCommunications = Android.Telephony.Data.ConnectionCapability.MissionCriticalCommunications -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityMms = Android.Telephony.Data.ConnectionCapability.Mms -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityRealTimeInteractive = Android.Telephony.Data.ConnectionCapability.RealTimeInteractive -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilitySupl = Android.Telephony.Data.ConnectionCapability.Supl -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityTimeCriticalCommunications = Android.Telephony.Data.ConnectionCapability.TimeCriticalCommunications -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityUnifiedCommunications = Android.Telephony.Data.ConnectionCapability.UnifiedCommunications -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityUnknown = Android.Telephony.Data.ConnectionCapability.Unknown -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityUplinkStreaming = Android.Telephony.Data.ConnectionCapability.UplinkStreaming -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Data.TrafficDescriptor.ConnectionCapabilityVehicularCommunications = Android.Telephony.Data.ConnectionCapability.VehicularCommunications -> Android.Telephony.Data.ConnectionCapability
+const Android.Telephony.Ims.ImsRegistrationAttributes.AttrRegistrationTypeEmergency = Android.Telephony.Ims.RegistrationAttributes.RegistrationTypeEmergency -> Android.Telephony.Ims.RegistrationAttributes
+const Android.Telephony.Ims.ImsRegistrationAttributes.AttrVirtualForAnonymousEmergencyCall = Android.Telephony.Ims.RegistrationAttributes.VirtualForAnonymousEmergencyCall -> Android.Telephony.Ims.RegistrationAttributes
+const Android.Telephony.NetworkRegistrationInfo.ServiceTypeEmergencySms = Android.Telephony.NetworkRegistrationInfoServiceType.EmergencySms -> Android.Telephony.NetworkRegistrationInfoServiceType
+const Android.Telephony.ParsedPhoneNumber.ErrorTypeFailedToValidateExtractedPhoneNumer = Android.Telephony.ParsedPhoneNumberErrorType.FailedToValidateExtractedPhoneNumer -> Android.Telephony.ParsedPhoneNumberErrorType
+const Android.Telephony.ParsedPhoneNumber.ErrorTypeNone = Android.Telephony.ParsedPhoneNumberErrorType.None -> Android.Telephony.ParsedPhoneNumberErrorType
+const Android.Telephony.ParsedPhoneNumber.ErrorTypeNumberParseException = Android.Telephony.ParsedPhoneNumberErrorType.NumberParseException -> Android.Telephony.ParsedPhoneNumberErrorType
+const Android.Telephony.ParsedPhoneNumber.ErrorTypeUnknown = Android.Telephony.ParsedPhoneNumberErrorType.Unknown -> Android.Telephony.ParsedPhoneNumberErrorType
+const Android.Telephony.ParsedPhoneNumber.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Telephony.ParsedPhoneNumber.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Telephony.Satellite.NtnSignalStrength.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Telephony.Satellite.NtnSignalStrength.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Telephony.Satellite.NtnSignalStrength.NtnSignalStrengthGood = Android.Telephony.Satellite.NtnSignalStrengthLevel.Good -> Android.Telephony.Satellite.NtnSignalStrengthLevel
+const Android.Telephony.Satellite.NtnSignalStrength.NtnSignalStrengthGreat = Android.Telephony.Satellite.NtnSignalStrengthLevel.Great -> Android.Telephony.Satellite.NtnSignalStrengthLevel
+const Android.Telephony.Satellite.NtnSignalStrength.NtnSignalStrengthModerate = Android.Telephony.Satellite.NtnSignalStrengthLevel.Moderate -> Android.Telephony.Satellite.NtnSignalStrengthLevel
+const Android.Telephony.Satellite.NtnSignalStrength.NtnSignalStrengthNone = Android.Telephony.Satellite.NtnSignalStrengthLevel.None -> Android.Telephony.Satellite.NtnSignalStrengthLevel
+const Android.Telephony.Satellite.NtnSignalStrength.NtnSignalStrengthPoor = Android.Telephony.Satellite.NtnSignalStrengthLevel.Poor -> Android.Telephony.Satellite.NtnSignalStrengthLevel
+const Android.Telephony.Satellite.SatelliteManager.PropertySatelliteDataOptimized = "android.telephony.PROPERTY_SATELLITE_DATA_OPTIMIZED" -> string!
+const Android.Telephony.SmsManager.ResultSmsSendFailedAfterMaxRetry = Android.Telephony.SmsResult.ResultSmsSendFailedAfterMaxRetry -> Android.Telephony.SmsResult
+const Android.Telephony.SubscriptionManager.PhoneNumberSourceTs43 = Android.Telephony.PhoneNumberSource.Ts43 -> Android.Telephony.PhoneNumberSource
+const Android.Telephony.SubscriptionPlan.BitrateUnknown = -1 -> long
+const Android.Telephony.SubscriptionPlan.PlanTypeBusiness = Android.Telephony.SubscriptionPlanType.Business -> Android.Telephony.SubscriptionPlanType
+const Android.Telephony.SubscriptionPlan.PlanTypeCellular = Android.Telephony.SubscriptionPlanType.Cellular -> Android.Telephony.SubscriptionPlanType
+const Android.Telephony.SubscriptionPlan.PlanTypeDataOnly = Android.Telephony.SubscriptionPlanType.DataOnly -> Android.Telephony.SubscriptionPlanType
+const Android.Telephony.SubscriptionPlan.PlanTypeFamily = Android.Telephony.SubscriptionPlanType.Family -> Android.Telephony.SubscriptionPlanType
+const Android.Telephony.SubscriptionPlan.PlanTypeIot = Android.Telephony.SubscriptionPlanType.Iot -> Android.Telephony.SubscriptionPlanType
+const Android.Telephony.SubscriptionPlan.PlanTypePostpaid = Android.Telephony.SubscriptionPlanType.Postpaid -> Android.Telephony.SubscriptionPlanType
+const Android.Telephony.SubscriptionPlan.PlanTypePrepaid = Android.Telephony.SubscriptionPlanType.Prepaid -> Android.Telephony.SubscriptionPlanType
+const Android.Telephony.SubscriptionPlan.PlanTypeRoaming = Android.Telephony.SubscriptionPlanType.Roaming -> Android.Telephony.SubscriptionPlanType
+const Android.Telephony.SubscriptionPlan.PlanTypeSatellite = Android.Telephony.SubscriptionPlanType.Satellite -> Android.Telephony.SubscriptionPlanType
+const Android.Telephony.SubscriptionPlan.PlanTypeTethering = Android.Telephony.SubscriptionPlanType.Tethering -> Android.Telephony.SubscriptionPlanType
+const Android.Telephony.SubscriptionPlan.UnspecifiedId = -1 -> int
+const Android.Telephony.TelephonyManager.TtyModeFull = Android.Telephony.TelephonyManagerTtyMode.Full -> Android.Telephony.TelephonyManagerTtyMode
+const Android.Telephony.TelephonyManager.TtyModeHco = Android.Telephony.TelephonyManagerTtyMode.Hco -> Android.Telephony.TelephonyManagerTtyMode
+const Android.Telephony.TelephonyManager.TtyModeOff = Android.Telephony.TelephonyManagerTtyMode.Off -> Android.Telephony.TelephonyManagerTtyMode
+const Android.Telephony.TelephonyManager.TtyModeVco = Android.Telephony.TelephonyManagerTtyMode.Vco -> Android.Telephony.TelephonyManagerTtyMode
+const Android.Text.InputType.TypeTextFlagEnableTextSuggestionSelected = Android.Text.InputTypes.TextFlagEnableTextSuggestionSelected -> Android.Text.InputTypes
+const Android.Views.Accessibility.AccessibilityEvent.ContentChangeTypeSortDirection = Android.Views.Accessibility.ContentChangeTypes.ContentChangeTypeSortDirection -> Android.Views.Accessibility.ContentChangeTypes
+const Android.Views.Accessibility.AccessibilityEvent.TextChangeTypeCommittedByIme = Android.Views.Accessibility.TextChangeTypes.CommittedByIme -> Android.Views.Accessibility.TextChangeTypes
+const Android.Views.Accessibility.AccessibilityEvent.TextChangeTypeConversionSuggestionSelectedByIme = Android.Views.Accessibility.TextChangeTypes.ConversionSuggestionSelectedByIme -> Android.Views.Accessibility.TextChangeTypes
+const Android.Views.Accessibility.AccessibilityEvent.TextChangeTypeInComposition = Android.Views.Accessibility.TextChangeTypes.InComposition -> Android.Views.Accessibility.TextChangeTypes
+const Android.Views.Accessibility.AccessibilityEvent.TextChangeTypeUndefined = Android.Views.Accessibility.TextChangeTypes.Undefined -> Android.Views.Accessibility.TextChangeTypes
+const Android.Views.Accessibility.AccessibilityNodeInfo.ActionArgumentSelectionParcelable = "android.view.accessibility.action.ARGUMENT_SELECTION_PARCELABLE" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.CollectionItemInfo.SortDirectionAscending = Android.Views.Accessibility.AccessibilityCollectionSortDirection.Ascending -> Android.Views.Accessibility.AccessibilityCollectionSortDirection
+const Android.Views.Accessibility.AccessibilityNodeInfo.CollectionItemInfo.SortDirectionDescending = Android.Views.Accessibility.AccessibilityCollectionSortDirection.Descending -> Android.Views.Accessibility.AccessibilityCollectionSortDirection
+const Android.Views.Accessibility.AccessibilityNodeInfo.CollectionItemInfo.SortDirectionNone = Android.Views.Accessibility.AccessibilityCollectionSortDirection.None -> Android.Views.Accessibility.AccessibilityCollectionSortDirection
+const Android.Views.Accessibility.AccessibilityNodeInfo.CollectionItemInfo.SortDirectionOther = Android.Views.Accessibility.AccessibilityCollectionSortDirection.Other -> Android.Views.Accessibility.AccessibilityCollectionSortDirection
+const Android.Views.Accessibility.AccessibilityNodeInfo.ExtraDataRequestLayoutBasedActionsKey = "android.view.accessibility.extra.DATA_REQUEST_LAYOUT_BASED_ACTIONS_KEY" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathAttributeArg = "arg" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathAttributeIntent = "intent" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagFraction = "mfrac" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagIdentifier = "mi" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagMath = "math" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagMultiscripts = "mmultiscripts" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagNoneScript = "none" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagNumber = "mn" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagOperator = "mo" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagOver = "mover" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagPrescriptDelimiter = "mprescripts" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagRoot = "mroot" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagRow = "mrow" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagSquareRoot = "msqrt" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagStringLiteral = "ms" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagSub = "msub" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagSubSup = "msubsup" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagSup = "msup" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagTable = "mtable" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagTableCell = "mtd" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagTableRow = "mtr" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagText = "mtext" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagUnder = "munder" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.MathTagUnderOver = "munderover" -> string!
+const Android.Views.Accessibility.AccessibilityNodeInfo.Selection.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Views.Accessibility.AccessibilityNodeInfo.Selection.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Views.Autofill.AutofillNoiseInjectedData.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Views.Autofill.AutofillNoiseInjectedData.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Views.Display.HdrCapabilities.HdrTypeHlgPlus = Android.Views.HdrType.HdrTypeHlgPlus -> Android.Views.HdrType
+const Android.Views.FrameRateVelocityPoint.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Views.FrameRateVelocityPoint.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Views.IWindowManager.PropertyCameraCompatAllowSimulateRequestedOrientation = "android.window.PROPERTY_CAMERA_COMPAT_ALLOW_SIMULATE_REQUESTED_ORIENTATION" -> string!
+const Android.Views.IWindowManager.PropertyCompatAllowExcludeCaptionInsets = "android.window.PROPERTY_COMPAT_ALLOW_EXCLUDE_CAPTION_INSETS" -> string!
+const Android.Views.InputMethods.EditorInfo.InterfaceConsts.TypeTextFlagEnableTextSuggestionSelected = Android.Text.InputTypes.TextFlagEnableTextSuggestionSelected -> Android.Text.InputTypes
+const Android.Views.KeyEvent.KeycodeAccessibility = Android.Views.Keycode.Accessibility -> Android.Views.Keycode
+const Android.Views.KeyEvent.KeycodeContextualInsert = Android.Views.Keycode.ContextualInsert -> Android.Views.Keycode
+const Android.Views.KeyEvent.KeycodeContextualSearch = Android.Views.Keycode.ContextualSearch -> Android.Views.Keycode
+const Android.Views.SurfaceControl.BufferTransformMirrorHorizontalRotate90 = Android.Views.BufferTransform.MirrorHorizontalRotate90 -> Android.Views.BufferTransform
+const Android.Views.SurfaceControl.BufferTransformMirrorVerticalRotate90 = Android.Views.BufferTransform.MirrorVerticalRotate90 -> Android.Views.BufferTransform
+const Android.Views.TextClassifiers.ITextClassifier.ExtraOtpTrustedPackages = "android.view.textclassifier.extra.OTP_TRUSTED_PACKAGES" -> string!
+const Android.Views.TextClassifiers.ITextClassifier.TypeSmsRetrieverOtp = "sms_retriever_otp" -> string!
+const Android.Views.TextClassifiers.ITextClassifier.TypeSmsWebOtp = "sms_web_otp" -> string!
+const Android.Views.TextClassifiers.TextClassifier.ExtraOtpTrustedPackages = "android.view.textclassifier.extra.OTP_TRUSTED_PACKAGES" -> string!
+const Android.Views.TextClassifiers.TextClassifier.TypeSmsRetrieverOtp = "sms_retriever_otp" -> string!
+const Android.Views.TextClassifiers.TextClassifier.TypeSmsWebOtp = "sms_web_otp" -> string!
+const Android.Views.View.PointerCaptureModeAbsolute = Android.Views.PointerCaptureMode.Absolute -> Android.Views.PointerCaptureMode
+const Android.Views.View.PointerCaptureModeRelative = Android.Views.PointerCaptureMode.Relative -> Android.Views.PointerCaptureMode
+const Android.Views.View.PointerCaptureModeUncaptured = Android.Views.PointerCaptureMode.Uncaptured -> Android.Views.PointerCaptureMode
+const Android.Views.View.RectangleOnScreenRequestSourceInputFocus = Android.Views.ViewRectangleOnScreenRequestSource.InputFocus -> Android.Views.ViewRectangleOnScreenRequestSource
+const Android.Views.View.RectangleOnScreenRequestSourceScrollOnly = Android.Views.ViewRectangleOnScreenRequestSource.ScrollOnly -> Android.Views.ViewRectangleOnScreenRequestSource
+const Android.Views.View.RectangleOnScreenRequestSourceTextCursor = Android.Views.ViewRectangleOnScreenRequestSource.TextCursor -> Android.Views.ViewRectangleOnScreenRequestSource
+const Android.Views.View.RectangleOnScreenRequestSourceUndefined = Android.Views.ViewRectangleOnScreenRequestSource.Undefined -> Android.Views.ViewRectangleOnScreenRequestSource
+const Android.Views.WindowManager.PropertyCameraCompatAllowSimulateRequestedOrientation = "android.window.PROPERTY_CAMERA_COMPAT_ALLOW_SIMULATE_REQUESTED_ORIENTATION" -> string!
+const Android.Views.WindowManager.PropertyCompatAllowExcludeCaptionInsets = "android.window.PROPERTY_COMPAT_ALLOW_EXCLUDE_CAPTION_INSETS" -> string!
+const Android.Webkit.WebChromeClient.FileChooserParams.ModeOpenFolder = Android.Webkit.ChromeFileChooserMode.OpenFolder -> Android.Webkit.ChromeFileChooserMode
+const Android.Webkit.WebChromeClient.FileChooserParams.PermissionModeRead = Android.Webkit.PermissionMode.Read -> Android.Webkit.PermissionMode
+const Android.Webkit.WebChromeClient.FileChooserParams.PermissionModeReadWrite = Android.Webkit.PermissionMode.ReadWrite -> Android.Webkit.PermissionMode
+const Android.Widget.PhotoPicker.PhotoPickerSelectionParams.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Widget.PhotoPicker.PhotoPickerSelectionParams.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+const Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.AspectRatioPortrait916 = Android.Widget.Photopicker.AspectRatio.Portrait916 -> Android.Widget.Photopicker.AspectRatio
+const Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.AspectRatioSquare11 = Android.Widget.Photopicker.AspectRatio.Square11 -> Android.Widget.Photopicker.AspectRatio
+const Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.AspectRatioUndefined = Android.Widget.Photopicker.AspectRatio.Undefined -> Android.Widget.Photopicker.AspectRatio
+const Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.InterfaceConsts.ContentsFileDescriptor = 1 -> int
+const Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.InterfaceConsts.ParcelableWriteReturnValue = Android.OS.ParcelableWriteFlags.ReturnValue -> Android.OS.ParcelableWriteFlags
+override Android.App.AnrTypes.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AnrWarningResult.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.AppFunctionActivityId.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.AppFunctionActivityState.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.AppFunctionMetadata.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.AppFunctionName.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.AppFunctionPackageMetadata.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.AppFunctionSchemaMetadata.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.AppFunctionSearchSpec.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.AppFunctionSearchSpec.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.AppFunctionState.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.AppFunctionUriGrant.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppFunctions.RegisterAppFunctionRequest.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppInteractionAttribution.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppInteractionAttribution.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppInteractionContract.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppSearch.AppSearchAccount.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppSearch.AppSearchAccount.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.AppSearch.SearchResult.TextMatchInfo.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.ApplicationExitInfo.AnrInfo.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Backup.FullRestoreDataInput.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Backup.FullRestoreDataInput.ThresholdClass.get -> nint
+override Android.App.Backup.FullRestoreDataInput.ThresholdType.get -> System.Type!
+override Android.App.HandoffActivityData.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.HandoffActivityData.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.HandoffActivityDataRequestInfo.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.HandoffActivityParams.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.HandoffActivityParams.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.InfeasibleActivityOptionsException.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.InfeasibleActivityOptionsException.ThresholdClass.get -> nint
+override Android.App.InfeasibleActivityOptionsException.ThresholdType.get -> System.Type!
+override Android.App.Notification.BridgedNotificationMetadata.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Notification.Metric.FixedDate.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Notification.Metric.FixedFloat.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Notification.Metric.FixedInt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Notification.Metric.FixedText.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Notification.Metric.FixedTime.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Notification.Metric.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Notification.Metric.MetricValue.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Notification.Metric.MetricValue.ThresholdClass.get -> nint
+override Android.App.Notification.Metric.MetricValue.ThresholdType.get -> System.Type!
+override Android.App.Notification.Metric.TimeDifference.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Notification.MetricStyle.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.Notification.ProjectedExtender.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.PermissionUI.LocationButtonProviderFactory.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.PermissionUI.LocationButtonProviderFactory.ThresholdClass.get -> nint
+override Android.App.PermissionUI.LocationButtonProviderFactory.ThresholdType.get -> System.Type!
+override Android.App.PermissionUI.LocationButtonRequest.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.PermissionUI.LocationButtonRequest.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.PrivateCompute.DataMigrationToPccService.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.PrivateCompute.DataMigrationToPccService.ThresholdClass.get -> nint
+override Android.App.PrivateCompute.DataMigrationToPccService.ThresholdType.get -> System.Type!
+override Android.App.PrivateCompute.MigrationException.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.PrivateCompute.MigrationRequestResult.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.PrivateCompute.PccClient.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.PrivateCompute.PccClient.ThresholdClass.get -> nint
+override Android.App.PrivateCompute.PccClient.ThresholdType.get -> System.Type!
+override Android.App.PrivateCompute.PccSandboxManager.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.PrivateCompute.PccService.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.PrivateCompute.PccService.ThresholdClass.get -> nint
+override Android.App.PrivateCompute.PccService.ThresholdType.get -> System.Type!
+override Android.App.TaskLocation.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.App.TaskLocation.ThresholdClass.get -> nint
+override Android.App.TaskLocation.ThresholdType.get -> System.Type!
+override Android.App.VoiceInteractions.VoiceInteractionManager.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Appwidget.AppWidgetEvent.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Bluetooth.BluetoothGattConnectionSettings.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Bluetooth.BluetoothGattConnectionSettings.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Bluetooth.BondStatus.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Bluetooth.EncryptionStatus.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Companion.ActionRequest.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Companion.ActionRequest.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Companion.ActionResult.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Companion.ActionResult.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Content.Context.UpdateBindingParams.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Content.Context.UpdateBindingParams.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Content.PM.Webapp.WebAppInstallRequest.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Content.PM.Webapp.WebAppInstallRequest.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Content.PM.Webapp.WebAppInstallRequest.ThresholdClass.get -> nint
+override Android.Content.PM.Webapp.WebAppInstallRequest.ThresholdType.get -> System.Type!
+override Android.Content.PM.Webapp.WebAppManager.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Content.PM.Webapp.WebAppQueryRequest.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Content.PM.Webapp.WebAppQueryRequest.ThresholdClass.get -> nint
+override Android.Content.PM.Webapp.WebAppQueryRequest.ThresholdType.get -> System.Type!
+override Android.Crypto.Hpke.AeadParameterSpec.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Crypto.Hpke.AeadParameterSpec.ThresholdClass.get -> nint
+override Android.Crypto.Hpke.AeadParameterSpec.ThresholdType.get -> System.Type!
+override Android.Crypto.Hpke.Hpke.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Crypto.Hpke.Hpke.ThresholdClass.get -> nint
+override Android.Crypto.Hpke.Hpke.ThresholdType.get -> System.Type!
+override Android.Crypto.Hpke.KdfParameterSpec.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Crypto.Hpke.KdfParameterSpec.ThresholdClass.get -> nint
+override Android.Crypto.Hpke.KdfParameterSpec.ThresholdType.get -> System.Type!
+override Android.Crypto.Hpke.KemParameterSpec.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Crypto.Hpke.KemParameterSpec.ThresholdClass.get -> nint
+override Android.Crypto.Hpke.KemParameterSpec.ThresholdType.get -> System.Type!
+override Android.Crypto.Hpke.Message.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Crypto.Hpke.Message.ThresholdClass.get -> nint
+override Android.Crypto.Hpke.Message.ThresholdType.get -> System.Type!
+override Android.Crypto.Hpke.Recipient.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Crypto.Hpke.Recipient.Builder.ThresholdClass.get -> nint
+override Android.Crypto.Hpke.Recipient.Builder.ThresholdType.get -> System.Type!
+override Android.Crypto.Hpke.Recipient.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Crypto.Hpke.Recipient.ThresholdClass.get -> nint
+override Android.Crypto.Hpke.Recipient.ThresholdType.get -> System.Type!
+override Android.Crypto.Hpke.Sender.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Crypto.Hpke.Sender.Builder.ThresholdClass.get -> nint
+override Android.Crypto.Hpke.Sender.Builder.ThresholdType.get -> System.Type!
+override Android.Crypto.Hpke.Sender.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Crypto.Hpke.Sender.ThresholdClass.get -> nint
+override Android.Crypto.Hpke.Sender.ThresholdType.get -> System.Type!
+override Android.Graphics.AndroidBitmapInfo.Equals(object? value) -> bool
+override Android.Graphics.Color.Equals(object? obj) -> bool
+override Android.Graphics.ColorValueMarshaler.CreateGenericValue(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions options, System.Type? targetType) -> Android.Graphics.Color
+override Android.Graphics.ColorValueMarshaler.CreateParameterToManagedExpression(Java.Interop.Expressions.JniValueMarshalerContext! context, System.Linq.Expressions.ParameterExpression! sourceValue, System.Reflection.ParameterAttributes synchronize, System.Type? targetType) -> System.Linq.Expressions.Expression!
+override Android.Graphics.Pdf.Component.FreeTextAnnotation.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Graphics.Pdf.Component.HighlightAnnotation.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Graphics.Pdf.Component.PdfAnnotation.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Graphics.Pdf.Component.PdfAnnotation.ThresholdClass.get -> nint
+override Android.Graphics.Pdf.Component.PdfAnnotation.ThresholdType.get -> System.Type!
+override Android.Graphics.Pdf.Component.PdfAnnotationType.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Graphics.Pdf.Component.PdfPageImageObject.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Graphics.Pdf.Component.PdfPageObject.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Graphics.Pdf.Component.PdfPageObject.ThresholdClass.get -> nint
+override Android.Graphics.Pdf.Component.PdfPageObject.ThresholdType.get -> System.Type!
+override Android.Graphics.Pdf.Component.PdfPageObjectType.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Graphics.Pdf.Component.PdfPagePathObject.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Graphics.Pdf.Component.PdfPageTextObject.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Graphics.Pdf.Component.PdfPageTextObjectFont.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Graphics.Pdf.Component.PdfPageTextObjectFont.ThresholdClass.get -> nint
+override Android.Graphics.Pdf.Component.PdfPageTextObjectFont.ThresholdType.get -> System.Type!
+override Android.Graphics.Pdf.Component.StampAnnotation.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Biometrics.FallbackOption.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Camera2.MultiResolutionImageReader.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Display.DeviceProductInfo.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Display.DisplayTopology.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Lights.ColorSequence.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Lights.ColorSequence.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Lights.MultiLightEffect.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Lights.MultiLightEffect.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Serial.SerialManager.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Serial.SerialPort.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Hardware.Serial.SerialPortResponse.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.ChangeLog.ChangeLogsResponse.DeletedMedicalResource.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.ThresholdClass.get -> nint
+override Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.ThresholdType.get -> System.Type!
+override Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.DataTypes.MenstrualCyclePhaseRecord.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.DataTypes.SymptomRecord.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.DataTypes.SymptomRecord.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.DeviceDataSource.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.DeviceDataSourceCapabilities.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.DeviceDataTypeSource.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.GetDeviceDataSourcesResponse.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.MatchmakingRequest.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.MatchmakingRequest.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.MatchmakingResponse.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Health.Connect.MatchmakingResponse.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Icu.Lang.UCharacter.IdentifierType.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Icu.Number.SkeletonSyntaxException.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Icu.Number.SkeletonSyntaxException.ThresholdClass.get -> nint
+override Android.Icu.Number.SkeletonSyntaxException.ThresholdType.get -> System.Type!
+override Android.Media.Projection.AppContentProjectionService.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.Projection.AppContentProjectionService.ThresholdClass.get -> nint
+override Android.Media.Projection.AppContentProjectionService.ThresholdType.get -> System.Type!
+override Android.Media.Projection.AppContentProjectionSession.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.Projection.AppContentProjectionSession.ThresholdClass.get -> nint
+override Android.Media.Projection.AppContentProjectionSession.ThresholdType.get -> System.Type!
+override Android.Media.Projection.AppContentRequest.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.Projection.MediaProjectionAppContent.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.Projection.MediaProjectionAppContent.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.Projection.MediaProjectionConfig.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.Quality.EqualizerBand.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.Quality.EqualizerCapabilities.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.Quality.EqualizerSettings.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.Quality.EqualizerSettings.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.SuggestedDeviceInfo.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Media.SuggestedDeviceInfo.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Dns.HttpsEndpoint.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Dns.HttpsEndpoint.ThresholdClass.get -> nint
+override Android.Net.Dns.HttpsEndpoint.ThresholdType.get -> System.Type!
+override Android.Net.Dns.HttpsRecord.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Dns.HttpsRecord.ThresholdClass.get -> nint
+override Android.Net.Dns.HttpsRecord.ThresholdType.get -> System.Type!
+override Android.Net.Http.Proxy.IHttpConnectCallback.Request.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Http.Proxy.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Http.ProxyOptions.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Ssl.EchConfigList.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Ssl.EchConfigList.ThresholdClass.get -> nint
+override Android.Net.Ssl.EchConfigList.ThresholdType.get -> System.Type!
+override Android.Net.Ssl.EchConfigMismatchException.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Ssl.EchConfigMismatchException.ThresholdClass.get -> nint
+override Android.Net.Ssl.EchConfigMismatchException.ThresholdType.get -> System.Type!
+override Android.Net.Ssl.InvalidEchDataException.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Ssl.InvalidEchDataException.ThresholdClass.get -> nint
+override Android.Net.Ssl.InvalidEchDataException.ThresholdType.get -> System.Type!
+override Android.Net.Wifi.Aware.AwareDataPathRequest.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Wifi.Aware.AwareDataPathRequest.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Net.Wifi.P2p.WifiP2pConnectionInfo.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Bundle.GetByteArray(string? key) -> byte[]?
+override Android.OS.Bundle.PutByteArray(string? key, byte[]? value) -> void
+override Android.OS.Storage.FileManager.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Storage.Operations.FileOperationEnqueueResult.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Storage.Operations.FileOperationRequest.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Storage.Operations.FileOperationRequest.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Storage.Operations.FileOperationResult.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Storage.Operations.Sources.AppDataFileSource.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Storage.Operations.Sources.AppDataFileSource.ToString() -> string!
+override Android.OS.Storage.Operations.Sources.OperationSource.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Storage.Operations.Sources.OperationSource.ThresholdClass.get -> nint
+override Android.OS.Storage.Operations.Sources.OperationSource.ThresholdType.get -> System.Type!
+override Android.OS.Storage.Operations.Targets.OperationTarget.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Storage.Operations.Targets.OperationTarget.ThresholdClass.get -> nint
+override Android.OS.Storage.Operations.Targets.OperationTarget.ThresholdType.get -> System.Type!
+override Android.OS.Storage.Operations.Targets.PccTarget.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Storage.Operations.Targets.PccTarget.ToString() -> string!
+override Android.OS.Vibrators.HapticFeedbackRequest.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.OS.Vibrators.HapticFeedbackRequest.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Provider.ContactsContract.Settings.AccountAttributes.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Provider.ContactsPickerSessionContract.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Provider.ContactsPickerSessionContract.Session.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Ble.BleSpecificData.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.DlTdoaMeasurement.AnchorLocation.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.DlTdoaMeasurement.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.DlTdoaMeasurement.RelativeLocation.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.DlTdoaMeasurement.Wgs84Location.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.DlTdoaMeasurement.ZElementExtension.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.MotionState.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.RangingDataExtras.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Raw.RawDtTagRangingConfig.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Raw.RawDtTagRangingConfig.DescribeContents() -> int
+override Android.Ranging.Raw.RawDtTagRangingConfig.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Raw.RawDtTagRangingConfig.WriteToParcel(Android.OS.Parcel! dest, Android.OS.ParcelableWriteFlags flags) -> void
+override Android.Ranging.Uwb.DlTdoaRangingParams.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Uwb.DlTdoaRangingParams.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Uwb.UwbSpecificData.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Wifi.PD.WifiPdRangingParams.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Wifi.PD.WifiPdRangingParams.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Wifi.Rtt.RttStationRangingParams.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Wifi.Rtt.RttStationRangingParams.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Ranging.Wifi.Rtt.WifiRttSpecificData.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Runtime.InputStreamAdapter.Read(byte[]? bytes) -> int
+override Android.Runtime.InputStreamAdapter.Read(byte[]? bytes, int offset, int length) -> int
+override Android.Runtime.OutputStreamAdapter.Write(byte[]? buffer) -> void
+override Android.Runtime.OutputStreamAdapter.Write(byte[]? buffer, int offset, int length) -> void
+override Android.Service.Chooser.ChooserManager.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Service.Chooser.ChooserManager.ThresholdClass.get -> nint
+override Android.Service.Chooser.ChooserManager.ThresholdType.get -> System.Type!
+override Android.Service.Chooser.ChooserSession.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Service.Chooser.ChooserSessionToken.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Service.Messaging.AlternativeMessageTransportService.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Service.Messaging.AlternativeMessageTransportService.ThresholdClass.get -> nint
+override Android.Service.Messaging.AlternativeMessageTransportService.ThresholdType.get -> System.Type!
+override Android.Systems.StructDlInfo.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Telephony.ParsedPhoneNumber.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Telephony.PhoneNumberManager.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Telephony.PhoneNumberManager.ThresholdClass.get -> nint
+override Android.Telephony.PhoneNumberManager.ThresholdType.get -> System.Type!
+override Android.Telephony.Satellite.NtnSignalStrength.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Text.ShowSecretsSetting.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Text.SpannableString.GetChars(int start, int end, char[]? dest, int off) -> void
+override Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Views.Accessibility.AccessibilityNodeInfo.Selection.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo.ThresholdClass.get -> nint
+override Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo.ThresholdType.get -> System.Type!
+override Android.Views.Autofill.AutofillNoiseInjectedData.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Views.BlurRegion.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Views.BlurRegion.ThresholdClass.get -> nint
+override Android.Views.BlurRegion.ThresholdType.get -> System.Type!
+override Android.Views.FrameRateVelocityPoint.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Views.RoundedRectBlurRegion.Copy() -> Android.Views.RoundedRectBlurRegion!
+override Android.Views.RoundedRectBlurRegion.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Views.SurfaceControlViewHost.LayoutParams.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Views.SurfaceControlViewHost.LayoutParams.ThresholdClass.get -> nint
+override Android.Views.SurfaceControlViewHost.LayoutParams.ThresholdType.get -> System.Type!
+override Android.Widget.AdapterView<T>.RawAdapter.get -> Java.Lang.Object?
+override Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Widget.PhotoPicker.PhotoPickerSelectionParams.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.Builder.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Java.Interop.JavaPeerProxy<T>.GetContainerFactory() -> Java.Interop.JavaPeerContainerFactory?
+override Java.Lang.IllegalCallerException.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Java.Lang.IllegalCallerException.ThresholdClass.get -> nint
+override Java.Lang.IllegalCallerException.ThresholdType.get -> System.Type!
+override Java.Lang.WrongThreadException.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Java.Util.Streams.Gatherers.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override System.Drawing.PointConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
+override System.Drawing.PointConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
+override System.Drawing.PointConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
+override System.Drawing.PointConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+override System.Drawing.PointConverter.CreateInstance(System.ComponentModel.ITypeDescriptorContext? context, System.Collections.IDictionary! propertyValues) -> object!
+override System.Drawing.PointConverter.GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
+override System.Drawing.PointConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext? context, object! value, System.Attribute![]? attributes) -> System.ComponentModel.PropertyDescriptorCollection?
+override System.Drawing.PointConverter.GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
+override System.Drawing.RectangleConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
+override System.Drawing.RectangleConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
+override System.Drawing.RectangleConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
+override System.Drawing.RectangleConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+override System.Drawing.RectangleConverter.CreateInstance(System.ComponentModel.ITypeDescriptorContext? context, System.Collections.IDictionary! propertyValues) -> object!
+override System.Drawing.RectangleConverter.GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
+override System.Drawing.RectangleConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext? context, object! value, System.Attribute![]? attributes) -> System.ComponentModel.PropertyDescriptorCollection?
+override System.Drawing.RectangleConverter.GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
+override System.Drawing.SizeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
+override System.Drawing.SizeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
+override System.Drawing.SizeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
+override System.Drawing.SizeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+override System.Drawing.SizeConverter.CreateInstance(System.ComponentModel.ITypeDescriptorContext? context, System.Collections.IDictionary! propertyValues) -> object!
+override System.Drawing.SizeConverter.GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
+override System.Drawing.SizeConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext? context, object! value, System.Attribute![]? attributes) -> System.ComponentModel.PropertyDescriptorCollection?
+override System.Drawing.SizeConverter.GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
+override System.Drawing.SizeFConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
+override System.Drawing.SizeFConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
+override System.Drawing.SizeFConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
+override System.Drawing.SizeFConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+override System.Drawing.SizeFConverter.CreateInstance(System.ComponentModel.ITypeDescriptorContext? context, System.Collections.IDictionary! propertyValues) -> object!
+override System.Drawing.SizeFConverter.GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
+override System.Drawing.SizeFConverter.GetProperties(System.ComponentModel.ITypeDescriptorContext? context, object! value, System.Attribute![]? attributes) -> System.ComponentModel.PropertyDescriptorCollection?
+override System.Drawing.SizeFConverter.GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
+override sealed Android.App.PrivateCompute.DataMigrationToPccService.OnBind(Android.Content.Intent? intent) -> Android.OS.IBinder?
+override sealed Android.App.PrivateCompute.PccService.OnBind(Android.Content.Intent? intent) -> Android.OS.IBinder!
+override sealed Android.Media.Projection.AppContentProjectionService.OnBind(Android.Content.Intent? intent) -> Android.OS.IBinder!
+override sealed Android.Service.Messaging.AlternativeMessageTransportService.OnBind(Android.Content.Intent? intent) -> Android.OS.IBinder?
+static Android.App.AnrWarningResult.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppFunctions.AppFunctionActivityId.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppFunctions.AppFunctionActivityState.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppFunctions.AppFunctionMetadata.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppFunctions.AppFunctionName.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppFunctions.AppFunctionPackageMetadata.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppFunctions.AppFunctionSchemaMetadata.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppFunctions.AppFunctionSearchSpec.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppFunctions.AppFunctionState.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppFunctions.AppFunctionUriGrant.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppInteractionAttribution.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppInteractionContract.GetDeviceAssistancePackageNames(Android.Content.Context! context) -> System.Collections.Generic.IList<string!>!
+static Android.App.AppSearch.AppSearchAccount.Schema.get -> Android.App.AppSearch.AppSearchSchema?
+static Android.App.AppSearch.SearchResult.EmbeddingMatchInfo.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppSearch.SearchResult.MatchRange.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.AppSearch.SearchResult.TextMatchInfo.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.ApplicationExitInfo.AnrInfo.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.HandoffActivityData.CreateWebHandoff(Android.Net.Uri! uri) -> Android.App.HandoffActivityData!
+static Android.App.HandoffActivityData.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.HandoffActivityParams.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.Notification.BridgedNotificationMetadata.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.Notification.CreateSemanticStyleAnnotation(int semanticStyle) -> Android.Text.Annotation!
+static Android.App.Notification.Metric.TimeDifference.ForPausedStopwatch(Java.Time.Duration! elapsedTime, int format) -> Android.App.Notification.Metric.TimeDifference!
+static Android.App.Notification.Metric.TimeDifference.ForPausedTimer(Java.Time.Duration! remainingTime, int format) -> Android.App.Notification.Metric.TimeDifference!
+static Android.App.Notification.Metric.TimeDifference.ForStopwatch(Java.Time.Instant! startTime, int format) -> Android.App.Notification.Metric.TimeDifference!
+static Android.App.Notification.Metric.TimeDifference.ForStopwatch(long startTime, int format) -> Android.App.Notification.Metric.TimeDifference!
+static Android.App.Notification.Metric.TimeDifference.ForTimer(Java.Time.Instant! endTime, int format) -> Android.App.Notification.Metric.TimeDifference!
+static Android.App.Notification.Metric.TimeDifference.ForTimer(long endTime, int format) -> Android.App.Notification.Metric.TimeDifference!
+static Android.App.PermissionUI.LocationButtonProviderFactory.Create(Android.Content.Context! context) -> Android.App.PermissionUI.ILocationButtonProvider!
+static Android.App.PermissionUI.LocationButtonRequest.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.PrivateCompute.MigrationRequestResult.Creator.get -> Android.OS.IParcelableCreator!
+static Android.App.PrivateCompute.PccClient.CreateInstance(Android.Content.Context! context, Android.OS.IBinder! binder) -> Android.App.PrivateCompute.PccClient!
+static Android.Appwidget.AppWidgetEvent.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Companion.ActionRequest.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Companion.ActionResult.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Crypto.Hpke.AeadParameterSpec.Aes128Gcm.get -> Android.Crypto.Hpke.AeadParameterSpec?
+static Android.Crypto.Hpke.AeadParameterSpec.Aes256Gcm.get -> Android.Crypto.Hpke.AeadParameterSpec?
+static Android.Crypto.Hpke.AeadParameterSpec.Chacha20poly1305.get -> Android.Crypto.Hpke.AeadParameterSpec?
+static Android.Crypto.Hpke.Hpke.GetInstance(string! suiteName) -> Android.Crypto.Hpke.Hpke!
+static Android.Crypto.Hpke.Hpke.GetInstance(string! suiteName, Java.Security.Provider! provider) -> Android.Crypto.Hpke.Hpke!
+static Android.Crypto.Hpke.Hpke.GetInstance(string! suiteName, string! providerName) -> Android.Crypto.Hpke.Hpke!
+static Android.Crypto.Hpke.Hpke.GetSuiteName(Android.Crypto.Hpke.KemParameterSpec! kem, Android.Crypto.Hpke.KdfParameterSpec! kdf, Android.Crypto.Hpke.AeadParameterSpec! aead) -> string!
+static Android.Crypto.Hpke.KdfParameterSpec.HkdfSha256.get -> Android.Crypto.Hpke.KdfParameterSpec?
+static Android.Crypto.Hpke.KdfParameterSpec.HkdfSha384.get -> Android.Crypto.Hpke.KdfParameterSpec?
+static Android.Crypto.Hpke.KdfParameterSpec.HkdfSha512.get -> Android.Crypto.Hpke.KdfParameterSpec?
+static Android.Crypto.Hpke.KemParameterSpec.DhkemP256HkdfSha256.get -> Android.Crypto.Hpke.KemParameterSpec?
+static Android.Crypto.Hpke.KemParameterSpec.DhkemP384HkdfSha384.get -> Android.Crypto.Hpke.KemParameterSpec?
+static Android.Crypto.Hpke.KemParameterSpec.DhkemP521HkdfSha256.get -> Android.Crypto.Hpke.KemParameterSpec?
+static Android.Crypto.Hpke.KemParameterSpec.DhkemX25519HkdfSha256.get -> Android.Crypto.Hpke.KemParameterSpec?
+static Android.Crypto.Hpke.KemParameterSpec.DhkemX448HkdfSha512.get -> Android.Crypto.Hpke.KemParameterSpec?
+static Android.Graphics.ColorSpace.Named.DisplayBt2020.get -> Android.Graphics.ColorSpace.Named?
+static Android.Graphics.ImageDecoder.DefaultProcessListener.get -> Android.Graphics.ImageDecoder.IOnHeaderDecodedListener?
+static Android.Graphics.ImageDecoder.DefaultProcessListener.set -> void
+static Android.Graphics.ImageDecoder.DefaultThreadListener.get -> Android.Graphics.ImageDecoder.IOnHeaderDecodedListener?
+static Android.Graphics.ImageDecoder.DefaultThreadListener.set -> void
+static Android.Graphics.Pdf.Component.PdfPageObjectType.IsValidType(int type) -> bool
+static Android.Hardware.Biometrics.BiometricPrompt.MaxFallbackOptions.get -> int
+static Android.Hardware.Biometrics.FallbackOption.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Hardware.Camera2.CameraCharacteristics.InfoDeviceType.get -> Android.Hardware.Camera2.CameraCharacteristics.Key!
+static Android.Hardware.Camera2.CaptureRequest.LogicalMultiCameraAdditionalResults.get -> Android.Hardware.Camera2.CaptureRequest.Key!
+static Android.Hardware.Camera2.CaptureResult.InfoDeviceType.get -> Android.Hardware.Camera2.CaptureResult.Key!
+static Android.Hardware.Camera2.CaptureResult.LogicalMultiCameraAdditionalResults.get -> Android.Hardware.Camera2.CaptureResult.Key!
+static Android.Hardware.Display.DeviceProductInfo.EdidStructureMetadata.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Hardware.Display.DisplayTopology.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Hardware.Lights.ColorSequence.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Hardware.Lights.MultiLightEffect.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Health.Connect.DeviceDataSource.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Health.Connect.DeviceDataTypeSource.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Health.Connect.DeviceDataTypeSource.OfDataType(Java.Lang.Class! dataType, bool isAvailable, bool isUserEnabled) -> Android.Health.Connect.DeviceDataTypeSource!
+static Android.Health.Connect.DeviceDataTypeSource.OfSymptomType(int symptomType, bool isAvailable, bool isUserEnabled) -> Android.Health.Connect.DeviceDataTypeSource!
+static Android.Health.Connect.GetDeviceDataSourcesResponse.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Health.Connect.HealthConnectManager.PermissionSensitiveDeviceDataSourceCapabilities.get -> System.Collections.Generic.ICollection<Java.Lang.Class!>!
+static Android.Health.Connect.MatchmakingRequest.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Health.Connect.MatchmakingResponse.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Icu.Lang.UCharacter.GetIdentifierTypes(int c, Java.Util.EnumSet? types) -> int
+static Android.Icu.Lang.UCharacter.HasIdentifierType(int c, Android.Icu.Lang.UCharacter.IdentifierType? type) -> bool
+static Android.Icu.Lang.UCharacter.IdentifierType.DefaultIgnorable.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.Deprecated.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.Exclusion.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.Inclusion.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.LimitedUse.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.NotCharacter.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.NotNfkc.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.NotXid.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.Obsolete.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.Recommended.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.Technical.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.UncommonUse.get -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.ValueOf(string? name) -> Android.Icu.Lang.UCharacter.IdentifierType?
+static Android.Icu.Lang.UCharacter.IdentifierType.Values() -> Android.Icu.Lang.UCharacter.IdentifierType![]?
+static Android.Icu.Lang.UCharacter.UnicodeBlock.BeriaErfe.get -> Android.Icu.Lang.UCharacter.UnicodeBlock?
+static Android.Icu.Lang.UCharacter.UnicodeBlock.CjkUnifiedIdeographsExtensionJ.get -> Android.Icu.Lang.UCharacter.UnicodeBlock?
+static Android.Icu.Lang.UCharacter.UnicodeBlock.MiscellaneousSymbolsSupplement.get -> Android.Icu.Lang.UCharacter.UnicodeBlock?
+static Android.Icu.Lang.UCharacter.UnicodeBlock.SharadaSupplement.get -> Android.Icu.Lang.UCharacter.UnicodeBlock?
+static Android.Icu.Lang.UCharacter.UnicodeBlock.Sidetic.get -> Android.Icu.Lang.UCharacter.UnicodeBlock?
+static Android.Icu.Lang.UCharacter.UnicodeBlock.TaiYo.get -> Android.Icu.Lang.UCharacter.UnicodeBlock?
+static Android.Icu.Lang.UCharacter.UnicodeBlock.TangutComponentsSupplement.get -> Android.Icu.Lang.UCharacter.UnicodeBlock?
+static Android.Icu.Lang.UCharacter.UnicodeBlock.TolongSiki.get -> Android.Icu.Lang.UCharacter.UnicodeBlock?
+static Android.Icu.Number.NumberFormatter.ForSkeleton(string? skeleton) -> Android.Icu.Number.UnlocalizedNumberFormatter?
+static Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit.Fridays.get -> Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit?
+static Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit.Mondays.get -> Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit?
+static Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit.Quarters.get -> Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit?
+static Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit.Saturdays.get -> Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit?
+static Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit.Sundays.get -> Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit?
+static Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit.Thursdays.get -> Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit?
+static Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit.Tuesdays.get -> Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit?
+static Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit.Wednesdays.get -> Android.Icu.Text.RelativeDateTimeFormatter.RelativeUnit?
+static Android.Icu.Util.MeasureUnit.LightSpeed.get -> Android.Icu.Util.MeasureUnit?
+static Android.Icu.Util.MeasureUnit.MeasurePrefix.Quecto.get -> Android.Icu.Util.MeasureUnit.MeasurePrefix?
+static Android.Icu.Util.MeasureUnit.MeasurePrefix.Quetta.get -> Android.Icu.Util.MeasureUnit.MeasurePrefix?
+static Android.Icu.Util.MeasureUnit.MeasurePrefix.Ronna.get -> Android.Icu.Util.MeasureUnit.MeasurePrefix?
+static Android.Icu.Util.MeasureUnit.MeasurePrefix.Ronto.get -> Android.Icu.Util.MeasureUnit.MeasurePrefix?
+static Android.Icu.Util.MeasureUnit.Night.get -> Android.Icu.Util.MeasureUnit?
+static Android.Icu.Util.VersionInfo.Unicode170.get -> Android.Icu.Util.VersionInfo?
+static Android.Media.AudioTrack.GetFlushWrittenFramesFromPositionSupport(Android.Media.AudioFormat! format, Android.Media.AudioAttributes! attributes) -> int
+static Android.Media.Projection.MediaProjectionAppContent.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Media.Quality.EqualizerBand.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Media.Quality.EqualizerCapabilities.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Media.Quality.EqualizerSettings.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Media.RingtoneManager.GetRingtoneUriForPhoneAccountHandle(Android.Content.Context! context, Android.Telecom.PhoneAccountHandle? phoneAccountHandle) -> Android.Net.Uri?
+static Android.Media.RingtoneManager.SetRingtoneUri(Android.Content.Context! context, Android.Net.Uri? ringtoneUri, Android.Telecom.PhoneAccountHandle? phoneAccountHandle) -> void
+static Android.Media.SuggestedDeviceInfo.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Net.Http.Proxy.CreateHttpProxy(int scheme, string! host, int port, Java.Util.Concurrent.IExecutor! executor, Android.Net.Http.Proxy.IHttpConnectCallback! callback) -> Android.Net.Http.Proxy!
+static Android.Net.Http.ProxyOptions.FromProxyList(System.Collections.Generic.IList<Android.Net.Http.Proxy!>! proxyList, int allProxiesFailedBehavior) -> Android.Net.Http.ProxyOptions!
+static Android.Net.Ssl.EchConfigList.FromBytes(byte[]! byteArr) -> Android.Net.Ssl.EchConfigList!
+static Android.Net.Ssl.SSLEngines.SetEchConfigList(Javax.Net.Ssl.SSLEngine! engine, Android.Net.Ssl.EchConfigList! echConfigList) -> void
+static Android.Net.Ssl.SSLSockets.SetEchConfigList(Javax.Net.Ssl.SSLSocket! socket, Android.Net.Ssl.EchConfigList! echConfigList) -> void
+static Android.Net.Wifi.Aware.AwareDataPathRequest.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Net.Wifi.Aware.WifiAwareManager.CreateTxtRecordMap(byte[]! txtRecordTlvBuffer) -> System.Collections.Generic.IDictionary<string!, string!>!
+static Android.Net.Wifi.Aware.WifiAwareManager.CreateTxtRecordTlvBuffer(System.Collections.Generic.IDictionary<string!, string!>! txtRecord) -> byte[]!
+static Android.Net.Wifi.P2p.WifiP2pConnectionInfo.Creator.get -> Android.OS.IParcelableCreator!
+static Android.OS.Build.GetBackportedFixStatus(long id) -> int
+static Android.OS.Build.StrongboxManufacturer.get -> string!
+static Android.OS.Build.StrongboxModel.get -> string!
+static Android.OS.Debug.GetInstanceCount(Java.Lang.Class! cls) -> long
+static Android.OS.Debug.GetInstanceCount(Java.Lang.Class! cls, bool includeAssignable) -> long
+static Android.OS.Debug.GetInstanceCounts(System.Collections.Generic.IList<Java.Lang.Class!>! classes) -> long[]!
+static Android.OS.Debug.GetInstanceCounts(System.Collections.Generic.IList<Java.Lang.Class!>! classes, bool includeAssignable) -> long[]!
+static Android.OS.Process.IsPrivateComputeCoreUid(int uid) -> bool
+static Android.OS.Storage.FileManager.MaxReportedFailures.get -> int
+static Android.OS.Storage.Operations.FileOperationEnqueueResult.Creator.get -> Android.OS.IParcelableCreator!
+static Android.OS.Storage.Operations.FileOperationRequest.Creator.get -> Android.OS.IParcelableCreator!
+static Android.OS.Storage.Operations.FileOperationResult.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Provider.CallLog.Calls.ContentUriWithVoipCalls.get -> Android.Net.Uri!
+static Android.Provider.CallLog.Calls.ContentVoipUri.get -> Android.Net.Uri!
+static Android.Provider.ContactsContract.Settings.GetAccountAttributes(Android.Content.ContentResolver! resolver, Android.Accounts.Account? account, string? dataSet) -> long
+static Android.Provider.ContactsContract.Settings.ResetAccountAttributes(Android.Content.ContentResolver! resolver, Android.Accounts.Account? account, string? dataSet) -> void
+static Android.Provider.ContactsContract.Settings.SetAccountAttributes(Android.Content.ContentResolver! resolver, Android.Accounts.Account? account, string? dataSet, long newAttributes) -> void
+static Android.Provider.ContactsPickerSessionContract.AuthorityUri.get -> Android.Net.Uri!
+static Android.Provider.ContactsPickerSessionContract.Session.ContentUri.get -> Android.Net.Uri!
+static Android.Provider.DocumentsContract.BuildTrashDocumentsUri(string! authority, string! rootId) -> Android.Net.Uri!
+static Android.Provider.DocumentsContract.RestoreDocumentFromTrash(Android.Content.ContentResolver! content, Android.Net.Uri! sourceDocumentUri, Android.Net.Uri? targetParentDocumentUri) -> Android.Net.Uri?
+static Android.Provider.DocumentsContract.TrashDocument(Android.Content.ContentResolver! content, Android.Net.Uri! documentUri) -> Android.Net.Uri?
+static Android.Provider.MediaStore.GetPackageForSearchMediaService(Android.Content.ContentResolver! resolver) -> string!
+static Android.Provider.MediaStore.RestoreFileFromTrash(Android.Content.ContentResolver! resolver, string! path, string? targetPath) -> string!
+static Android.Provider.MediaStore.TrashFile(Android.Content.ContentResolver! resolver, string! path) -> string!
+static Android.Ranging.Ble.BleSpecificData.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.DlTdoaMeasurement.AnchorLocation.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.DlTdoaMeasurement.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.DlTdoaMeasurement.RelativeLocation.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.DlTdoaMeasurement.Wgs84Location.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.DlTdoaMeasurement.ZElementExtension.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.MotionState.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.RangingDataExtras.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.Raw.RawDtTagRangingConfig.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.Uwb.DlTdoaRangingParams.CreateFromFiraConfigPacket(byte[]! config, byte[]? rangingRoundIndexes) -> Android.Ranging.Uwb.DlTdoaRangingParams!
+static Android.Ranging.Uwb.DlTdoaRangingParams.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.Uwb.UwbSpecificData.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.Wifi.PD.WifiPdRangingCapabilities.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.Wifi.PD.WifiPdRangingParams.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.Wifi.Rtt.RttStationRangingParams.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Ranging.Wifi.Rtt.WifiRttSpecificData.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Runtime.JNIEnv.GetClassNameFromInstance(nint jobject) -> string?
+static Android.Security.NetworkSecurityPolicy.Instance.get -> Android.Security.NetworkSecurityPolicy!
+static Android.Service.Chooser.ChooserSessionToken.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Systems.Os.Dladdr(long addr) -> Android.Systems.StructDlInfo?
+static Android.Telephony.ParsedPhoneNumber.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Telephony.Satellite.NtnSignalStrength.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Telephony.SubscriptionPlan.Builder.CreateNonrecurring(Java.Time.Period! duration) -> Android.Telephony.SubscriptionPlan.Builder!
+static Android.Text.ShowSecretsSetting.RegisterCallback(Android.Content.Context! context, Java.Lang.IRunnable! callback) -> Java.Lang.IRunnable!
+static Android.Text.ShowSecretsSetting.RegisterCallback(Android.Content.Context! context, Java.Util.Concurrent.IExecutor! executor, Java.Lang.IRunnable! callback) -> Java.Lang.IRunnable!
+static Android.Text.ShowSecretsSetting.ShouldShowPhysicalInput(Android.Content.Context! context) -> bool
+static Android.Text.ShowSecretsSetting.ShouldShowTouchInput(Android.Content.Context! context) -> bool
+static Android.Views.Accessibility.AccessibilityNodeInfo.AccessibilityAction.ActionSetExtendedSelection.get -> Android.Views.Accessibility.AccessibilityNodeInfo.AccessibilityAction!
+static Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Views.Accessibility.AccessibilityNodeInfo.MathInfo.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Views.Accessibility.AccessibilityNodeInfo.Selection.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Views.Accessibility.AccessibilityNodeInfo.SelectionPosition.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Views.Autofill.AutofillNoiseInjectedData.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Views.FrameRateVelocityPoint.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Views.Inspectors.WindowInspector.AddGlobalWindowViewsListener(Java.Util.Concurrent.IExecutor! executor, Java.Util.Functions.IConsumer! consumer) -> void
+static Android.Views.Inspectors.WindowInspector.RemoveGlobalWindowViewsListener(Java.Util.Functions.IConsumer! consumer) -> void
+static Android.Views.View.RegisterCalledFromWrongThreadListener(Android.Views.View.ICalledFromWrongThreadListener! listener) -> void
+static Android.Views.View.UnregisterCalledFromWrongThreadListener(Android.Views.View.ICalledFromWrongThreadListener! listener) -> void
+static Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Creator.get -> Android.OS.IParcelableCreator!
+static Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.Creator.get -> Android.OS.IParcelableCreator!
+static Java.Interop.JavaPeerContainerFactory.Create<T>() -> Java.Interop.JavaPeerContainerFactory!
+static Java.Interop.JavaPeerProxy.GetActivationPeer(nint jniSelf) -> Java.Interop.IJavaPeerable?
+static Java.Interop.JavaPeerProxy.MarkActivationPeerReplaceable(nint jniSelf) -> void
+static Java.Interop.JavaPeerProxy.SetActivationPeerReference(Java.Interop.IJavaPeerable! peer, nint jniSelf) -> void
+static Java.Interop.JavaPeerProxy.ShouldSkipActivation(nint jniSelf) -> bool
+static Java.Lang.Character.UnicodeBlock.CjkUnifiedIdeographsExtensionI.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeBlock.EgyptianHieroglyphsExtendedA.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeBlock.Garay.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeBlock.GurungKhema.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeBlock.KiratRai.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeBlock.MyanmarExtendedC.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeBlock.OlOnal.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeBlock.Sunuwar.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeBlock.SymbolsForLegacyComputingSupplement.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeBlock.Todhri.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeBlock.TuluTigalari.get -> Java.Lang.Character.UnicodeBlock?
+static Java.Lang.Character.UnicodeScript.Garay.get -> Java.Lang.Character.UnicodeScript?
+static Java.Lang.Character.UnicodeScript.GurungKhema.get -> Java.Lang.Character.UnicodeScript?
+static Java.Lang.Character.UnicodeScript.KiratRai.get -> Java.Lang.Character.UnicodeScript?
+static Java.Lang.Character.UnicodeScript.OlOnal.get -> Java.Lang.Character.UnicodeScript?
+static Java.Lang.Character.UnicodeScript.Sunuwar.get -> Java.Lang.Character.UnicodeScript?
+static Java.Lang.Character.UnicodeScript.Todhri.get -> Java.Lang.Character.UnicodeScript?
+static Java.Lang.Character.UnicodeScript.TuluTigalari.get -> Java.Lang.Character.UnicodeScript?
+static Java.Lang.Math.PowExact(int x, int n) -> int
+static Java.Lang.Math.PowExact(long x, int n) -> long
+static Java.Lang.Math.UnsignedMultiplyExact(int x, int y) -> int
+static Java.Lang.Math.UnsignedMultiplyExact(long x, int y) -> long
+static Java.Lang.Math.UnsignedMultiplyExact(long x, long y) -> long
+static Java.Lang.Math.UnsignedPowExact(int x, int n) -> int
+static Java.Lang.Math.UnsignedPowExact(long x, int n) -> long
+static Java.Lang.StrictMath.PowExact(int x, int n) -> int
+static Java.Lang.StrictMath.PowExact(long x, int n) -> long
+static Java.Lang.StrictMath.UnsignedMultiplyExact(int x, int y) -> int
+static Java.Lang.StrictMath.UnsignedMultiplyExact(long x, int y) -> long
+static Java.Lang.StrictMath.UnsignedMultiplyExact(long x, long y) -> long
+static Java.Lang.StrictMath.UnsignedPowExact(int x, int n) -> int
+static Java.Lang.StrictMath.UnsignedPowExact(long x, int n) -> long
+static Java.Lang.Thread.Sleep(Java.Time.Duration? duration) -> void
+static Java.Nio.FileNio.FileSystems.NewFileSystem(Java.Nio.FileNio.IPath? path) -> Java.Nio.FileNio.FileSystem?
+static Java.Nio.FileNio.FileSystems.NewFileSystem(Java.Nio.FileNio.IPath? path, System.Collections.Generic.IDictionary<string!, object!>? env) -> Java.Nio.FileNio.FileSystem?
+static Java.Nio.FileNio.FileSystems.NewFileSystem(Java.Nio.FileNio.IPath? path, System.Collections.Generic.IDictionary<string!, object!>? env, Java.Lang.ClassLoader? loader) -> Java.Nio.FileNio.FileSystem?
+static Java.Nio.FileNio.Files.ReadString(Java.Nio.FileNio.IPath? path) -> string?
+static Java.Nio.FileNio.Files.ReadString(Java.Nio.FileNio.IPath? path, Java.Nio.Charset.Charset? cs) -> string?
+static Java.Nio.FileNio.Files.WriteString(Java.Nio.FileNio.IPath? path, Java.Lang.ICharSequence? csq, Java.Nio.Charset.Charset? cs, params Java.Nio.FileNio.IOpenOption![]? options) -> Java.Nio.FileNio.IPath?
+static Java.Nio.FileNio.Files.WriteString(Java.Nio.FileNio.IPath? path, Java.Lang.ICharSequence? csq, params Java.Nio.FileNio.IOpenOption![]? options) -> Java.Nio.FileNio.IPath?
+static Java.Nio.FileNio.Files.WriteString(Java.Nio.FileNio.IPath? path, string? csq, Java.Nio.Charset.Charset? cs, params Java.Nio.FileNio.IOpenOption![]? options) -> Java.Nio.FileNio.IPath?
+static Java.Nio.FileNio.Files.WriteString(Java.Nio.FileNio.IPath? path, string? csq, params Java.Nio.FileNio.IOpenOption![]? options) -> Java.Nio.FileNio.IPath?
+static Java.Security.Spec.NamedParameterSpec.MlDsa65.get -> Java.Security.Spec.NamedParameterSpec?
+static Java.Security.Spec.NamedParameterSpec.MlDsa87.get -> Java.Security.Spec.NamedParameterSpec?
+static Java.Util.Streams.Gatherer.DefaultCombiner() -> Java.Util.Functions.IBinaryOperator?
+static Java.Util.Streams.Gatherer.DefaultFinisher() -> Java.Util.Functions.IBiConsumer?
+static Java.Util.Streams.Gatherer.DefaultInitializer() -> Java.Util.Functions.ISupplier?
+static Java.Util.Streams.Gatherer.Of(Java.Util.Functions.ISupplier? initializer, Java.Util.Streams.IGatherer.IIntegrator? integrator, Java.Util.Functions.IBinaryOperator? combiner, Java.Util.Functions.IBiConsumer? finisher) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.Gatherer.Of(Java.Util.Streams.IGatherer.IIntegrator? integrator) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.Gatherer.Of(Java.Util.Streams.IGatherer.IIntegrator? integrator, Java.Util.Functions.IBiConsumer? finisher) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.Gatherer.OfSequential(Java.Util.Functions.ISupplier? initializer, Java.Util.Streams.IGatherer.IIntegrator? integrator) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.Gatherer.OfSequential(Java.Util.Functions.ISupplier? initializer, Java.Util.Streams.IGatherer.IIntegrator? integrator, Java.Util.Functions.IBiConsumer? finisher) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.Gatherer.OfSequential(Java.Util.Streams.IGatherer.IIntegrator? integrator) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.Gatherer.OfSequential(Java.Util.Streams.IGatherer.IIntegrator? integrator, Java.Util.Functions.IBiConsumer? finisher) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.Gatherers.Fold(Java.Util.Functions.ISupplier? initial, Java.Util.Functions.IBiFunction? folder) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.Gatherers.Scan(Java.Util.Functions.ISupplier? initial, Java.Util.Functions.IBiFunction? scanner) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.Gatherers.WindowFixed(int windowSize) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.Gatherers.WindowSliding(int windowSize) -> Java.Util.Streams.IGatherer?
+static Java.Util.Streams.IGatherer.Integrator.Of(Java.Util.Streams.IGatherer.IIntegrator? integrator) -> Java.Util.Streams.IGatherer.IIntegrator?
+static Java.Util.Streams.IGatherer.Integrator.OfGreedy(Java.Util.Streams.IGatherer.IIntegrator.IGreedy? greedy) -> Java.Util.Streams.IGatherer.IIntegrator.IGreedy?
+static Javax.Xml.Parsers.DocumentBuilderFactory.NewDefaultInstance() -> Javax.Xml.Parsers.DocumentBuilderFactory?
+static Javax.Xml.Parsers.DocumentBuilderFactory.NewDefaultNSInstance() -> Javax.Xml.Parsers.DocumentBuilderFactory?
+static Javax.Xml.Parsers.DocumentBuilderFactory.NewNSInstance() -> Javax.Xml.Parsers.DocumentBuilderFactory?
+static Javax.Xml.Parsers.DocumentBuilderFactory.NewNSInstance(string? factoryClassName, Java.Lang.ClassLoader? classLoader) -> Javax.Xml.Parsers.DocumentBuilderFactory?
+static Microsoft.Android.Runtime.TrimmableTypeMap.Initialize(System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>! typeMap, System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Type!>! proxyMap) -> void
+static Microsoft.Android.Runtime.TrimmableTypeMap.Initialize(System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>! typeMap, System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Type!>! proxyMap, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>?[]![]? arrayMapsByUniverseAndRank) -> void
+static Microsoft.Android.Runtime.TrimmableTypeMap.Initialize(System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>! typeMap, System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Type!>! proxyMap, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>?[]? arrayMapsByRank) -> void
+static Microsoft.Android.Runtime.TrimmableTypeMap.Initialize(System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>![]! typeMaps, System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Type!>![]! proxyMaps) -> void
+static Microsoft.Android.Runtime.TrimmableTypeMap.Initialize(System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>![]! typeMaps, System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Type!>![]! proxyMaps, System.Collections.Generic.IReadOnlyDictionary<string!, System.Type!>?[]![]? arrayMapsByUniverseAndRank) -> void
+virtual Android.App.Activity.OnHandoffActivityDataRequested(Android.App.HandoffActivityDataRequestInfo! requestInfo) -> Android.App.HandoffActivityData?
+virtual Android.App.ActivityManager.AppTask.MoveTaskTo(Android.App.TaskLocation! location, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+virtual Android.App.ActivityManager.AppTask.RequestWindowingLayer(int layer, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+virtual Android.App.ActivityManager.RegisterAnrWarningListener(Java.Util.Concurrent.IExecutor! executor, Java.Util.Functions.IConsumer! listener) -> void
+virtual Android.App.ActivityManager.UnregisterAnrWarningListener(Java.Util.Functions.IConsumer! listener) -> void
+virtual Android.App.ActivityOptions.IsMovableTaskRequired.get -> bool
+virtual Android.App.ActivityOptions.SetMovableTaskRequired(bool movableTaskRequired) -> Android.App.ActivityOptions!
+virtual Android.App.Admin.DevicePolicyManager.EnableSystemApp(Android.Content.ComponentName? admin, Android.Content.Intent? intent) -> int
+virtual Android.App.Admin.DevicePolicyManager.EnableSystemApp(Android.Content.ComponentName? admin, string? packageName) -> void
+virtual Android.App.Admin.DevicePolicyManager.SetCrossProfileWidgetProviders(System.Collections.Generic.ICollection<string!>! packageNames) -> void
+virtual Android.App.Admin.DevicePolicyManager.SetDeviceOwnerLockScreenInfo(Android.Content.ComponentName? admin, Java.Lang.ICharSequence? info) -> void
+virtual Android.App.Admin.DevicePolicyManager.SetPermissionPolicy(Android.Content.ComponentName? admin, Android.App.Admin.PermissionPolicy policy) -> void
+virtual Android.App.AlarmManager.SetExactAndAllowWhileIdle(Android.App.AlarmType type, long triggerAtMillis, string! tag, Java.Util.Concurrent.IExecutor! executor, Android.App.AlarmManager.IOnAlarmListener! listener) -> void
+virtual Android.App.AppSearch.AppSearchSchema.PropertyConfig.Description.get -> string!
+virtual Android.App.Assist.AssistStructure.ViewNode.AutofillNoiseInjectedData.get -> Android.Views.Autofill.AutofillNoiseInjectedData?
+virtual Android.App.Backup.BackupAgent.OnEstimateFullBackupBytes(long quotaBytes, int transportFlags) -> long
+virtual Android.App.Backup.BackupAgent.OnRestoreFile(Android.App.Backup.FullRestoreDataInput! data) -> void
+virtual Android.App.Backup.FullRestoreDataInput.AppVersionCode.get -> long
+virtual Android.App.Backup.FullRestoreDataInput.ContentVersion.get -> string!
+virtual Android.App.Backup.FullRestoreDataInput.Data.get -> Android.OS.ParcelFileDescriptor!
+virtual Android.App.Backup.FullRestoreDataInput.Destination.get -> Java.IO.File!
+virtual Android.App.Backup.FullRestoreDataInput.Mode.get -> long
+virtual Android.App.Backup.FullRestoreDataInput.ModificationTimeSeconds.get -> long
+virtual Android.App.Backup.FullRestoreDataInput.Size.get -> long
+virtual Android.App.Backup.FullRestoreDataInput.TransportFlags.get -> int
+virtual Android.App.Backup.FullRestoreDataInput.Type.get -> int
+virtual Android.App.Job.JobScheduler.GetPendingJobReasonStats(int jobId) -> System.Collections.Generic.IDictionary<Java.Lang.Integer!, Java.Time.Duration!>!
+virtual Android.App.KeyguardManager.AddDeviceLockedStateListener(Java.Util.Concurrent.IExecutor! executor, Android.App.KeyguardManager.IDeviceLockedStateListener! listener) -> void
+virtual Android.App.KeyguardManager.RemoveDeviceLockedStateListener(Android.App.KeyguardManager.IDeviceLockedStateListener! listener) -> void
+virtual Android.App.Notification.Action.EmphasisHint.get -> int
+virtual Android.App.Notification.Action.StyleHint.get -> int
+virtual Android.App.Notification.Builder.SetHasSummarizedContent(bool hasSummarizedContent) -> Android.App.Notification.Builder!
+virtual Android.App.Notification.Builder.SetRequestPromotedOngoing(bool requestPromotedOngoing) -> Android.App.Notification.Builder!
+virtual Android.App.Notification.GetBridgedNotificationMetadata() -> Android.App.Notification.BridgedNotificationMetadata?
+virtual Android.App.Notification.HasSummarizedContent.get -> bool
+virtual Android.App.Notification.IsRequestPromotedOngoing.get -> bool
+virtual Android.App.PrivateCompute.PccClient.SendData(Android.OS.Bundle! data) -> void
+virtual Android.App.StatusBarManager.ShowPowerMenu(Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! receiver) -> void
+virtual Android.App.TaskLocation.Bounds.get -> Android.Graphics.Rect!
+virtual Android.App.TaskLocation.DisplayId.get -> int
+virtual Android.Appwidget.AppWidgetHostView.StartVisibilityTracking() -> void
+virtual Android.Appwidget.AppWidgetHostView.StopVisibilityTracking() -> void
+virtual Android.Appwidget.AppWidgetManager.QueryAppWidgetEvents(long beginTime, long endTime) -> System.Collections.Generic.IList<Android.Appwidget.AppWidgetEvent!>!
+virtual Android.Bluetooth.BluetoothGattCallback.OnSubrateChange(Android.Bluetooth.BluetoothGatt! gatt, int subrateMode, int status) -> void
+virtual Android.Bluetooth.BluetoothGattServerCallback.OnSubrateChange(Android.Bluetooth.BluetoothDevice! device, int subrateMode, int status) -> void
+virtual Android.Companion.CompanionDeviceService.OnActionRequested(Android.Companion.AssociationInfo! associationInfo, Android.Companion.ActionRequest! request) -> void
+virtual Android.Content.Context.RebindService(Android.Content.IServiceConnection! conn, Android.Content.Context.BindServiceFlags! flags) -> void
+virtual Android.Content.Context.UpdateServiceBindings(System.Collections.Generic.ICollection<Android.Content.Context.UpdateBindingParams!>! params) -> void
+virtual Android.Content.Context.UpdateableFlags.get -> Android.Content.Context.BindServiceFlags!
+virtual Android.Content.OM.FabricatedOverlay.SetResourceValue(string! resourceName, float dimensionValue, int dimensionUnit, string? configuration) -> void
+virtual Android.Content.OM.FabricatedOverlay.SetResourceValue(string! resourceName, float value, string? configuration) -> void
+virtual Android.Content.PM.PackageInfo.IsAppMetadataVerified.get -> bool
+virtual Android.Content.PM.PackageInstaller.SessionParams.SetExtensionParams(Android.OS.PersistableBundle! extensionParams) -> void
+virtual Android.Content.PM.PackageManager.GetAppUidForPrivateComputeCoreUid(int pccUid) -> int
+virtual Android.Content.PM.Webapp.WebAppInstallRequest.ManifestUrl.get -> string!
+virtual Android.Content.PM.Webapp.WebAppInstallRequest.TitleFormatted.get -> Java.Lang.ICharSequence!
+virtual Android.Content.PM.Webapp.WebAppQueryRequest.PackageName.get -> string!
+virtual Android.Crypto.Hpke.Hpke.Open(Java.Security.IPrivateKey! recipientKey, byte[]? info, Android.Crypto.Hpke.Message! message, byte[]? aad) -> byte[]!
+virtual Android.Crypto.Hpke.Hpke.Provider.get -> Java.Security.Provider!
+virtual Android.Crypto.Hpke.Hpke.Seal(Java.Security.IPublicKey! recipientKey, byte[]? info, byte[]! plaintext, byte[]? aad) -> Android.Crypto.Hpke.Message!
+virtual Android.Crypto.Hpke.Message.GetCiphertext() -> byte[]!
+virtual Android.Crypto.Hpke.Message.GetEncapsulated() -> byte[]!
+virtual Android.Crypto.Hpke.Recipient.Builder.Build() -> Android.Crypto.Hpke.Recipient!
+virtual Android.Crypto.Hpke.Recipient.Builder.SetApplicationInfo(byte[]! applicationInfo) -> Android.Crypto.Hpke.Recipient.Builder!
+virtual Android.Crypto.Hpke.Recipient.Builder.SetPsk(byte[]! psk, byte[]! pskId) -> Android.Crypto.Hpke.Recipient.Builder!
+virtual Android.Crypto.Hpke.Recipient.Builder.SetSenderKey(Java.Security.IPublicKey! senderKey) -> Android.Crypto.Hpke.Recipient.Builder!
+virtual Android.Crypto.Hpke.Recipient.Export(int length, byte[]? context) -> byte[]!
+virtual Android.Crypto.Hpke.Recipient.Open(byte[]! ciphertext, byte[]? aad) -> byte[]!
+virtual Android.Crypto.Hpke.Recipient.Provider.get -> Java.Security.Provider!
+virtual Android.Crypto.Hpke.Recipient.Spi.get -> Android.Crypto.Hpke.IHpkeSpi!
+virtual Android.Crypto.Hpke.Sender.Builder.Build() -> Android.Crypto.Hpke.Sender!
+virtual Android.Crypto.Hpke.Sender.Builder.SetApplicationInfo(byte[]! applicationInfo) -> Android.Crypto.Hpke.Sender.Builder!
+virtual Android.Crypto.Hpke.Sender.Builder.SetPsk(byte[]! psk, byte[]! pskId) -> Android.Crypto.Hpke.Sender.Builder!
+virtual Android.Crypto.Hpke.Sender.Builder.SetSenderKey(Java.Security.IPrivateKey! senderKey) -> Android.Crypto.Hpke.Sender.Builder!
+virtual Android.Crypto.Hpke.Sender.Export(int length, byte[]? context) -> byte[]!
+virtual Android.Crypto.Hpke.Sender.GetEncapsulated() -> byte[]!
+virtual Android.Crypto.Hpke.Sender.Provider.get -> Java.Security.Provider!
+virtual Android.Crypto.Hpke.Sender.Seal(byte[]! plaintext, byte[]? aad) -> byte[]!
+virtual Android.Crypto.Hpke.Sender.Spi.get -> Android.Crypto.Hpke.IHpkeSpi!
+virtual Android.Graphics.Paint.FontVariationOverride.get -> string?
+virtual Android.Graphics.Paint.FontVariationOverride.set -> void
+virtual Android.Graphics.Pdf.Component.PdfAnnotation.PdfAnnotationType.get -> int
+virtual Android.Graphics.Pdf.Component.PdfPageObject.GetMatrix() -> float[]!
+virtual Android.Graphics.Pdf.Component.PdfPageObject.PdfObjectType.get -> int
+virtual Android.Graphics.Pdf.Component.PdfPageObject.SetMatrix(Android.Graphics.Matrix! matrix) -> void
+virtual Android.Graphics.Pdf.Component.PdfPageObject.Transform(float a, float b, float c, float d, float e, float f) -> void
+virtual Android.Graphics.Pdf.Component.PdfPageTextObjectFont.Bold.get -> bool
+virtual Android.Graphics.Pdf.Component.PdfPageTextObjectFont.Bold.set -> void
+virtual Android.Graphics.Pdf.Component.PdfPageTextObjectFont.FontFamily.get -> int
+virtual Android.Graphics.Pdf.Component.PdfPageTextObjectFont.FontFamily.set -> void
+virtual Android.Graphics.Pdf.Component.PdfPageTextObjectFont.Italic.get -> bool
+virtual Android.Graphics.Pdf.Component.PdfPageTextObjectFont.Italic.set -> void
+virtual Android.Graphics.RuntimeShader.SetWorkingColorSpace(Android.Graphics.ColorSpace? colorSpace) -> void
+virtual Android.Hardware.Biometrics.BiometricManager.BiometricSensorStrengths.get -> System.Collections.Generic.IDictionary<Java.Lang.Integer!, Java.Lang.Integer!>!
+virtual Android.Hardware.Biometrics.BiometricPrompt.Builder.AddFallbackOption(Java.Lang.ICharSequence! text, int iconType, Java.Util.Concurrent.IExecutor! executor, Android.Content.IDialogInterfaceOnClickListener! listener) -> Android.Hardware.Biometrics.BiometricPrompt.Builder!
+virtual Android.Hardware.Biometrics.BiometricPrompt.FallbackOptions.get -> System.Collections.Generic.IList<Android.Hardware.Biometrics.FallbackOption!>!
+virtual Android.Hardware.Camera2.CameraCaptureSession.UpdateOutputConfigurations(System.Collections.Generic.IList<Android.Hardware.Camera2.Params.OutputConfiguration!>! configurations) -> void
+virtual Android.Hardware.Camera2.CameraManager.AvailabilityCallback.OnCameraRemoved(string! cameraId) -> void
+virtual Android.Hardware.Camera2.MultiResolutionImageReader.OnActiveOutputSurfacesListener.get -> Android.Hardware.Camera2.MultiResolutionImageReader.IOnActiveOutputSurfacesListener?
+virtual Android.Hardware.Camera2.MultiResolutionImageReader.SetOnActiveOutputSurfacesListener(Java.Util.Concurrent.IExecutor! executor, Android.Hardware.Camera2.MultiResolutionImageReader.IOnActiveOutputSurfacesListener! listener) -> void
+virtual Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.AlcoholByVolume.get -> Android.Health.Connect.DataTypes.Units.Percentage?
+virtual Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.BeverageType.get -> int
+virtual Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.Date.get -> Java.Time.LocalDate?
+virtual Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.NotesFormatted.get -> Java.Lang.ICharSequence?
+virtual Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.ServingVolume.get -> Android.Health.Connect.DataTypes.Units.Volume?
+virtual Android.Health.Connect.DataTypes.AlcoholConsumptionRecord.TemporalType.get -> int
+virtual Android.Health.Connect.HealthConnectManager.CreateMatchmakingIntent(Android.Health.Connect.MatchmakingRequest! request) -> Android.Content.Intent!
+virtual Android.Health.Connect.HealthConnectManager.GetCurrentDeviceDataSource(Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+virtual Android.Health.Connect.HealthConnectManager.GetDeviceDataSourceCapabilities(Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+virtual Android.Health.Connect.HealthConnectManager.GetDeviceDataSources(Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+virtual Android.Health.Connect.HealthConnectManager.IsMatchmakingPossible(Android.Health.Connect.MatchmakingRequest! request, Java.Util.Concurrent.IExecutor! executor, Android.OS.IOutcomeReceiver! callback) -> void
+virtual Android.Icu.Number.NumberFormatterSettings.ToSkeleton() -> string?
+virtual Android.Icu.Text.DateFormat.Format(Java.Time.Temporal.ITemporal? date, Java.Lang.StringBuffer? toAppendTo, Java.Text.FieldPosition? fieldPosition) -> Java.Lang.StringBuffer?
+virtual Android.Icu.Text.DateIntervalFormat.FormatToValue(Java.Time.Temporal.ITemporal? fromTemporal, Java.Time.Temporal.ITemporal? toTemporal) -> Android.Icu.Text.DateIntervalFormat.FormattedDateInterval?
+virtual Android.Icu.Text.UnicodeSet.CodePoints() -> Java.Lang.IIterable?
+virtual Android.Media.AudioFormat.Builder.SetChannelAcnMask(int channelAcnMask) -> Android.Media.AudioFormat.Builder!
+virtual Android.Media.AudioFormat.ChannelAcnMask.get -> int
+virtual Android.Media.AudioTrack.Builder.SetCodecProvenance(string! codecMediaType) -> Android.Media.AudioTrack.Builder!
+virtual Android.Media.AudioTrack.CodecProvenance.get -> string!
+virtual Android.Media.AudioTrack.FlushWrittenFramesFromPosition(long positionInFrames, int accuracy) -> long
+virtual Android.Media.AudioTrack.WrittenFramesCount.get -> long
+virtual Android.Media.LoudnessCodecController.LoudnessCodecUpdateHandler.Invoke(Android.Media.MediaCodec! mediaCodec, Android.OS.Bundle! codecValues) -> Android.OS.Bundle!
+virtual Android.Media.MediaRecorder.SetVideoEncodingQuality(int quality) -> void
+virtual Android.Media.MediaRoute2ProviderService.OnDiscoveryPreferenceChanged(Android.Media.RouteDiscoveryPreference! compositePreference, System.Collections.Generic.IDictionary<string!, Android.Media.RouteDiscoveryPreference!>! perAppPreferences) -> void
+virtual Android.Media.MediaRouter2.GetControllerHintsHandler.Invoke(Android.Media.MediaRoute2Info! route) -> Android.OS.Bundle?
+virtual Android.Media.Projection.AppContentProjectionSession.IsAudioRequested.get -> bool
+virtual Android.Media.Projection.AppContentProjectionSession.NotifySessionStop() -> void
+virtual Android.Media.RemoteControlClient.GetPlaybackPositionHandler.Invoke() -> long
+virtual Android.Net.Dns.HttpsEndpoint.HttpsRecords.get -> System.Collections.Generic.IList<Android.Net.Dns.HttpsRecord!>!
+virtual Android.Net.Dns.HttpsEndpoint.IpAddresses.get -> System.Collections.Generic.IList<Java.Net.InetAddress!>!
+virtual Android.Net.Dns.HttpsRecord.AlpnIds.get -> System.Collections.Generic.IList<string!>!
+virtual Android.Net.Dns.HttpsRecord.EchConfigList.get -> Android.Net.Ssl.EchConfigList?
+virtual Android.Net.Dns.HttpsRecord.IpAddressHints.get -> System.Collections.Generic.IList<Java.Net.InetAddress!>!
+virtual Android.Net.Dns.HttpsRecord.OwnerName.get -> string!
+virtual Android.Net.Dns.HttpsRecord.Port.get -> int
+virtual Android.Net.Dns.HttpsRecord.Priority.get -> int
+virtual Android.Net.Dns.HttpsRecord.TargetName.get -> string!
+virtual Android.Net.Http.HttpEngine.Builder.SetConnectionMigrationOptions(Android.Net.Http.ConnectionMigrationOptions! options) -> Android.Net.Http.HttpEngine.Builder!
+virtual Android.Net.Http.HttpEngine.Builder.SetDnsOptions(Android.Net.Http.DnsOptions! options) -> Android.Net.Http.HttpEngine.Builder!
+virtual Android.Net.Http.HttpEngine.Builder.SetProxyOptions(Android.Net.Http.ProxyOptions! options) -> Android.Net.Http.HttpEngine.Builder!
+virtual Android.Net.Http.HttpEngine.Builder.SetQuicOptions(Android.Net.Http.QuicOptions! options) -> Android.Net.Http.HttpEngine.Builder!
+virtual Android.Net.Ssl.EchConfigList.ToBytes() -> byte[]!
+virtual Android.Net.Ssl.EchConfigMismatchException.HasRetryConfigList.get -> bool
+virtual Android.Net.Ssl.EchConfigMismatchException.PublicHostname.get -> string?
+virtual Android.Net.Ssl.EchConfigMismatchException.RetryConfigList.get -> Android.Net.Ssl.EchConfigList?
+virtual Android.Net.Wifi.Aware.DiscoverySession.InitiateBootstrappingRequest(Android.Net.Wifi.Aware.PeerHandle! peerHandle, Android.Net.Wifi.Aware.AwarePairingBootstrappingMethods method, byte[]! message) -> void
+virtual Android.Net.Wifi.Aware.DiscoverySession.ReleaseDataPath(Android.Net.Wifi.Aware.PeerHandle! peerHandle) -> bool
+virtual Android.Net.Wifi.Aware.DiscoverySessionCallback.OnBootstrappingSucceeded(Android.Net.Wifi.Aware.PeerHandle! peerHandle, Android.Net.Wifi.Aware.AwarePairingBootstrappingMethods method, byte[]? message) -> void
+virtual Android.Net.Wifi.Aware.DiscoverySessionCallback.OnDataPathConnected(Android.Net.Wifi.Aware.PeerHandle! peerHandle, Android.Net.Wifi.Aware.WifiAwareNetworkInfo! info) -> void
+virtual Android.Net.Wifi.Aware.DiscoverySessionCallback.OnDataPathDisconnected(Android.Net.Wifi.Aware.PeerHandle! peerHandle) -> void
+virtual Android.Net.Wifi.Aware.DiscoverySessionCallback.OnDataPathRequestFailed(Android.Net.Wifi.Aware.PeerHandle! peerHandle, int reason) -> void
+virtual Android.Net.Wifi.Aware.DiscoverySessionCallback.OnDataPathRequestReceived(Android.Net.Wifi.Aware.PeerHandle! peerHandle) -> void
+virtual Android.Net.Wifi.Aware.PublishDiscoverySession.AcceptDataPathRequest(Android.Net.Wifi.Aware.PeerHandle! peerHandle, Android.Net.Wifi.Aware.AwareDataPathRequest! request) -> bool
+virtual Android.Net.Wifi.Aware.PublishDiscoverySession.RejectDataPathRequest(Android.Net.Wifi.Aware.PeerHandle! peerHandle) -> bool
+virtual Android.Net.Wifi.Aware.SubscribeDiscoverySession.InitiateDataPathRequest(Android.Net.Wifi.Aware.PeerHandle! peerHandle, Android.Net.Wifi.Aware.AwareDataPathRequest! request) -> bool
+virtual Android.Net.Wifi.P2p.WifiP2pConfig.PairingDiscoveryChannelFrequencyMhz.get -> int
+virtual Android.Net.Wifi.P2p.WifiP2pDevice.WifiP2pConnectionInfo.get -> Android.Net.Wifi.P2p.WifiP2pConnectionInfo?
+virtual Android.Net.Wifi.P2p.WifiP2pGroup.WifiP2pGroupClientConnectionInfo.get -> Android.Net.Wifi.P2p.WifiP2pConnectionInfo?
+virtual Android.Net.Wifi.P2p.WifiP2pManager.SetConnectionRequestResult(Android.Net.Wifi.P2p.WifiP2pManager.Channel! c, Android.Net.MacAddress! deviceAddress, int result, string? pinOrPassword, Android.Net.Wifi.P2p.WifiP2pManager.IActionListener? listener) -> void
+virtual Android.Net.Wifi.WifiConfiguration.AllowedToUpdateByOtherUsers.get -> bool
+virtual Android.Net.Wifi.WifiConfiguration.AllowedToUpdateByOtherUsers.set -> void
+virtual Android.Nfc.CardEmulators.HostApduService.ProcessPollingFrames(System.Collections.Generic.IList<Android.Nfc.CardEmulators.PollingFrame!>! frames) -> void
+virtual Android.OS.BaseBundle.GetByteArray(string? key) -> byte[]?
+virtual Android.OS.BaseBundle.PutByteArray(string? key, byte[]? value) -> void
+virtual Android.OS.MessageQueue.FileDescriptorEventHandler.Invoke(Java.IO.FileDescriptor! fd, Android.OS.MessageQueueEventType events) -> int
+virtual Android.Provider.DocumentsProvider.QueryTrashDocuments(string! rootId, string![]? projection, Android.OS.Bundle? queryArgs, Android.OS.CancellationSignal? signal) -> Android.Database.ICursor?
+virtual Android.Provider.DocumentsProvider.RestoreDocumentFromTrash(string! documentId, string? targetParentDocumentId) -> string?
+virtual Android.Provider.DocumentsProvider.TrashDocument(string! documentId) -> string?
+virtual Android.Security.Keystore.KeyInfo.IsUnlockedDeviceRequired.get -> bool
+virtual Android.Security.NetworkSecurityPolicy.GetDomainEncryptionMode(string! hostname) -> int
+virtual Android.Service.Chooser.ChooserManager.GetSession(Android.Service.Chooser.ChooserSessionToken! token) -> Android.Service.Chooser.ChooserSession?
+virtual Android.Service.Chooser.ChooserManager.StartSession(Android.Content.Context! context, Android.Content.Intent! chooserIntent) -> Android.Service.Chooser.ChooserSession!
+virtual Android.Service.Notification.NotificationListenerService.Ranking.Summarization.get -> string?
+virtual Android.Service.Voice.VoiceInteractionSession.GetAppFunctionActivityId(Android.Service.Voice.VoiceInteractionSession.ActivityId! activityId) -> Android.App.AppFunctions.AppFunctionActivityId!
+virtual Android.Telecom.Call.Details.AssociatedUser.get -> Android.OS.UserHandle!
+virtual Android.Telecom.CallRedirectionService.OnPlaceCall(Android.Net.Uri! handle, Android.Net.Uri! originalHandle, Android.Telecom.PhoneAccountHandle! initialPhoneAccount, bool allowInteractiveResponse) -> void
+virtual Android.Telecom.Conference.NotifyConferenceMergeFailed() -> void
+virtual Android.Telecom.Conference.OnMerge(Android.Telecom.Conference! conference) -> void
+virtual Android.Telecom.Connection.OnTransfer(Android.Net.Uri! address, bool isConfirmationRequired) -> void
+virtual Android.Telecom.Connection.OnTransfer(Android.Telecom.Connection! toConnection) -> void
+virtual Android.Telecom.ConnectionService.OnConferenceAdded(Android.Telecom.Conference! conference) -> void
+virtual Android.Telecom.ConnectionService.OnConferenceRemoved(Android.Telecom.Conference! conference) -> void
+virtual Android.Telecom.ConnectionService.OnConnectionAdded(Android.Telecom.Connection! connection) -> void
+virtual Android.Telecom.ConnectionService.OnConnectionRemoved(Android.Telecom.Connection! connection) -> void
+virtual Android.Telecom.ConnectionService.OnCreateConferenceComplete(Android.Telecom.Conference! conference) -> void
+virtual Android.Telecom.ConnectionService.OnCreateConnectionComplete(Android.Telecom.Connection! connection) -> void
+virtual Android.Telecom.InCallService.OnCallEndpointRequested(Android.Telecom.CallEndpoint! callEndpoint) -> void
+virtual Android.Telecom.TelecomManager.IsInExternalCall.get -> bool
+virtual Android.Telephony.PhoneNumberManager.ParsePhoneNumber(System.Collections.Generic.IList<Android.Net.Uri!>? associatedUris, string! countryIso) -> Android.Telephony.ParsedPhoneNumber!
+virtual Android.Telephony.SubscriptionInfo.StreamingAppMaxDownlinkKbps.get -> long
+virtual Android.Telephony.SubscriptionInfo.StreamingAppMaxUplinkKbps.get -> long
+virtual Android.Telephony.SubscriptionManager.SetTs43PhoneNumber(int subscriptionId, string! number) -> void
+virtual Android.Telephony.SubscriptionPlan.Builder.SetDataUsageResetTime(Java.Time.ZonedDateTime? dataUsageResetTime) -> Android.Telephony.SubscriptionPlan.Builder!
+virtual Android.Telephony.SubscriptionPlan.Builder.SetId(int id) -> Android.Telephony.SubscriptionPlan.Builder!
+virtual Android.Telephony.SubscriptionPlan.Builder.SetStreamingAppMaxDownlinkKbps(long downlinkKbps) -> Android.Telephony.SubscriptionPlan.Builder!
+virtual Android.Telephony.SubscriptionPlan.Builder.SetStreamingAppMaxUplinkKbps(long uplinkKbps) -> Android.Telephony.SubscriptionPlan.Builder!
+virtual Android.Telephony.SubscriptionPlan.Builder.SetTypes(int[]! types) -> Android.Telephony.SubscriptionPlan.Builder!
+virtual Android.Telephony.TelephonyManager.CurrentTtyMode.get -> int
+virtual Android.Telephony.TelephonyManager.GetServiceStateForSlot(int slotIndex) -> Android.Telephony.ServiceState?
+virtual Android.Views.Accessibility.AccessibilityNodeInfo.GetSelection() -> Android.Views.Accessibility.AccessibilityNodeInfo.Selection?
+virtual Android.Views.Accessibility.AccessibilityNodeInfo.GetStructuredDataInfo() -> Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo?
+virtual Android.Views.Accessibility.AccessibilityNodeInfo.SetExtraRenderingInfo(Android.Views.Accessibility.AccessibilityNodeInfo.ExtraRenderingInfo? extraRenderingInfo) -> void
+virtual Android.Views.Accessibility.AccessibilityNodeInfo.SetSelection(Android.Views.Accessibility.AccessibilityNodeInfo.Selection? selection) -> void
+virtual Android.Views.Accessibility.AccessibilityNodeInfo.SetStructuredDataInfo(Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo? info) -> void
+virtual Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo.Attributes.get -> System.Collections.Generic.IDictionary<string!, string!>!
+virtual Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo.GetAttribute(string! attributeKey) -> string?
+virtual Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo.PutAttribute(string! attributeKey, string! value) -> void
+virtual Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo.RemoveAttribute(string! attributeKey) -> void
+virtual Android.Views.Accessibility.AccessibilityNodeInfo.StructuredDataInfo.Tag.get -> string!
+virtual Android.Views.BlurRegion.Alpha.get -> float
+virtual Android.Views.BlurRegion.Alpha.set -> void
+virtual Android.Views.BlurRegion.BlurRadius.get -> float
+virtual Android.Views.BlurRegion.BlurRadius.set -> void
+virtual Android.Views.ContentCaptures.ContentCaptureSession.NotifyContentInteractionEvent(Android.Views.Autofill.AutofillId! autofillId) -> void
+virtual Android.Views.Display.FrameRateVelocityMapping.get -> System.Collections.Generic.IList<Android.Views.FrameRateVelocityPoint!>!
+virtual Android.Views.Display.IsInternal.get -> bool
+virtual Android.Views.InputMethods.InputMethodSubtype.InputMethodSubtypeBuilder.SetSubtypeShortLabel(Java.Lang.ICharSequence! subtypeShortLabel) -> Android.Views.InputMethods.InputMethodSubtype.InputMethodSubtypeBuilder!
+virtual Android.Views.ReceiveContentHandler.Invoke(Android.Views.View! view, Android.Views.ContentInfo! payload) -> Android.Views.ContentInfo?
+virtual Android.Views.Surface.ProducerThrottlingEnabled.get -> bool
+virtual Android.Views.Surface.ProducerThrottlingEnabled.set -> void
+virtual Android.Views.SurfaceControlViewHost.GetLayoutParams() -> Android.Views.SurfaceControlViewHost.LayoutParams!
+virtual Android.Views.SurfaceControlViewHost.LayoutParams.Height.get -> int
+virtual Android.Views.SurfaceControlViewHost.LayoutParams.IsFocusable.get -> bool
+virtual Android.Views.SurfaceControlViewHost.LayoutParams.Title.get -> string!
+virtual Android.Views.SurfaceControlViewHost.LayoutParams.Title.set -> void
+virtual Android.Views.SurfaceControlViewHost.LayoutParams.Width.get -> int
+virtual Android.Views.SurfaceControlViewHost.Relayout(Android.Views.SurfaceControlViewHost.LayoutParams! attrs) -> void
+virtual Android.Views.SurfaceControlViewHost.SetView(Android.Views.View! view, Android.Views.SurfaceControlViewHost.LayoutParams! attrs) -> void
+virtual Android.Views.SurfaceView.BlurRegions.get -> System.Collections.Generic.IList<Android.Views.BlurRegion!>!
+virtual Android.Views.SurfaceView.SetBlurRegions(System.Collections.Generic.ICollection<Android.Views.BlurRegion!>? blurRegions) -> void
+virtual Android.Views.View.ApplyWindowInsetsHandler.Invoke(Android.Views.View! v, Android.Views.WindowInsets! insets) -> Android.Views.WindowInsets!
+virtual Android.Views.View.PerformHapticFeedback(Android.OS.Vibrators.HapticFeedbackRequest! request) -> bool
+virtual Android.Views.View.RequestPointerCapture(int mode) -> void
+virtual Android.Views.View.RequestRectangleOnScreen(Android.Graphics.Rect! rectangle, bool immediate, int source) -> bool
+virtual Android.Views.ViewConfiguration.DoubleTapTimeoutMillis.get -> int
+virtual Android.Views.ViewConfiguration.LongPressTimeoutMillis.get -> int
+virtual Android.Views.ViewConfiguration.MultiPressTimeoutMillis.get -> int
+virtual Android.Views.ViewConfiguration.ScrollFrictionAmount.get -> float
+virtual Android.Views.ViewConfiguration.TapTimeoutMillis.get -> int
+virtual Android.Views.ViewConfiguration.TextCursorBlinkIntervalMillis.get -> int
+virtual Android.Views.WindowManagerLayoutParams.HasKeyboardCapture.get -> bool
+virtual Android.Views.WindowManagerLayoutParams.SetKeyboardCaptureEnabled(bool enabled) -> void
+virtual Android.Webkit.WebChromeClient.FileChooserParams.PermissionMode.get -> int
+virtual Android.Widget.RemoteViews.SetAppWidgetEventTag(int viewId, int tag) -> void
+virtual Android.Widget.RemoteViews.SetViewPadding(int viewId, float left, float top, float right, float bottom, int units) -> void
+virtual Java.Interop.JavaPeerProxy.GetContainerFactory() -> Java.Interop.JavaPeerContainerFactory?
+virtual Java.Nio.CharBuffer.GetChars(int srcBegin, int srcEnd, char[]! dst, int dstBegin) -> void
+virtual Javax.Net.Ssl.ExtendedSSLSession.StatusResponses.get -> System.Collections.Generic.IList<byte[]!>?
+virtual Javax.Net.Ssl.SSLParameters.GetNamedGroups() -> string![]?
+virtual Javax.Net.Ssl.SSLParameters.SetNamedGroups(string![]? namedGroups) -> void

--- a/src/Mono.Android/System.Drawing/PointConverter.cs
+++ b/src/Mono.Android/System.Drawing/PointConverter.cs
@@ -42,8 +42,8 @@ namespace System.Drawing {
 	{
 		public PointConverter() { }
 
-		public override bool CanConvertFrom (ITypeDescriptorContext context,
-						     Type sourceType)
+		public override bool CanConvertFrom (ITypeDescriptorContext? context,
+					     Type sourceType)
 		{
 			if (sourceType == typeof (string))
 				return true;
@@ -51,8 +51,8 @@ namespace System.Drawing {
 			return base.CanConvertFrom (context, sourceType);
 		}
 
-		public override bool CanConvertTo (ITypeDescriptorContext context,
-						   Type destinationType)
+		public override bool CanConvertTo (ITypeDescriptorContext? context,
+					   Type? destinationType)
 		{
 			if (destinationType == typeof (string))
 				return true;
@@ -63,8 +63,8 @@ namespace System.Drawing {
 			return base.CanConvertTo (context, destinationType);
 		}
 
-		public override object? ConvertFrom (ITypeDescriptorContext context,
-						    CultureInfo culture,
+		public override object? ConvertFrom (ITypeDescriptorContext? context,
+					    CultureInfo? culture,
 						    object value)
 		{
 			if (culture == null)
@@ -90,9 +90,9 @@ namespace System.Drawing {
 			return new Point (numSubs[0], numSubs[1]);
 		}
 
-		public override object? ConvertTo (ITypeDescriptorContext context,
-						  CultureInfo culture,
-						  object value,
+		public override object? ConvertTo (ITypeDescriptorContext? context,
+					  CultureInfo? culture,
+					  object? value,
 						  Type destinationType)
 		{
 			if (culture == null)
@@ -115,7 +115,7 @@ namespace System.Drawing {
 			return base.ConvertTo (context, culture, value, destinationType);
 		}
 
-		public override object CreateInstance (ITypeDescriptorContext context,
+		public override object CreateInstance (ITypeDescriptorContext? context,
 						       IDictionary propertyValues)
 		{
 			var ox = propertyValues ["X"];
@@ -129,15 +129,15 @@ namespace System.Drawing {
 		}
 
 
-		public override bool GetCreateInstanceSupported (ITypeDescriptorContext context)
+		public override bool GetCreateInstanceSupported (ITypeDescriptorContext? context)
 		{
 			return true;
 		}
 
 		[RequiresUnreferencedCode ("The Type of value cannot be statically discovered.")]
 		public override PropertyDescriptorCollection? GetProperties (
-							ITypeDescriptorContext context,
-							object value, Attribute[] attributes)
+						ITypeDescriptorContext? context,
+						object value, Attribute[]? attributes)
 		{
 			if (value is Point)
 				return TypeDescriptor.GetProperties (value, attributes);
@@ -145,7 +145,7 @@ namespace System.Drawing {
 			return base.GetProperties (context, value, attributes);
 		}
 		
-		public override bool GetPropertiesSupported (ITypeDescriptorContext context)
+		public override bool GetPropertiesSupported (ITypeDescriptorContext? context)
 		{
 			return true;
 		}

--- a/src/Mono.Android/System.Drawing/RectangleConverter.cs
+++ b/src/Mono.Android/System.Drawing/RectangleConverter.cs
@@ -46,7 +46,7 @@ namespace System.Drawing {
 		{
 		}
 		
-		public override bool CanConvertFrom (ITypeDescriptorContext context,
+		public override bool CanConvertFrom (ITypeDescriptorContext? context,
 						     Type sourceType)
 		{
 			if (sourceType == typeof (string))
@@ -55,8 +55,8 @@ namespace System.Drawing {
 			return base.CanConvertFrom (context, sourceType);
 		}
 
-		public override bool CanConvertTo (ITypeDescriptorContext context,
-						   Type destinationType)
+		public override bool CanConvertTo (ITypeDescriptorContext? context,
+					   Type? destinationType)
 		{
 			if (destinationType == typeof (string))
 				return true;
@@ -67,10 +67,12 @@ namespace System.Drawing {
 			return base.CanConvertTo (context, destinationType);
 		}
 
-		public override object? ConvertFrom (ITypeDescriptorContext context,
-						    CultureInfo culture,
-						    object value)
+		public override object? ConvertFrom (ITypeDescriptorContext? context,
+					    CultureInfo? culture,
+					    object value)
 		{
+			if (culture == null)
+				culture = CultureInfo.CurrentCulture;
 			string? s = value as string;
 			if (s == null)
 				return base.ConvertFrom (context, culture, value);
@@ -92,11 +94,13 @@ namespace System.Drawing {
 			return new Rectangle (numSubs[0], numSubs[1], numSubs[2], numSubs[3]);
 		}
 
-		public override object? ConvertTo (ITypeDescriptorContext context,
-						  CultureInfo culture,
-						  object value,
-						  Type destinationType)
+		public override object? ConvertTo (ITypeDescriptorContext? context,
+					  CultureInfo? culture,
+					  object? value,
+					  Type destinationType)
 		{
+			if (culture == null)
+				culture = CultureInfo.CurrentCulture;
 			// BADSPEC: "The default implementation calls the object's
 			// ToString method if the object is valid and if the destination
 			// type is string." MS does not behave as per the specs.
@@ -126,7 +130,7 @@ namespace System.Drawing {
 			return base.ConvertTo (context, culture, value, destinationType);
 		}
 
-		public override object CreateInstance (ITypeDescriptorContext context,
+		public override object CreateInstance (ITypeDescriptorContext? context,
 						       IDictionary propertyValues)
 		{
 			var ox = propertyValues ["X"];
@@ -143,15 +147,15 @@ namespace System.Drawing {
 			return new Rectangle (x, y, width, height);
 		}
 
-		public override bool GetCreateInstanceSupported (ITypeDescriptorContext context)
+		public override bool GetCreateInstanceSupported (ITypeDescriptorContext? context)
 		{
 			return true;
 		}
 
 		[RequiresUnreferencedCode ("The Type of value cannot be statically discovered.")]
 		public override PropertyDescriptorCollection? GetProperties (
-							ITypeDescriptorContext context,
-							object value, Attribute[] attributes)
+						ITypeDescriptorContext? context,
+						object value, Attribute[]? attributes)
 		{
 			if (value is Rectangle)
 				return TypeDescriptor.GetProperties (value, attributes);
@@ -159,7 +163,7 @@ namespace System.Drawing {
 			return base.GetProperties (context, value, attributes);
 		}
 		
-		public override bool GetPropertiesSupported (ITypeDescriptorContext context)
+		public override bool GetPropertiesSupported (ITypeDescriptorContext? context)
 		{
 			return true;
 		}

--- a/src/Mono.Android/System.Drawing/SizeConverter.cs
+++ b/src/Mono.Android/System.Drawing/SizeConverter.cs
@@ -45,7 +45,7 @@ namespace System.Drawing {
 		{
 		}
 
-		public override bool CanConvertFrom (ITypeDescriptorContext context,
+		public override bool CanConvertFrom (ITypeDescriptorContext? context,
 						     Type sourceType)
 		{
 			if (sourceType == typeof (string))
@@ -54,8 +54,8 @@ namespace System.Drawing {
 			return base.CanConvertFrom (context, sourceType);
 		}
 
-		public override bool CanConvertTo (ITypeDescriptorContext context,
-						   Type destinationType)
+		public override bool CanConvertTo (ITypeDescriptorContext? context,
+					   Type? destinationType)
 		{
 			if (destinationType == typeof (string))
 				return true;
@@ -66,8 +66,8 @@ namespace System.Drawing {
 			return base.CanConvertTo (context, destinationType);
 		}
 
-		public override object? ConvertFrom (ITypeDescriptorContext context,
-						    CultureInfo culture,
+		public override object? ConvertFrom (ITypeDescriptorContext? context,
+					    CultureInfo? culture,
 						    object value)
 		{
 			if (culture == null)
@@ -93,9 +93,9 @@ namespace System.Drawing {
 			return new Size (numSubs[0], numSubs[1]);
 		}
 
-		public override object? ConvertTo (ITypeDescriptorContext context,
-						  CultureInfo culture,
-						  object value,
+		public override object? ConvertTo (ITypeDescriptorContext? context,
+					  CultureInfo? culture,
+					  object? value,
 						  Type destinationType)
 		{
 			if (culture == null)
@@ -118,7 +118,7 @@ namespace System.Drawing {
 			return base.ConvertTo (context, culture, value, destinationType);
 		}
 
-		public override object CreateInstance (ITypeDescriptorContext context,
+		public override object CreateInstance (ITypeDescriptorContext? context,
 						       IDictionary propertyValues)
 		{
 			var ow = propertyValues ["Width"];
@@ -131,15 +131,15 @@ namespace System.Drawing {
 			return new Size (width, height);
 		}
 
-		public override bool GetCreateInstanceSupported (ITypeDescriptorContext context)
+		public override bool GetCreateInstanceSupported (ITypeDescriptorContext? context)
 		{
 			return true;
 		}
 
 		[RequiresUnreferencedCode ("The Type of value cannot be statically discovered.")]
 		public override PropertyDescriptorCollection? GetProperties (
-							ITypeDescriptorContext context,
-							object value, Attribute[] attributes)
+						ITypeDescriptorContext? context,
+						object value, Attribute[]? attributes)
 		{
 			if (value is Size)
 				return TypeDescriptor.GetProperties (value, attributes);
@@ -147,7 +147,7 @@ namespace System.Drawing {
 			return base.GetProperties (context, value, attributes);
 		}
 		
-		public override bool GetPropertiesSupported (ITypeDescriptorContext context)
+		public override bool GetPropertiesSupported (ITypeDescriptorContext? context)
 		{
 			return true;
 		}

--- a/src/Mono.Android/System.Drawing/SizeFConverter.cs
+++ b/src/Mono.Android/System.Drawing/SizeFConverter.cs
@@ -48,7 +48,7 @@ namespace System.Drawing
 
 		}
 
-		public override bool CanConvertFrom (ITypeDescriptorContext context, Type sourceType)
+		public override bool CanConvertFrom (ITypeDescriptorContext? context, Type sourceType)
 		{
 			if (sourceType == typeof (string))
 				return true;
@@ -56,7 +56,7 @@ namespace System.Drawing
 			return base.CanConvertFrom (context, sourceType);
 		}
 
-		public override bool CanConvertTo (ITypeDescriptorContext context, Type destinationType)
+		public override bool CanConvertTo (ITypeDescriptorContext? context, Type? destinationType)
 		{
 			if (destinationType == typeof (string))
 				return true;
@@ -67,8 +67,10 @@ namespace System.Drawing
 			return base.CanConvertTo (context, destinationType);
 		}
 
-		public override object? ConvertFrom (ITypeDescriptorContext context, CultureInfo culture, object value)
+		public override object? ConvertFrom (ITypeDescriptorContext? context, CultureInfo? culture, object value)
 		{
+			if (culture == null)
+				culture = CultureInfo.CurrentCulture;
 			var s = value as string;
 			if (s == null)
 				return base.ConvertFrom (context, culture, value);
@@ -91,8 +93,10 @@ namespace System.Drawing
 
 		}
 
-		public override object? ConvertTo (ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		public override object? ConvertTo (ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
 		{
+			if (culture == null)
+				culture = CultureInfo.CurrentCulture;
 			if (value is SizeF) {
 				SizeF size = (SizeF) value;
 				if (destinationType == typeof (string)) {
@@ -107,20 +111,20 @@ namespace System.Drawing
 			return base.ConvertTo (context, culture, value, destinationType);
 		}
 
-		public override object CreateInstance (ITypeDescriptorContext context, IDictionary propertyValues)
+		public override object CreateInstance (ITypeDescriptorContext? context, IDictionary propertyValues)
 		{
 			float w = (float) propertyValues ["Width"]!;
 			float h = (float) propertyValues ["Height"]!;
 			return new SizeF (w, h);
 		}
 
-		public override bool GetCreateInstanceSupported (ITypeDescriptorContext context)
+		public override bool GetCreateInstanceSupported (ITypeDescriptorContext? context)
 		{
 			return true;
 		}
 
 		[RequiresUnreferencedCode ("The Type of value cannot be statically discovered.")]
-		public override PropertyDescriptorCollection? GetProperties (ITypeDescriptorContext context, object value, Attribute[] attributes)
+		public override PropertyDescriptorCollection? GetProperties (ITypeDescriptorContext? context, object value, Attribute[]? attributes)
 		{
 			if (value is SizeF)
 				return TypeDescriptor.GetProperties (value, attributes);
@@ -128,7 +132,7 @@ namespace System.Drawing
 			return base.GetProperties (context, value, attributes);
 		}
 
-		public override bool GetPropertiesSupported (ITypeDescriptorContext context)
+		public override bool GetPropertiesSupported (ITypeDescriptorContext? context)
 		{
 			return true;
 		}

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -784,7 +784,7 @@ namespace Xamarin.Android.Net
 		// failures must be surfaced as HttpRequestException rather than the legacy WebException. To avoid breaking
 		// existing code that migrated from classic Xamarin.Android and still inspects WebException (and its
 		// WebExceptionStatus), we keep the original WebException as the inner exception.
-		static HttpRequestException CreateHttpRequestException (string message, Exception? innerException, WebExceptionStatus status)
+		static HttpRequestException CreateHttpRequestException (string? message, Exception? innerException, WebExceptionStatus status)
 			=> new HttpRequestException (message, new WebException (message, innerException, status, null));
 
 		protected virtual async Task WriteRequestContentToOutput (HttpRequestMessage request, HttpURLConnection httpConnection, CancellationToken cancellationToken)

--- a/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs
@@ -49,8 +49,10 @@ namespace Xamarin.Android.Net
 				_serverCertificateCustomValidationCallback = serverCertificateCustomValidationCallback;
 			}
 
-			public void CheckServerTrusted (JavaX509Certificate[] javaChain, string authType)
+			public void CheckServerTrusted (JavaX509Certificate[]? javaChain, string? authType)
 			{
+				ArgumentNullException.ThrowIfNull (javaChain);
+				ArgumentNullException.ThrowIfNull (authType);
 				var sslPolicyErrors = SslPolicyErrors.None;
 
 				try {
@@ -78,7 +80,7 @@ namespace Xamarin.Android.Net
 				}
 			}
 
-			public void CheckClientTrusted (JavaX509Certificate[] chain, string authType)
+			public void CheckClientTrusted (JavaX509Certificate[]? chain, string? authType)
 				=> _internalTrustManager.CheckClientTrusted (chain, authType);
 
 			public JavaX509Certificate[] GetAcceptedIssuers ()
@@ -150,11 +152,11 @@ namespace Xamarin.Android.Net
 				public byte[] GetId () => throw new InvalidOperationException ();
 				public Java.Security.Cert.Certificate[] GetLocalCertificates () => throw new InvalidOperationException ();
 				public Javax.Security.Cert.X509Certificate[] GetPeerCertificateChain () => throw new InvalidOperationException ();
-				public Java.Lang.Object GetValue(string name) => throw new InvalidOperationException ();
+				public Java.Lang.Object GetValue(string? name) => throw new InvalidOperationException ();
 				public string[] GetValueNames () => throw new InvalidOperationException ();
 				public void Invalidate () => throw new InvalidOperationException ();
-				public void PutValue(string name, Java.Lang.Object value) => throw new InvalidOperationException ();
-				public void RemoveValue(string name) => throw new InvalidOperationException ();
+				public void PutValue(string? name, Java.Lang.Object? value) => throw new InvalidOperationException ();
+				public void RemoveValue(string? name) => throw new InvalidOperationException ();
 			}
 		}
 

--- a/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/ServerCertificateCustomValidator.cs
@@ -81,7 +81,11 @@ namespace Xamarin.Android.Net
 			}
 
 			public void CheckClientTrusted (JavaX509Certificate[]? chain, string? authType)
-				=> _internalTrustManager.CheckClientTrusted (chain, authType);
+			{
+				ArgumentNullException.ThrowIfNull (chain);
+				ArgumentNullException.ThrowIfNull (authType);
+				_internalTrustManager.CheckClientTrusted (chain, authType);
+			}
 
 			public JavaX509Certificate[] GetAcceptedIssuers ()
 				=> _internalTrustManager.GetAcceptedIssuers () ?? Array.Empty<JavaX509Certificate> ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1794,20 +1794,7 @@ namespace UnnamedProject
 				StringAssertEx.Contains ("error XA4310", builder.LastBuildOutput, "Error should be XA4310");
 				StringAssertEx.Contains ("`DoesNotExist`", builder.LastBuildOutput, "Error should include the name of the nonexistent file");
 
-				if (runtime != AndroidRuntime.NativeAOT) {
-					builder.AssertHasNoWarnings ();
-					return;
-				}
-
-				// NativeAOT currently (Nov 2025) produces the following warning
-				//  warning IL3053: Assembly 'Mono.Android' produced AOT analysis warnings.
-				string expectedWarning = "warning IL3053:";
-				Assert.IsNotNull (
-					builder.LastBuildOutput
-					  .SkipWhile (x => !x.StartsWith ("Build FAILED.", StringComparison.Ordinal))
-					  .FirstOrDefault (x => x.Contains (expectedWarning)),
-					$"Build output should contain '{expectedWarning}'."
-				);
+				builder.AssertHasNoWarnings ();
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -481,38 +481,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
-				if (runtime == AndroidRuntime.NativeAOT) {
-					// NativeAOT currently (Jul 2026) produces 2 `ILC : AOT analysis warning IL3050`
-					// warnings: a single distinct warning (the reflection-backed ManagedTypeManager
-					// constructor, which chains to the [RequiresDynamicCode] ReflectionJniTypeManager
-					// base and is therefore not Native AOT compatible), surfaced twice in the MSBuild
-					// summary (once per publish target context). Even though this test expects no
-					// warnings and the above likely make the app not work correctly at run time, it is
-					// still worth running this test under NativeAOT to test for the absence of other
-					// warnings.
-					int numberOfExpectedWarnings = 2;
-
-					// MSBuild prints a "    N Warning(s)" summary line near the end of the build; parse N so the
-					// assertion can report the actual count instead of a bare "Expected: True But was: False".
-					var warningSummaryLine = b.LastBuildOutput.LastOrDefault (x => x.TrimEnd ().EndsWith ("Warning(s)", StringComparison.Ordinal));
-					int actualNumberOfWarnings = -1;
-					if (warningSummaryLine != null) {
-						var summary = warningSummaryLine.Trim ();
-						var firstSpace = summary.IndexOf (' ');
-						if (firstSpace > 0) {
-							int.TryParse (summary.Substring (0, firstSpace), out actualNumberOfWarnings);
-						}
-					}
-
-					Assert.AreEqual (numberOfExpectedWarnings, actualNumberOfWarnings,
-						$"{b.BuildLogFile} should have exactly {numberOfExpectedWarnings} MSBuild warnings for NativeAOT, but found {actualNumberOfWarnings}.");
-
-					const string expectedWarningIL3050 = "ILC : AOT analysis warning IL3050:";
-					var warnings = b.LastBuildOutput.SkipWhile (x => !x.StartsWith ("Build succeeded.", StringComparison.Ordinal)).Where (x => x.Contains (expectedWarningIL3050, StringComparison.Ordinal));
-					Assert.IsTrue (warnings.Count () == numberOfExpectedWarnings, $"Expected {numberOfExpectedWarnings} 'IL3050' warnings, found {warnings.Count ()}");
-				} else {
-					b.AssertHasNoWarnings ();
-				}
+				b.AssertHasNoWarnings ();
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Warning: end of file not at end of a line"),
 					"Should not get a warning from the <CompileNativeAssembly/> task.");
 				var lockFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, ".__lock");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -326,12 +326,7 @@ public class JavaSourceTest {
 
 			// NOTE: Preview API levels emit XA4211
 			if (!preview) {
-				if (runtime != AndroidRuntime.NativeAOT) {
-					dotnet.AssertHasNoWarnings ();
-				} else {
-					// NativeAOT currently issues 1 warning
-					dotnet.AssertHasSomeWarnings (1);
-				}
+				dotnet.AssertHasNoWarnings ();
 			}
 
 			// Only check latest TFM, as previous or preview TFMs will come from NuGet


### PR DESCRIPTION
Supersedes #11999 (that PR was from a fork; this one is rebased on latest `main` and pushed to an origin branch so it runs the full CI). #11999 will be closed.

## Summary

Reduces the C# build warnings in `src/Mono.Android` by fixing the warnings that originate in **hand-written source**, and completes the API-37 public API baseline so the public API analyzer passes.

It **intentionally does not** remove every `NoWarn` suppression, nor the `Mono.Android.csproj` entry in `_AllowProjectWarnings` (in `Directory.Build.props`). The warnings that remain all originate in **generated code** and require changes to the code generators — see "Why suppressions remain" below.

## What is fixed (hand-written code)

- **CS8765** - override parameter nullability aligned to the base member (`System.Drawing` `TypeConverter` subclasses, `SyncContext`, Java stream adapters, `Color`/`AndroidBitmapInfo` equality, `AdapterView.RawAdapter`).
- **CS8764** - `JavaObject.ToString()` returns non-null to match `Java.Lang.Object.ToString()`.
- **CS8767** - interface-implementation parameter nullability aligned to the interface (`IComparer`, `ISpliterator`, `ISetCookie`, `IX509TrustManager`/`ISSLSession`, `IXmlPullParser`).
- **CS0114 / CS0108** - `new` added to members that intentionally hide an inherited member (generic collection specializations, static helpers, `IXmlResourceParser` disambiguation, `StringBuffer`/`StringBuilder.Append`, `AsyncTask.class_ref`, `JavaProxyThrowable.InnerException`, `SparseArray<E>`, `ArrayAdapter<T>`, `JavaList.Equals`).

### Public API baseline (RS0016 / RS0017)

Some of the nullability fixes change the annotations of public members, and the API-37 baseline was missing a large number of generated binding members. `PublicAPI/API-37/PublicAPI.Unshipped.txt` is regenerated (via the `RS0016` code fix, plus `*REMOVED*` markers for stale signatures) so **`RS0016`/`RS0017` are satisfied and remain enforced** (they are not in `NoWarn`).

## Why suppressions remain

The remaining warnings are all in **generated code** and cannot be fixed here without changing the generators:

- **`mcw/*.cs`** (binding generator): `CS0108`, `CS0114`, `CS0618`, `CS0809`, `CS8613`, `CS8764`, `CS8765`, `CS8766`, `CS8767`.
- **`JNIEnv.g.cs`** (`jnienv-gen`, `// Generated file; DO NOT EDIT!`): `RS0041` (public members using oblivious reference types).

These files are regenerated on every build, so the fix must happen in the generator. Until those follow-ups land, we keep the corresponding codes in `<NoWarn>` and keep `<_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Mono.Android.csproj' ">true</_AllowProjectWarnings>`. Removing either now would turn hundreds of generated-code warnings into build errors under `TreatWarningsAsErrors`.

## Follow-ups

- **Binding generator** - emit warning-free `mcw/*.cs`, then drop `CS0108;CS0114;CS0618;CS0809;CS8613;CS8764;CS8765;CS8766;CS8767` from `NoWarn`.
- **`jnienv-gen`** - annotate `JNIEnv.g.cs` output, then drop `RS0041` from `NoWarn`.
- **CS0436** - handled in #11669.

Once those land, the remaining `NoWarn` codes and the `_AllowProjectWarnings` opt-in for `Mono.Android.csproj` can be removed.
