### PR TITLE
Fix GridView.Adapter CA1416 false positive

### DIFF
--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1564,7 +1564,40 @@ namespace generatortests
 		}
 
 		[Test]
-		public void UnsupportedOSPlatformIgnoresPropertyAccessorMovedToBaseMethod ()
+		public void UnsupportedOSPlatformIgnoresPropertySetterMovedToStandaloneBaseMethod ()
+		{
+			var xml = @$"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.example' jni-name='com/example'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' final='false' name='Base' static='false' visibility='public'>
+			       <method abstract='false' deprecated='not deprecated' final='false' name='setValue' bridge='false' managedName='SetRawValue' native='false' propertyName='RawValue' return='void' static='false' synchronized='false' synthetic='false' visibility='public'>
+			         <parameter name='value' type='java.lang.Object' />
+			       </method>
+			     </class>
+			    <class abstract='false' deprecated='not deprecated' extends='com.example.Base' extends-generic-aware='com.example.Base' final='false' name='Derived' static='false' visibility='public'>
+			       <method abstract='false' deprecated='not deprecated' final='false' name='getValue' bridge='false' native='false' return='java.lang.Object' static='false' synchronized='false' synthetic='false' visibility='public' />
+			       <method abstract='false' deprecated='not deprecated' final='false' name='setValue' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public' removed-since='15'>
+			         <parameter name='value' type='java.lang.Object' />
+			       </method>
+			     </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var klass = gens.Single (g => g.Name == "Derived");
+			var property = klass.Properties.Single (p => p.Name == "Value");
+			var actual = GetGeneratedTypeOutput (klass);
+
+			Assert.IsNotNull (property.Setter, "The removed setter must be tested as a property accessor.");
+			StringAssert.Contains ("public virtual unsafe Java.Lang.Object Value {", actual);
+			StringAssert.Contains ("set {", actual);
+			StringAssert.DoesNotContain ("[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android15.0\")]", actual);
+		}
+
+		[Test]
+		public void UnsupportedOSPlatformIgnoresSpecializedGenericBasePropertySetter ()
 		{
 			var xml = @$"<api>
 			  <package name='java.lang' jni-name='java/lang'>
@@ -1588,12 +1621,7 @@ namespace generatortests
 			         <parameter name='value' type='T' />
 			       </method>
 			     </class>
-			    <class abstract='true' deprecated='not deprecated' extends='android.widget.AdapterView' extends-generic-aware='android.widget.AdapterView&lt;android.widget.ListAdapter&gt;' final='false' name='AbsListView' static='false' visibility='public'>
-			       <method abstract='false' deprecated='not deprecated' final='false' name='setAdapter' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public'>
-			         <parameter name='value' type='android.widget.ListAdapter' />
-			       </method>
-			     </class>
-			    <class abstract='false' deprecated='not deprecated' extends='android.widget.AbsListView' extends-generic-aware='android.widget.AbsListView' final='false' name='GridView' static='false' visibility='public'>
+			    <class abstract='false' deprecated='not deprecated' extends='android.widget.AdapterView' extends-generic-aware='android.widget.AdapterView&lt;android.widget.ListAdapter&gt;' final='false' name='GridView' static='false' visibility='public'>
 			       <method abstract='false' deprecated='not deprecated' final='false' name='getAdapter' bridge='false' native='false' return='android.widget.ListAdapter' static='false' synchronized='false' synthetic='false' visibility='public' />
 			       <method abstract='false' deprecated='not deprecated' final='false' name='setAdapter' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public' removed-since='15'>
 			         <parameter name='value' type='android.widget.ListAdapter' />
@@ -1604,9 +1632,52 @@ namespace generatortests
 
 			var gens = ParseApiDefinition (xml);
 			var klass = gens.Single (g => g.Name == "GridView");
+			var property = klass.Properties.Single (p => p.Name == "Adapter");
 			var actual = GetGeneratedTypeOutput (klass);
 
+			Assert.IsNotNull (property.Setter, "The specialized setter must be tested as a property accessor.");
+			StringAssert.Contains ("set {", actual);
 			StringAssert.DoesNotContain ("[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android15.0\")]", actual);
+		}
+
+		[Test]
+		public void UnsupportedOSPlatformPreservesPropertySetterForDifferentGenericBaseParameter ()
+		{
+			var xml = @$"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' final='true' name='String' static='false' visibility='public' />
+			  </package>
+			  <package name='com.example' jni-name='com/example'>
+			    <interface abstract='true' deprecated='not deprecated' final='false' name='Container' static='false' visibility='public'>
+			       <typeParameters>
+			         <typeParameter name='E' />
+			       </typeParameters>
+			     </interface>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' final='false' name='Base' static='false' visibility='public'>
+			       <method abstract='false' deprecated='not deprecated' final='false' name='setValue' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public'>
+			         <parameter name='value' type='com.example.Container&lt;java.lang.String&gt;' />
+			       </method>
+			     </class>
+			    <class abstract='false' deprecated='not deprecated' extends='com.example.Base' extends-generic-aware='com.example.Base' final='false' name='Derived' static='false' visibility='public'>
+			       <method abstract='false' deprecated='not deprecated' final='false' name='getValue' bridge='false' native='false' return='java.lang.String' static='false' synchronized='false' synthetic='false' visibility='public' />
+			       <method abstract='false' deprecated='not deprecated' final='false' name='setValue' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public' removed-since='15'>
+			         <parameter name='value' type='java.lang.String' />
+			       </method>
+			     </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var baseSetter = gens.Single (g => g.Name == "Base").GetAllMethods ().Single (m => m.JavaName == "setValue");
+			var klass = gens.Single (g => g.Name == "Derived");
+			var property = klass.Properties.Single (p => p.Name == "Value");
+			var actual = GetGeneratedTypeOutput (klass);
+
+			Assert.IsTrue (baseSetter.Parameters [0].IsGeneric, $"Expected a concrete generic parameter, but found {baseSetter.Parameters [0].Symbol.GetType ().FullName}.");
+			Assert.IsNotNull (property.Setter, "The removed setter must be tested as a property accessor.");
+			StringAssert.Contains ("set {", actual);
+			StringAssert.Contains ("[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android15.0\")]", actual);
 		}
 
 		[Test]

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1564,6 +1564,52 @@ namespace generatortests
 		}
 
 		[Test]
