### PR TITLE
[Mono.Android] Preserve HEAD requests on redirect in AndroidMessageHandler

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -1050,8 +1050,10 @@ namespace Xamarin.Android.Net
 				case HttpStatusCode.Moved:             // 301
 				case HttpStatusCode.Redirect:          // 302
 				case HttpStatusCode.SeeOther:          // 303
-					redirectState.MethodChanged = redirectState.Method != HttpMethod.Get;
-					redirectState.Method = HttpMethod.Get;
+					if (redirectState.Method != HttpMethod.Get && redirectState.Method != HttpMethod.Head) {
+						redirectState.MethodChanged = true;
+						redirectState.Method = HttpMethod.Get;
+					}
 					break;
 
 				case HttpStatusCode.NotModified:       // 304

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
@@ -256,6 +256,24 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
+		public async Task AndroidMessageHandlerPreservesHeadMethodOnRedirect ()
+		{
+			using var server = LocalHttpServer.Start ();
+			Uri redirectUri = server.GetUri ("head");
+			Uri requestUri = server.GetUri ($"redirect-to?url={Uri.EscapeDataString (redirectUri.ToString ())}&status_code=302");
+
+			using var handler = new AndroidMessageHandler ();
+			using var client = new HttpClient (handler);
+			using var request = new HttpRequestMessage (HttpMethod.Head, requestUri);
+			using HttpResponseMessage response = await client.SendAsync (request);
+
+			Assert.AreEqual (HttpStatusCode.OK, response.StatusCode);
+			Assert.AreEqual (HttpMethod.Head, response.RequestMessage.Method);
+			Assert.AreEqual (redirectUri, response.RequestMessage.RequestUri);
+			server.AssertNoUnhandledExceptions ();
+		}
+
+		[Test]
 		public async Task AndroidMessageHandlerSendsClientCertificate ([Values(true, false)] bool setClientCertificateOptionsExplicitly)
 		{
 			using X509Certificate2 certificate = BuildClientCertificate ();

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/LocalTestServers.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/LocalTestServers.cs
@@ -249,6 +249,8 @@ namespace Xamarin.Android.NetTests {
 					return WriteCompressedStringAsync (stream, "gzip", "{ \"gzipped\": true }", "application/json");
 				case "/ok":
 					return WriteStringAsync (stream, "OK", "text/plain");
+				case "/head":
+					return HandleHead (stream, request);
 				case "/post":
 					return HandlePost (stream, request);
 				case "/redirect-to":
@@ -257,6 +259,12 @@ namespace Xamarin.Android.NetTests {
 				default:
 					return WriteResponseAsync (stream, HttpStatusCode.NotFound, "", "text/plain", null, null);
 			}
+		}
+
+		static Task HandleHead (Stream stream, LocalHttpRequest request)
+		{
+			HttpStatusCode statusCode = request.Method == "HEAD" ? HttpStatusCode.OK : HttpStatusCode.MethodNotAllowed;
+			return WriteResponseAsync (stream, statusCode, "", "text/plain", null, null);
 		}
 
 		static Task HandlePost (Stream stream, LocalHttpRequest request)


### PR DESCRIPTION
`AndroidMessageHandler` converted every non-GET request to GET when following 301, 302, or 303 redirects. This incorrectly changed HEAD requests and could cause the redirected resource body to be downloaded.

Preserve HEAD across these redirects while retaining the existing conversion behavior for other methods.

Fixes dotnet/android#12103

The regression test uses a local HTTP server that returns a 302 redirect and rejects the follow-up request unless its wire method is HEAD. The test passes on `emulator-5600`.