### PR TITLE
[tests] Disable flaky TryFindClass UTF-8 gref test

### DIFF
--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
@@ -91,46 +91,24 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		[Ignore ("Frequently failing: https://github.com/dotnet/android/issues/12031")]
 		public void TryFindClass_Utf8_DoesNotLeakGlobalRefs ()
 		{
-			AssertDoesNotLeakGlobalRefs (() => {
-				Assert.IsFalse (JniEnvironment.Types.TryFindClass ("does/not/Exist"u8, out var notFound));
-				Assert.IsFalse (notFound.IsValid);
-			},
+			int grefsBefore = JniEnvironment.Runtime.GlobalReferenceCount;
+			JniEnvironment.Types.TryFindClass ("does/not/Exist"u8, out _);
+			int grefsAfter = JniEnvironment.Runtime.GlobalReferenceCount;
+			Assert.AreEqual (grefsBefore, grefsAfter,
 				"TryFindClass for non-existent classes should not leak global references");
 		}
 
 		[Test]
 		public void TryFindClass_String_DoesNotLeakGlobalRefs ()
 		{
-			AssertDoesNotLeakGlobalRefs (() => {
-				Assert.IsFalse (JniEnvironment.Types.TryFindClass ("does/not/Exist", out var notFound));
-				Assert.IsFalse (notFound.IsValid);
-			},
-				"TryFindClass for non-existent classes should not leak global references");
-		}
-
-		static void AssertDoesNotLeakGlobalRefs (Action action, string message)
-		{
-#if __ANDROID__
-			// Android's gref count is process-wide, and the on-device runner/runtime can
-			// create persistent grefs on background threads while a test is executing.
-			// Repeat the operation to amplify a per-call leak above ambient noise.
-			const int iterations = 200;
-			const int tolerance = 100;
-#else
-			const int iterations = 1;
-			const int tolerance = 0;
-#endif
-			action ();
-
 			int grefsBefore = JniEnvironment.Runtime.GlobalReferenceCount;
-			for (int i = 0; i < iterations; ++i)
-				action ();
+			JniEnvironment.Types.TryFindClass ("does/not/Exist", out _);
 			int grefsAfter = JniEnvironment.Runtime.GlobalReferenceCount;
-			int delta = grefsAfter - grefsBefore;
-			Assert.LessOrEqual (delta, tolerance,
-				$"{message}. Before={grefsBefore}, After={grefsAfter}, Delta={delta}, Iterations={iterations}, Tolerance={tolerance}");
+			Assert.AreEqual (grefsBefore, grefsAfter,
+				"TryFindClass for non-existent classes should not leak global references");
 		}
 
 		[Test]

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
@@ -93,29 +93,44 @@ namespace Java.InteropTests
 		[Test]
 		public void TryFindClass_Utf8_DoesNotLeakGlobalRefs ()
 		{
-			// Prime the fallback miss path so this assertion doesn't include one-time runtime caches.
-			Assert.IsFalse (JniEnvironment.Types.TryFindClass ("does/not/Exist/Warmup"u8, out var warmup));
-			Assert.IsFalse (warmup.IsValid);
-
-			int grefsBefore = JniEnvironment.Runtime.GlobalReferenceCount;
-			JniEnvironment.Types.TryFindClass ("does/not/Exist"u8, out _);
-			int grefsAfter = JniEnvironment.Runtime.GlobalReferenceCount;
-			Assert.AreEqual (grefsBefore, grefsAfter,
+			AssertDoesNotLeakGlobalRefs (() => {
+				Assert.IsFalse (JniEnvironment.Types.TryFindClass ("does/not/Exist"u8, out var notFound));
+				Assert.IsFalse (notFound.IsValid);
+			},
 				"TryFindClass for non-existent classes should not leak global references");
 		}
 
 		[Test]
 		public void TryFindClass_String_DoesNotLeakGlobalRefs ()
 		{
-			// Prime the fallback miss path so this assertion doesn't include one-time runtime caches.
-			Assert.IsFalse (JniEnvironment.Types.TryFindClass ("does/not/Exist/Warmup", out var warmup));
-			Assert.IsFalse (warmup.IsValid);
+			AssertDoesNotLeakGlobalRefs (() => {
+				Assert.IsFalse (JniEnvironment.Types.TryFindClass ("does/not/Exist", out var notFound));
+				Assert.IsFalse (notFound.IsValid);
+			},
+				"TryFindClass for non-existent classes should not leak global references");
+		}
+
+		static void AssertDoesNotLeakGlobalRefs (Action action, string message)
+		{
+#if __ANDROID__
+			// Android's gref count is process-wide, and the on-device runner/runtime can
+			// create persistent grefs on background threads while a test is executing.
+			// Repeat the operation to amplify a per-call leak above ambient noise.
+			const int iterations = 200;
+			const int tolerance = 100;
+#else
+			const int iterations = 1;
+			const int tolerance = 0;
+#endif
+			action ();
 
 			int grefsBefore = JniEnvironment.Runtime.GlobalReferenceCount;
-			JniEnvironment.Types.TryFindClass ("does/not/Exist", out _);
+			for (int i = 0; i < iterations; ++i)
+				action ();
 			int grefsAfter = JniEnvironment.Runtime.GlobalReferenceCount;
-			Assert.AreEqual (grefsBefore, grefsAfter,
-				"TryFindClass for non-existent classes should not leak global references");
+			int delta = grefsAfter - grefsBefore;
+			Assert.LessOrEqual (delta, tolerance,
+				$"{message}. Before={grefsBefore}, After={grefsAfter}, Delta={delta}, Iterations={iterations}, Tolerance={tolerance}");
 		}
 
 		[Test]

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
@@ -91,6 +91,7 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		[Ignore ("Frequently failing: https://github.com/dotnet/android/issues/12031")]
 		public void TryFindClass_Utf8_DoesNotLeakGlobalRefs ()
 		{
 			int grefsBefore = JniEnvironment.Runtime.GlobalReferenceCount;

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
@@ -91,9 +91,12 @@ namespace Java.InteropTests
 		}
 
 		[Test]
-		[Ignore ("Frequently failing: https://github.com/dotnet/android/issues/12031")]
 		public void TryFindClass_Utf8_DoesNotLeakGlobalRefs ()
 		{
+			// Prime the fallback miss path so this assertion doesn't include one-time runtime caches.
+			Assert.IsFalse (JniEnvironment.Types.TryFindClass ("does/not/Exist/Warmup"u8, out var warmup));
+			Assert.IsFalse (warmup.IsValid);
+
 			int grefsBefore = JniEnvironment.Runtime.GlobalReferenceCount;
 			JniEnvironment.Types.TryFindClass ("does/not/Exist"u8, out _);
 			int grefsAfter = JniEnvironment.Runtime.GlobalReferenceCount;
@@ -104,6 +107,10 @@ namespace Java.InteropTests
 		[Test]
 		public void TryFindClass_String_DoesNotLeakGlobalRefs ()
 		{
+			// Prime the fallback miss path so this assertion doesn't include one-time runtime caches.
+			Assert.IsFalse (JniEnvironment.Types.TryFindClass ("does/not/Exist/Warmup", out var warmup));
+			Assert.IsFalse (warmup.IsValid);
+
 			int grefsBefore = JniEnvironment.Runtime.GlobalReferenceCount;
 			JniEnvironment.Types.TryFindClass ("does/not/Exist", out _);
 			int grefsAfter = JniEnvironment.Runtime.GlobalReferenceCount;


### PR DESCRIPTION
Temporarily ignores `TryFindClass_Utf8_DoesNotLeakGlobalRefs`, which is failing frequently in CI.

Tracking issue: https://github.com/dotnet/android/issues/12031

Current hypothesis: this test is not a reliable exact leak assertion on Android because the runtime gref count is process-wide. NUnit test execution is serialized (`NumberOfTestWorkers=0`), but unrelated runtime/test-infrastructure work can still allocate persistent grefs on other threads while the assertion is running. The linked issue tracks finding a better way to test memory/reference leaks.

Example failure: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1498907&view=results
