### PR TITLE
[runtime] Set CoreCLR crash report directory on Android

### DIFF
--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -316,11 +316,13 @@ void Host::Java_mono_android_Runtime_initInternal (
 	jstring_array_wrapper applicationDirs (env, appDirs);
 	jstring_wrapper language (env, lang);
 	jstring_wrapper &files_dir = applicationDirs[Constants::APP_DIRS_FILES_DIR_INDEX];
+	jstring_wrapper &cache_dir = applicationDirs[Constants::APP_DIRS_CACHE_DIR_INDEX];
 	HostEnvironment::setup_environment (
 		language,
 		files_dir,
-		applicationDirs[Constants::APP_DIRS_CACHE_DIR_INDEX]
+		cache_dir
 	);
+	HostEnvironment::set_variable_if_unset ("DOTNET_CrashReportRootPath"sv, cache_dir);
 
 	java_TimeZone = RuntimeUtil::get_class_from_runtime_field (env, runtimeClass, "java_util_TimeZone"sv, true);
 

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -39,6 +39,12 @@ namespace xamarin::android {
 		}
 
 		[[gnu::flatten, gnu::always_inline]]
+		static void set_variable_if_unset (std::string_view const& name, jstring_wrapper &value) noexcept
+		{
+			Util::set_environment_variable_if_unset (name, value);
+		}
+
+		[[gnu::flatten, gnu::always_inline]]
 		static void set_system_property (const char *name, const char *value) noexcept
 		{
 			// TODO: should we **actually** try to set the system property here? Would that even work? Needs testing

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -161,6 +161,15 @@ namespace xamarin::android {
 		}
 
 		[[gnu::flatten, gnu::always_inline]]
+		static void set_environment_variable_if_unset (std::string_view const& name, jstring_wrapper& value) noexcept
+		{
+			log_debug (LOG_DEFAULT, "Setting environment variable {} = '{}' if unset", name, value.get_string_view ());
+			if (::setenv (name.data (), value.get_cstr (), 0) < 0) {
+				log_warn (LOG_DEFAULT, "Failed to set environment variable '{}': {}", name, ::strerror (errno));
+			}
+		}
+
+		[[gnu::flatten, gnu::always_inline]]
 		static void set_environment_variable (std::string_view const& name, jstring_wrapper& value) noexcept
 		{
 			set_environment_variable (name.data (), value.get_cstr ());

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Xml.Linq;
@@ -2125,6 +2126,68 @@ MONO_GC_PARAMS=bridge-implementation=new",
 						"The Environment variable \"DOTNET_MODIFIABLE_ASSEMBLIES\" was not set."
 				);
 			}
+		}
+
+		[Test]
+		public void CoreClrCrashReportUsesCacheDirectory ([Values] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				ProjectName = nameof (CoreClrCrashReportUsesCacheDirectory),
+				RootNamespace = nameof (CoreClrCrashReportUsesCacheDirectory),
+				IsRelease = isRelease,
+				EnableDefaultItems = true,
+				OtherBuildItems = {
+					new BuildItem ("AndroidEnvironment", "env.txt") {
+						TextContent = () => "DOTNET_EnableCrashReport=1",
+					},
+				},
+			};
+			if (isRelease) {
+				// Release apps only need to be debuggable here so that run-as can retrieve the crash report.
+				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
+				proj.SetRuntimeIdentifiers (new [] { DeviceAbi });
+			}
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", """
+		var crashReportRootPath = Environment.GetEnvironmentVariable ("DOTNET_CrashReportRootPath");
+		var crashReportDirectory = crashReportRootPath == null
+			? null
+			: System.IO.Path.Combine (crashReportRootPath, ".dotnet", "crash-reports");
+		Console.WriteLine ("DOTNET_CrashReportRootPath=" + crashReportRootPath);
+		Console.WriteLine ("CacheDir=" + CacheDir.AbsolutePath);
+		Console.WriteLine ("CrashReportDirectory=" + crashReportDirectory);
+		Console.WriteLine ("#CRASH-REPORT-ROOT-PATH-VALID#" +
+			(crashReportRootPath == CacheDir.AbsolutePath && System.IO.Directory.Exists (crashReportDirectory)));
+		Console.WriteLine ("#CRASH-REPORT-FAILFAST#");
+		Console.Out.Flush ();
+		Environment.FailFast ("MSBuildDeviceIntegration crash report test");
+		""");
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Install (proj), "App should have installed.");
+			RunAdbCommand ($"shell run-as {proj.PackageName} rm -rf cache/.dotnet");
+			RunProjectAndAssert (proj, builder);
+
+			const string reportDirectory = "cache/.dotnet/crash-reports";
+			string crashReportPath = "";
+			WaitFor (
+				TimeSpan.FromSeconds (ActivityStartTimeoutInSeconds),
+				() => {
+					var output = RunAdbCommand ($"shell run-as {proj.PackageName} find {reportDirectory} -type f -name '*.crashreport.json'").Trim ();
+					crashReportPath = output
+						.Split (new [] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+						.FirstOrDefault (path => path.EndsWith (".crashreport.json", StringComparison.Ordinal));
+					return !string.IsNullOrEmpty (crashReportPath);
+				},
+				intervalInMS: 1000
+			);
+			Assert.IsNotEmpty (crashReportPath, $"CoreCLR did not create a crash report in {reportDirectory}.");
+
+			var crashReportJson = RunAdbCommand ($"exec-out run-as {proj.PackageName} cat {crashReportPath}");
+			var localCrashReport = Path.Combine (Root, builder.ProjectDirectory, "crashreport.json");
+			File.WriteAllText (localCrashReport, crashReportJson);
+			TestContext.AddTestAttachment (localCrashReport);
+
+			using var crashReport = JsonDocument.Parse (File.ReadAllText (localCrashReport));
+			Assert.AreEqual (JsonValueKind.Object, crashReport.RootElement.ValueKind, "CoreCLR crash report should contain a JSON object.");
 		}
 
 		[Test]


### PR DESCRIPTION
## Summary

- initialize `DOTNET_CrashReportRootPath` from Android's app-private cache directory before CoreCLR starts
- preserve an existing value while allowing packaged `AndroidEnvironment` settings to override the default
- add Debug and Release device coverage that triggers `Environment.FailFast()`, retrieves the generated report, and validates it as JSON

## Context

This follows the corresponding macOS/iOS work:

- [dotnet/macios#25820](https://github.com/dotnet/macios/issues/25820)
- [dotnet/macios#25823](https://github.com/dotnet/macios/pull/25823)

CoreCLR manages reports beneath `<DOTNET_CrashReportRootPath>/.dotnet/crash-reports` in [`InProcCrashReportLifecycle`](https://github.com/dotnet/runtime/blob/e5fc9669cc6a67694d46987c753cc13d995b2623/src/coreclr/debug/crashreport/inproccrashreportlifecycle.cpp), introduced by [dotnet/runtime#128738](https://github.com/dotnet/runtime/pull/128738).

## Testing

Not run locally because this worktree does not contain a built local Android SDK and `adb` is unavailable. The added `MSBuildDeviceIntegration` test exercises the generated crash report end to end on-device.