### PR TITLE
[build] Exclude SourceLink runtime assets to pin System.IO.Hashing

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,7 +9,18 @@
 
   <!-- Embed Source Link information in PDBs for every project in the repo. -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <!--
+      SourceLink is a build-time only package (PrivateAssets="All"), but in 10.x its dependency
+      Microsoft.Build.Tasks.Git pulls System.IO.Hashing in as a *runtime* asset (e.g. 10.0.300 -> 10.0.8).
+      Projects that reference System.IO.Hashing only transitively would then ship that version into the
+      SDK pack's `tools/` directory, where it collides with the $(SystemIOHashingPackageVersion) the build
+      tasks are compiled against (System.IO.Hashing bumps its AssemblyVersion every patch: 10.0.0.8 vs
+      10.0.0.9), producing a MissingMethodException (XACRP7000) on System.IO.Hashing.Crc64.Hash at build
+      time. Exclude SourceLink's runtime assets so it can never contribute a floating System.IO.Hashing;
+      source linking is unaffected (it runs via SourceLink's build assets). Mirrors the same pin in
+      external/Java.Interop/Directory.Build.targets.
+    -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <!-- Automatically add NRT attribute support for netstandard2.0 projects using NRT -->


### PR DESCRIPTION
## Summary

`Microsoft.SourceLink.GitHub` is a build-time-only package (`PrivateAssets="All"`), but in its 10.x line its `Microsoft.Build.Tasks.Git` dependency pulls **`System.IO.Hashing` in as a *runtime* asset** (e.g. `Microsoft.Build.Tasks.Git 10.0.300` → `System.IO.Hashing 10.0.8`). Any project that references `System.IO.Hashing` only *transitively* then ships that version into the .NET for Android SDK pack's `tools/` directory, where it collides with the pinned `$(SystemIOHashingPackageVersion)` (currently `10.0.9`) that the build tasks are compiled against.

Because `System.IO.Hashing` bumps its **`AssemblyVersion` every patch** (`10.0.0.8` vs `10.0.0.9`), the mismatched assembly produces a hard **`XACRP7000` / `MissingMethodException: System.IO.Hashing.Crc64.Hash(...)`** at app build time.

## Fix

Add `ExcludeAssets="runtime"` to the repo-wide `Microsoft.SourceLink.GitHub` reference in the root `Directory.Build.targets`, so SourceLink can never contribute a floating `System.IO.Hashing` runtime asset. Source linking is unaffected — it runs via SourceLink's **build** assets, which are untouched.

```diff
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" ExcludeAssets="runtime" />
```

This **mirrors the pin already present in [`external/Java.Interop/Directory.Build.targets`](https://github.com/dotnet/android/blob/main/external/Java.Interop/Directory.Build.targets)** (which fixed the same float for `class-parse`/`jcw-gen`/`generator` after those hit it).

## Why now (future-proofing)

The main repo currently references SourceLink **8.0.0**, whose `Microsoft.Build.Tasks.Git 8.0.0` does **not** depend on `System.IO.Hashing` — so the float isn't active on `main` *today*. But the moment the repo bumps SourceLink to 10.x (as Java.Interop already has), the transitive `System.IO.Hashing 10.0.8` would reappear and reintroduce the `XACRP7000` failures. This tiny, precedent-matching pin makes the repo robust against that regression.

## Verification

- `dotnet restore` succeeds; `System.IO.Hashing` still resolves to the pinned `10.0.9`.
- `ExcludeAssets="runtime"` only excludes runtime assets — SourceLink's build/targets assets (which perform source linking) are unaffected.
- Change is a single attribute + explanatory comment in one file.