+		public void UnsupportedOSPlatformIgnoresPropertyAccessorMovedToBaseMethod ()
+		{
+			var xml = @$"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='android.widget' jni-name='android/widget'>
+			    <interface abstract='true' deprecated='not deprecated' final='false' name='Adapter' static='false' visibility='public' />
+			    <interface abstract='true' deprecated='not deprecated' final='false' name='ListAdapter' static='false' visibility='public'>
+			       <implements name='android.widget.Adapter' name-generic-aware='android.widget.Adapter' />
+			     </interface>
+			    <class abstract='true' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' final='false' name='AdapterView' static='false' visibility='public'>
+			       <typeParameters>
+			         <typeParameter name='T' interfaceBounds='android.widget.Adapter'>
+			           <genericConstraints>
+			             <genericConstraint type='android.widget.Adapter' />
+			           </genericConstraints>
+			         </typeParameter>
+			       </typeParameters>
+			       <method abstract='true' deprecated='not deprecated' final='false' name='getAdapter' bridge='false' native='false' return='T' static='false' synchronized='false' synthetic='false' visibility='public' />
+			       <method abstract='true' deprecated='not deprecated' final='false' name='setAdapter' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public'>
+			         <parameter name='value' type='T' />
+			       </method>
+			     </class>
+			    <class abstract='true' deprecated='not deprecated' extends='android.widget.AdapterView' extends-generic-aware='android.widget.AdapterView&lt;android.widget.ListAdapter&gt;' final='false' name='AbsListView' static='false' visibility='public'>
+			       <method abstract='false' deprecated='not deprecated' final='false' name='setAdapter' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public'>
+			         <parameter name='value' type='android.widget.ListAdapter' />
+			       </method>
+			     </class>
+			    <class abstract='false' deprecated='not deprecated' extends='android.widget.AbsListView' extends-generic-aware='android.widget.AbsListView' final='false' name='GridView' static='false' visibility='public'>
+			       <method abstract='false' deprecated='not deprecated' final='false' name='getAdapter' bridge='false' native='false' return='android.widget.ListAdapter' static='false' synchronized='false' synthetic='false' visibility='public' />
+			       <method abstract='false' deprecated='not deprecated' final='false' name='setAdapter' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public' removed-since='15'>
+			         <parameter name='value' type='android.widget.ListAdapter' />
+			       </method>
+			     </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var klass = gens.Single (g => g.Name == "GridView");
+			var actual = GetGeneratedTypeOutput (klass);
+
+			StringAssert.DoesNotContain ("[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android15.0\")]", actual);
+		}
+
+		[Test]
 		public void StringPropertyOverride ([Values ("true", "false")] string final)
 		{
 			var xml = @$"<api>

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -357,7 +357,7 @@ namespace MonoDroid.Generation
 								ParameterList.Equals (mm.Parameters, m.Parameters)) ||
 							(m == prop.Setter &&
 								(ParameterList.Equals (mm.Parameters, m.Parameters) ||
-									(mm.Parameters.Count == 1 && mm.Parameters [0].IsGeneric)))));
+									(mm.Parameters.Count == 1 && mm.Parameters [0].Symbol is GenericTypeParameter)))));
 						if (bm != null) {
 							m.ApiRemovedSince = default;
 							break;

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -339,36 +339,29 @@ namespace MonoDroid.Generation
 				}
 			}
 
