### PR TITLE
[Mono.Android] Handle JNI failures during CoreCLR GC bridge processing

### DIFF
--- a/src/native/clr/host/bridge-processing.cc
+++ b/src/native/clr/host/bridge-processing.cc
@@ -174,6 +174,7 @@ bool BridgeProcessingShared::add_reference (jobject from, jobject to) noexcept
 
 	env->DeleteLocalRef (java_class);
 	env->CallVoidMethod (from, add_method_id, to);
+	abort_on_pending_java_exception ("A Java exception was thrown by monodroidAddReference during GC bridge processing"sv);
 	return true;
 }
 
@@ -217,6 +218,18 @@ void BridgeProcessingShared::clear_references (jobject handle) noexcept
 
 	env->DeleteLocalRef (java_class);
 	env->CallVoidMethod (handle, clear_method_id);
+	abort_on_pending_java_exception ("A Java exception was thrown by monodroidClearReferences during GC bridge processing"sv);
+}
+
+void BridgeProcessingShared::abort_on_pending_java_exception (std::string_view message) noexcept
+{
+	if (!env->ExceptionCheck ()) [[likely]] {
+		return;
+	}
+
+	env->ExceptionDescribe ();
+	env->ExceptionClear ();
+	Helpers::abort_application (LOG_GC, message);
 }
 
 void BridgeProcessingShared::take_global_ref (HandleContext &context) noexcept
@@ -230,6 +243,11 @@ void BridgeProcessingShared::take_global_ref (HandleContext &context) noexcept
 	log_weak_to_gref (weak, handle);
 
 	if (handle == nullptr) {
+		// A null result normally means the weak reference's target was collected by the Java GC.
+		// However, NewGlobalRef can also fail (returning null with a pending exception) when the VM
+		// is out of memory or the global reference table is full. Treating that as "collected" would
+		// tear down a live peer, so distinguish the two and fail fast on a genuine failure.
+		abort_on_pending_java_exception ("Failed to promote a weak global reference to a global reference during GC bridge processing"sv);
 		log_weak_ref_collected (weak);
 	}
 
@@ -249,6 +267,16 @@ void BridgeProcessingShared::take_weak_global_ref (const HandleContext &context)
 	log_take_weak_global_ref (handle);
 
 	jobject weak = env->NewWeakGlobalRef (handle);
+	if (weak == nullptr) [[unlikely]] {
+		// `handle` is a valid strong global reference, so NewWeakGlobalRef only returns null when the
+		// VM is out of memory. Continuing would delete the strong reference below and lose the object
+		// (a later NewGlobalRef of a null weak reference would look like a collected peer), so fail fast.
+		if (env->ExceptionCheck ()) {
+			env->ExceptionDescribe ();
+			env->ExceptionClear ();
+		}
+		Helpers::abort_application (LOG_GC, "Failed to create a weak global reference during GC bridge processing"sv);
+	}
 	log_weak_gref_new (handle, weak);
 
 	context.control_block->handle = weak;

--- a/src/native/clr/host/bridge-processing.cc
+++ b/src/native/clr/host/bridge-processing.cc
@@ -271,11 +271,10 @@ void BridgeProcessingShared::take_weak_global_ref (const HandleContext &context)
 		// `handle` is a valid strong global reference, so NewWeakGlobalRef only returns null when the
 		// VM is out of memory. Continuing would delete the strong reference below and lose the object
 		// (a later NewGlobalRef of a null weak reference would look like a collected peer), so fail fast.
-		if (env->ExceptionCheck ()) {
-			env->ExceptionDescribe ();
-			env->ExceptionClear ();
-		}
-		Helpers::abort_application (LOG_GC, "Failed to create a weak global reference during GC bridge processing"sv);
+		// The OOM failure raises a pending exception; abort unconditionally in case it somehow did not.
+		constexpr std::string_view failure = "Failed to create a weak global reference during GC bridge processing"sv;
+		abort_on_pending_java_exception (failure);
+		Helpers::abort_application (LOG_GC, failure);
 	}
 	log_weak_gref_new (handle, weak);
 

