### PR TITLE
[Microsoft.Android.Build.BaseTasks] Guard LogCodedError overloads

### DIFF
--- a/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AsyncTask.cs
+++ b/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AsyncTask.cs
@@ -152,21 +152,25 @@ namespace Microsoft.Android.Build.Tasks
 		}
 
 		public void LogError (string message)
-			=> LogCodedError (code: null, message: message, file: null, lineNumber: 0);
+			=> LogCodedErrorCore (code: null, message: message, file: null, lineNumber: 0);
 
 		public void LogError (string message, params object [] messageArgs)
-			=> LogCodedError (code: null, message: string.Format (message, messageArgs));
+			=> LogCodedErrorCore (code: null, message: FormatMessage (message, messageArgs), file: null, lineNumber: 0);
 
 		public void LogCodedError (string? code, string message)
-			=> LogCodedError (code: code, message: message, file: null, lineNumber: 0);
+			=> LogCodedErrorCore (code: code, message: message, file: null, lineNumber: 0);
 
 		public void LogCodedError (string? code, string message, params object [] messageArgs)
-			=> LogCodedError (code: code, message: string.Format (message, messageArgs), file: null, lineNumber: 0);
+			=> LogCodedErrorCore (code: code, message: FormatMessage (message, messageArgs), file: null, lineNumber: 0);
 
 		public void LogCodedError (string? code, string? file, int lineNumber, string message, params object [] messageArgs)
-			=> LogCodedError (code: code, message: string.Format (message, messageArgs), file: file, lineNumber: lineNumber);
+			=> LogCodedErrorCore (code: code, message: FormatMessage (message, messageArgs), file: file, lineNumber: lineNumber);
 
+		[Obsolete ("This overload binds ambiguously when the trailing arguments are (string, int): a call meant to format the message, e.g. LogCodedError (\"XA0000\", Resources.XA0000, someString, someInt), silently binds here and treats the arguments as a source file and line number instead of substituting them into the message. To format the message use LogCodedError (code, message, params object[]); to attach a source location use LogCodedError (code, file, lineNumber, message, params object[]).", error: true)]
 		public void LogCodedError (string? code, string message, string? file, int lineNumber)
