### PR TITLE
[coreclr] Add crash report build property

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1571,6 +1571,15 @@ MSBuild property also controls what
 will be embedded into the `.apk` or `.aab`, which can impact deployment and
 rebuild times.
 
+## EnableCrashReport
+
+A boolean property that sets the `DOTNET_EnableCrashReport` environment
+variable to `1` when using the CoreCLR runtime. This enables crash report
+generation at application startup.
+
+This property is `False` by default and is ignored when `$(UseMonoRuntime)`
+is `True`.
+
 ## EnableDiagnostics
 
 Synonym for the [`$(AndroidEnableProfiler)`](#androidenableprofiler)

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1574,8 +1574,8 @@ rebuild times.
 ## EnableCrashReport
 
 A boolean property that sets the `DOTNET_EnableCrashReport` environment
-variable to `1` when using the CoreCLR runtime. This enables crash report
-generation at application startup.
+variable to `1` when using the CoreCLR or NativeAOT runtime. This enables
+crash report generation at application startup.
 
 This property is `False` by default and is ignored when `$(UseMonoRuntime)`
 is `True`.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1602,27 +1602,28 @@ namespace UnnamedProject
 			var ret = new List<object[]> ();
 
 			foreach (AndroidRuntime runtime in new[] { AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT }) {
-				AddTestData (true, "LowercaseMD5", "", runtime);
-				AddTestData (true, "LowercaseCrc64", "", runtime);
-				AddTestData (false, "", "127.0.0.1:9000,suspend,connect", runtime);
+				AddTestData (true, "LowercaseMD5", "", runtime, true);
+				AddTestData (true, "LowercaseCrc64", "", runtime, false);
+				AddTestData (false, "", "127.0.0.1:9000,suspend,connect", runtime, false);
 			}
 
 			return ret;
 
-			void AddTestData (bool useInterpreter, string packageNamingPolicy, string diagnosticConfiguration, AndroidRuntime runtime)
+			void AddTestData (bool useInterpreter, string packageNamingPolicy, string diagnosticConfiguration, AndroidRuntime runtime, bool enableCrashReport)
 			{
 				ret.Add (new object[] {
 					useInterpreter,
 					packageNamingPolicy,
 					diagnosticConfiguration,
-					runtime
+					runtime,
+					enableCrashReport,
 				});
 			}
 		}
 
 		[Test]
 		[TestCaseSource (nameof (Get_EnvironmentVariablesData))]
-		public void EnvironmentVariables (bool useInterpreter, string packageNamingPolicy, string diagnosticConfiguration, AndroidRuntime runtime)
+		public void EnvironmentVariables (bool useInterpreter, string packageNamingPolicy, string diagnosticConfiguration, AndroidRuntime runtime, bool enableCrashReport)
 		{
 			// NativeAOT supports neither the interpreter nor debug builds, but what we test here is
 			// environment file creation and contents, and that's relevant to NativeAOT too
@@ -1650,6 +1651,7 @@ namespace UnnamedProject
 			};
 			proj.SetRuntime (runtime);
 			proj.SetProperty ("UseInterpreter", useInterpreter.ToString ());
+			proj.SetProperty ("EnableCrashReport", enableCrashReport.ToString ());
 			if (!string.IsNullOrEmpty (packageNamingPolicy))
 				proj.SetProperty ("AndroidPackageNamingPolicy", packageNamingPolicy);
 			if (!string.IsNullOrEmpty (diagnosticConfiguration))
@@ -1665,6 +1667,8 @@ namespace UnnamedProject
 					values.Add ("DOTNET_MODIFIABLE_ASSEMBLIES=Debug");
 				if (!string.IsNullOrEmpty (diagnosticConfiguration))
 					values.Add ($"DOTNET_DiagnosticPorts={diagnosticConfiguration}");
+				if (enableCrashReport)
+					values.Add ("DOTNET_EnableCrashReport=1");
 				Assert.AreEqual (string.Join (Environment.NewLine, values), File.ReadAllText (environment).Trim ());
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1602,7 +1602,7 @@ namespace UnnamedProject
 			var ret = new List<object[]> ();
 
 			foreach (AndroidRuntime runtime in new[] { AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT }) {
-				AddTestData (true, "LowercaseMD5", "", runtime, true);
+				AddTestData (true, "LowercaseMD5", "", runtime, runtime == AndroidRuntime.CoreCLR);
 				AddTestData (true, "LowercaseCrc64", "", runtime, false);
 				AddTestData (false, "", "127.0.0.1:9000,suspend,connect", runtime, false);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1650,6 +1650,7 @@ because xbuild doesn't support framework reference assemblies.
     <_GeneratedAndroidEnvironment Include="mono.enable_assembly_preload=0" Condition=" '$(AndroidEnablePreloadAssemblies)' != 'True' " />
     <_GeneratedAndroidEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES=Debug" Condition=" '$(AndroidIncludeDebugSymbols)' == 'true' and '$(AndroidUseInterpreter)' == 'true' " />
     <_GeneratedAndroidEnvironment Include="DOTNET_DiagnosticPorts=$(DiagnosticConfiguration)" Condition=" '$(DiagnosticConfiguration)' != '' " />
+    <_GeneratedAndroidEnvironment Include="DOTNET_EnableCrashReport=1" Condition=" '$(EnableCrashReport)' == 'true' and '$(UseMonoRuntime)' != 'true' " />
     <!-- RuntimeEnvironmentVariable items come from 'dotnet run -e NAME=VALUE' -->
     <_GeneratedAndroidEnvironment Include="@(RuntimeEnvironmentVariable->'%(Identity)=%(Value)')" />
   </ItemGroup>


### PR DESCRIPTION
Add an `EnableCrashReport` MSBuild property that writes `DOTNET_EnableCrashReport=1` into the generated Android environment file for CoreCLR and NativeAOT applications. This allows crash reporting to be enabled before runtime startup.

Extend the environment-file tests to cover enabled and disabled values for CoreCLR, and document the property.

Android side of: dotnet/macios#26130

Tests were not run because the local .NET for Android SDK is not built in this worktree.