### PR TITLE
Enable android-arm NativeAOT runtime packs

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -115,6 +115,7 @@ projects that use the Microsoft.Android.Runtimes framework in .NET 6+.
     <ItemGroup Condition=" '$(AndroidRuntime)' == 'NativeAOT' ">
       <NativeRuntimeAsset Condition=" Exists('$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.debug-static-debug.a') " Include="$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.debug-static-debug.a" />
       <NativeRuntimeAsset Condition=" Exists('$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.release-static-release.a') " Include="$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.release-static-release.a" />
+      <NativeRuntimeAsset Condition=" Exists('$(XAPackagesDir)\microsoft.netcore.app.runtime.nativeaot.$(AndroidRID)\$(MicrosoftNETCoreAppRefPackageVersion)\runtimes\$(AndroidRID)\native\libSystem.Security.Cryptography.Native.Android.a') " Include="$(XAPackagesDir)\microsoft.netcore.app.runtime.nativeaot.$(AndroidRID)\$(MicrosoftNETCoreAppRefPackageVersion)\runtimes\$(AndroidRID)\native\libSystem.Security.Cryptography.Native.Android.a" />
       <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(AndroidLatestStableApiLevel)\Microsoft.Android.Runtime.NativeAOT.dll" />
     </ItemGroup>
 

--- a/build-tools/scripts/Ndk.projitems
+++ b/build-tools/scripts/Ndk.projitems
@@ -24,7 +24,7 @@
       <AndroidRID>android-arm</AndroidRID>
       <SupportMonoVM>True</SupportMonoVM>
       <SupportCoreCLR>True</SupportCoreCLR>
-      <SupportNativeAOT>False</SupportNativeAOT>
+      <SupportNativeAOT>True</SupportNativeAOT>
     </AndroidSupportedTargetJitAbi>
 
     <AndroidSupportedTargetJitAbi

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -386,6 +386,8 @@
 	<attr path="/api/package[@name='android.widget']/class[@name='TextView']/method[@name='getHighlightColor']" name="return" api-since="16">Android.Graphics.Color</attr>
 	<attr path="/api/package[@name='android.widget']/class[@name='TextView']/method[@name='getShadowColor']" name="return" api-since="16">Android.Graphics.Color</attr>
 