--- a/src/native/clr/include/host/bridge-processing-shared.hh
+++ b/src/native/clr/include/host/bridge-processing-shared.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <jni.h>
+#include <string_view>
 #include <unordered_map>
 
 #include <host/gc-bridge.hh>
@@ -50,6 +51,11 @@ private:
 
 	void clear_references_if_needed (const HandleContext &context) noexcept;
 	void clear_references (jobject handle) noexcept;
+
+	// If a Java exception is pending on `env`, describe it, clear it, and abort. Bridge
+	// processing has no safe way to recover from an exception thrown by a peer's reference
+	// callbacks, and leaving an exception pending would make subsequent JNI calls undefined.
+	void abort_on_pending_java_exception (std::string_view message) noexcept;
 
 	void log_missing_add_references_method (jclass java_class) noexcept;
 	void log_missing_clear_references_method (jclass java_class) noexcept;


### PR DESCRIPTION
> [!NOTE]
> This pull request was created with the assistance of GitHub Copilot. The code and description were AI-generated and reviewed by the author.

## Summary

Bridge processing in the CoreCLR/NativeAOT shared native host
(`src/native/clr/host/bridge-processing.cc`) called several JNI functions
without checking for failure. This could leave a Java exception pending —
making the next JNI call undefined behaviour (a CheckJNI abort on debug
builds) — or silently mis-handle an out-of-memory condition as a *collected*
object, tearing down a peer that is still alive. This follows the pattern
already used by `GCBridge::trigger_java_gc` and fails fast with a clear
diagnostic.

## Changes

- **`add_reference` / `clear_references`** — check for a pending exception
  after the `CallVoidMethod` invocations of `monodroidAddReference` /
  `monodroidClearReferences`. The generated `monodroidAddReference` lazily
  allocates and appends to an `ArrayList`, so it can throw
  `OutOfMemoryError` under the same memory pressure that triggers a GC.
  Previously the exception was left pending (undefined behaviour on the next
  JNI call) and the keep-alive edge was silently dropped, risking premature
  collection of a still-referenced peer.

- **`take_weak_global_ref`** — `NewWeakGlobalRef` of a valid strong global
  reference only returns null when the VM is out of memory. The old code
  stored the null and then deleted the strong reference, losing the object
  (a subsequent `NewGlobalRef` of a null weak reference looks like a
  collected peer). A null result now fails fast.

- **`take_global_ref`** — a null `NewGlobalRef` result normally means the
  weak reference's target was collected, but it can also indicate a resource
  failure (null with a pending exception). Treating the latter as "collected"
  would tear down a live peer, so the two cases are now distinguished.

These are fault paths (out-of-memory, or a peer callback throwing); normal
bridge processing is unaffected.

## Testing

Built the CoreCLR `android-arm64` runtime with these changes and ran the full
`Mono.Android.NET-Tests` suite on an API 36 `arm64-v8a` emulator with
`-p:UseMonoRuntime=false` (CoreCLR):

- **915 passed, 0 failed, 55 skipped.**
- With `debug.mono.log=gc`, the GC bridge ran 12 times during the suite,
  exercising the hardened `add_reference` / `clear_references` /
  `take_global_ref` / `take_weak_global_ref` paths, with **no CheckJNI / JNI
  errors** and none of the new fail-fast paths triggered (CheckJNI is active
  for the debuggable test app).
- One unrelated timing-sensitive test (`JavaObjectTest.UnregisterFromRuntime`,
  a registered-peer count assertion) flaked once under heavy GC-spew logging
  and passed on a clean run; it is not affected by these changes.

The new abort paths are only reachable under out-of-memory / a throwing peer
callback and were not exercised by fault injection.

> [!NOTE]
> This touches the same file as #12040 (GC bridge JNI-overhead cleanup); the two
> changes are independent but edit adjacent code, so a trivial merge conflict is
> expected depending on merge order.
