### PR TITLE
[NativeAOT] Use POSIX primitives for GC bridge processing

### DIFF
--- a/src/native/clr/host/gc-bridge.cc
+++ b/src/native/clr/host/gc-bridge.cc
@@ -11,44 +11,39 @@
 
 using namespace xamarin::android;
 
-namespace {
-	sem_t shared_args_semaphore {};
-	MarkCrossReferencesArgs *shared_args = nullptr;
+void GCBridge::initialize_shared_args_semaphore () noexcept
+{
+	int ret = sem_init (&shared_args_semaphore, 0, 0);
+	abort_unless (ret == 0, "Failed to initialize GC bridge semaphore");
+}
 
-	void initialize_shared_args_semaphore () noexcept
-	{
-		int ret = sem_init (&shared_args_semaphore, 0, 0);
-		abort_unless (ret == 0, "Failed to initialize GC bridge semaphore");
-	}
+void GCBridge::start_bridge_processing_thread () noexcept
+{
+	pthread_t thread {};
+	int ret = pthread_create (&thread, nullptr, bridge_processing_thread_entry, nullptr);
+	abort_unless (ret == 0, "Failed to create GC bridge processing thread");
 
-	void start_bridge_processing_thread (void *(*thread_entry)(void*)) noexcept
-	{
-		pthread_t thread {};
-		int ret = pthread_create (&thread, nullptr, thread_entry, nullptr);
-		abort_unless (ret == 0, "Failed to create GC bridge processing thread");
+	ret = pthread_detach (thread);
+	abort_unless (ret == 0, "Failed to detach GC bridge processing thread");
+}
 
-		ret = pthread_detach (thread);
-		abort_unless (ret == 0, "Failed to detach GC bridge processing thread");
-	}
+void GCBridge::publish_shared_args (MarkCrossReferencesArgs *args) noexcept
+{
+	__atomic_store_n (&shared_args, args, __ATOMIC_RELEASE);
 
-	void publish_shared_args (MarkCrossReferencesArgs *args) noexcept
-	{
-		__atomic_store_n (&shared_args, args, __ATOMIC_RELEASE);
+	int ret = sem_post (&shared_args_semaphore);
+	abort_unless (ret == 0, "Failed to release GC bridge semaphore");
+}
 
-		int ret = sem_post (&shared_args_semaphore);
-		abort_unless (ret == 0, "Failed to release GC bridge semaphore");
-	}
+auto GCBridge::wait_for_shared_args () noexcept -> MarkCrossReferencesArgs*
+{
+	int ret;
+	do {
+		ret = sem_wait (&shared_args_semaphore);
+	} while (ret == -1 && errno == EINTR);
+	abort_unless (ret == 0, "Failed to acquire GC bridge semaphore");
 
-	auto wait_for_shared_args () noexcept -> MarkCrossReferencesArgs*
-	{
-		int ret;
-		do {
-			ret = sem_wait (&shared_args_semaphore);
-		} while (ret == -1 && errno == EINTR);
-		abort_unless (ret == 0, "Failed to acquire GC bridge semaphore");
-
-		return __atomic_load_n (&shared_args, __ATOMIC_ACQUIRE);
-	}
+	return __atomic_load_n (&shared_args, __ATOMIC_ACQUIRE);
 }
 
 void GCBridge::initialize_on_onload (JNIEnv *env) noexcept
@@ -91,7 +86,7 @@ BridgeProcessingFtn GCBridge::initialize_callback (
 	bridge_processing_finished_callback = bridge_processing_finished;
 
 	initialize_shared_args_semaphore ();
-	start_bridge_processing_thread (bridge_processing_thread_entry);
+	start_bridge_processing_thread ();
 
 	return mark_cross_references;
 }

--- a/src/native/clr/host/gc-bridge.cc
+++ b/src/native/clr/host/gc-bridge.cc
@@ -73,24 +73,6 @@ void GCBridge::initialize_on_runtime_init (JNIEnv *env, jclass runtimeClass) noe
 	BridgeProcessing::initialize_on_runtime_init (env, runtimeClass);
 }
 