+			=> LogCodedErrorCore (code: code, message: message, file: file, lineNumber: lineNumber);
+
+		void LogCodedErrorCore (string? code, string message, string? file, int lineNumber)
 		{
 			if (uiThreadId == Thread.CurrentThread.ManagedThreadId) {
 #pragma warning disable 618
@@ -201,21 +205,25 @@ namespace Microsoft.Android.Build.Tasks
 		}
 
 		public void LogWarning (string message)
-			=> LogCodedWarning (code: null, message: message, file: null, lineNumber: 0);
+			=> LogCodedWarningCore (code: null, message: message, file: null, lineNumber: 0);
 
 		public void LogWarning (string message, params object [] messageArgs)
-			=> LogCodedWarning (code: null, message: string.Format (message, messageArgs));
+			=> LogCodedWarningCore (code: null, message: FormatMessage (message, messageArgs), file: null, lineNumber: 0);
 
 		public void LogCodedWarning (string? code, string message)
-			=> LogCodedWarning (code: code, message: message, file: null, lineNumber: 0);
+			=> LogCodedWarningCore (code: code, message: message, file: null, lineNumber: 0);
 
 		public void LogCodedWarning (string? code, string message, params object [] messageArgs)
-			=> LogCodedWarning (code: code, message: string.Format (message, messageArgs), file: null, lineNumber: 0);
+			=> LogCodedWarningCore (code: code, message: FormatMessage (message, messageArgs), file: null, lineNumber: 0);
 
 		public void LogCodedWarning (string? code, string? file, int lineNumber, string message, params object [] messageArgs)
-			=> LogCodedWarning (code: code, message: string.Format (message, messageArgs), file: file, lineNumber: lineNumber);
+			=> LogCodedWarningCore (code: code, message: FormatMessage (message, messageArgs), file: file, lineNumber: lineNumber);
 
+		[Obsolete ("This overload binds ambiguously when the trailing arguments are (string, int): a call meant to format the message, e.g. LogCodedWarning (\"XA0000\", Resources.XA0000, someString, someInt), silently binds here and treats the arguments as a source file and line number instead of substituting them into the message. To format the message use LogCodedWarning (code, message, params object[]); to attach a source location use LogCodedWarning (code, file, lineNumber, message, params object[]).", error: true)]
 		public void LogCodedWarning (string? code, string message, string? file, int lineNumber)
+			=> LogCodedWarningCore (code: code, message: message, file: file, lineNumber: lineNumber);
+
+		void LogCodedWarningCore (string? code, string message, string? file, int lineNumber)
 		{
 			if (uiThreadId == Thread.CurrentThread.ManagedThreadId) {
 #pragma warning disable 618
@@ -247,6 +255,11 @@ namespace Microsoft.Android.Build.Tasks
 			);
 			EnqueueMessage (warningMessageQueue, data, warningDataAvailable);
 		}
+
+		// Returns the message verbatim when there are no arguments, so pre-formatted messages
+		// that contain literal '{' or '}' characters are not passed through string.Format.
+		static string FormatMessage (string message, object [] messageArgs)
+			=> messageArgs is null || messageArgs.Length == 0 ? message : string.Format (message, messageArgs);
 
 		public void LogCustomBuildEvent (CustomBuildEventArgs e)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -186,9 +186,9 @@ namespace Xamarin.Android.Tasks {
 				if (level.Contains ("error") || (line != 0 && !file.IsNullOrEmpty ())) {
 					var errorCode = GetErrorCodeForFile (message, file);
 					if (manifestError)
-						LogCodedError (errorCode, string.Format (Xamarin.Android.Tasks.Properties.Resources.AAPTManifestError, message.TrimEnd('.')), AndroidManifestFile?.ItemSpec ?? "", 0);
+						LogCodedError (errorCode, AndroidManifestFile?.ItemSpec ?? "", 0, string.Format (Xamarin.Android.Tasks.Properties.Resources.AAPTManifestError, message.TrimEnd('.')));
 					else
-						LogCodedError (errorCode, AddAdditionalErrorText (errorCode, message), file, line);
+						LogCodedError (errorCode, file, line, AddAdditionalErrorText (errorCode, message));
 					return true;
 				}
 			}


### PR DESCRIPTION
## Why this is necessary

[#11994](https://github.com/dotnet/android/pull/11994) fixed the `XA0145` emulator boot-timeout error rendering literal `{0}`/`{1}` placeholders instead of the AVD name and timeout. The underlying cause was overload resolution, and it can bite any coded-error call whose trailing arguments happen to be `(string, int)`:

```csharp
LogCodedError ("XA0145", Resources.XA0145, Device, BootTimeoutSeconds);
```

This binds to `LogCodedError (code, message, string? file, int lineNumber)` instead of the `params object[]` formatting overload, because a non-`params` method that matches the `(string, int)` tail exactly is always preferred. The result: the message is logged verbatim (placeholders never substituted) and `Device`/`BootTimeoutSeconds` are silently reinterpreted as a source file and line number. #11994 patched the one call site; this PR turns the whole class of bug into a build break.

## Approach

- **Extract private sinks.** The real logging body moved into `LogCodedErrorCore` / `LogCodedWarningCore`. Every public overload now delegates to them, so no overload routes through the trap internally.
- **Obsolete the trap overloads.** `LogCodedError (code, message, string? file, int lineNumber)` and its `LogCodedWarning` twin are now `[Obsolete (error: true)]` with a message steering callers to either the formatting overload (`code, message, params object[]`) or the file-first overload (`code, file, lineNumber, message, ...`). Any accidental `(string, int)` tail now fails to compile with `CS0619`.
- **Fix a latent FormatException.** A new `FormatMessage` helper returns the message verbatim when there are no args, so pre-formatted messages containing literal `{`/`}` (e.g. raw `aapt2` output) are never run through `string.Format`.
- **Migrate the intentional callers.** `Aapt2`'s two file+line calls now use the file-first overload.

## Notes for reviewers

- The `Log`/`log` extension-method versions in `MSBuildExtensions` were never affected; that overload set has no ambiguous trailing overload, so nothing there changed.
- I audited every `AsyncTask` caller in the repo: only `BootAndroidEmulator` (already fixed in #11994) and `Aapt2` used the trap shape. Everything else passes a trailing `string`/object or has the `int` in a non-trap position.
- Verified by building `Microsoft.Android.Build.BaseTasks` clean and compiling a probe against the built assembly: the `(string, int)` tail now errors `CS0619`, while `string.Format`, file-first, and literal-brace forms all compile.

## Unit tests

No new tests. The behavior is enforced at compile time (`CS0619`), and the runtime substitution is already covered by the `BootAndroidEmulatorTests` added in #11994.