### PR TITLE
[TrimmableTypeMap] Emit empty stubs for trimmed per-assembly typemaps

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyGenerator.cs
@@ -34,4 +34,21 @@ public sealed class TypeMapAssemblyGenerator
 		var emitter = new TypeMapAssemblyEmitter (_systemRuntimeVersion);
 		emitter.Emit (model, stream, useSharedTypemapUniverse);
 	}
+
+	/// <summary>
+	/// Emits an empty typemap assembly (containing no type map entries) with the given
+	/// <paramref name="assemblyName"/>, writing it to <paramref name="stream"/>. Used to satisfy
+	/// <c>[assembly: TypeMapAssemblyTarget&lt;T&gt;("name")]</c> references to per-assembly typemaps
+	/// that the trimmer removed (their target Java binding was unused): the runtime can still
+	/// <c>Assembly.Load</c> the stub, which contributes no mappings, instead of throwing
+	/// <see cref="System.IO.FileNotFoundException"/>.
+	/// </summary>
+	/// <param name="stream">Stream to write the output PE assembly to.</param>
+	/// <param name="assemblyName">Assembly name for the generated stub.</param>
+	public void GenerateEmpty (Stream stream, string assemblyName)
+	{
+		var builder = new PEAssemblyBuilder (_systemRuntimeVersion);
+		builder.EmitPreamble (assemblyName, assemblyName + ".dll");
+		builder.WritePE (stream);
+	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
@@ -1,6 +1,8 @@
 <!-- Trimmable typemap: CoreCLR-specific (ILLink integration). -->
 <Project>
 
+  <UsingTask TaskName="Xamarin.Android.Tasks.GenerateMissingTypeMapStubs" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+
   <PropertyGroup>
     <_TrimmableRuntimeProviderJavaName Condition=" '$(_TrimmableRuntimeProviderJavaName)' == '' ">mono.MonoRuntimeProvider</_TrimmableRuntimeProviderJavaName>
   </PropertyGroup>
@@ -114,6 +116,27 @@
       <_PostTrimDeletedCopiedJavaFiles Remove="@(_PostTrimDeletedCopiedJavaFiles)" />
     </ItemGroup>
   </Target>
+  <!-- After ILLink trims per-assembly _X.TypeMap assemblies whose target Java binding was unused,
+       the root _Microsoft.Android.TypeMaps assembly still carries
+       [assembly: TypeMapAssemblyTarget<T>("_X.TypeMap")] attributes pointing at the trimmed
+       assemblies. Those attributes reference the assembly by an opaque name string, so ILLink cannot
+       follow (or prune) them, and at startup CoreCLR's TypeMapping would Assembly.Load each one and
+       throw FileNotFoundException. Emit an empty stub for each trimmed typemap so Assembly.Load
+       succeeds (contributing no mappings) while leaving the linked root - and ILLink's reconciled
+       assembly references in it - untouched. Runs before the linked TypeMap DLLs are handed to the
+       publish/ReadyToRun pipeline. -->
+  <Target Name="_GenerateMissingTrimmableTypeMapStubs"
+      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(PublishTrimmed)' == 'true' and '$(RuntimeIdentifier)' != '' "
+      AfterTargets="ILLink"
+      BeforeTargets="_AddTrimmableTypeMapToResolvedFileToPublish;CreateReadyToRunImages">
+    <GenerateMissingTypeMapStubs
+        Condition="Exists('$(IntermediateOutputPath)linked')"
+        TypeMapDirectory="$(_TypeMapOutputDirectory)"
+        LinkedAssembliesDirectory="$(IntermediateOutputPath)linked"
+        RootTypeMapAssemblyName="$(_TypeMapAssemblyName)"
+        TargetFrameworkVersion="$(TargetFrameworkVersion)" />
+  </Target>
+
   <!-- Add linked TypeMap DLLs to the normal publish assembly pipeline.  The SDK R2R
        target only compiles ResolvedFileToPublish items with PostprocessAssembly=true. -->
   <Target Name="_AddTrimmableTypeMapToResolvedFileToPublish"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMissingTypeMapStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMissingTypeMapStubs.cs
@@ -67,7 +67,7 @@ public class GenerateMissingTypeMapStubs : AndroidTask
 
 			using var stream = new MemoryStream ();
 			generator.GenerateEmpty (stream, name);
-			Files.CopyIfBytesChanged (stream.ToArray (), linkedPath);
+			Files.CopyIfStreamChanged (stream, linkedPath);
 			Log.LogDebugMessage ($"Generated empty typemap stub for trimmed assembly '{name}'.");
 			stubs.Add (new TaskItem (linkedPath));
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMissingTypeMapStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMissingTypeMapStubs.cs
@@ -1,0 +1,91 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Android.Sdk.TrimmableTypeMap;
+
+namespace Xamarin.Android.Tasks;
+
+/// <summary>
+/// Emits empty stub assemblies for per-assembly typemaps (<c>_X.TypeMap.dll</c>) that the root
+/// <c>_Microsoft.Android.TypeMaps</c> assembly references via
+/// <c>[assembly: TypeMapAssemblyTarget&lt;T&gt;("_X.TypeMap")]</c> but that ILLink trimmed away because
+/// their target Java binding was unused.
+///
+/// Those attributes carry an opaque assembly-name string rather than a metadata reference, so ILLink
+/// cannot follow (or prune) them, and at startup CoreCLR's <c>TypeMapping</c> enumerates every
+/// attribute and calls <c>Assembly.Load</c> on the named assembly, throwing
+/// <c>FileNotFoundException</c> for the trimmed ones. Emitting an empty, entry-free stub for each keeps
+/// <c>Assembly.Load</c> succeeding (the stub contributes no type map entries) without editing the
+/// linked root assembly, so ILLink's reconciled assembly references are preserved.
+/// </summary>
+public class GenerateMissingTypeMapStubs : AndroidTask
+{
+	public override string TaskPrefix => "GMTS";
+
+	/// <summary>Directory holding every per-assembly typemap generated before trimming; defines the full referenced set.</summary>
+	[Required]
+	public string TypeMapDirectory { get; set; } = "";
+
+	/// <summary>Directory holding the surviving (post-trim) assemblies, e.g. the <c>linked/</c> output. Stubs are written here.</summary>
+	[Required]
+	public string LinkedAssembliesDirectory { get; set; } = "";
+
+	/// <summary>The root typemap assembly name to skip, e.g. <c>_Microsoft.Android.TypeMaps</c>.</summary>
+	[Required]
+	public string RootTypeMapAssemblyName { get; set; } = "";
+
+	/// <summary>Used to derive the emitted assembly's System.Runtime reference version.</summary>
+	[Required]
+	public string TargetFrameworkVersion { get; set; } = "";
+
+	[Output]
+	public ITaskItem [] GeneratedStubs { get; set; } = [];
+
+	public override bool RunTask ()
+	{
+		var stubs = new List<ITaskItem> ();
+		if (!Directory.Exists (TypeMapDirectory) || !Directory.Exists (LinkedAssembliesDirectory)) {
+			Log.LogDebugMessage ($"TypeMap directory '{TypeMapDirectory}' or linked directory '{LinkedAssembliesDirectory}' not found; skipping stub generation.");
+			GeneratedStubs = stubs.ToArray ();
+			return true;
+		}
+
+		var systemRuntimeVersion = ParseTargetFrameworkVersion (TargetFrameworkVersion);
+		var generator = new TypeMapAssemblyGenerator (systemRuntimeVersion);
+
+		foreach (var file in Directory.EnumerateFiles (TypeMapDirectory, "_*.TypeMap.dll")) {
+			var name = Path.GetFileNameWithoutExtension (file);
+			if (string.IsNullOrEmpty (name) || string.Equals (name, RootTypeMapAssemblyName, StringComparison.Ordinal))
+				continue;
+			var linkedPath = Path.Combine (LinkedAssembliesDirectory, name + ".dll");
+			if (File.Exists (linkedPath))
+				continue; // survived trimming; a real typemap already ships
+
+			using var stream = new MemoryStream ();
+			generator.GenerateEmpty (stream, name);
+			Files.CopyIfBytesChanged (stream.ToArray (), linkedPath);
+			Log.LogDebugMessage ($"Generated empty typemap stub for trimmed assembly '{name}'.");
+			stubs.Add (new TaskItem (linkedPath));
+		}
+
+		if (stubs.Count > 0)
+			Log.LogDebugMessage ($"Generated {stubs.Count} empty typemap stub(s) for trimmed per-assembly typemaps.");
+		GeneratedStubs = stubs.ToArray ();
+		return !Log.HasLoggedErrors;
+	}
+
+	static Version ParseTargetFrameworkVersion (string tfv)
+	{
+		if (tfv.Length > 0 && (tfv [0] == 'v' || tfv [0] == 'V')) {
+			tfv = tfv.Substring (1);
+		}
+		if (Version.TryParse (tfv, out var version)) {
+			return version;
+		}
+		throw new ArgumentException ($"Cannot parse TargetFrameworkVersion '{tfv}' as a Version.");
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateMissingTypeMapStubsTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateMissingTypeMapStubsTests.cs
@@ -1,0 +1,87 @@
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.Build.Framework;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests {
+	[TestFixture]
+	[Parallelizable (ParallelScope.Children)]
+	public class GenerateMissingTypeMapStubsTests : BaseTest {
+
+		[Test]
+		public void Execute_TrimmedTypeMap_GeneratesLoadableStub ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			var typeMapDir = Path.Combine (path, "typemap");
+			var linkedDir = Path.Combine (path, "linked");
+			Directory.CreateDirectory (typeMapDir);
+			Directory.CreateDirectory (linkedDir);
+
+			// Pre-trim: two per-assembly typemaps plus the root were generated.
+			File.WriteAllText (Path.Combine (typeMapDir, "_Kept.TypeMap.dll"), "not-a-real-assembly");
+			File.WriteAllText (Path.Combine (typeMapDir, "_Trimmed.TypeMap.dll"), "not-a-real-assembly");
+			File.WriteAllText (Path.Combine (typeMapDir, "_Microsoft.Android.TypeMaps.dll"), "not-a-real-assembly");
+
+			// Post-trim (linked/): the root and one typemap survived; _Trimmed was trimmed away.
+			File.WriteAllText (Path.Combine (linkedDir, "_Kept.TypeMap.dll"), "survivor");
+			File.WriteAllText (Path.Combine (linkedDir, "_Microsoft.Android.TypeMaps.dll"), "survivor-root");
+
+			var task = new GenerateMissingTypeMapStubs {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				TypeMapDirectory = typeMapDir,
+				LinkedAssembliesDirectory = linkedDir,
+				RootTypeMapAssemblyName = "_Microsoft.Android.TypeMaps",
+				TargetFrameworkVersion = "v11.0",
+			};
+
+			Assert.IsTrue (task.Execute (), "Task should succeed.");
+
+			// Only the trimmed-away typemap should get a stub; the survivor and the root are left alone.
+			var stubs = task.GeneratedStubs.Select (i => i.ItemSpec).ToArray ();
+			Assert.AreEqual (1, stubs.Length, "Exactly one stub should be generated.");
+			var stubPath = Path.Combine (linkedDir, "_Trimmed.TypeMap.dll");
+			CollectionAssert.Contains (stubs, stubPath);
+			FileAssert.Exists (stubPath);
+
+			Assert.AreEqual ("survivor", File.ReadAllText (Path.Combine (linkedDir, "_Kept.TypeMap.dll")),
+				"A surviving typemap must not be overwritten.");
+			Assert.AreEqual ("survivor-root", File.ReadAllText (Path.Combine (linkedDir, "_Microsoft.Android.TypeMaps.dll")),
+				"The root typemap must not be overwritten.");
+
+			// The stub must be a valid managed PE assembly named after the trimmed typemap.
+			using var stubStream = File.OpenRead (stubPath);
+			using var peReader = new PEReader (stubStream);
+			Assert.IsTrue (peReader.HasMetadata, "Stub should be a managed PE assembly.");
+			var reader = peReader.GetMetadataReader ();
+			var assemblyName = reader.GetString (reader.GetAssemblyDefinition ().Name);
+			Assert.AreEqual ("_Trimmed.TypeMap", assemblyName, "Stub assembly name should match the trimmed typemap.");
+		}
+
+		[Test]
+		public void Execute_NothingTrimmed_GeneratesNoStubs ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			var typeMapDir = Path.Combine (path, "typemap");
+			var linkedDir = Path.Combine (path, "linked");
+			Directory.CreateDirectory (typeMapDir);
+			Directory.CreateDirectory (linkedDir);
+
+			File.WriteAllText (Path.Combine (typeMapDir, "_Kept.TypeMap.dll"), "not-a-real-assembly");
+			File.WriteAllText (Path.Combine (linkedDir, "_Kept.TypeMap.dll"), "survivor");
+
+			var task = new GenerateMissingTypeMapStubs {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				TypeMapDirectory = typeMapDir,
+				LinkedAssembliesDirectory = linkedDir,
+				RootTypeMapAssemblyName = "_Microsoft.Android.TypeMaps",
+				TargetFrameworkVersion = "v11.0",
+			};
+
+			Assert.IsTrue (task.Execute (), "Task should succeed.");
+			Assert.IsEmpty (task.GeneratedStubs, "No stubs should be generated when nothing was trimmed.");
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The root `_Microsoft.Android.TypeMaps` assembly is generated **before** trimming with an `[assembly: TypeMapAssemblyTarget<T>("_X.TypeMap")]` entry for every per-assembly typemap. ILLink can trim individual `_X.TypeMap` assemblies when their target Java binding is unused, but those attributes reference the assembly by an **opaque name string** (not a metadata reference), so ILLink neither keeps the target nor prunes the attribute.

At startup, CoreCLR's `TypeMapping` enumerates every `TypeMapAssemblyTarget` attribute and `Assembly.Load`s the named assembly, throwing for the trimmed ones:

```
System.IO.FileNotFoundException: Could not load file or assembly '_GoogleGson.TypeMap, Culture=neutral, PublicKeyToken=null'.
   at System.Runtime.InteropServices.TypeMapLazyDictionary.ProcessAttributes(...)
   at System.Runtime.InteropServices.TypeMapping.GetOrCreateExternalTypeMapping[TTypeMapGroup]()
   at Microsoft.Android.Runtime.TypeMapLoader.Initialize()
   at Android.Runtime.JNIEnvInit.InitializeTrimmableTypeMapData()
```

Found while running a real .NET MAUI app on **CoreCLR + trimmable typemap** (Release, `android-arm64`): six unused bindings — `GoogleGson`, `Jsr305Binding`, `Xamarin.AndroidX.Print`, `Xamarin.JavaX.Inject`, `Xamarin.JSpecify`, `Xamarin.Kotlin.StdLib` — were trimmed together with their `_X.TypeMap` assemblies, but the dangling `TypeMapAssemblyTarget` attributes on the root remained, so the app crashed on launch.

## Fix

After ILLink, emit an **empty (entry-free) stub assembly** for each per-assembly typemap that was trimmed away, so `Assembly.Load` succeeds and contributes no mappings. Stubs are written into the `linked/` output before the typemap DLLs flow into the publish/ReadyToRun pipeline.

- New task `GenerateMissingTypeMapStubs` — compares the pre-trim typemap set against the surviving `linked/` set and emits a stub for each missing one.
- New public helper `TypeMapAssemblyGenerator.GenerateEmpty(...)` — uses the existing `PEAssemblyBuilder` (System.Reflection.Metadata; no Mono.Cecil).
- Wired into `Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets` (`AfterTargets="ILLink"`).

### Why stubs, and not "regenerate the root without the dangling entries"?

Regenerating the root re-introduces references to the `System.Runtime.InteropServices` **facade** (which ILLink had reconciled to `System.Private.CoreLib` in the linked root). The shipped, trimmed facade no longer forwards `TypeMapping`, so a regenerated root fails at runtime with `TypeLoadException: Could not load type 'System.Runtime.InteropServices.TypeMapping'`. Emitting stubs leaves ILLink's reconciled root untouched.

## Testing

- Existing trimmable-typemap unit tests: **616 passed**.
- Manual end-to-end: the MAUI app (CoreCLR, trimmable, Release) now builds, installs, and launches to its first page with **no crash** — previously it crashed at startup. The six dangling `TypeMapAssemblyTarget`s now resolve to empty stubs.
- APK size impact is negligible (6 stubs ≈ 12 KB uncompressed).

## Notes / follow-ups

- Scope: wired into the **CoreCLR** trimmable path (where the runtime `Assembly.Load` crash occurs). The NativeAOT trimmable path resolves typemaps at ILC time; happy to extend if equivalent handling is wanted there.
- Can add unit / build-integration tests for `GenerateMissingTypeMapStubs` / `GenerateEmpty` as a follow-up.