-BridgeProcessingFtn GCBridge::initialize_callback (
-	BridgeProcessingStartedFtn bridge_processing_started,
-	BridgeProcessingFinishedFtn bridge_processing_finished) noexcept
-{
-	abort_if_invalid_pointer_argument (bridge_processing_started, "bridge_processing_started");
-	abort_if_invalid_pointer_argument (bridge_processing_finished, "bridge_processing_finished");
-	abort_unless (bridge_processing_started_callback == nullptr, "GC bridge processing started callback is already set");
-	abort_unless (bridge_processing_finished_callback == nullptr, "GC bridge processing finished callback is already set");
-
-	bridge_processing_started_callback = bridge_processing_started;
-	bridge_processing_finished_callback = bridge_processing_finished;
-
-	initialize_shared_args_semaphore ();
-	start_bridge_processing_thread ();
-
-	return mark_cross_references;
-}
-
 void GCBridge::trigger_java_gc (JNIEnv *env) noexcept
 {
 	abort_if_invalid_pointer_argument (env, "env");

--- a/src/native/clr/host/gc-bridge.cc
+++ b/src/native/clr/host/gc-bridge.cc
@@ -1,3 +1,5 @@
+#include <cerrno>
+
 #include <host/gc-bridge.hh>
 #include <host/bridge-processing.hh>
 #include <host/os-bridge.hh>
@@ -55,8 +57,9 @@ void GCBridge::mark_cross_references (MarkCrossReferencesArgs *args) noexcept
 	abort_unless (args->CrossReferences != nullptr || args->CrossReferenceCount == 0, "CrossReferences must not be null if CrossReferenceCount is greater than 0");
 	log_mark_cross_references_args_if_enabled (args);
 
-	shared_args.store (args);
-	shared_args_semaphore.release ();
+	__atomic_store_n (&shared_args, args, __ATOMIC_RELEASE);
+	int ret = sem_post (&shared_args_semaphore);
+	abort_unless (ret == 0, "Failed to release GC bridge semaphore");
 }
 
 void GCBridge::bridge_processing () noexcept
@@ -66,8 +69,13 @@ void GCBridge::bridge_processing () noexcept
 
 	while (true) {
 		// wait until mark cross references args are set by the GC callback
-		shared_args_semaphore.acquire ();
-		MarkCrossReferencesArgs *args = shared_args.load ();
+		int ret;
+		do {
+			ret = sem_wait (&shared_args_semaphore);
+		} while (ret == -1 && errno == EINTR);
+		abort_unless (ret == 0, "Failed to acquire GC bridge semaphore");
+
+		MarkCrossReferencesArgs *args = __atomic_load_n (&shared_args, __ATOMIC_ACQUIRE);
 
 		bridge_processing_started_callback (args);
 
@@ -76,6 +84,12 @@ void GCBridge::bridge_processing () noexcept
 
 		bridge_processing_finished_callback (args);
 	}
+}
+
+auto GCBridge::bridge_processing_thread_entry ([[maybe_unused]] void *arg) noexcept -> void*
+{
+	bridge_processing ();
+	return nullptr;
 }
 
 [[gnu::always_inline]]

--- a/src/native/clr/host/gc-bridge.cc
+++ b/src/native/clr/host/gc-bridge.cc
@@ -1,4 +1,6 @@
 #include <cerrno>
+#include <pthread.h>
+#include <semaphore.h>
 
 #include <host/gc-bridge.hh>
 #include <host/bridge-processing.hh>
@@ -8,6 +10,46 @@
 #include <shared/helpers.hh>
 
 using namespace xamarin::android;
