### PR TITLE
[build] Centralize Java.Interop Kotlin fixture repositories

### DIFF
--- a/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/build.gradle.kts
+++ b/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/build.gradle.kts
@@ -2,10 +2,6 @@ plugins {
     kotlin("jvm") version "2.0.21"
 }
 
-repositories {
-    mavenCentral()
-}
-
 // Don't pin a jvmToolchain -- it would force Gradle to auto-provision a
 // matching JDK and fail in CI environments without download repositories
 // configured. Use whatever JDK the caller already set in JAVA_HOME (the

--- a/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/settings.gradle.kts
+++ b/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/settings.gradle.kts
@@ -1,1 +1,14 @@
+// See: eng/gradle/plugin-repositories.gradle, eng/gradle/dependency-repositories.gradle
+pluginManagement {
+    apply(from = "$rootDir/../../../../../eng/gradle/plugin-repositories.gradle", to = this)
+}
+
+if (System.getenv("ANDROID_MIRROR_MAVEN_DEPENDENCIES") == "true") {
+    apply(from = "$rootDir/../../../../../eng/gradle/credential-provider.gradle")
+}
+
+dependencyResolutionManagement {
+    apply(from = "$rootDir/../../../../../eng/gradle/dependency-repositories.gradle", to = this)
+}
+
 rootProject.name = "kotlin-inline-class-fixtures"


### PR DESCRIPTION
## Summary

- route the Java.Interop Kotlin fixture's plugin and dependency resolution through the shared `eng/gradle` repository scripts
- remove the fixture-local `mavenCentral()` declaration
- load the Azure Artifacts credential provider only when `ANDROID_MIRROR_MAVEN_DEPENDENCIES=true`, matching the current mirror-seeding design

This brings the Kotlin fixture under centralized Maven repository selection while keeping regular CI on anonymous mirror reads.

## Validation

- local/default Gradle `classes` build with refreshed dependencies
- anonymous CI mirror build with `RUNNINGONCI=true` and a fresh Gradle dependency cache
- `Xamarin.Android.Tools.Bytecode-Tests`: 96 passed, 2 skipped