+	<remove-node api-since="37" path="/api/package[@name='android.app.appfunctions']/class[@name='AppFunctionState']" />
+
 	<attr api-since="36.1" path="/api/package[@name='android.graphics.pdf.component']/*/method[
 	    starts-with(@jni-signature, '(I)') and (
 	    @name='setTextColor'

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -386,8 +386,6 @@
 	<attr path="/api/package[@name='android.widget']/class[@name='TextView']/method[@name='getHighlightColor']" name="return" api-since="16">Android.Graphics.Color</attr>
 	<attr path="/api/package[@name='android.widget']/class[@name='TextView']/method[@name='getShadowColor']" name="return" api-since="16">Android.Graphics.Color</attr>
 
-	<remove-node api-since="37" path="/api/package[@name='android.app.appfunctions']/class[@name='AppFunctionState']" />
-
 	<attr api-since="36.1" path="/api/package[@name='android.graphics.pdf.component']/*/method[
 	    starts-with(@jni-signature, '(I)') and (
 	    @name='setTextColor'

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
@@ -10,6 +10,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup>
     <AndroidNETSdkVersion>@ANDROID_PACK_VERSION_LONG@</AndroidNETSdkVersion>
     <XamarinAndroidVersion>@ANDROID_PACK_VERSION_LONG@</XamarinAndroidVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>@MICROSOFT_NETCORE_APP_REF_PACKAGE_VERSION@</MicrosoftNETCoreAppRefPackageVersion>
     <_AndroidLatestStableApiLevel>@ANDROID_LATEST_STABLE_API_LEVEL@</_AndroidLatestStableApiLevel>
     <_AndroidLatestUnstableApiLevel>@ANDROID_LATEST_UNSTABLE_API_LEVEL@</_AndroidLatestUnstableApiLevel>
   </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -35,7 +35,8 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
     <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(RuntimeIdentifier)' == 'android-arm' ">
+  <!-- Outer restores use RuntimeIdentifiers; RuntimeIdentifier is only set in per-RID inner builds. -->
+  <ItemGroup>
     <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler">
       <ILCompilerPackVersion>$(MicrosoftNETCoreAppRefPackageVersion)</ILCompilerPackVersion>
     </KnownILCompilerPack>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -22,7 +22,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
     <AllowPublishAotWithoutRuntimeIdentifier Condition=" '$(AllowPublishAotWithoutRuntimeIdentifier)' == '' ">true</AllowPublishAotWithoutRuntimeIdentifier>
     <!-- NativeAOT's targets currently gives an error about cross-compilation -->
     <DisableUnsupportedError Condition=" $([MSBuild]::IsOSPlatform('windows')) and '$(DisableUnsupportedError)' == '' ">true</DisableUnsupportedError>
-    <!-- HACK: make dotnet restore include Microsoft.NETCore.App.Runtime.NativeAOT.linux-bionic-arm64 -->
+    <!-- HACK: make dotnet restore include Microsoft.NETCore.App.Runtime.NativeAOT.* packs -->
     <_IsPublishing Condition=" '$(_IsPublishing)' == '' ">true</_IsPublishing>
     <!-- ResolvedFileToPublish is not populated until _AndroidComputeIlcCompileInputs, so
          proguard generation must run after that target instead of after ILLink. -->
@@ -34,6 +34,18 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
          exported as native symbols so JNI can find them via dlsym. -->
     <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(RuntimeIdentifier)' == 'android-arm' ">
+    <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler">
+      <ILCompilerPackVersion>$(MicrosoftNETCoreAppRefPackageVersion)</ILCompilerPackVersion>
+    </KnownILCompilerPack>
+    <_AndroidNetCoreAppNativeAotKnownRuntimePack Include="@(KnownRuntimePack->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('RuntimePackLabels', 'NativeAOT'))" />
+    <KnownRuntimePack Remove="@(_AndroidNetCoreAppNativeAotKnownRuntimePack)" />
+    <KnownRuntimePack Include="@(_AndroidNetCoreAppNativeAotKnownRuntimePack)">
+      <LatestRuntimeFrameworkVersion>$(MicrosoftNETCoreAppRefPackageVersion)</LatestRuntimeFrameworkVersion>
+      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);android-arm</RuntimePackRuntimeIdentifiers>
+    </KnownRuntimePack>
+  </ItemGroup>
 
   <!-- Default property values for NativeAOT Debug configuration -->
   <PropertyGroup Condition="'$(DebugSymbols)' == 'true'">
@@ -90,9 +102,16 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
     <PropertyGroup>
       <_NdkAbi Condition=" '$(RuntimeIdentifier)' == 'android-arm64' ">aarch64</_NdkAbi>
       <_NdkAbi Condition=" '$(RuntimeIdentifier)' == 'android-x64' ">x86_64</_NdkAbi>
+      <_NdkAbi Condition=" '$(RuntimeIdentifier)' == 'android-arm' ">arm</_NdkAbi>
       <_NDKApiLevel Condition=" '$(RuntimeIdentifier)' == 'android-arm64' ">$(AndroidNdkApiLevel_Arm64)</_NDKApiLevel>
       <_NDKApiLevel Condition=" '$(RuntimeIdentifier)' == 'android-x64' ">$(AndroidNdkAPiLevel_X64)</_NDKApiLevel>
-      <_NdkSysrootAbi>$(_NdkAbi)-linux-android</_NdkSysrootAbi>
+      <_NDKApiLevel Condition=" '$(RuntimeIdentifier)' == 'android-arm' ">$(AndroidNdkApiLevel_Arm)</_NDKApiLevel>
+      <_NdkClangPrefix Condition=" '$(RuntimeIdentifier)' == 'android-arm64' ">aarch64-linux-android</_NdkClangPrefix>
+      <_NdkClangPrefix Condition=" '$(RuntimeIdentifier)' == 'android-x64' ">x86_64-linux-android</_NdkClangPrefix>
+      <_NdkClangPrefix Condition=" '$(RuntimeIdentifier)' == 'android-arm' ">armv7a-linux-androideabi</_NdkClangPrefix>
+      <_NdkSysrootAbi Condition=" '$(RuntimeIdentifier)' == 'android-arm64' ">aarch64-linux-android</_NdkSysrootAbi>
+      <_NdkSysrootAbi Condition=" '$(RuntimeIdentifier)' == 'android-x64' ">x86_64-linux-android</_NdkSysrootAbi>
+      <_NdkSysrootAbi Condition=" '$(RuntimeIdentifier)' == 'android-arm' ">arm-linux-androideabi</_NdkSysrootAbi>
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('windows')) ">windows-x86_64</_NdkPrebuiltAbi>
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('osx')) ">darwin-x86_64</_NdkPrebuiltAbi>
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('linux')) ">linux-x86_64</_NdkPrebuiltAbi>
@@ -128,8 +147,8 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
           application. If, for some reason, `clang++` has to be used, `<LinkerArgs>` need to be
           added to pass `-nostdlib` to it.
       -->
