### PR TITLE
[ci] Use 1ES outputs for Android Tools logs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -112,6 +112,7 @@ extends:
 
     - template: /build-tools/automation/yaml-templates/stage-xamarin-android-tools-tests.yaml@self
       parameters:
+        use1ESTemplate: true
         # The internal Xamarin.Android pipeline uses 1ES Pipeline Templates, which
         # require Windows jobs to run on a 1ES-hosted pool. macOS is fine on the
         # hosted Azure Pipelines pool as long as `os: macOS` is set (which is now

--- a/build-tools/automation/yaml-templates/stage-xamarin-android-tools-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-xamarin-android-tools-tests.yaml
@@ -24,6 +24,9 @@ parameters:
 - name: condition
   type: string
   default: succeeded()
+- name: use1ESTemplate
+  type: boolean
+  default: false
 - name: windowsPool
   type: object
   # NOTE: This default is a Microsoft-hosted Azure Pipelines pool, which is NOT
@@ -69,6 +72,15 @@ stages:
     timeoutInMinutes: 30
     workspace:
       clean: all
+    ${{ if eq(parameters.use1ESTemplate, true) }}:
+      templateContext:
+        outputs:
+        - output: pipelineArtifact
+          displayName: Upload build logs
+          condition: always()
+          targetPath: $(Build.ArtifactStagingDirectory)
+          artifactName: android-tools-logs-windows
+          sbomEnabled: false
     steps:
     - checkout: self
       clean: true
@@ -91,12 +103,13 @@ stages:
         command: test
         projects: $(XatSourceDirectory)/bin/TestDebug/**/*-Tests.dll
 
-    - task: PublishBuildArtifacts@1
-      displayName: Upload build logs
-      condition: always()
-      inputs:
-        pathToPublish: $(Build.ArtifactStagingDirectory)
-        artifactName: android-tools-logs-windows
+    - ${{ if eq(parameters.use1ESTemplate, false) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload build logs
+        condition: always()
+        inputs:
+          pathToPublish: $(Build.ArtifactStagingDirectory)
+          artifactName: android-tools-logs-windows
 
   # Check - "Xamarin.Android (Android Tools Tests Mac - .NET)"
   - job: xamarin_android_tools_mac
@@ -105,6 +118,15 @@ stages:
     timeoutInMinutes: 30
     workspace:
       clean: all
+    ${{ if eq(parameters.use1ESTemplate, true) }}:
+      templateContext:
+        outputs:
+        - output: pipelineArtifact
+          displayName: Upload build logs
+          condition: always()
+          targetPath: $(Build.ArtifactStagingDirectory)
+          artifactName: android-tools-logs-mac
+          sbomEnabled: false
     steps:
     - checkout: self
       clean: true
@@ -127,9 +149,10 @@ stages:
         command: test
         projects: $(XatSourceDirectory)/bin/TestDebug/**/*-Tests.dll
 
-    - task: PublishBuildArtifacts@1
-      displayName: Upload build logs
-      condition: always()
-      inputs:
-        pathToPublish: $(Build.ArtifactStagingDirectory)
-        artifactName: android-tools-logs-mac
+    - ${{ if eq(parameters.use1ESTemplate, false) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload build logs
+        condition: always()
+        inputs:
+          pathToPublish: $(Build.ArtifactStagingDirectory)
+          artifactName: android-tools-logs-mac


### PR DESCRIPTION
The official Xamarin.Android pipeline fails template validation because 1ES Pipeline Templates prohibit `PublishBuildArtifacts@1`.

Use 1ES `templateContext.outputs` to publish Android Tools logs from official builds. Keep the existing `PublishBuildArtifacts@1` path for the shared public pipeline template, which does not use 1ES.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: [AZDO build 14643527](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_build/results?buildId=14643527)
- [x] Unit tests: Not applicable; this changes pipeline YAML only.