### PR TITLE
[build] Restrict Maven authentication to mirror seeding

### DIFF
--- a/.github/instructions/gradle.instructions.md
+++ b/.github/instructions/gradle.instructions.md
@@ -12,9 +12,6 @@ All `src/*` Gradle projects share two repo config files: **`eng/gradle/plugin-re
 pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
-plugins {
-    id 'com.microsoft.azure.artifacts.credprovider' version '1.1.1'
-}
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
 }
@@ -54,5 +51,4 @@ After it succeeds, just re-run the failed CI job. No PR edits needed — the pac
 ## Don'ts
 
 - Don't hard-code Maven repo URLs in `build.gradle` / `settings.gradle`; use the shared file.
-- Don't wrap `plugins {}` in `if (...)` — Gradle rejects it.
 - Don't use modern `plugins { id 'com.android.application' version '...' }` DSL without confirming the plugin is in `dotnet-public-maven`; prefer `buildscript { ... } / apply plugin: '...'` when in doubt.

--- a/.github/instructions/gradle.instructions.md
+++ b/.github/instructions/gradle.instructions.md
@@ -12,8 +12,7 @@ All `src/*` Gradle projects share two repo config files: **`eng/gradle/plugin-re
 pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
-def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
-if (runningOnCI == 'true') {
+if (System.getenv('RUNNINGONCI') == 'true') {
     apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
 }
 dependencyResolutionManagement {
@@ -26,15 +25,16 @@ rootProject.name = '<project>'
 
 ## CI vs local
 
-Both files switch on `System.getenv('RunningOnCI')` (or `RUNNINGONCI` — AzDO uppercases env vars on Linux/macOS agents):
+Both files switch on `System.getenv('RUNNINGONCI')`. Azure DevOps exports the
+`RunningOnCI` pipeline variable under this normalized environment-variable name.
 
-- **`RunningOnCI=true`** (Azure DevOps, set in `build-tools/automation/yaml-templates/variables.yaml`) → dnceng `dotnet-public-maven` feed (CFSClean isolation, https://aka.ms/1es/netiso/CFS). Anonymous read of cached packages.
+- **`RUNNINGONCI=true`** (Azure DevOps, sourced from `RunningOnCI` in `build-tools/automation/yaml-templates/variables.yaml`) → dnceng `dotnet-public-maven` feed (CFSClean isolation, https://aka.ms/1es/netiso/CFS). Anonymous read of cached packages.
 - **unset** (local, Dependabot, GitHub Actions) → `google()` + `mavenCentral()` + `gradlePluginPortal()` for plugins, `google()` + `mavenCentral()` for deps. No credentials needed.
 
 The Azure Artifacts credential provider is also loaded only when
-`RunningOnCI=true`, so local builds never attempt Azure authentication.
+`RUNNINGONCI=true`, so local builds never attempt Azure authentication.
 
-Test the CI path locally: `$env:RunningOnCI='true'` (PowerShell) or `RunningOnCI=true ...` (bash).
+Test the CI path locally: `$env:RUNNINGONCI='true'` (PowerShell) or `RUNNINGONCI=true ...` (bash).
 
 ## When CI fails 401 on a Dependabot bump
 

--- a/.github/instructions/gradle.instructions.md
+++ b/.github/instructions/gradle.instructions.md
@@ -12,7 +12,7 @@ All `src/*` Gradle projects share two repo config files: **`eng/gradle/plugin-re
 pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
-if (System.getenv('RUNNINGONCI') == 'true') {
+if (System.getenv('ANDROID_MIRROR_MAVEN_DEPENDENCIES') == 'true') {
     apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
 }
 dependencyResolutionManagement {
@@ -31,8 +31,9 @@ Both files switch on `System.getenv('RUNNINGONCI')`. Azure DevOps exports the
 - **`RUNNINGONCI=true`** (Azure DevOps, sourced from `RunningOnCI` in `build-tools/automation/yaml-templates/variables.yaml`) → dnceng `dotnet-public-maven` feed (CFSClean isolation, https://aka.ms/1es/netiso/CFS). Anonymous read of cached packages.
 - **unset** (local, Dependabot, GitHub Actions) → `google()` + `mavenCentral()` + `gradlePluginPortal()` for plugins, `google()` + `mavenCentral()` for deps. No credentials needed.
 
-The Azure Artifacts credential provider is also loaded only when
-`RUNNINGONCI=true`, so local builds never attempt Azure authentication.
+CI reads cached packages from the mirror anonymously. The Azure Artifacts
+credential provider is loaded only when `ANDROID_MIRROR_MAVEN_DEPENDENCIES=true`;
+`mirror-dependencies.ps1` sets this while seeding uncached packages.
 
 Test the CI path locally: `$env:RUNNINGONCI='true'` (PowerShell) or `RUNNINGONCI=true ...` (bash).
 

--- a/.github/instructions/gradle.instructions.md
+++ b/.github/instructions/gradle.instructions.md
@@ -12,6 +12,10 @@ All `src/*` Gradle projects share two repo config files: **`eng/gradle/plugin-re
 pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
+def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
+if (runningOnCI == 'true') {
+    apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
+}
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
 }
@@ -26,6 +30,9 @@ Both files switch on `System.getenv('RunningOnCI')` (or `RUNNINGONCI` — AzDO u
 
 - **`RunningOnCI=true`** (Azure DevOps, set in `build-tools/automation/yaml-templates/variables.yaml`) → dnceng `dotnet-public-maven` feed (CFSClean isolation, https://aka.ms/1es/netiso/CFS). Anonymous read of cached packages.
 - **unset** (local, Dependabot, GitHub Actions) → `google()` + `mavenCentral()` + `gradlePluginPortal()` for plugins, `google()` + `mavenCentral()` for deps. No credentials needed.
+
+The Azure Artifacts credential provider is also loaded only when
+`RunningOnCI=true`, so local builds never attempt Azure authentication.
 
 Test the CI path locally: `$env:RunningOnCI='true'` (PowerShell) or `RunningOnCI=true ...` (bash).
 

--- a/eng/gradle/credential-provider.gradle
+++ b/eng/gradle/credential-provider.gradle
@@ -1,0 +1,15 @@
+// Azure DevOps uses this plugin to authenticate with the Maven mirror.
+// This script is only applied when RunningOnCI=true.
+buildscript {
+    repositories {
+        maven {
+            url = 'https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1'
+            name = 'AzureArtifacts'
+        }
+    }
+    dependencies {
+        classpath 'com.microsoft.azure:artifacts-gradle-credprovider:1.1.1'
+    }
+}
+
+apply plugin: com.microsoft.azure.artifacts.credprovider.gradle.GradleCredentialProviderPlugin

--- a/eng/gradle/credential-provider.gradle
+++ b/eng/gradle/credential-provider.gradle
@@ -1,5 +1,5 @@
 // Azure DevOps uses this plugin to authenticate with the Maven mirror.
-// This script is only applied when RunningOnCI=true.
+// This script is only applied when RUNNINGONCI=true.
 buildscript {
     repositories {
         maven {

--- a/eng/gradle/credential-provider.gradle
+++ b/eng/gradle/credential-provider.gradle
@@ -1,5 +1,5 @@
-// Azure DevOps uses this plugin to authenticate with the Maven mirror.
-// This script is only applied when RUNNINGONCI=true.
+// The dependency-mirroring helper uses this plugin to authenticate with the
+// Maven mirror. Regular local and CI builds do not apply this script.
 buildscript {
     repositories {
         maven {
@@ -12,4 +12,6 @@ buildscript {
     }
 }
 
+// Plugins loaded through an applied script's buildscript classpath cannot be
+// resolved by ID; Gradle requires the implementation class in this context.
 apply plugin: com.microsoft.azure.artifacts.credprovider.gradle.GradleCredentialProviderPlugin

--- a/eng/gradle/dependency-repositories.gradle
+++ b/eng/gradle/dependency-repositories.gradle
@@ -2,13 +2,10 @@
 // (dependencyResolutionManagement.repositories) across every settings.gradle
 // in this repo. See plugin-repositories.gradle for plugin resolution.
 //
-// Switches on RunningOnCI for the same CFSClean reasons described there.
+// Switches on RUNNINGONCI for the same CFSClean reasons described there.
 
 repositories {
-    // AzDO uppercases pipeline variables when exporting them as env vars on
-    // Linux/macOS agents, so check both spellings.
-    def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
-    if (runningOnCI == 'true') {
+    if (System.getenv('RUNNINGONCI') == 'true') {
         maven {
             url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
             name = 'dotnet-public-maven'

--- a/eng/gradle/dependency-repositories.gradle
+++ b/eng/gradle/dependency-repositories.gradle
@@ -3,9 +3,6 @@
 // in this repo. See plugin-repositories.gradle for plugin resolution.
 //
 // Switches on RunningOnCI for the same CFSClean reasons described there.
-// AzureArtifacts is intentionally NOT included here — it only hosts the
-// credprovider plugin, so listing it in this scope would add a 404 round-trip
-// to every dependency lookup.
 
 repositories {
     // AzDO uppercases pipeline variables when exporting them as env vars on

--- a/eng/gradle/mirror-dependencies.ps1
+++ b/eng/gradle/mirror-dependencies.ps1
@@ -11,7 +11,7 @@
     so a developer has to authenticate locally once to seed the feed.
 
     This script does that by running the requested gradle build in a loop:
-      1. Run gradle with RunningOnCI=true so it points at the dnceng feed.
+      1. Run gradle with RUNNINGONCI=true so it points at the dnceng feed.
       2. Parse any 'Could not GET' URLs out of the build log.
       3. Re-fetch each failing URL with an Azure DevOps OAuth bearer token
          (obtained via `az account get-access-token`). The feed's upstream
@@ -113,7 +113,7 @@ if ($AndroidHome) { Write-Host "ANDROID_HOME: $AndroidHome" }
 Get-AzDevOpsToken | Out-Null
 
 if ($AndroidHome) { $env:ANDROID_HOME = $AndroidHome }
-$env:RunningOnCI = 'true'
+$env:RUNNINGONCI = 'true'
 
 Push-Location $projectDirAbs
 try {

--- a/eng/gradle/mirror-dependencies.ps1
+++ b/eng/gradle/mirror-dependencies.ps1
@@ -114,6 +114,7 @@ Get-AzDevOpsToken | Out-Null
 
 if ($AndroidHome) { $env:ANDROID_HOME = $AndroidHome }
 $env:RUNNINGONCI = 'true'
+$env:ANDROID_MIRROR_MAVEN_DEPENDENCIES = 'true'
 
 Push-Location $projectDirAbs
 try {

--- a/eng/gradle/plugin-repositories.gradle
+++ b/eng/gradle/plugin-repositories.gradle
@@ -7,9 +7,6 @@
 // isolation compliance (https://aka.ms/1es/netiso/CFS). Locally and from
 // GitHub Actions (e.g. Dependabot), the standard Gradle Plugin Portal is used.
 //
-// AzureArtifacts (anonymous public feed) is always included because every
-// settings.gradle loads the artifacts-credprovider plugin from there.
-//
 // The dnceng feed proxies public sources. Once any package has been pulled
 // through the feed (an authenticated request), it is cached and anonymous
 // reads work forever after. CI therefore does NOT need credentials — it just
@@ -22,13 +19,6 @@
 // After it succeeds, just re-run the failed CI job — no PR edit is needed.
 
 repositories {
-    // Anonymous public Azure Artifacts feed that hosts the
-    // artifacts-credprovider Gradle plugin (loaded by every settings.gradle).
-    maven {
-        url = 'https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1'
-        name = 'AzureArtifacts'
-    }
-
     // AzDO uppercases pipeline variables when exporting them as env vars on
     // Linux/macOS agents, so check both spellings.
     def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')

--- a/eng/gradle/plugin-repositories.gradle
+++ b/eng/gradle/plugin-repositories.gradle
@@ -2,7 +2,7 @@
 // across every settings.gradle in this repo. See plugin-repositories.gradle's
 // sibling, dependency-repositories.gradle, for project dependency resolution.
 //
-// In our Azure DevOps CI pipeline (RunningOnCI=true), plugins resolve through
+// In our Azure DevOps CI pipeline (RUNNINGONCI=true), plugins resolve through
 // the dnceng Azure Artifacts feed (dotnet-public-maven) for CFSClean network
 // isolation compliance (https://aka.ms/1es/netiso/CFS). Locally and from
 // GitHub Actions (e.g. Dependabot), the standard Gradle Plugin Portal is used.
@@ -19,10 +19,7 @@
 // After it succeeds, just re-run the failed CI job — no PR edit is needed.
 
 repositories {
-    // AzDO uppercases pipeline variables when exporting them as env vars on
-    // Linux/macOS agents, so check both spellings.
-    def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
-    if (runningOnCI == 'true') {
+    if (System.getenv('RUNNINGONCI') == 'true') {
         maven {
             url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
             name = 'dotnet-public-maven'

--- a/src/manifestmerger/settings.gradle
+++ b/src/manifestmerger/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-if (System.getenv('RUNNINGONCI') == 'true') {
+if (System.getenv('ANDROID_MIRROR_MAVEN_DEPENDENCIES') == 'true') {
     apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
 }
 

--- a/src/manifestmerger/settings.gradle
+++ b/src/manifestmerger/settings.gradle
@@ -3,10 +3,6 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-plugins {
-    id 'com.microsoft.azure.artifacts.credprovider' version '1.1.1'
-}
-
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
 }

--- a/src/manifestmerger/settings.gradle
+++ b/src/manifestmerger/settings.gradle
@@ -3,8 +3,7 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
-if (runningOnCI == 'true') {
+if (System.getenv('RUNNINGONCI') == 'true') {
     apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
 }
 

--- a/src/manifestmerger/settings.gradle
+++ b/src/manifestmerger/settings.gradle
@@ -3,6 +3,11 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
+def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
+if (runningOnCI == 'true') {
+    apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
+}
+
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
 }

--- a/src/proguard-android/settings.gradle
+++ b/src/proguard-android/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-if (System.getenv('RUNNINGONCI') == 'true') {
+if (System.getenv('ANDROID_MIRROR_MAVEN_DEPENDENCIES') == 'true') {
     apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
 }
 

--- a/src/proguard-android/settings.gradle
+++ b/src/proguard-android/settings.gradle
@@ -3,10 +3,6 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-plugins {
-    id 'com.microsoft.azure.artifacts.credprovider' version '1.1.1'
-}
-
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
 }

--- a/src/proguard-android/settings.gradle
+++ b/src/proguard-android/settings.gradle
@@ -3,8 +3,7 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
-if (runningOnCI == 'true') {
+if (System.getenv('RUNNINGONCI') == 'true') {
     apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
 }
 

--- a/src/proguard-android/settings.gradle
+++ b/src/proguard-android/settings.gradle
@@ -3,6 +3,11 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
+def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
+if (runningOnCI == 'true') {
+    apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
+}
+
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
 }

--- a/src/r8/settings.gradle
+++ b/src/r8/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-if (System.getenv('RUNNINGONCI') == 'true') {
+if (System.getenv('ANDROID_MIRROR_MAVEN_DEPENDENCIES') == 'true') {
     apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
 }
 

--- a/src/r8/settings.gradle
+++ b/src/r8/settings.gradle
@@ -3,10 +3,6 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-plugins {
-    id 'com.microsoft.azure.artifacts.credprovider' version '1.1.1'
-}
-
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
 }

--- a/src/r8/settings.gradle
+++ b/src/r8/settings.gradle
@@ -3,8 +3,7 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
-if (runningOnCI == 'true') {
+if (System.getenv('RUNNINGONCI') == 'true') {
     apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
 }
 

--- a/src/r8/settings.gradle
+++ b/src/r8/settings.gradle
@@ -3,6 +3,11 @@ pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
+def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
+if (runningOnCI == 'true') {
+    apply from: "${rootDir}/../../eng/gradle/credential-provider.gradle"
+}
+
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
 }

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/settings.gradle
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/settings.gradle
@@ -3,10 +3,6 @@ pluginManagement {
     apply from: "${rootDir}/../../../../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-plugins {
-    id 'com.microsoft.azure.artifacts.credprovider' version '1.1.1'
-}
-
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../../../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
 }

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/settings.gradle
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
     apply from: "${rootDir}/../../../../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-if (System.getenv('RUNNINGONCI') == 'true') {
+if (System.getenv('ANDROID_MIRROR_MAVEN_DEPENDENCIES') == 'true') {
     apply from: "${rootDir}/../../../../../eng/gradle/credential-provider.gradle"
 }
 

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/settings.gradle
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/settings.gradle
@@ -3,6 +3,11 @@ pluginManagement {
     apply from: "${rootDir}/../../../../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
+def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
+if (runningOnCI == 'true') {
+    apply from: "${rootDir}/../../../../../eng/gradle/credential-provider.gradle"
+}
+
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../../../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
 }

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/settings.gradle
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/settings.gradle
@@ -3,8 +3,7 @@ pluginManagement {
     apply from: "${rootDir}/../../../../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
 }
 
-def runningOnCI = System.getenv('RunningOnCI') ?: System.getenv('RUNNINGONCI')
-if (runningOnCI == 'true') {
+if (System.getenv('RUNNINGONCI') == 'true') {
     apply from: "${rootDir}/../../../../../eng/gradle/credential-provider.gradle"
 }
 


### PR DESCRIPTION
PR #11711 centralized Gradle repository configuration, but applying the Azure Artifacts credential provider during ordinary builds caused authentication dialogs for local developers. CI does not need that provider because it reads packages already cached in `dotnet-public-maven` anonymously.

This keeps repository selection and authentication as separate controls:

- `RUNNINGONCI=true` selects `dotnet-public-maven` for Azure DevOps builds.
- `ANDROID_MIRROR_MAVEN_DEPENDENCIES=true` loads the credential provider only while `mirror-dependencies.ps1` seeds uncached packages.
- Local builds use Google, Maven Central, and the Gradle Plugin Portal without loading Azure authentication code.

The credential provider is loaded through an applied script so it can be gated dynamically. Gradle cannot resolve a plugin by ID from that script's isolated `buildscript` classpath, so this context requires its implementation class.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: Follow-up to #11711
- [x] Unit tests: Configured all four Gradle projects in local, anonymous CI, and authenticated mirror-helper modes.