-      <CppCompilerAndLinker>$(_NdkAbi)-linux-android$(_NDKApiLevel)-clang$(_NdkWrapperScriptExt)</CppCompilerAndLinker>
-      <CppLinker>$(_NdkAbi)-linux-android$(_NDKApiLevel)-clang$(_NdkWrapperScriptExt)</CppLinker>
+      <CppCompilerAndLinker>$(_NdkClangPrefix)$(_NDKApiLevel)-clang$(_NdkWrapperScriptExt)</CppCompilerAndLinker>
+      <CppLinker>$(_NdkClangPrefix)$(_NDKApiLevel)-clang$(_NdkWrapperScriptExt)</CppLinker>
       <ObjCopyName>llvm-objcopy</ObjCopyName>
 
       <!-- We must ensure this is `false`, as it would interfere with statically linking libc++ -->
@@ -214,6 +233,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
 
   <Target Name="_PrepareNativeAotAndroidAppInputs">
     <ItemGroup>
+      <_PrivateBuildTargetAbi Condition=" '$(RuntimeIdentifier)' == 'android-arm' " Include="armeabi-v7a" />
       <_PrivateBuildTargetAbi Condition=" '$(RuntimeIdentifier)' == 'android-arm64' " Include="arm64-v8a" />
       <_PrivateBuildTargetAbi Condition=" '$(RuntimeIdentifier)' == 'android-x64' " Include="x86_64" />
     </ItemGroup>
@@ -360,6 +380,10 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <_NativeAotSystemLibraries Include="log" />
       <_NativeAotSystemLibraries Include="m" />
       <_NativeAotSystemLibraries Include="c" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' == 'true' and Exists('$(_NativeAotRuntimePackNativeDir)libSystem.Security.Cryptography.Native.Android.a') ">
+      <_NativeAotLinkLibraries Remove="$(IlcSdkPath)libSystem.Security.Cryptography.Native.Android.a" />
+      <_NativeAotLinkLibraries Include="$(_NativeAotRuntimePackNativeDir)libSystem.Security.Cryptography.Native.Android.a" />
     </ItemGroup>
 
     <!-- When using workload linker, resolve libc++/libnaot from runtime pack dir.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -15,6 +15,7 @@
         "Microsoft.Android.Runtime.CoreCLR.37.android-arm",
         "Microsoft.Android.Runtime.CoreCLR.37.android-arm64",
         "Microsoft.Android.Runtime.CoreCLR.37.android-x64",
+        "Microsoft.Android.Runtime.NativeAOT.37.android-arm",
         "Microsoft.Android.Runtime.NativeAOT.37.android-arm64",
         "Microsoft.Android.Runtime.NativeAOT.37.android-x64",
         "Microsoft.Android.Templates"
@@ -88,6 +89,10 @@
       "version": "@WORKLOAD_VERSION@"
     },
     "Microsoft.Android.Runtime.CoreCLR.37.android-x64": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.NativeAOT.37.android-arm": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
 using Xamarin.ProjectTools;
@@ -11,6 +13,35 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("Node-2")]
 	public class NativeAotBuildTests : BaseTest
 	{
+		[Test]
+		public void RestoreNativeAot_AndroidArmRuntimePack ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.NativeAOT);
+			proj.SetRuntimeIdentifiers (["armeabi-v7a"]);
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (
+				builder.RunTarget (proj, "Restore"),
+				"Restore should succeed for android-arm."
+			);
+
+			var intermediate = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath);
+			var assets = File.ReadAllText (Path.Combine (intermediate, "..", "project.assets.json"));
+			StringAssert.Contains (
+				"\"Microsoft.NETCore.App.Runtime.NativeAOT.android-arm\"",
+				assets,
+				"Restore should select the android-arm NativeAOT runtime pack."
+			);
+			StringAssert.DoesNotContain (
+				"\"Microsoft.NETCore.App.Runtime.NativeAOT.linux-bionic-arm\"",
+				assets,
+				"Restore should not fall back to the linux-bionic-arm NativeAOT runtime pack."
+			);
+		}
+
 		[Test]
 		public void BuildNativeAot_WithoutNdk ()
 		{
@@ -41,6 +72,25 @@ namespace Xamarin.Android.Build.Tests
 					"_AndroidUseWorkloadNativeLinker=false",
 				}),
 				"Build should succeed with NDK linker."
