### PR TITLE
[templates] Update androidtest to MSTest 4.3.2

### DIFF
--- a/src/Microsoft.Android.Templates/androidtest/AndroidTest1.csproj
+++ b/src/Microsoft.Android.Templates/androidtest/AndroidTest1.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.3" />
+    <PackageReference Include="MSTest" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2480,12 +2480,19 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 				"The 'am start' command should contain '--user 0' when AndroidDeviceUserId is set.");
 		}
 
-		[Test]
-		[TestCase ("run", AndroidRuntime.CoreCLR)]
-		[TestCase ("test", AndroidRuntime.CoreCLR)]
-		public void DotNetNewAndroidTest (string mode, AndroidRuntime runtime)
+		public enum MSTestPackageChannel
 		{
-			var templateName = $"DotNetNewAndroidTest_{mode}_{runtime}";
+			Stable,
+			Nightly,
+		}
+
+		[Test]
+		[TestCase ("run", MSTestPackageChannel.Nightly)]
+		[TestCase ("test", MSTestPackageChannel.Stable)]
+		[TestCase ("test", MSTestPackageChannel.Nightly)]
+		public void DotNetNewAndroidTest (string mode, MSTestPackageChannel msTestPackageChannel)
+		{
+			var templateName = $"DotNetNewAndroidTest_{mode}_{msTestPackageChannel}";
 			var projectDirectory = Path.Combine (Root, "temp", templateName);
 			if (Directory.Exists (projectDirectory))
 				Directory.Delete (projectDirectory, true);
@@ -2494,22 +2501,21 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 			var dotnet = new DotNetCLI (Path.Combine (projectDirectory, $"{templateName}.csproj"));
 			Assert.IsTrue (dotnet.New ("androidtest"), "`dotnet new androidtest` should succeed");
 
-			// Override the MSTest version from the template with the version used by our build
-			var msTestVersion = GetAssemblyMetadataValue ("MSTestPackageVersion");
-			var csprojPath = Path.Combine (projectDirectory, $"{templateName}.csproj");
-			var doc = XDocument.Load (csprojPath);
-			var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
-			var msTestRef = doc.Descendants (ns + "PackageReference")
-				.FirstOrDefault (e => e.Attribute ("Include")?.Value == "MSTest");
-			Assert.IsNotNull (msTestRef, "MSTest PackageReference should exist in the generated project");
-			msTestRef.SetAttributeValue ("Version", msTestVersion);
-			doc.Save (csprojPath);
+			var buildParameters = new List<string> ();
 
-			bool useMonoRuntime = runtime == AndroidRuntime.MonoVM;
-			var buildParameters = new List<string> {
-				$"UseMonoRuntime={useMonoRuntime}",
-				"RestoreAdditionalProjectSources=https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json",
-			};
+			if (msTestPackageChannel == MSTestPackageChannel.Nightly) {
+				// Override the stable template version with the version used by our build.
+				var msTestVersion = GetAssemblyMetadataValue ("MSTestPackageVersion");
+				var csprojPath = Path.Combine (projectDirectory, $"{templateName}.csproj");
+				var doc = XDocument.Load (csprojPath);
+				var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+				var msTestRef = doc.Descendants (ns + "PackageReference")
+					.FirstOrDefault (e => e.Attribute ("Include")?.Value == "MSTest");
+				Assert.IsNotNull (msTestRef, "MSTest PackageReference should exist in the generated project");
+				msTestRef.SetAttributeValue ("Version", msTestVersion);
+				doc.Save (csprojPath);
+				buildParameters.Add ("RestoreAdditionalProjectSources=https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json");
+			}
 
 			// Build and assert 0 warnings
 			Assert.IsTrue (dotnet.Build (parameters: buildParameters.ToArray ()), "`dotnet build` should succeed");


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [x] Unit tests

The `androidtest` template should use the latest stable MSTest release so newly created Android test projects receive current fixes and behavior. Update the template package reference from MSTest 4.2.3 to 4.3.2.

Extend `DotNetNewAndroidTest` so `dotnet test` exercises both the stable package from the generated template and the nightly MSTest package used by the repository build. The nightly case continues to rewrite the package version and add the test-tools feed; the stable case leaves the generated project unchanged.