### PR TITLE
[TrimmableTypeMap] Compile generated JCWs in place instead of copying to android/src

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
@@ -163,6 +163,7 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
         ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
         ClassesZip="$(_AndroidIntermediateClassesZip)"
         StubSourceDirectory="$(_AndroidIntermediateJavaSourceDirectory)"
+        AdditionalStubSourceDirectories="@(_AdditionalJavaStubDirectory)"
         JavaSourceFiles="@(_JavaSource)"
         ToolPath="$(JavacToolPath)"
         ToolExe="$(JavacToolExe)"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -61,6 +61,15 @@
     </IncrementalCleanDependsOn>
   </PropertyGroup>
 
+  <!-- Compile the generator's Java Callable Wrappers in place from their output directory
+       instead of copying every .java into android/src (which was hundreds of per-file copies).
+       This is a static ItemGroup so the directory is registered even on incremental builds where
+       _GenerateJavaStubs is skipped; _CompileJava globs it via _FindJavaStubFiles for
+       incrementality and compiles it via the Javac AdditionalStubSourceDirectories parameter. -->
+  <ItemGroup>
+    <_AdditionalJavaStubDirectory Include="$([MSBuild]::EnsureTrailingSlash('$(_TypeMapJavaStubsSourceDirectory)'))" />
+  </ItemGroup>
+
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap"
         Value="true" Trim="true" />
@@ -163,15 +172,10 @@
       <Output TaskParameter="AdditionalProviderSources" ItemName="_AdditionalProviderSources" />
     </GenerateTrimmableTypeMap>
 
-    <!-- Mirror any Java sources the generator deleted into the android/src copies so a
-         removed type does not leave a stale .java (and stale .class) behind. Busting the
-         Java compile stamp forces _CompileJava to drop the corresponding class output. -->
-    <ItemGroup>
-      <_DeletedCopiedJavaFiles Remove="@(_DeletedCopiedJavaFiles)" />
-      <_DeletedCopiedJavaFiles Include="@(_DeletedJavaFiles->'$(IntermediateOutputPath)android/src/%(RelativePath)')" />
-    </ItemGroup>
-    <Delete Files="@(_DeletedCopiedJavaFiles)" />
-    <Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_DeletedCopiedJavaFiles->Count())' != '0' " />
+    <!-- If the generator removed a Java source, bust the Java compile stamp so _CompileJava
+         re-runs (it fully cleans its class output each run, dropping the stale .class). The
+         JCWs are compiled in place, so there are no android/src copies to delete. -->
+    <Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_DeletedJavaFiles->Count())' != '0' " />
 
     <!-- Touch only the stamp: it is the target's sole Output and incremental sentinel.
          The generated TypeMap DLLs and the assemblies list are written via CopyIfStreamChanged
@@ -181,7 +185,6 @@
 
     <ItemGroup>
       <FileWrites Remove="@(_DeletedJavaFiles)" />
-      <FileWrites Remove="@(_DeletedCopiedJavaFiles)" />
       <FileWrites Include="@(_GeneratedTypeMapAssemblies)" />
       <FileWrites Include="@(_GeneratedJavaFiles)" />
       <FileWrites Include="$(_TypeMapAssembliesListFile)" />
@@ -234,18 +237,15 @@
     </ReadLinesFromFile>
     <ItemGroup>
       <_TypeMapJavaFilesForFileWrites Include="$(_TypeMapJavaOutputDirectory)/**/*.java" />
-      <!-- For CoreCLR + PublishTrimmed the JCWs copied into android/src come from the post-trim
-           `linked-java` directory. _GeneratePostTrimTrimmableTypeMapJavaSources is now incremental,
-           so re-emit its outputs here too; otherwise IncrementalClean deletes linked-java (and its
-           android/src copies) on builds where post-trim is skipped. The glob is empty for
-           configurations that have no post-trim pass. -->
+      <!-- For CoreCLR + PublishTrimmed the JCWs come from the post-trim `linked-java` directory.
+           _GeneratePostTrimTrimmableTypeMapJavaSources is now incremental, so re-emit its outputs
+           here too; otherwise IncrementalClean deletes linked-java on builds where post-trim is
+           skipped. The glob is empty for configurations that have no post-trim pass. -->
       <_TypeMapPostTrimJavaFilesForFileWrites Include="$(_PostTrimTypeMapJavaOutputDirectory)/**/*.java" />
 
       <FileWrites Include="@(_GeneratedTypeMapAssembliesForFileWrites)" />
       <FileWrites Include="@(_TypeMapJavaFilesForFileWrites)" />