+
+namespace {
+	sem_t shared_args_semaphore {};
+	MarkCrossReferencesArgs *shared_args = nullptr;
+
+	void initialize_shared_args_semaphore () noexcept
+	{
+		int ret = sem_init (&shared_args_semaphore, 0, 0);
+		abort_unless (ret == 0, "Failed to initialize GC bridge semaphore");
+	}
+
+	void start_bridge_processing_thread (void *(*thread_entry)(void*)) noexcept
+	{
+		pthread_t thread {};
+		int ret = pthread_create (&thread, nullptr, thread_entry, nullptr);
+		abort_unless (ret == 0, "Failed to create GC bridge processing thread");
+
+		ret = pthread_detach (thread);
+		abort_unless (ret == 0, "Failed to detach GC bridge processing thread");
+	}
+
+	void publish_shared_args (MarkCrossReferencesArgs *args) noexcept
+	{
+		__atomic_store_n (&shared_args, args, __ATOMIC_RELEASE);
+
+		int ret = sem_post (&shared_args_semaphore);
+		abort_unless (ret == 0, "Failed to release GC bridge semaphore");
+	}
+
+	auto wait_for_shared_args () noexcept -> MarkCrossReferencesArgs*
+	{
+		int ret;
+		do {
+			ret = sem_wait (&shared_args_semaphore);
+		} while (ret == -1 && errno == EINTR);
+		abort_unless (ret == 0, "Failed to acquire GC bridge semaphore");
+
+		return __atomic_load_n (&shared_args, __ATOMIC_ACQUIRE);
+	}
+}
 
 void GCBridge::initialize_on_onload (JNIEnv *env) noexcept
 {
@@ -36,6 +78,24 @@ void GCBridge::initialize_on_runtime_init (JNIEnv *env, jclass runtimeClass) noe
 	BridgeProcessing::initialize_on_runtime_init (env, runtimeClass);
 }
 
+BridgeProcessingFtn GCBridge::initialize_callback (
+	BridgeProcessingStartedFtn bridge_processing_started,
+	BridgeProcessingFinishedFtn bridge_processing_finished) noexcept
+{
+	abort_if_invalid_pointer_argument (bridge_processing_started, "bridge_processing_started");
+	abort_if_invalid_pointer_argument (bridge_processing_finished, "bridge_processing_finished");
+	abort_unless (bridge_processing_started_callback == nullptr, "GC bridge processing started callback is already set");
+	abort_unless (bridge_processing_finished_callback == nullptr, "GC bridge processing finished callback is already set");
+
+	bridge_processing_started_callback = bridge_processing_started;
+	bridge_processing_finished_callback = bridge_processing_finished;
+
+	initialize_shared_args_semaphore ();
+	start_bridge_processing_thread (bridge_processing_thread_entry);
+
+	return mark_cross_references;
+}
+
 void GCBridge::trigger_java_gc (JNIEnv *env) noexcept
 {
 	abort_if_invalid_pointer_argument (env, "env");
@@ -57,9 +117,7 @@ void GCBridge::mark_cross_references (MarkCrossReferencesArgs *args) noexcept
 	abort_unless (args->CrossReferences != nullptr || args->CrossReferenceCount == 0, "CrossReferences must not be null if CrossReferenceCount is greater than 0");
 	log_mark_cross_references_args_if_enabled (args);
 
-	__atomic_store_n (&shared_args, args, __ATOMIC_RELEASE);
-	int ret = sem_post (&shared_args_semaphore);
-	abort_unless (ret == 0, "Failed to release GC bridge semaphore");
+	publish_shared_args (args);
 }
 
 void GCBridge::bridge_processing () noexcept