-			// Process property getter/setter methods for ApiRemovedSince fixup
+			// A property accessor can correspond to a standalone method in a base class
+			// when the accessor types differ. Compare the underlying Java methods.
 			foreach (var prop in Properties) {
-				for (var bt = GetBaseGen (opt); bt != null; bt = bt.GetBaseGen (opt)) {
-					var baseProp = bt.Properties.FirstOrDefault (p => p.Name == prop.Name && p.Type == prop.Type);
-					if (baseProp == null) {
+				foreach (var m in new [] { prop.Getter, prop.Setter }) {
+					if (m == null || m.ApiRemovedSince == 0) {
 						continue;
 					}
 
-					bool shouldBreak = false;
-					if (prop.Getter != null && prop.Getter.ApiRemovedSince > 0 && baseProp.Getter != null && baseProp.Getter.ApiRemovedSince == 0) {
-						if (baseProp.Getter.Visibility == prop.Getter.Visibility &&
-							ParameterList.Equals (baseProp.Getter.Parameters, prop.Getter.Parameters) &&
-							baseProp.Getter.RetVal.FullName == prop.Getter.RetVal.FullName) {
-							// If a "removed" property getter overrides a "not removed" getter, the method was
-							// likely moved to a base class, so don't mark it as removed.
-							prop.Getter.ApiRemovedSince = default;
-							shouldBreak = true;
+					for (var bt = GetBaseGen (opt); bt != null; bt = bt.GetBaseGen (opt)) {
+						var bm = bt.GetAllMethods ().FirstOrDefault (mm =>
+							mm.ApiRemovedSince == 0 &&
+							mm.JavaName == m.JavaName &&
+							mm.Visibility == m.Visibility &&
+							((m == prop.Getter &&
+								mm.RetVal.FullName == m.RetVal.FullName &&
+								ParameterList.Equals (mm.Parameters, m.Parameters)) ||
+							(m == prop.Setter &&
+								(ParameterList.Equals (mm.Parameters, m.Parameters) ||
+									(mm.Parameters.Count == 1 && mm.Parameters [0].IsGeneric)))));
+						if (bm != null) {
+							m.ApiRemovedSince = default;
+							break;
 						}
-					}
-					if (prop.Setter != null && prop.Setter.ApiRemovedSince > 0 && baseProp.Setter != null && baseProp.Setter.ApiRemovedSince == 0) {
-						if (baseProp.Setter.Visibility == prop.Setter.Visibility &&
-							ParameterList.Equals (baseProp.Setter.Parameters, prop.Setter.Parameters)) {
-							// If a "removed" property setter overrides a "not removed" setter, the method was
-							// likely moved to a base class, so don't mark it as removed.
-							prop.Setter.ApiRemovedSince = default;
-							shouldBreak = true;
-						}
-					}
-					if (shouldBreak) {
-						break;
 					}
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -478,6 +478,18 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True"); // Disables API 29 warning in Xamarin.Build.Download
 			proj.SetProperty ("AndroidPackageFormat", packageFormat);
 			proj.SetProperty ("TrimmerSingleWarn", "false");
+			// Regression tests for:
+			// https://github.com/dotnet/android/issues/10509
+			// https://github.com/dotnet/android/issues/12107
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}",
+				"""
+					// These should not cause warnings
+					new FrameLayout (this).Foreground = null;
+					new GridView (this).Adapter = null;
+					new ListView (this).Adapter = null;
+					Console.WriteLine (Android.Provider.MediaStore.Video.IVideoColumns.DateTaken);
+					Console.WriteLine (Android.Provider.MediaStore.Images.IImageColumns.DateTaken);
+				""");
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 


### PR DESCRIPTION
## Summary

- match removed property accessors against supported Java base methods
- handle setters that specialize generic base setter type parameters without matching unrelated concrete generic types
- add focused positive and negative generator regression coverage
- add end-to-end analyzer regression coverage for `GridView.Adapter`
- preserve the existing regression cases for `FrameLayout.Foreground`, `ListView.Adapter`, and `MediaStore.DateTaken`

## Context

This finishes the regression coverage and generator work started in:

- https://github.com/dotnet/android/pull/10510
- https://github.com/dotnet/java-interop/pull/1374

The relevant history is:

- https://github.com/dotnet/java-interop/pull/1313 introduced suppression of `[UnsupportedOSPlatform]` on supported overrides.
- https://github.com/dotnet/java-interop/pull/1366 extended that handling to properties.
- https://github.com/dotnet/java-interop/pull/1367 reverted the platform-attribute changes from `release/10.0.1xx` to reduce risk for .NET 10: https://github.com/dotnet/java-interop/commit/0ad0d4078f2058a133d0dc0554e556ee1072a076
- The changes remained on `main`, where the generic `GridView.Adapter` setter case was investigated in the unfinished Java.Interop PR above but left unresolved.

Java.Interop is now integrated into this repository, so this applies the focused generator fix directly in-tree.

## Testing

- all 466 Java.Interop generator tests pass
- positive mutation checks fail when the accessor fix is disabled
- the concrete-generic guard fails with the previous broad `IsGeneric` match
- the 10-case Android `BuildHasNoWarnings` matrix passes, with the three unsupported Debug NativeAOT cases skipped

Fixes: https://github.com/dotnet/android/issues/12107