+			);
+		}
+
+		[Test]
+		public void BuildNativeAot_AndroidArm_WithNdkLinker ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.NativeAOT);
+			proj.SetRuntimeIdentifiers (["armeabi-v7a"]);
+			proj.SetProperty ("_SkipNdkResolution", "false");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (
+				builder.Build (proj, parameters: [
+					"_AndroidUseWorkloadNativeLinker=false",
+				]),
+				"android-arm build should succeed with NDK linker."
 			);
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -284,6 +284,7 @@
       <_BundledVersionsCacheLines Include="AndroidLatestUnstableApiLevel=$(AndroidLatestUnstableApiLevel)" />
       <_BundledVersionsCacheLines Include="DotNetTargetFramework=$(DotNetTargetFramework)" />
       <_BundledVersionsCacheLines Include="DotNetTargetFrameworkVersion=$(DotNetTargetFrameworkVersion)" />
+      <_BundledVersionsCacheLines Include="MicrosoftNETCoreAppRefPackageVersion=$(MicrosoftNETCoreAppRefPackageVersion)" />
     </ItemGroup>
     <WriteLinesToFile
         File="$(IntermediateOutputPath)_GenerateBundledVersions.cache"
@@ -303,7 +304,7 @@
     <ReplaceFileContents
         SourceFile="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\in\Microsoft.Android.Sdk.BundledVersions.in.targets"
         DestinationFile="$(MSBuildThisFileDirectory)\Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.BundledVersions.targets"
-        Replacements="@ANDROID_PACK_VERSION_LONG@=$(AndroidPackVersionLong);@ANDROID_LATEST_STABLE_API_LEVEL@=$(AndroidLatestStableApiLevel);@ANDROID_LATEST_UNSTABLE_API_LEVEL@=$(AndroidLatestUnstableApiLevel);@DOTNET_TARGET_FRAMEWORK@=$(DotNetTargetFramework)" >
+        Replacements="@ANDROID_PACK_VERSION_LONG@=$(AndroidPackVersionLong);@ANDROID_LATEST_STABLE_API_LEVEL@=$(AndroidLatestStableApiLevel);@ANDROID_LATEST_UNSTABLE_API_LEVEL@=$(AndroidLatestUnstableApiLevel);@DOTNET_TARGET_FRAMEWORK@=$(DotNetTargetFramework);@MICROSOFT_NETCORE_APP_REF_PACKAGE_VERSION@=$(MicrosoftNETCoreAppRefPackageVersion)" >
     </ReplaceFileContents>
     <ReplaceFileContents
         SourceFile="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\Sdk\AutoImport.in.props"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -35,6 +35,7 @@
 		<!-- Enable nuget package conflict resolution -->
 		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 
+		<AndroidNdkApiLevel_Arm>@NDK_ARMEABI_V7_API@</AndroidNdkApiLevel_Arm>
 		<AndroidNdkApiLevel_Arm64>@NDK_ARM64_V8A_API@</AndroidNdkApiLevel_Arm64>
 		<AndroidNdkApiLevel_X64>@NDK_X86_64_API@</AndroidNdkApiLevel_X64>
 	</PropertyGroup>

--- a/src/native/CMakePresets.json.in
+++ b/src/native/CMakePresets.json.in
@@ -152,6 +152,11 @@
         },
 
         {
+            "name": "nativeaot-default-debug-armeabi-v7a",
+            "inherits": ["nativeaot-default-common", "common-debug", "common-armeabi-v7a"]
+        },
+
+        {
             "name": "coreclr-default-debug-armeabi-v7a",
             "inherits": ["default-common", "common-debug", "common-armeabi-v7a"]
         },
