### PR TITLE
[tests] Disable flaky InstallAndroidDependenciesTest

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Android.Build.Tests
 	public class AndroidDependenciesTests : BaseTest
 	{
 		[Test]
+		[Ignore ("Flaky test that intermittently fails when downloading the Android SDK/JDK over the network in CI. See: https://github.com/dotnet/android/issues/11973")]
 		[NonParallelizable] // Do not run environment modifying tests in parallel.
 		public void InstallAndroidDependenciesTest ([Values ("GoogleV2", "Xamarin")] string manifestType, [Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 		{


### PR DESCRIPTION
### Description

`InstallAndroidDependenciesTest` (in `AndroidDependenciesTests`) downloads the Android SDK and JDK over the network as part of the `InstallAndroidDependencies` target. These network downloads fail intermittently in CI, and the existing in-test retry logic (up to 3 attempts) has not been enough to make the test reliable.

This PR disables the test for **all** parameter combinations (`manifestType` × `runtime`) by adding an `[Ignore]` attribute, following the same pattern used for other flaky tests in this repo (e.g. `IncrementalBuildTest.BasicApplicationRepetitiveBuild`).

Example recent failure:

```
Failed InstallAndroidDependenciesTest("Xamarin",CoreCLR) [2 s]
  Xamarin.ProjectTools.FailedBuildException : Build failure: UnnamedProject.csproj
```

The test remains in the codebase and can be re-enabled once the underlying network flakiness is addressed.

See: https://github.com/dotnet/android/issues/11973