### PR TITLE
[NativeAOT] Preserve IGCUserPeer methods through R8

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_trimmable_nativeaot.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_trimmable_nativeaot.cfg
@@ -4,6 +4,8 @@
 
 -keep class net.dot.jni.** { *; <init>(...); }
 -keep class net.dot.android.crypto.** { *; <init>(...); }
+# NativeAOT resolves these interface methods through JNI during startup.
+-keep class mono.android.IGCUserPeer { *; }
 
 -keepclassmembers class * extends android.view.View {
    *** set*(...);


### PR DESCRIPTION
## Summary

- preserve mono.android.IGCUserPeer and its members in the trimmable NativeAOT R8 configuration
- prevent startup failure after #12040 began resolving the interface methods through JNI

## Validation

- compiled the repository IGCUserPeer.java and processed it with the repository R8
- confirmed the fixed DEX retains IGCUserPeer, monodroidAddReference, and monodroidClearReferences
- confirmed the same input without the new rule strips the JNI methods

## Regression

Build 1506967 aborts during NativeAOT startup with NoSuchMethodError for both IGCUserPeer methods: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1506967