@@ -159,6 +164,11 @@
         {
             "name": "default-release-armeabi-v7a",
             "inherits": ["default-common", "common-release", "common-armeabi-v7a"]
+        },
+
+        {
+            "name": "nativeaot-default-release-armeabi-v7a",
+            "inherits": ["nativeaot-default-common", "common-release", "common-armeabi-v7a"]
         },
 
         {

--- a/src/native/native-nativeaot.csproj
+++ b/src/native/native-nativeaot.csproj
@@ -8,7 +8,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
     <AndroidSupportedTargetAotAbis>arm64:x86_64</AndroidSupportedTargetAotAbis>
-    <AndroidSupportedTargetJitAbis>arm64-v8a:x86_64</AndroidSupportedTargetJitAbis>
+    <AndroidSupportedTargetJitAbis>armeabi-v7a:arm64-v8a:x86_64</AndroidSupportedTargetJitAbis>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />

--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -373,6 +373,14 @@
                          RuntimePackName="$(_RuntimePackName)" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(CMakeRuntimeFlavor)' == 'NativeAOT' ">
+      <_RuntimePackFiles Include="$(XAPackagesDir)\microsoft.netcore.app.runtime.nativeaot.%(AndroidSupportedTargetJitAbi.AndroidRID)\$(MicrosoftNETCoreAppRefPackageVersion)\runtimes\%(AndroidSupportedTargetJitAbi.AndroidRID)\native\libSystem.Security.Cryptography.Native.Android.a"
+                         Condition="Exists('$(XAPackagesDir)\microsoft.netcore.app.runtime.nativeaot.%(AndroidSupportedTargetJitAbi.AndroidRID)\$(MicrosoftNETCoreAppRefPackageVersion)\runtimes\%(AndroidSupportedTargetJitAbi.AndroidRID)\native\libSystem.Security.Cryptography.Native.Android.a')"
+                         AndroidRID="%(AndroidSupportedTargetJitAbi.AndroidRID)"
+                         AndroidRuntime="$(CMakeRuntimeFlavor)"
+                         RuntimePackName="$(_RuntimePackName)" />
+    </ItemGroup>
+
     <Copy
         SourceFiles="%(_RuntimePackFiles.Identity)"
         DestinationFolder="$(MicrosoftAndroidPacksRootDir)Microsoft.Android.Runtime.%(_RuntimePackFiles.RuntimePackName).$(AndroidApiLevel).%(_RuntimePackFiles.AndroidRID)\$(AndroidPackVersion)\runtimes\%(_RuntimePackFiles.AndroidRID)\native"

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -38,9 +38,9 @@ inside xaprepare.
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-x64"   Version="[$(DotNetRuntimePacksVersion)]" />
 
     <!-- NativeAOT Android runtime packs -->
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-arm"   Version="[$(DotNetRuntimePacksVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-arm64" Version="[$(DotNetRuntimePacksVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-x64"   Version="[$(DotNetRuntimePacksVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-arm"   Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-arm64" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-x64"   Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
 
     <!-- CoreCLR Android runtime packs -->
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm"   Version="[$(DotNetRuntimePacksVersion)]" />

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -36,6 +36,12 @@ inside xaprepare.
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-arm64" Version="[$(DotNetRuntimePacksVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-x86"   Version="[$(DotNetRuntimePacksVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-x64"   Version="[$(DotNetRuntimePacksVersion)]" />
+
+    <!-- NativeAOT Android runtime packs -->
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-arm"   Version="[$(DotNetRuntimePacksVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-arm64" Version="[$(DotNetRuntimePacksVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-x64"   Version="[$(DotNetRuntimePacksVersion)]" />
+
     <!-- CoreCLR Android runtime packs -->
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm"   Version="[$(DotNetRuntimePacksVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm64" Version="[$(DotNetRuntimePacksVersion)]" />


### PR DESCRIPTION
## Summary

- enable android-arm NativeAOT runtime-pack resolution for .NET for Android apps
- add the android-arm NativeAOT runtime pack to the workload manifest and native runtime build
- download NativeAOT Android runtime packs and copy Android crypto archive assets into Microsoft.Android.Runtime.NativeAOT packs
- keep android-arm NativeAOT runtime pack and ILCompiler versions aligned with the dotnet/runtime dependency version
- include an API 37 metadata fix needed for this branch to build locally

## Validation

- `make prepare && make all MSBUILD_ARGS="/m:1 /nr:false /p:UseSharedCompilation=false"`
- `./dotnet-local.sh publish samples/NativeAOT/NativeAOT.csproj -c Release -r android-arm -tl:off -nr:false`
- verified generated assets resolve `Microsoft.NETCore.App.Runtime.NativeAOT.android-arm` and `Microsoft.DotNet.ILCompiler` to `11.0.0-preview.7.26355.102`
- installed and launched the published APK on Samsung A16 (`armeabi-v7a`), process stayed alive with no fatal logcat lines

Note: local sample publish required replacing the built SDK tools `System.IO.Hashing.dll` with the package's `netstandard2.0` asset to avoid a current main-branch MSBuild task assembly-load mismatch. The repo build itself passed without that local workaround.

> [!NOTE]
> This PR description was created with GitHub Copilot.