-      <FileWrites Include="@(_TypeMapJavaFilesForFileWrites->'$(IntermediateOutputPath)android/src/%(RecursiveDir)%(Filename)%(Extension)')" />
       <FileWrites Include="@(_TypeMapPostTrimJavaFilesForFileWrites)" />
-      <FileWrites Include="@(_TypeMapPostTrimJavaFilesForFileWrites->'$(IntermediateOutputPath)android/src/%(RecursiveDir)%(Filename)%(Extension)')" />
       <FileWrites Include="$(_PostTrimTrimmableTypeMapJavaStamp)" Condition="Exists('$(_PostTrimTrimmableTypeMapJavaStamp)')" />
       <FileWrites Include="$(_TypeMapAssembliesListFile)" />
       <FileWrites Include="$(_TrimmableTypeMapOutputStamp)" Condition="Exists('$(_TrimmableTypeMapOutputStamp)')" />
@@ -371,14 +371,9 @@
       Inputs="$(_TrimmableJavaSourceStamp);@(_EnvironmentFiles)"
       Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
 
-    <ItemGroup>
-      <_TypeMapJavaFiles Include="$(_TypeMapJavaStubsSourceDirectory)/**/*.java" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_TypeMapJavaFiles)" DestinationFolder="$(IntermediateOutputPath)android/src/%(RecursiveDir)" SkipUnchangedFiles="true" />
-
-    <ItemGroup>
-      <FileWrites Include="@(_TypeMapJavaFiles->'$(IntermediateOutputPath)android/src/%(RecursiveDir)%(Filename)%(Extension)')" />
-    </ItemGroup>
+    <!-- The generated Java Callable Wrappers are compiled in place from
+         @(_AdditionalJavaStubDirectory) (see _CompileJava / _FindJavaStubFiles); they are no
+         longer copied into android/src. -->
 
     <!-- NativeAOT bootstrap Java sources depend on environment files, so include them as inputs -->
     <GenerateNativeAotBootstrapSources

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
@@ -73,6 +73,9 @@ namespace Xamarin.Android.Tasks
 
 				WriteJavaSourcesFromDirectory (sw, StubSourceDirectory);
 
