### PR TITLE
[tests] Disable flaky UnregisterFromRuntime peer-count test

### DIFF
--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -44,6 +44,7 @@ namespace Java.InteropTests
 #endif  // !NO_GC_BRIDGE_SUPPORT
 
 		[Test]
+		[Ignore ("Frequently failing: https://github.com/dotnet/android/issues/12031")]
 		public void UnregisterFromRuntime ()
 		{
 			int registeredCount = JniRuntime.CurrentRuntime.ValueManager.GetSurfacedPeers ().Count;


### PR DESCRIPTION
Temporarily ignores `JavaObjectTest.UnregisterFromRuntime`, which intermittently fails when the process-wide surfaced-peer count changes while the assertion is running.

This has the same shared-process isolation problem as the GREF assertion disabled in #12032. Issue #12031 now tracks both affected tests and the proposal to move reference/peer leak checks into a dedicated device test process with controlled lifecycle and concurrency.

Example failure: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1504514&view=results