@@ -69,13 +127,7 @@ void GCBridge::bridge_processing () noexcept
 
 	while (true) {
 		// wait until mark cross references args are set by the GC callback
-		int ret;
-		do {
-			ret = sem_wait (&shared_args_semaphore);
-		} while (ret == -1 && errno == EINTR);
-		abort_unless (ret == 0, "Failed to acquire GC bridge semaphore");
-
-		MarkCrossReferencesArgs *args = __atomic_load_n (&shared_args, __ATOMIC_ACQUIRE);
+		MarkCrossReferencesArgs *args = wait_for_shared_args ();
 
 		bridge_processing_started_callback (args);
 

--- a/src/native/clr/include/host/gc-bridge.hh
+++ b/src/native/clr/include/host/gc-bridge.hh
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <atomic>
+#include <pthread.h>
+#include <semaphore.h>
+
 #include <jni.h>
-#include <thread>
-#include <semaphore>
-#include <shared_mutex>
-#include <unordered_map>
 
 #include <shared/cpp-util.hh>
 
@@ -72,8 +70,14 @@ namespace xamarin::android {
 			GCBridge::bridge_processing_started_callback = bridge_processing_started;
 			GCBridge::bridge_processing_finished_callback = bridge_processing_finished;
 
-			bridge_processing_thread = std::thread { GCBridge::bridge_processing };
-			bridge_processing_thread.detach ();
+			int ret = sem_init (&shared_args_semaphore, 0, 0);
+			abort_unless (ret == 0, "Failed to initialize GC bridge semaphore");
+
+			ret = pthread_create (&bridge_processing_thread, nullptr, GCBridge::bridge_processing_thread_entry, nullptr);
+			abort_unless (ret == 0, "Failed to create GC bridge processing thread");
+
+			ret = pthread_detach (bridge_processing_thread);
+			abort_unless (ret == 0, "Failed to detach GC bridge processing thread");
 
 			return mark_cross_references;
 		}
@@ -81,10 +85,9 @@ namespace xamarin::android {
 		static void trigger_java_gc (JNIEnv *env) noexcept;
 
 	private:
-		static inline std::thread bridge_processing_thread {};
-
-		static inline std::binary_semaphore shared_args_semaphore{0};
-		static inline std::atomic<MarkCrossReferencesArgs*> shared_args;
+		static inline pthread_t bridge_processing_thread {};
+		static inline sem_t shared_args_semaphore {};
+		static inline MarkCrossReferencesArgs *shared_args = nullptr;
 
 		static inline jobject Runtime_instance = nullptr;
 		static inline jmethodID Runtime_gc = nullptr;
@@ -93,6 +96,7 @@ namespace xamarin::android {
 		static inline BridgeProcessingFinishedFtn bridge_processing_finished_callback = nullptr;
 
 		static void bridge_processing () noexcept;
+		static auto bridge_processing_thread_entry (void *arg) noexcept -> void*;
 		static void mark_cross_references (MarkCrossReferencesArgs *args) noexcept;
 		
 		static void log_mark_cross_references_args_if_enabled (MarkCrossReferencesArgs *args) noexcept;

--- a/src/native/clr/include/host/gc-bridge.hh
+++ b/src/native/clr/include/host/gc-bridge.hh
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <pthread.h>
-#include <semaphore.h>
-
 #include <jni.h>
 
 #include <shared/cpp-util.hh>
@@ -60,35 +57,11 @@ namespace xamarin::android {
 
 		static BridgeProcessingFtn initialize_callback (
 			BridgeProcessingStartedFtn bridge_processing_started,
-			BridgeProcessingFinishedFtn bridge_processing_finished) noexcept
-		{
-			abort_if_invalid_pointer_argument (bridge_processing_started, "bridge_processing_started");
-			abort_if_invalid_pointer_argument (bridge_processing_finished, "bridge_processing_finished");
-			abort_unless (GCBridge::bridge_processing_started_callback == nullptr, "GC bridge processing started callback is already set");
-			abort_unless (GCBridge::bridge_processing_finished_callback == nullptr, "GC bridge processing finished callback is already set");
-
-			GCBridge::bridge_processing_started_callback = bridge_processing_started;
-			GCBridge::bridge_processing_finished_callback = bridge_processing_finished;
-
-			int ret = sem_init (&shared_args_semaphore, 0, 0);
-			abort_unless (ret == 0, "Failed to initialize GC bridge semaphore");
-
-			ret = pthread_create (&bridge_processing_thread, nullptr, GCBridge::bridge_processing_thread_entry, nullptr);
-			abort_unless (ret == 0, "Failed to create GC bridge processing thread");
-
-			ret = pthread_detach (bridge_processing_thread);
-			abort_unless (ret == 0, "Failed to detach GC bridge processing thread");
-
-			return mark_cross_references;
-		}
+			BridgeProcessingFinishedFtn bridge_processing_finished) noexcept;
 
 		static void trigger_java_gc (JNIEnv *env) noexcept;
 
 	private:
-		static inline pthread_t bridge_processing_thread {};
-		static inline sem_t shared_args_semaphore {};
-		static inline MarkCrossReferencesArgs *shared_args = nullptr;
-
 		static inline jobject Runtime_instance = nullptr;
 		static inline jmethodID Runtime_gc = nullptr;
 

--- a/src/native/clr/include/host/gc-bridge.hh
+++ b/src/native/clr/include/host/gc-bridge.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <semaphore.h>
+
 #include <jni.h>
 
 #include <shared/cpp-util.hh>
@@ -62,11 +64,19 @@ namespace xamarin::android {
 		static void trigger_java_gc (JNIEnv *env) noexcept;
 
 	private:
+		static inline sem_t shared_args_semaphore {};
+		static inline MarkCrossReferencesArgs *shared_args = nullptr;
+
 		static inline jobject Runtime_instance = nullptr;
 		static inline jmethodID Runtime_gc = nullptr;
 
 		static inline BridgeProcessingStartedFtn bridge_processing_started_callback = nullptr;
 		static inline BridgeProcessingFinishedFtn bridge_processing_finished_callback = nullptr;
+
+		static void initialize_shared_args_semaphore () noexcept;
+		static void start_bridge_processing_thread () noexcept;
+		static void publish_shared_args (MarkCrossReferencesArgs *args) noexcept;
+		static auto wait_for_shared_args () noexcept -> MarkCrossReferencesArgs*;
 
 		static void bridge_processing () noexcept;
 		static auto bridge_processing_thread_entry (void *arg) noexcept -> void*;

--- a/src/native/clr/include/host/gc-bridge.hh
+++ b/src/native/clr/include/host/gc-bridge.hh
@@ -59,7 +59,21 @@ namespace xamarin::android {
 
 		static BridgeProcessingFtn initialize_callback (
 			BridgeProcessingStartedFtn bridge_processing_started,
-			BridgeProcessingFinishedFtn bridge_processing_finished) noexcept;
+			BridgeProcessingFinishedFtn bridge_processing_finished) noexcept
+		{
+			abort_if_invalid_pointer_argument (bridge_processing_started, "bridge_processing_started");
+			abort_if_invalid_pointer_argument (bridge_processing_finished, "bridge_processing_finished");
+			abort_unless (GCBridge::bridge_processing_started_callback == nullptr, "GC bridge processing started callback is already set");
+			abort_unless (GCBridge::bridge_processing_finished_callback == nullptr, "GC bridge processing finished callback is already set");
+
+			GCBridge::bridge_processing_started_callback = bridge_processing_started;
+			GCBridge::bridge_processing_finished_callback = bridge_processing_finished;
+
+			initialize_shared_args_semaphore ();
+			start_bridge_processing_thread ();
+
+			return mark_cross_references;
+		}
 
 		static void trigger_java_gc (JNIEnv *env) noexcept;
 

--- a/src/native/clr/include/host/gc-bridge.hh
+++ b/src/native/clr/include/host/gc-bridge.hh
@@ -79,6 +79,9 @@ namespace xamarin::android {
 
 	private:
 		static inline sem_t shared_args_semaphore {};
+		// JavaMarshal serializes bridge rounds: it does not publish another argument block until
+		// bridge_processing_finished_callback has completed. This is therefore a single-slot
+		// handoff; the semaphore signals availability but does not queue distinct argument blocks.
 		static inline MarkCrossReferencesArgs *shared_args = nullptr;
 
 		static inline jobject Runtime_instance = nullptr;


### PR DESCRIPTION
## Summary

Replace the NativeAOT-reachable GC bridge's C++ threading primitives with POSIX primitives.

This removes the `std::thread`, `std::binary_semaphore`, and associated libc++ atomic-wait/thread runtime dependency from this subsystem as part of #12139.

## Changes

- replace the detached `std::thread` worker with `pthread_create()` / `pthread_detach()`;
- replace `std::binary_semaphore` with `sem_t`;
- retry `sem_wait()` after `EINTR`;
- preserve acquire/release synchronization for the shared callback argument with compiler atomics;
- surface pthread/semaphore failures through the existing abort helpers;
- document the JavaMarshal one-outstanding-round invariant that makes `shared_args` an intentional single-slot handoff rather than a queue.

The bridge-processing algorithm and callback lifecycle are unchanged.

## Validation

- `git diff --check`;
- Release build of `src/native/native-nativeaot.csproj`;
- Release build of `src/native/native-clr.csproj`;
- focused concurrency review covering initialization, the one-outstanding-round contract, memory ordering, EINTR, and detached worker behavior;
- latest head: `12bc25740`.

Part of #12139.