+				// StubSourceDirectory and the AdditionalStubSourceDirectories entries must be
+				// disjoint: a .java found under more than one directory is written to the response
+				// file more than once, which makes javac fail with a "duplicate class" error.
 				if (AdditionalStubSourceDirectories != null)
 					foreach (var dir in AdditionalStubSourceDirectories)
 						WriteJavaSourcesFromDirectory (sw, dir.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
@@ -17,6 +17,11 @@ namespace Xamarin.Android.Tasks
 	{
 		public string? StubSourceDirectory { get; set; }
 
+		// Extra directories whose *.java are compiled in place, in addition to StubSourceDirectory.
+		// Used by the trimmable type map so the generated Java Callable Wrappers can be compiled
+		// directly from the generator's output directory instead of being copied into android/src.
+		public ITaskItem[]? AdditionalStubSourceDirectories { get; set; }
+
 		public ITaskItem[]? JavaSourceFiles { get; set; }
 
 		public ITaskItem[]? Jars { get; set; }
@@ -66,33 +71,42 @@ namespace Xamarin.Android.Tasks
 					foreach (var file in JavaSourceFiles.Where (p => Path.GetExtension (p.ItemSpec) == ".java"))
 						sw.WriteLine (string.Format ("\"{0}\"", file.ItemSpec.Replace (@"\", @"\\")));
 
-				if (StubSourceDirectory.IsNullOrEmpty ())
-					return;
+				WriteJavaSourcesFromDirectory (sw, StubSourceDirectory);
 
-				if (!Directory.Exists (StubSourceDirectory))
-					return;
-
-				foreach (var file in Directory.GetFiles (StubSourceDirectory, "*.java", SearchOption.AllDirectories)) {
-					// This makes sense.  BAD sense.  but sense.
-					// Problem:
-					//    A perfectly sensible path like "E:\tmp\a.java" generates a
-					//    javac error that "E:       mp.java" can't be found.
-					// Cause:
-					//    javac uses java.io.StreamTokenizer to parse @response files, and
-					//    the docs for StreamTokenizer.quoteChar(int) [0] say:
-					//      The usual escape sequences such as "\n" and "\t" are recognized
-					//      and converted to single characters as the string is parsed.
-					//    i.e. '\' is an escape character!
-					// Solution:
-					//    Since '\' is an escape character, we need to escape it.
-					// [0] http://download.oracle.com/javase/1.4.2/docs/api/java/io/StreamTokenizer.html#quoteChar(int)
-					sw.WriteLine (string.Format ("\"{0}\"",
-								file.Replace (@"\", @"\\").Normalize (NormalizationForm.FormC)));
-				}
+				if (AdditionalStubSourceDirectories != null)
+					foreach (var dir in AdditionalStubSourceDirectories)
+						WriteJavaSourcesFromDirectory (sw, dir.ItemSpec);
 			}
 			Log.LogDebugMessage ($"javac response file contents: {TemporarySourceListFile}");
 			foreach (var line in File.ReadLines (TemporarySourceListFile)) {
 				Log.LogDebugMessage ($"  {line}");
+			}
+		}
+
+		void WriteJavaSourcesFromDirectory (StreamWriter sw, string? directory)
+		{
+			if (directory.IsNullOrEmpty ())
+				return;
+
+			if (!Directory.Exists (directory))
+				return;
+
+			foreach (var file in Directory.GetFiles (directory, "*.java", SearchOption.AllDirectories)) {
+				// This makes sense.  BAD sense.  but sense.
+				// Problem:
+				//    A perfectly sensible path like "E:\tmp\a.java" generates a
+				//    javac error that "E:       mp.java" can't be found.
+				// Cause:
+				//    javac uses java.io.StreamTokenizer to parse @response files, and
+				//    the docs for StreamTokenizer.quoteChar(int) [0] say:
+				//      The usual escape sequences such as "\n" and "\t" are recognized
+				//      and converted to single characters as the string is parsed.
+				//    i.e. '\' is an escape character!
+				// Solution:
+				//    Since '\' is an escape character, we need to escape it.
+				// [0] http://download.oracle.com/javase/1.4.2/docs/api/java/io/StreamTokenizer.html#quoteChar(int)
+				sw.WriteLine (string.Format ("\"{0}\"",
+							file.Replace (@"\", @"\\").Normalize (NormalizationForm.FormC)));
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Android.Build.Tests {
 		}
 
 		[Test]
-		public void Build_WithTrimmableTypeMap_DeletesStaleGeneratedJavaSourcesAndCopies ()
+		public void Build_WithTrimmableTypeMap_DeletesStaleGeneratedJavaSources ()
 		{
 			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: false)) {
 				return;
@@ -116,19 +116,15 @@ namespace Xamarin.Android.Build.Tests {
 			var staleRelativePath = Path.Combine ("crc64stale", "Old.java");
 			var staleClassPath = Path.Combine ("crc64stale", "Old.class");
 			var staleGeneratedJava = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "java", staleRelativePath));
-			var staleCopiedJava = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src", staleRelativePath));
 			var staleCompiledClass = builder.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes", staleClassPath));
 			var staleGeneratedJavaDirectory = Path.GetDirectoryName (staleGeneratedJava);
-			var staleCopiedJavaDirectory = Path.GetDirectoryName (staleCopiedJava);
 			var staleCompiledClassDirectory = Path.GetDirectoryName (staleCompiledClass);
-			if (staleGeneratedJavaDirectory is null || staleCopiedJavaDirectory is null || staleCompiledClassDirectory is null) {
+			if (staleGeneratedJavaDirectory is null || staleCompiledClassDirectory is null) {
 				throw new InvalidOperationException ("Could not determine stale Java output directories.");
 			}
 			Directory.CreateDirectory (staleGeneratedJavaDirectory);
-			Directory.CreateDirectory (staleCopiedJavaDirectory);
 			Directory.CreateDirectory (staleCompiledClassDirectory);
 			File.WriteAllText (staleGeneratedJava, "package crc64stale; public class Old {}");
-			File.WriteAllText (staleCopiedJava, "package crc64stale; public class Old {}");
 			File.WriteAllBytes (staleCompiledClass, []);
 
 			proj.MainActivity += Environment.NewLine + "// Force trimmable typemap regeneration.";
@@ -138,12 +134,11 @@ namespace Xamarin.Android.Build.Tests {
 			builder.Output.AssertTargetIsNotSkipped ("_CompileJava");
 
 			FileAssert.DoesNotExist (staleGeneratedJava, "Regenerated trimmable typemap should delete stale Java sources.");
-			FileAssert.DoesNotExist (staleCopiedJava, "Regenerated trimmable typemap should delete stale android/src Java copies.");
-			FileAssert.DoesNotExist (staleCompiledClass, "Deleting stale copied Java sources should force Java recompilation and remove stale class outputs.");
+			FileAssert.DoesNotExist (staleCompiledClass, "Deleting stale generated Java sources should force Java recompilation and remove stale class outputs.");
 		}
 
 		[Test]
-		public void Build_WithTrimmableTypeMap_CopiesUpdatedGeneratedJavaSources ()
+		public void Build_WithTrimmableTypeMap_RecompilesUpdatedGeneratedJavaSources ()
 		{
 			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: false)) {
 				return;
@@ -161,15 +156,12 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsNotEmpty (generatedJavaFiles, "Test setup should have generated trimmable typemap Java sources.");
 
 			var generatedJava = generatedJavaFiles [0];
-			var relativePath = Path.GetRelativePath (generatedJavaDirectory, generatedJava);
-			var copiedJava = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src", relativePath));
 			var typeMapStamp = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "_GenerateTrimmableTypeMap.stamp"));
 			var javaStubsStamp = builder.Output.GetIntermediaryPath (Path.Combine ("stamp", "_GenerateJavaStubs.stamp"));
-			FileAssert.Exists (copiedJava, "First build should have copied generated Java sources to android/src.");
 			FileAssert.Exists (typeMapStamp, "First build should have written the trimmable typemap output stamp.");
 			FileAssert.Exists (javaStubsStamp, "First build should have written the Java stubs output stamp.");
 
-			var updatedJava = File.ReadAllText (generatedJava) + "\n// Force generated Java copy regression.\n";
+			var updatedJava = File.ReadAllText (generatedJava) + "\n// Force generated Java recompilation regression.\n";
 			File.WriteAllText (generatedJava, updatedJava);
 			var stampTime = DateTime.UtcNow;
 			File.SetLastWriteTimeUtc (typeMapStamp, stampTime);
@@ -178,38 +170,40 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true), "Second build should have succeeded.");
 			builder.Output.AssertTargetIsNotSkipped ("_GenerateJavaStubs");
 			builder.Output.AssertTargetIsNotSkipped ("_CompileJava");
-			Assert.AreEqual (updatedJava, File.ReadAllText (copiedJava), "Updated generated Java sources should be copied to android/src even when typemap assemblies do not change.");
+			Assert.AreEqual (updatedJava, File.ReadAllText (generatedJava), "Updated generated Java sources should be compiled in place from the generator output directory even when typemap assemblies do not change.");
+
+			var relativePath = Path.GetRelativePath (generatedJavaDirectory, generatedJava);
+			var compiledClass = builder.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes", Path.ChangeExtension (relativePath, ".class")));
+			FileAssert.Exists (compiledClass, "Updated generated Java sources should be compiled in place into android/bin/classes.");
 		}
 
-		// The JCWs that actually get compiled and packaged are the ones copied into
-		// $(IntermediateOutputPath)android/src. For CoreCLR + PublishTrimmed those come from
-		// the post-trim `typemap/linked-java` directory, which `_GeneratePostTrimTrimmableTypeMapJavaSources`
-		// (re)generates from the linked assemblies. The incrementality contract is that
-		// android/src must always stay consistent with linked-java; if `_GenerateJavaStubs` is
-		// skipped while linked-java changed, android/src would be left stale.
-		static void AssertAndroidSrcMatchesLinkedJava (ProjectBuilder builder, string message)
+		// The JCWs that actually get compiled and packaged are the generated Java sources compiled
+		// in place from their output directory (no longer copied into $(IntermediateOutputPath)android/src).
+		// For CoreCLR + PublishTrimmed those come from the post-trim `typemap/linked-java` directory,
+		// which `_GeneratePostTrimTrimmableTypeMapJavaSources` (re)generates from the linked assemblies
+		// and `_CompileJava` compiles via the Javac AdditionalStubSourceDirectories parameter.
+		static void AssertLinkedJavaCompiledInPlace (ProjectBuilder builder, string message)
 		{
 			var linkedJavaDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "linked-java"));
 			DirectoryAssert.Exists (linkedJavaDirectory, $"{message}: post-trim linked-java directory should exist.");
-			var androidSrcDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src"));
-			DirectoryAssert.Exists (androidSrcDirectory, $"{message}: android/src directory should exist.");
 
 			var linkedJavaFiles = Directory.GetFiles (linkedJavaDirectory, "*.java", SearchOption.AllDirectories);
 			Assert.IsNotEmpty (linkedJavaFiles, $"{message}: post-trim build should have generated linked-java JCWs.");
 
+			var androidSrcDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src"));
+			var classesDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes"));
 			foreach (var linkedJava in linkedJavaFiles) {
 				var relativePath = Path.GetRelativePath (linkedJavaDirectory, linkedJava);
 				var copiedJava = Path.Combine (androidSrcDirectory, relativePath);
-				FileAssert.Exists (copiedJava, $"{message}: linked-java JCW '{relativePath}' should be copied to android/src.");
-				Assert.AreEqual (
-					File.ReadAllText (linkedJava),
-					File.ReadAllText (copiedJava),
-					$"{message}: android/src copy of '{relativePath}' should match the post-trim linked-java source.");
+				FileAssert.DoesNotExist (copiedJava, $"{message}: linked-java JCW '{relativePath}' should be compiled in place, not copied to android/src.");
+
+				var compiledClass = Path.Combine (classesDirectory, Path.ChangeExtension (relativePath, ".class"));
+				FileAssert.Exists (compiledClass, $"{message}: linked-java JCW '{relativePath}' should be compiled in place into android/bin/classes.");
 			}
 		}
 
 		[Test]
-		public void Build_WithTrimmableTypeMap_PublishTrimmed_KeepsAndroidSrcConsistentWithLinkedJava ()
+		public void Build_WithTrimmableTypeMap_PublishTrimmed_CompilesLinkedJavaInPlace ()
 		{
 			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {
 				return;
@@ -223,16 +217,16 @@ namespace Xamarin.Android.Build.Tests {
 
 			using var builder = CreateApkBuilder ();
 			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
-			AssertAndroidSrcMatchesLinkedJava (builder, "After first build");
+			AssertLinkedJavaCompiledInPlace (builder, "After first build");
 
-			// A no-op rebuild must not leave android/src out of sync with linked-java, even though
+			// A no-op rebuild must not start copying linked-java into android/src, even though
 			// the post-trim Java generation may run again.
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "No-op rebuild should have succeeded.");
-			AssertAndroidSrcMatchesLinkedJava (builder, "After no-op rebuild");
+			AssertLinkedJavaCompiledInPlace (builder, "After no-op rebuild");
 		}
 
 		[Test]
-		public void Build_WithTrimmableTypeMap_PublishTrimmed_DeletesStaleAndroidSrcWhenLinkedJavaShrinks ()
+		public void Build_WithTrimmableTypeMap_PublishTrimmed_DeletesStaleLinkedJavaWhenLinkedJavaShrinks ()
 		{
 			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {
 				return;
@@ -248,30 +242,26 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
 
 			// Simulate a JCW the post-trim pass produced on a previous build but no longer
-			// produces (e.g. its type was trimmed away). It lives in both the post-trim
-			// `linked-java` source directory and its android/src copy, with a compiled .class.
+			// produces (e.g. its type was trimmed away). It lives in the post-trim
+			// `linked-java` source directory (compiled in place), with a compiled .class.
 			var staleRelativePath = Path.Combine ("crc64stale", "Old.java");
 			var staleClassPath = Path.Combine ("crc64stale", "Old.class");
 			var staleLinkedJava = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "linked-java", staleRelativePath));
-			var staleCopiedJava = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src", staleRelativePath));
 			var staleCompiledClass = builder.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes", staleClassPath));
 			var staleLinkedJavaDirectory = Path.GetDirectoryName (staleLinkedJava);
-			var staleCopiedJavaDirectory = Path.GetDirectoryName (staleCopiedJava);
 			var staleCompiledClassDirectory = Path.GetDirectoryName (staleCompiledClass);
-			if (staleLinkedJavaDirectory is null || staleCopiedJavaDirectory is null || staleCompiledClassDirectory is null) {
+			if (staleLinkedJavaDirectory is null || staleCompiledClassDirectory is null) {
 				throw new InvalidOperationException ("Could not determine stale Java output directories.");
 			}
 			Directory.CreateDirectory (staleLinkedJavaDirectory);
-			Directory.CreateDirectory (staleCopiedJavaDirectory);
 			Directory.CreateDirectory (staleCompiledClassDirectory);
 			File.WriteAllText (staleLinkedJava, "package crc64stale; public class Old {}");
-			File.WriteAllText (staleCopiedJava, "package crc64stale; public class Old {}");
 			File.WriteAllBytes (staleCompiledClass, []);
 
 			// Force the post-trim Java generation to re-run by removing its stamp (without a source
 			// change, which would trigger an unrelated incremental CrossGen rebuild). It wipes and
-			// regenerates linked-java (dropping the stale JCW), so android/src must drop its stale
-			// copy too.
+			// regenerates linked-java (dropping the stale JCW); the JCWs are compiled in place, so
+			// busting the compile stamp must drop the stale .class too.
 			var postTrimStamp = builder.Output.GetIntermediaryPath (Path.Combine ("stamp", "_GeneratePostTrimTrimmableTypeMapJavaSources.stamp"));
 			FileAssert.Exists (postTrimStamp, "First build should have written the post-trim Java stamp.");
 			File.Delete (postTrimStamp);
@@ -281,8 +271,7 @@ namespace Xamarin.Android.Build.Tests {
 			builder.Output.AssertTargetIsNotSkipped ("_CompileJava");
 
 			FileAssert.DoesNotExist (staleLinkedJava, "Post-trim regeneration should drop the stale linked-java JCW.");
-			FileAssert.DoesNotExist (staleCopiedJava, "Regenerated post-trim JCWs should delete the stale android/src copy that is no longer produced.");
-			FileAssert.DoesNotExist (staleCompiledClass, "Deleting the stale android/src copy should force Java recompilation and remove the stale class output.");
+			FileAssert.DoesNotExist (staleCompiledClass, "Dropping the stale linked-java JCW should force Java recompilation and remove the stale class output.");
 		}
 
 		[Test]
@@ -301,10 +290,10 @@ namespace Xamarin.Android.Build.Tests {
 			using var builder = CreateApkBuilder ();
 			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
 
-			// A no-op rebuild should not regenerate the post-trim JCWs or recopy them. If
+			// A no-op rebuild should not regenerate the post-trim JCWs or recompile them. If
 			// _GeneratePostTrimTrimmableTypeMapJavaSources runs on every build, the JCWs that feed
 			// _GenerateJavaStubs are rewritten each time, which both wastes work and means
-			// _GenerateJavaStubs must re-run to stay consistent (otherwise android/src goes stale).
+			// _GenerateJavaStubs must re-run to stay consistent (otherwise the compiled JCWs go stale).
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "No-op rebuild should have succeeded.");
 			builder.Output.AssertTargetIsSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
 			builder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
@@ -559,7 +548,7 @@ namespace Xamarin.Android.Build.Tests {
 			var typeMapDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("android-arm64", "typemap"));
 			var linkedAssemblyDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("android-arm64", "linked"));
 			var readyToRunAssemblyDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("android-arm64", "R2R"));
-			var javaSourceDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("android-arm64", "android", "src"));
+			var javaSourceDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("android-arm64", "typemap", "linked-java"));
 			var dexFile = builder.Output.GetIntermediaryPath (Path.Combine ("android-arm64", "android", "bin", "classes.dex"));
 			var acwMapPath = builder.Output.GetIntermediaryPath (Path.Combine ("android-arm64", "acw-map.txt"));
 			var proguardPrimaryPath = builder.Output.GetIntermediaryPath (Path.Combine ("android-arm64", "proguard", "proguard_project_primary.cfg"));
@@ -904,7 +893,7 @@ namespace UnnamedProject {
 				"Post-trim Java source generation should keep the app activity JCW.");
 			FileAssert.DoesNotExist (
 				Path.Combine (javaSourceDirectory, "mono", "android", "animation", "Animator_AnimatorListenerImplementor.java"),
-				"Post-trim Java source generation should not copy framework listener implementors removed by ILLink.");
+				"Post-trim Java source generation should not generate framework listener implementors removed by ILLink.");
 
 			FileAssert.Exists (acwMapPath, "Post-trim scan should rewrite acw-map.txt for R8.");
 			var acwMap = File.ReadAllText (acwMapPath);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1925,6 +1925,10 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_FindJavaStubFiles" DependsOnTargets="_GenerateJavaStubs;_ManifestMerger;_ConvertCustomView;$(_AfterConvertCustomView);_GenerateEnvironmentFiles;">
   <ItemGroup>
     <_JavaStubFiles Include="$(_AndroidIntermediateJavaSourceDirectory)**\*.java" />
+    <!-- Additional Java source directories compiled in place (e.g. the trimmable type map's
+         generated Java Callable Wrappers, which are no longer copied into android/src). Track
+         their *.java as _CompileJava inputs so edits/additions/removals trigger recompilation. -->
+    <_JavaStubFiles Include="@(_AdditionalJavaStubDirectory->'%(Identity)**\*.java')" />
     <FileWrites Include="@(_JavaStubFiles)" />
   </ItemGroup>
 </Target>


### PR DESCRIPTION
## Goal

Stop copying every generated Java Callable Wrapper into `android/src` on the trimmable type map path; compile them **in place** from the generator's output directory instead.

Based on `main`. Applies to the trimmable type map generally (CoreCLR and NativeAOT).

## Background

On the trimmable path, `_GenerateTrimmableTypeMap` writes the JCW `.java` into `obj/.../typemap/java`, and `_GenerateJavaStubs` then copied **every** file into `obj/.../android/src` before `_CompileJava`. A binlog of `samples/NativeAOT` (arm64, Release) showed ~324 files copied (68 batched `Copy` invocations) dominating the `_GenerateJavaStubs` window — pure file I/O for files that were just generated.

## Change

Compile the JCWs directly from their output directory:

- **`Javac` task** (`JavaCompileToolTask`): add `AdditionalStubSourceDirectories`. Each directory is globbed for `*.java` and compiled alongside `StubSourceDirectory`. javac globs the directory *at compile time*, so this is robust to incremental builds where `_GenerateJavaStubs` is skipped (the files persist on disk) — the same model as the existing `android/src` glob.
- **`_FindJavaStubFiles`**: also glob `@(_AdditionalJavaStubDirectory)` into `@(_JavaStubFiles)` so JCW edits/additions/removals remain `_CompileJava` inputs (incrementality).
- **Trimmable targets**: register the generator's Java output dir (`_TypeMapJavaStubsSourceDirectory`) as `@(_AdditionalJavaStubDirectory)` in a **static** `ItemGroup` (visible even when `_GenerateJavaStubs` is skipped); drop the `Copy` and the `android/src` `FileWrites`; and bust the Java compile stamp on `@(_DeletedJavaFiles)` so a removed type still forces recompilation.

The generator already manages its own output directory (writes changed files, deletes stale ones) and `_CompileJava` fully cleans its class output each run, so removing the copy leaves no stale `.java`/`.class` behind.

## Validation

`samples/NativeAOT` (arm64, Release), trimmable type map:

- Clean build: JCWs are no longer copied into `android/src` (`android/src/mono/android` → **0** files; 323 compiled in place from `typemap/java`).
- **`classes.dex` is byte-identical** to a build with the copy (same SHA) — output-equivalent.
- Incremental no-op build stays incremental (`_CompileJava` / `_GenerateJavaStubs` skipped; ~12s vs ~34s clean).

CoreCLR + `PublishTrimmed` (post-trim `linked-java` path) exercises the same code and is deferred to CI in the full matrix.

---

Draft until CI confirms the full matrix (device tests + CoreCLR trimmable + baselines).
