### PR TITLE
Resolve and refresh Android command-line tools by installed Pkg.Revision

### DIFF
--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/CommandLineToolsResolver.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/CommandLineToolsResolver.cs
@@ -1,0 +1,259 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace Xamarin.Android.Tools;
+
+static class CommandLineToolsResolver
+{
+	const string PackageRevisionProperty = "Pkg.Revision";
+
+	public static CommandLineTool? Find (
+		string sdkPath,
+		string toolName,
+		string extension,
+		bool includeLegacy,
+		Action<TraceLevel, string>? logger = null)
+	{
+		var cmdlineToolsDir = Path.Combine (sdkPath, "cmdline-tools");
+		if (Directory.Exists (cmdlineToolsDir)) {
+			var candidates = FindCandidates (cmdlineToolsDir, toolName, extension, logger);
+			if (candidates.Count > 0) {
+				candidates.Sort (CompareCandidates);
+				var selected = candidates [0];
+				logger?.Invoke (
+					TraceLevel.Verbose,
+					$"Selected '{selected.Tool.Path}' from command-line tools revision '{selected.Tool.Revision ?? "unknown"}'.");
+				return selected.Tool;
+			}
+		}
+
+		if (!includeLegacy)
+			return null;
+
+		var legacyPath = Path.Combine (sdkPath, "tools", "bin", toolName + extension);
+		if (!File.Exists (legacyPath))
+			return null;
+
+		logger?.Invoke (TraceLevel.Verbose, $"Selected legacy command-line tool '{legacyPath}'.");
+		return new CommandLineTool (legacyPath);
+	}
+
+	internal static bool TryParseRevision (string? value, out ParsedRevision revision)
+	{
+		revision = default;
+		if (value is null)
+			return false;
+
+		var text = value.Trim ();
+		if (text.Length == 0)
+			return false;
+		var suffixIndex = -1;
+		for (var i = 0; i < text.Length; i++) {
+			if (text [i] == '-' || char.IsWhiteSpace (text [i])) {
+				suffixIndex = i;
+				break;
+			}
+		}
+
+		var versionText = suffixIndex >= 0 ? text.Substring (0, suffixIndex) : text;
+		var prerelease = suffixIndex >= 0 ? text.Substring (suffixIndex + 1).Trim () : null;
+		if (suffixIndex >= 0 && string.IsNullOrEmpty (prerelease))
+			return false;
+
+		if (!Version.TryParse (versionText, out var parsedVersion))
+			return false;
+
+		var normalizedVersion = new Version (
+			parsedVersion.Major,
+			Math.Max (parsedVersion.Minor, 0),
+			Math.Max (parsedVersion.Build, 0),
+			Math.Max (parsedVersion.Revision, 0));
+		revision = new ParsedRevision (normalizedVersion, prerelease);
+		return true;
+	}
+
+	static List<Candidate> FindCandidates (
+		string cmdlineToolsDir,
+		string toolName,
+		string extension,
+		Action<TraceLevel, string>? logger)
+	{
+		var candidates = new List<Candidate> ();
+		try {
+			foreach (var directory in Directory.GetDirectories (cmdlineToolsDir)) {
+				var directoryName = Path.GetFileName (directory);
+				if (string.IsNullOrEmpty (directoryName))
+					continue;
+
+				var toolPath = Path.Combine (directory, "bin", toolName + extension);
+				if (!File.Exists (toolPath))
+					continue;
+
+				string? revisionText = null;
+				var revision = default (ParsedRevision?);
+				var revisionFromSource = false;
+
+				if (TryReadPackageRevision (directory, logger, out var packageRevision)) {
+					if (TryParseRevision (packageRevision, out var parsedRevision)) {
+						revisionText = packageRevision;
+						revision = parsedRevision;
+						revisionFromSource = true;
+					} else {
+						logger?.Invoke (
+							TraceLevel.Warning,
+							$"Ignoring invalid {PackageRevisionProperty} in '{Path.Combine (directory, "source.properties")}': '{packageRevision}'.");
+					}
+				}
+
+				if (revision is null && TryParseRevision (directoryName, out var directoryRevision)) {
+					revisionText = directoryName;
+					revision = directoryRevision;
+				}
+
+				candidates.Add (new Candidate (
+					directoryName,
+					new CommandLineTool (toolPath, revisionText),
+					revision,
+					revisionFromSource));
+			}
+		} catch (IOException ex) {
+			logger?.Invoke (TraceLevel.Warning, $"Could not enumerate '{cmdlineToolsDir}': {ex.Message}");
+		} catch (UnauthorizedAccessException ex) {
+			logger?.Invoke (TraceLevel.Warning, $"Could not enumerate '{cmdlineToolsDir}': {ex.Message}");
+		}
+
+		return candidates;
+	}
+
+	static bool TryReadPackageRevision (
+		string directory,
+		Action<TraceLevel, string>? logger,
+		out string? revision)
+	{
+		revision = null;
+		var sourceProperties = Path.Combine (directory, "source.properties");
+		if (!File.Exists (sourceProperties))
+			return false;
+
+		try {
+			foreach (var line in File.ReadLines (sourceProperties)) {
+				var separator = line.IndexOf ('=');
+				if (separator < 0)
+					continue;
+
+				var propertyName = line.Substring (0, separator).Trim ();
+				if (!string.Equals (propertyName, PackageRevisionProperty, StringComparison.Ordinal))
+					continue;
+
+				revision = line.Substring (separator + 1).Trim ();
+				return true;
+			}
+		} catch (IOException ex) {
+			logger?.Invoke (TraceLevel.Warning, $"Could not read '{sourceProperties}': {ex.Message}");
+		} catch (UnauthorizedAccessException ex) {
+			logger?.Invoke (TraceLevel.Warning, $"Could not read '{sourceProperties}': {ex.Message}");
+		}
+
+		return false;
+	}
+
+	static int CompareCandidates (Candidate first, Candidate second)
+	{
+		if (first.Revision.HasValue != second.Revision.HasValue)
+			return first.Revision.HasValue ? -1 : 1;
+
+		if (first.Revision is ParsedRevision firstRevision && second.Revision is ParsedRevision secondRevision) {
+			var revisionComparison = secondRevision.CompareTo (firstRevision);
+			if (revisionComparison != 0)
+				return revisionComparison;
+		}
+
+		if (first.RevisionFromSource != second.RevisionFromSource)
+			return first.RevisionFromSource ? -1 : 1;
+
+		var firstIsLatest = string.Equals (first.DirectoryName, "latest", StringComparison.Ordinal);
+		var secondIsLatest = string.Equals (second.DirectoryName, "latest", StringComparison.Ordinal);
+		if (firstIsLatest != secondIsLatest)
+			return firstIsLatest ? -1 : 1;
+
+		return string.Compare (first.DirectoryName, second.DirectoryName, StringComparison.Ordinal);
+	}
+
+	sealed class Candidate
+	{
+		public string DirectoryName { get; }
+		public CommandLineTool Tool { get; }
+		public ParsedRevision? Revision { get; }
+		public bool RevisionFromSource { get; }
+
+		public Candidate (
+			string directoryName,
+			CommandLineTool tool,
+			ParsedRevision? revision,
+			bool revisionFromSource)
+		{
+			DirectoryName = directoryName;
+			Tool = tool;
+			Revision = revision;
+			RevisionFromSource = revisionFromSource;
+		}
+	}
+
+	internal readonly struct ParsedRevision : IComparable<ParsedRevision>
+	{
+		public Version Version { get; }
+		public string? Prerelease { get; }
+
+		public ParsedRevision (Version version, string? prerelease)
+		{
+			Version = version;
+			Prerelease = prerelease;
+		}
+
+		public int CompareTo (ParsedRevision other)
+		{
+			var versionComparison = Version.CompareTo (other.Version);
+			if (versionComparison != 0)
+				return versionComparison;
+
+			var isPrerelease = !string.IsNullOrEmpty (Prerelease);
+			var otherIsPrerelease = !string.IsNullOrEmpty (other.Prerelease);
+			if (isPrerelease != otherIsPrerelease)
+				return isPrerelease ? -1 : 1;
+
+			return ComparePrerelease (Prerelease, other.Prerelease);
+		}
+
+		static int ComparePrerelease (string? first, string? second)
+		{
+			if (first is null || second is null)
+				return string.Compare (first, second, StringComparison.OrdinalIgnoreCase);
+
+			var firstNumberStart = FindTrailingNumberStart (first);
+			var secondNumberStart = FindTrailingNumberStart (second);
+			if (firstNumberStart < first.Length && secondNumberStart < second.Length) {
+				var firstLabel = first.Substring (0, firstNumberStart);
+				var secondLabel = second.Substring (0, secondNumberStart);
+				if (string.Equals (firstLabel, secondLabel, StringComparison.OrdinalIgnoreCase) &&
+					long.TryParse (first.Substring (firstNumberStart), out var firstNumber) &&
+					long.TryParse (second.Substring (secondNumberStart), out var secondNumber))
+					return firstNumber.CompareTo (secondNumber);
+			}
+
+			return string.Compare (first, second, StringComparison.OrdinalIgnoreCase);
+		}
+
+		static int FindTrailingNumberStart (string value)
+		{
+			var index = value.Length;
+			while (index > 0 && char.IsDigit (value [index - 1]))
+				index--;
+			return index;
+		}
+	}
+}

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/CommandLineToolsResolver.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/CommandLineToolsResolver.cs
@@ -16,7 +16,6 @@ static class CommandLineToolsResolver
 		string sdkPath,
 		string toolName,
 		string extension,
-		bool includeLegacy,
 		Action<TraceLevel, string>? logger = null)
 	{
 		var cmdlineToolsDir = Path.Combine (sdkPath, "cmdline-tools");
@@ -32,15 +31,7 @@ static class CommandLineToolsResolver
 			}
 		}
 
-		if (!includeLegacy)
-			return null;
-
-		var legacyPath = Path.Combine (sdkPath, "tools", "bin", toolName + extension);
-		if (!File.Exists (legacyPath))
-			return null;
-
-		logger?.Invoke (TraceLevel.Verbose, $"Selected legacy command-line tool '{legacyPath}'.");
-		return new CommandLineTool (legacyPath);
+		return null;
 	}
 
 	internal static bool TryParseRevision (string? value, out ParsedRevision revision)
@@ -68,12 +59,7 @@ static class CommandLineToolsResolver
 		if (!Version.TryParse (versionText, out var parsedVersion))
 			return false;
 
-		var normalizedVersion = new Version (
-			parsedVersion.Major,
-			Math.Max (parsedVersion.Minor, 0),
-			Math.Max (parsedVersion.Build, 0),
-			Math.Max (parsedVersion.Revision, 0));
-		revision = new ParsedRevision (normalizedVersion, prerelease);
+		revision = new ParsedRevision (parsedVersion, prerelease);
 		return true;
 	}
 
@@ -137,22 +123,8 @@ static class CommandLineToolsResolver
 	{
 		revision = null;
 		var sourceProperties = Path.Combine (directory, "source.properties");
-		if (!File.Exists (sourceProperties))
-			return false;
-
 		try {
-			foreach (var line in File.ReadLines (sourceProperties)) {
-				var separator = line.IndexOf ('=');
-				if (separator < 0)
-					continue;
-
-				var propertyName = line.Substring (0, separator).Trim ();
-				if (!string.Equals (propertyName, PackageRevisionProperty, StringComparison.Ordinal))
-					continue;
-
-				revision = line.Substring (separator + 1).Trim ();
-				return true;
-			}
+			return SourceProperties.TryGetProperty (sourceProperties, PackageRevisionProperty, out revision);
 		} catch (IOException ex) {
 			logger?.Invoke (TraceLevel.Warning, $"Could not read '{sourceProperties}': {ex.Message}");
 		} catch (UnauthorizedAccessException ex) {

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Models/Sdk/CommandLineTool.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Models/Sdk/CommandLineTool.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Xamarin.Android.Tools;
 
 /// <summary>Information about an installed Android SDK command-line tool.</summary>
@@ -18,8 +20,12 @@ public sealed class CommandLineTool
 	/// <summary>Creates information for a resolved Android SDK command-line tool.</summary>
 	/// <param name="path">The full path to the requested executable.</param>
 	/// <param name="revision">The installed command-line tools revision, when available.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
 	public CommandLineTool (string path, string? revision = null)
 	{
+		if (path is null)
+			throw new ArgumentNullException (nameof (path));
+
 		Path = path;
 		Revision = revision;
 	}

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Models/Sdk/CommandLineTool.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Models/Sdk/CommandLineTool.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Xamarin.Android.Tools;
+
+/// <summary>Information about an installed Android SDK command-line tool.</summary>
+public sealed class CommandLineTool
+{
+	/// <summary>Gets the full path to the requested executable.</summary>
+	public string Path { get; }
+
+	/// <summary>
+	/// Gets the installed command-line tools revision from <c>source.properties</c>,
+	/// or the versioned directory name when package metadata is unavailable.
+	/// </summary>
+	public string? Revision { get; }
+
+	/// <summary>Creates information for a resolved Android SDK command-line tool.</summary>
+	/// <param name="path">The full path to the requested executable.</param>
+	/// <param name="revision">The installed command-line tools revision, when available.</param>
+	public CommandLineTool (string path, string? revision = null)
+	{
+		Path = path;
+		Revision = revision;
+	}
+}

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Models/Sdk/SdkBootstrapPhase.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Models/Sdk/SdkBootstrapPhase.cs
@@ -17,5 +17,9 @@ public enum SdkBootstrapPhase
 	/// <summary>Extracting the archive.</summary>
 	Extracting,
 	/// <summary>Bootstrap completed successfully.</summary>
-	Complete
+	Complete,
+	/// <summary>Checking Google's package catalog for a newer command-line tools revision.</summary>
+	CheckingForUpdates,
+	/// <summary>Installing the current command-line tools package.</summary>
+	Installing
 }

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Models/Sdk/SdkBootstrapProgress.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Models/Sdk/SdkBootstrapProgress.cs
@@ -3,5 +3,5 @@
 
 namespace Xamarin.Android.Tools;
 
-/// <summary>Progress information for SDK bootstrap operations.</summary>
+/// <summary>Progress information for SDK bootstrap and command-line tools refresh operations.</summary>
 public record SdkBootstrapProgress (SdkBootstrapPhase Phase, int PercentComplete = -1, string Message = "");

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
@@ -246,7 +246,8 @@ namespace Xamarin.Android.Tools
 
 		/// <summary>
 		/// Searches for a cmdline-tools binary in the SDK.
-		/// Prefers the "latest" symlink, then the highest versioned directory.
+		/// Selects the highest installed revision reported by source.properties,
+		/// with deterministic directory-name fallback when metadata is unavailable.
 		/// </summary>
 		/// <param name="sdkPath">Root path to the Android SDK.</param>
 		/// <param name="toolName">Tool binary name without extension (e.g., "avdmanager").</param>
@@ -254,51 +255,12 @@ namespace Xamarin.Android.Tools
 		/// <param name="logger">Optional logger for diagnostic messages.</param>
 		internal static string? FindCmdlineTool (string sdkPath, string toolName, string extension, Action<TraceLevel, string>? logger = null)
 		{
-			var cmdlineToolsDir = Path.Combine (sdkPath, "cmdline-tools");
-
-			if (Directory.Exists (cmdlineToolsDir)) {
-				// Prefer "latest" symlink first — it's the SDK's own recommended default
-				var latestPath = Path.Combine (cmdlineToolsDir, "latest", "bin", toolName + extension);
-				if (File.Exists (latestPath))
-					return latestPath;
-
-				try {
-					var subdirs = new List<(string name, Version version, bool isPreRelease)> ();
-					foreach (var dir in Directory.GetDirectories (cmdlineToolsDir)) {
-						var name = Path.GetFileName (dir);
-						if (string.IsNullOrEmpty (name) || name == "latest")
-							continue;
-						// Strip pre-release suffixes (e.g., "5.0-rc1" → "5.0") before parsing
-						var versionStr = name;
-						var dashIndex = name.IndexOf ('-');
-						var isPreRelease = dashIndex >= 0;
-						if (isPreRelease)
-							versionStr = name.Substring (0, dashIndex);
-						Version.TryParse (versionStr, out var v);
-						subdirs.Add ((name, v ?? new Version (0, 0), isPreRelease));
-					}
-					// Sort by version descending, then prefer stable (non-prerelease) over prerelease
-					subdirs.Sort ((a, b) => {
-						var cmp = b.version.CompareTo (a.version);
-						if (cmp != 0) return cmp;
-						if (a.isPreRelease != b.isPreRelease)
-							return a.isPreRelease ? 1 : -1; // stable first
-						return string.Compare (a.name, b.name, StringComparison.Ordinal);
-					});
-
-					foreach (var (name, _, _) in subdirs) {
-						var toolPath = Path.Combine (cmdlineToolsDir, name, "bin", toolName + extension);
-						if (File.Exists (toolPath))
-							return toolPath;
-					}
-				} catch (IOException ex) {
-					logger?.Invoke (TraceLevel.Warning, $"FindCmdlineTool: IO error enumerating {cmdlineToolsDir}: {ex.Message}");
-				} catch (UnauthorizedAccessException ex) {
-					logger?.Invoke (TraceLevel.Warning, $"FindCmdlineTool: Permission denied on {cmdlineToolsDir}: {ex.Message}");
-				}
-			}
-
-			return null;
+			return CommandLineToolsResolver.Find (
+				sdkPath,
+				toolName,
+				extension,
+				includeLegacy: false,
+				logger: logger)?.Path;
 		}
 
 		internal static IEnumerable<string> FindExecutablesInPath (string executable)

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
@@ -259,7 +259,6 @@ namespace Xamarin.Android.Tools
 				sdkPath,
 				toolName,
 				extension,
-				includeLegacy: false,
 				logger: logger)?.Path;
 		}
 

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -38,6 +38,10 @@ Xamarin.Android.Tools.AdbRunner.WaitForDeviceAsync(string? serial = null, System
 Xamarin.Android.Tools.ChecksumType
 Xamarin.Android.Tools.ChecksumType.Sha1 = 0 -> Xamarin.Android.Tools.ChecksumType
 Xamarin.Android.Tools.ChecksumType.Sha256 = 1 -> Xamarin.Android.Tools.ChecksumType
+Xamarin.Android.Tools.CommandLineTool
+Xamarin.Android.Tools.CommandLineTool.CommandLineTool(string! path, string? revision = null) -> void
+Xamarin.Android.Tools.CommandLineTool.Path.get -> string!
+Xamarin.Android.Tools.CommandLineTool.Revision.get -> string?
 Xamarin.Android.Tools.JdkInstallPhase
 Xamarin.Android.Tools.JdkInstallPhase.Complete = 4 -> Xamarin.Android.Tools.JdkInstallPhase
 Xamarin.Android.Tools.JdkInstallPhase.Downloading = 0 -> Xamarin.Android.Tools.JdkInstallPhase
@@ -69,9 +73,11 @@ Xamarin.Android.Tools.JdkVersionInfo.MajorVersion.get -> int
 Xamarin.Android.Tools.JdkVersionInfo.ResolvedUrl.get -> string?
 Xamarin.Android.Tools.JdkVersionInfo.Size.get -> long
 Xamarin.Android.Tools.SdkBootstrapPhase
+Xamarin.Android.Tools.SdkBootstrapPhase.CheckingForUpdates = 5 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapPhase.Complete = 4 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapPhase.Downloading = 1 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapPhase.Extracting = 3 -> Xamarin.Android.Tools.SdkBootstrapPhase
+Xamarin.Android.Tools.SdkBootstrapPhase.Installing = 6 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapPhase.ReadingManifest = 0 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapPhase.Verifying = 2 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapProgress
@@ -98,6 +104,8 @@ Xamarin.Android.Tools.SdkManager.AndroidSdkPath.set -> void
 Xamarin.Android.Tools.SdkManager.AreLicensesAccepted() -> bool
 Xamarin.Android.Tools.SdkManager.BootstrapAsync(string! targetPath, System.IProgress<Xamarin.Android.Tools.SdkBootstrapProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Xamarin.Android.Tools.SdkManager.Dispose() -> void
+Xamarin.Android.Tools.SdkManager.EnsureLatestCommandLineToolsAsync(string! targetPath, System.IProgress<Xamarin.Android.Tools.SdkBootstrapProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Xamarin.Android.Tools.CommandLineTool!>!
+Xamarin.Android.Tools.SdkManager.FindSdkManager() -> Xamarin.Android.Tools.CommandLineTool?
 Xamarin.Android.Tools.SdkManager.FindSdkManagerPath() -> string?
 Xamarin.Android.Tools.SdkManager.GetPendingLicensesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.SdkLicense!>!>!
 Xamarin.Android.Tools.SdkManager.InstallAsync(System.Collections.Generic.IEnumerable<string!>! packages, bool acceptLicenses = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -38,6 +38,10 @@ Xamarin.Android.Tools.AdbRunner.WaitForDeviceAsync(string? serial = null, System
 Xamarin.Android.Tools.ChecksumType
 Xamarin.Android.Tools.ChecksumType.Sha1 = 0 -> Xamarin.Android.Tools.ChecksumType
 Xamarin.Android.Tools.ChecksumType.Sha256 = 1 -> Xamarin.Android.Tools.ChecksumType
+Xamarin.Android.Tools.CommandLineTool
+Xamarin.Android.Tools.CommandLineTool.CommandLineTool(string! path, string? revision = null) -> void
+Xamarin.Android.Tools.CommandLineTool.Path.get -> string!
+Xamarin.Android.Tools.CommandLineTool.Revision.get -> string?
 Xamarin.Android.Tools.JdkInstallPhase
 Xamarin.Android.Tools.JdkInstallPhase.Complete = 4 -> Xamarin.Android.Tools.JdkInstallPhase
 Xamarin.Android.Tools.JdkInstallPhase.Downloading = 0 -> Xamarin.Android.Tools.JdkInstallPhase
@@ -69,9 +73,11 @@ Xamarin.Android.Tools.JdkVersionInfo.MajorVersion.get -> int
 Xamarin.Android.Tools.JdkVersionInfo.ResolvedUrl.get -> string?
 Xamarin.Android.Tools.JdkVersionInfo.Size.get -> long
 Xamarin.Android.Tools.SdkBootstrapPhase
+Xamarin.Android.Tools.SdkBootstrapPhase.CheckingForUpdates = 5 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapPhase.Complete = 4 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapPhase.Downloading = 1 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapPhase.Extracting = 3 -> Xamarin.Android.Tools.SdkBootstrapPhase
+Xamarin.Android.Tools.SdkBootstrapPhase.Installing = 6 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapPhase.ReadingManifest = 0 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapPhase.Verifying = 2 -> Xamarin.Android.Tools.SdkBootstrapPhase
 Xamarin.Android.Tools.SdkBootstrapProgress
@@ -98,6 +104,8 @@ Xamarin.Android.Tools.SdkManager.AndroidSdkPath.set -> void
 Xamarin.Android.Tools.SdkManager.AreLicensesAccepted() -> bool
 Xamarin.Android.Tools.SdkManager.BootstrapAsync(string! targetPath, System.IProgress<Xamarin.Android.Tools.SdkBootstrapProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Xamarin.Android.Tools.SdkManager.Dispose() -> void
+Xamarin.Android.Tools.SdkManager.EnsureLatestCommandLineToolsAsync(string! targetPath, System.IProgress<Xamarin.Android.Tools.SdkBootstrapProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Xamarin.Android.Tools.CommandLineTool!>!
+Xamarin.Android.Tools.SdkManager.FindSdkManager() -> Xamarin.Android.Tools.CommandLineTool?
 Xamarin.Android.Tools.SdkManager.FindSdkManagerPath() -> string?
 Xamarin.Android.Tools.SdkManager.GetPendingLicensesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.SdkLicense!>!>!
 Xamarin.Android.Tools.SdkManager.InstallAsync(System.Collections.Generic.IEnumerable<string!>! packages, bool acceptLicenses = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.CommandLineTools.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.CommandLineTools.cs
@@ -84,6 +84,7 @@ public partial class SdkManager
 		Func<CancellationToken, Task<(IReadOnlyList<SdkPackage> Installed, IReadOnlyList<SdkPackage> Available)>> listAsync,
 		Func<IEnumerable<string>, bool, CancellationToken, Task> installAsync)
 	{
+		ThrowIfDisposed ();
 		cancellationToken.ThrowIfCancellationRequested ();
 		AndroidSdkPath = targetPath;
 

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.CommandLineTools.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.CommandLineTools.cs
@@ -21,11 +21,6 @@ public partial class SdkManager
 	/// The selected executable and revision, or <see langword="null"/> when no compatible
 	/// <c>sdkmanager</c> is installed.
 	/// </returns>
-	/// <remarks>
-	/// The legacy <c>tools/bin/sdkmanager</c> location remains supported because it uses
-	/// the same package-management command contract. Other command-line tools do not use
-	/// this legacy fallback.
-	/// </remarks>
 	public CommandLineTool? FindSdkManager ()
 	{
 		var sdkPath = AndroidSdkPath;
@@ -37,7 +32,6 @@ public partial class SdkManager
 			sdkPath,
 			"sdkmanager",
 			extension,
-			includeLegacy: true,
 			logger: logger);
 	}
 

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.CommandLineTools.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.CommandLineTools.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Tools;
+
+public partial class SdkManager
+{
+	const string LatestCommandLineToolsPackage = "cmdline-tools;latest";
+
+	/// <summary>
+	/// Finds the installed <c>sdkmanager</c> from the highest command-line tools
+	/// revision reported by <c>source.properties</c>.
+	/// </summary>
+	/// <returns>
+	/// The selected executable and revision, or <see langword="null"/> when no compatible
+	/// <c>sdkmanager</c> is installed.
+	/// </returns>
+	/// <remarks>
+	/// The legacy <c>tools/bin/sdkmanager</c> location remains supported because it uses
+	/// the same package-management command contract. Other command-line tools do not use
+	/// this legacy fallback.
+	/// </remarks>
+	public CommandLineTool? FindSdkManager ()
+	{
+		var sdkPath = AndroidSdkPath;
+		if (sdkPath is null || sdkPath.Length == 0)
+			return null;
+
+		var extension = OS.IsWindows ? ".bat" : "";
+		return CommandLineToolsResolver.Find (
+			sdkPath,
+			"sdkmanager",
+			extension,
+			includeLegacy: true,
+			logger: logger);
+	}
+
+	/// <summary>
+	/// Finds the installed <c>sdkmanager</c> executable path.
+	/// </summary>
+	/// <returns>The selected executable path, or <see langword="null"/> when none is installed.</returns>
+	public string? FindSdkManagerPath ()
+	{
+		return FindSdkManager ()?.Path;
+	}
+
+	/// <summary>
+	/// Ensures the Android SDK contains the current Google <c>cmdline-tools;latest</c> package.
+	/// </summary>
+	/// <param name="targetPath">The Android SDK root path.</param>
+	/// <param name="progress">Optional progress callback for bootstrap, catalog checking, and installation.</param>
+	/// <param name="cancellationToken">Cancellation token.</param>
+	/// <returns>The selected <c>sdkmanager</c> executable and installed revision.</returns>
+	public Task<CommandLineTool> EnsureLatestCommandLineToolsAsync (
+		string targetPath,
+		IProgress<SdkBootstrapProgress>? progress = null,
+		CancellationToken cancellationToken = default)
+	{
+		ThrowIfDisposed ();
+		if (string.IsNullOrEmpty (targetPath))
+			throw new ArgumentNullException (nameof (targetPath));
+
+		progress ??= NullProgress;
+		return EnsureLatestCommandLineToolsAsync (
+			targetPath,
+			progress,
+			cancellationToken,
+			BootstrapAsync,
+			ListAsync,
+			(packages, acceptLicenses, token) => InstallAsync (packages, acceptLicenses, token));
+	}
+
+	internal async Task<CommandLineTool> EnsureLatestCommandLineToolsAsync (
+		string targetPath,
+		IProgress<SdkBootstrapProgress> progress,
+		CancellationToken cancellationToken,
+		Func<string, IProgress<SdkBootstrapProgress>?, CancellationToken, Task> bootstrapAsync,
+		Func<CancellationToken, Task<(IReadOnlyList<SdkPackage> Installed, IReadOnlyList<SdkPackage> Available)>> listAsync,
+		Func<IEnumerable<string>, bool, CancellationToken, Task> installAsync)
+	{
+		cancellationToken.ThrowIfCancellationRequested ();
+		AndroidSdkPath = targetPath;
+
+		var selected = FindSdkManager ();
+		if (selected is null) {
+			logger (System.Diagnostics.TraceLevel.Info, "No sdkmanager found; bootstrapping command-line tools.");
+			await bootstrapAsync (
+				targetPath,
+				new BootstrapProgressForwarder (progress),
+				cancellationToken).ConfigureAwait (false);
+			AndroidSdkPath = targetPath;
+			selected = FindSdkManager ();
+			if (selected is null)
+				throw new InvalidOperationException ("Android SDK bootstrap completed without installing sdkmanager.");
+		}
+
+		progress.Report (new SdkBootstrapProgress (
+			SdkBootstrapPhase.CheckingForUpdates,
+			Message: "Checking the latest command-line tools revision..."));
+		var (installed, available) = await listAsync (cancellationToken).ConfigureAwait (false);
+		SdkPackage? latestPackage = null;
+		CommandLineToolsResolver.ParsedRevision? latestRevision = null;
+		foreach (var package in available.Concat (installed)) {
+			if (!string.Equals (package.Path, LatestCommandLineToolsPackage, StringComparison.Ordinal) ||
+				!CommandLineToolsResolver.TryParseRevision (package.Version, out var packageRevision))
+				continue;
+			if (latestRevision.HasValue && packageRevision.CompareTo (latestRevision.Value) <= 0)
+				continue;
+
+			latestPackage = package;
+			latestRevision = packageRevision;
+		}
+		if (latestPackage is null || !latestRevision.HasValue)
+			throw new InvalidOperationException ("Could not determine the latest command-line tools revision from sdkmanager.");
+		var catalogRevision = latestRevision.Value;
+
+		var shouldInstall =
+			!CommandLineToolsResolver.TryParseRevision (selected.Revision, out var selectedRevision) ||
+			selectedRevision.CompareTo (catalogRevision) < 0;
+
+		if (shouldInstall) {
+			progress.Report (new SdkBootstrapProgress (
+				SdkBootstrapPhase.Installing,
+				Message: $"Installing {LatestCommandLineToolsPackage} {latestPackage.Version}..."));
+			await installAsync ([LatestCommandLineToolsPackage], true, cancellationToken).ConfigureAwait (false);
+
+			selected = FindSdkManager ();
+			if (selected is null)
+				throw new InvalidOperationException ("The latest command-line tools package was installed, but sdkmanager could not be found.");
+			if (!CommandLineToolsResolver.TryParseRevision (selected.Revision, out selectedRevision))
+				throw new InvalidOperationException ($"The installed sdkmanager revision '{selected.Revision ?? "unknown"}' could not be parsed.");
+			if (selectedRevision.CompareTo (catalogRevision) < 0)
+				throw new InvalidOperationException (
+					$"The resolved command-line tools revision '{selected.Revision}' is older than the catalog revision '{latestPackage.Version}'.");
+		} else {
+			logger (System.Diagnostics.TraceLevel.Info, $"Command-line tools {selected.Revision} is already current.");
+		}
+
+		progress.Report (new SdkBootstrapProgress (
+			SdkBootstrapPhase.Complete,
+			100,
+			$"Command-line tools {selected.Revision} are ready."));
+		return selected;
+	}
+
+	sealed class BootstrapProgressForwarder : IProgress<SdkBootstrapProgress>
+	{
+		readonly IProgress<SdkBootstrapProgress> progress;
+
+		public BootstrapProgressForwarder (IProgress<SdkBootstrapProgress> progress)
+		{
+			this.progress = progress;
+		}
+
+		public void Report (SdkBootstrapProgress value)
+		{
+			if (value.Phase != SdkBootstrapPhase.Complete)
+				progress.Report (value);
+		}
+	}
+}

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.Packages.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.Packages.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,38 +12,6 @@ namespace Xamarin.Android.Tools;
 
 public partial class SdkManager
 {
-	public string? FindSdkManagerPath ()
-	{
-		if (string.IsNullOrEmpty (AndroidSdkPath))
-			return null;
-
-		var ext = OS.IsWindows ? ".bat" : string.Empty;
-		var cmdlineToolsDir = Path.Combine (AndroidSdkPath, "cmdline-tools");
-
-		if (Directory.Exists (cmdlineToolsDir)) {
-			try {
-				// Versioned dirs sorted descending, then "latest" as fallback
-				var searchDirs = Directory.GetDirectories (cmdlineToolsDir)
-					.Select (Path.GetFileName)
-					.Where (n => n != "latest" && !string.IsNullOrEmpty (n))
-					.OrderByDescending (n => Version.TryParse (n, out var v) ? v : new Version (0, 0))
-					.Append ("latest");
-
-				foreach (var dir in searchDirs) {
-					var toolPath = Path.Combine (cmdlineToolsDir, dir!, "bin", "sdkmanager" + ext);
-					if (File.Exists (toolPath))
-						return toolPath;
-				}
-			} catch (Exception ex) {
-				logger (TraceLevel.Verbose, $"Error enumerating cmdline-tools directories: {ex.Message}");
-			}
-		}
-
-		// Legacy fallback: tools/bin/sdkmanager
-		var legacyPath = Path.Combine (AndroidSdkPath, "tools", "bin", "sdkmanager" + ext);
-		return File.Exists (legacyPath) ? legacyPath : null;
-	}
-
 	public async Task<(IReadOnlyList<SdkPackage> Installed, IReadOnlyList<SdkPackage> Available)> ListAsync (CancellationToken cancellationToken = default)
 	{
 		var sdkManagerPath = RequireSdkManagerPath ();
@@ -110,19 +77,23 @@ public partial class SdkManager
 		var installed = new List<SdkPackage> ();
 		var available = new List<SdkPackage> ();
 		List<SdkPackage>? target = null;
+		var parsingUpdates = false;
 
 		foreach (var line in output.Split (new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)) {
 			var trimmed = line.Trim ();
 
-			if (trimmed.Contains ("Installed packages:")) { target = installed; continue; }
-			if (trimmed.Contains ("Available Packages:")) { target = available; continue; }
-			if (trimmed.Contains ("Available Updates:")) { target = null; continue; }
+			if (trimmed.Contains ("Installed packages:")) { target = installed; parsingUpdates = false; continue; }
+			if (trimmed.Contains ("Available Packages:")) { target = available; parsingUpdates = false; continue; }
+			if (trimmed.Contains ("Available Updates:")) { target = available; parsingUpdates = true; continue; }
 
 			if (target is null || trimmed.StartsWith ("Path", StringComparison.Ordinal) || trimmed.StartsWith ("---", StringComparison.Ordinal))
 				continue;
 
 			var parts = trimmed.Split ('|');
-			if (parts.Length < 2)
+			if (parsingUpdates && string.Equals (parts [0].Trim (), "ID", StringComparison.Ordinal))
+				continue;
+			var versionIndex = parsingUpdates ? 2 : 1;
+			if (parts.Length <= versionIndex)
 				continue;
 
 			var path = parts[0].Trim ();
@@ -131,8 +102,8 @@ public partial class SdkManager
 
 			target.Add (new SdkPackage (
 				path,
-				Version: parts[1].Trim (),
-				Description: parts.Length > 2 ? parts[2].Trim () : null,
+				Version: parts[versionIndex].Trim (),
+				Description: !parsingUpdates && parts.Length > 2 ? parts[2].Trim () : null,
 				IsInstalled: target == installed
 			));
 		}

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -13,8 +13,6 @@ namespace Xamarin.Android.Tools
 		const int MinimumCompatibleNDKMajorVersion = 16;
 		const int MaximumCompatibleNDKMajorVersion = 28;
 
-		static readonly char[] SourcePropertiesKeyValueSplit = new char[] { '=' };
-
 		// Per https://developer.android.com/studio/command-line/variables#envar
 		#pragma warning disable CS0618 // ANDROID_SDK_ROOT is obsolete but still needed for compat
 		protected static readonly string[] AndroidSdkEnvVars = {EnvironmentVariableNames.AndroidHome, EnvironmentVariableNames.AndroidSdkRoot};
@@ -213,28 +211,17 @@ namespace Xamarin.Android.Tools
 					return;
 				}
 
-				foreach (string line in File.ReadLines (propsFilePath)) {
-					string[] parts = line.Split (SourcePropertiesKeyValueSplit, 2, StringSplitOptions.RemoveEmptyEntries);
-					if (parts.Length != 2) {
-						continue;
-					}
+				if (!SourceProperties.TryGetProperty (propsFilePath, "Pkg.Revision", out var revision) ||
+					!Version.TryParse (revision, out var ndkVer) ||
+					ndkInstances.ContainsKey (ndkVer))
+					return;
 
-					if (String.Compare ("Pkg.Revision", parts[0].Trim (), StringComparison.Ordinal) != 0) {
-						continue;
-					}
-
-					if (!Version.TryParse (parts[1].Trim (), out Version? ndkVer) || ndkVer == null || ndkInstances.ContainsKey (ndkVer)) {
-						continue;
-					}
-
-					if (ndkVer.Major < MinimumCompatibleNDKMajorVersion || ndkVer.Major > MaximumCompatibleNDKMajorVersion) {
-						Logger (TraceLevel.Verbose, $"Skipping NDK in '{path}': version {ndkVer} is out of the accepted range (major version must be between {MinimumCompatibleNDKMajorVersion} and {MaximumCompatibleNDKMajorVersion}");
-						continue;
-					}
-
-					ndkInstances.Add (ndkVer, path);
+				if (ndkVer.Major < MinimumCompatibleNDKMajorVersion || ndkVer.Major > MaximumCompatibleNDKMajorVersion) {
+					Logger (TraceLevel.Verbose, $"Skipping NDK in '{path}': version {ndkVer} is out of the accepted range (major version must be between {MinimumCompatibleNDKMajorVersion} and {MaximumCompatibleNDKMajorVersion}");
 					return;
 				}
+
+				ndkInstances.Add (ndkVer, path);
 			}
 		}
 
@@ -326,4 +313,3 @@ namespace Xamarin.Android.Tools
 		}
 	}
 }
-

--- a/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/SourceProperties.cs
+++ b/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/SourceProperties.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+
+namespace Xamarin.Android.Tools;
+
+static class SourceProperties
+{
+	public static bool TryGetProperty (string filePath, string propertyName, out string? value)
+	{
+		value = null;
+		if (!File.Exists (filePath))
+			return false;
+
+		foreach (var line in File.ReadLines (filePath)) {
+			var separator = line.IndexOf ('=');
+			if (separator < 0)
+				continue;
+
+			var name = line.Substring (0, separator).Trim ();
+			if (!string.Equals (name, propertyName, StringComparison.Ordinal))
+				continue;
+
+			value = line.Substring (separator + 1).Trim ();
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/CommandLineToolsResolverTests.cs
+++ b/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/CommandLineToolsResolverTests.cs
@@ -36,6 +36,12 @@ public class CommandLineToolsResolverTests
 	}
 
 	[Test]
+	public void CommandLineTool_NullPath_Throws ()
+	{
+		Assert.Throws<ArgumentNullException> (() => new CommandLineTool (null));
+	}
+
+	[Test]
 	public void FindCommandLineTool_LatestHasHigherPackageRevision_SelectsLatest ()
 	{
 		CreateCommandLineTool ("19.0", "sdkmanager", "19.0");
@@ -334,6 +340,21 @@ public class CommandLineToolsResolverTests
 			(_, _, _) => Task.CompletedTask));
 
 		Assert.That (exception?.Message, Does.Contain ("without installing sdkmanager"));
+	}
+
+	[Test]
+	public void EnsureLatestCommandLineToolsAsync_Disposed_Throws ()
+	{
+		using var manager = CreateSdkManager ();
+		manager.Dispose ();
+
+		Assert.ThrowsAsync<ObjectDisposedException> (() => manager.EnsureLatestCommandLineToolsAsync (
+			SdkDirectory,
+			new ProgressCollector (),
+			CancellationToken.None,
+			(_, _, _) => Task.CompletedTask,
+			_ => CreatePackageList ("22.0"),
+			(_, _, _) => Task.CompletedTask));
 	}
 
 	[Test]

--- a/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/CommandLineToolsResolverTests.cs
+++ b/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/CommandLineToolsResolverTests.cs
@@ -1,0 +1,416 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.Tools.Tests;
+
+[TestFixture]
+public class CommandLineToolsResolverTests
+{
+	string sdkDirectory = "";
+
+	string SdkDirectory => sdkDirectory;
+	string ExecutableExtension => OS.IsWindows ? ".bat" : "";
+
+	[SetUp]
+	public void SetUp ()
+	{
+		sdkDirectory = Path.Combine (Path.GetTempPath (), $"cmdline-tools-test-{Path.GetRandomFileName ()}");
+		Directory.CreateDirectory (sdkDirectory);
+	}
+
+	[TearDown]
+	public void TearDown ()
+	{
+		if (Directory.Exists (sdkDirectory))
+			Directory.Delete (sdkDirectory, recursive: true);
+		sdkDirectory = "";
+	}
+
+	[Test]
+	public void FindCommandLineTool_LatestHasHigherPackageRevision_SelectsLatest ()
+	{
+		CreateCommandLineTool ("19.0", "sdkmanager", "19.0");
+		CreateCommandLineTool ("19.0", "avdmanager", "19.0");
+		var expectedSdkManager = CreateCommandLineTool ("latest", "sdkmanager", "22.0");
+		var expectedAvdManager = CreateCommandLineTool ("latest", "avdmanager", "22.0");
+
+		using var manager = CreateSdkManager ();
+		var selected = manager.FindSdkManager ();
+
+		Assert.That (selected?.Path, Is.EqualTo (expectedSdkManager));
+		Assert.That (selected?.Revision, Is.EqualTo ("22.0"));
+		Assert.That (manager.FindSdkManagerPath (), Is.EqualTo (expectedSdkManager));
+		Assert.That (
+			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
+			Is.EqualTo (expectedAvdManager));
+	}
+
+	[Test]
+	public void FindCommandLineTool_NumericHasHigherPackageRevision_SelectsNumeric ()
+	{
+		var expectedSdkManager = CreateCommandLineTool ("22.0", "sdkmanager", "22.0");
+		var expectedAvdManager = CreateCommandLineTool ("22.0", "avdmanager", "22.0");
+		CreateCommandLineTool ("latest", "sdkmanager", "19.0");
+		CreateCommandLineTool ("latest", "avdmanager", "19.0");
+
+		using var manager = CreateSdkManager ();
+		var selected = manager.FindSdkManager ();
+
+		Assert.That (selected?.Path, Is.EqualTo (expectedSdkManager));
+		Assert.That (selected?.Revision, Is.EqualTo ("22.0"));
+		Assert.That (
+			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
+			Is.EqualTo (expectedAvdManager));
+	}
+
+	[Test]
+	public void FindCommandLineTool_DirectoryNamesDisagreeWithPackageRevision_UsesPackageRevision ()
+	{
+		CreateCommandLineTool ("99.0", "sdkmanager", "19.0");
+		CreateCommandLineTool ("99.0", "avdmanager", "19.0");
+		var expectedSdkManager = CreateCommandLineTool ("1.0", "sdkmanager", "22.0");
+		var expectedAvdManager = CreateCommandLineTool ("1.0", "avdmanager", "22.0");
+
+		using var manager = CreateSdkManager ();
+
+		Assert.That (manager.FindSdkManagerPath (), Is.EqualTo (expectedSdkManager));
+		Assert.That (
+			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
+			Is.EqualTo (expectedAvdManager));
+	}
+
+	[Test]
+	public void FindCommandLineTool_MissingAndMalformedPackageRevision_UsesDirectoryVersion ()
+	{
+		var expectedSdkManager = CreateCommandLineTool ("22.0", "sdkmanager");
+		var expectedAvdManager = CreateCommandLineTool ("22.0", "avdmanager");
+		CreateCommandLineTool ("latest", "sdkmanager", "not-a-version");
+		CreateCommandLineTool ("latest", "avdmanager", "not-a-version");
+
+		using var manager = CreateSdkManager ();
+		var selected = manager.FindSdkManager ();
+
+		Assert.That (selected?.Path, Is.EqualTo (expectedSdkManager));
+		Assert.That (selected?.Revision, Is.EqualTo ("22.0"));
+		Assert.That (
+			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
+			Is.EqualTo (expectedAvdManager));
+	}
+
+	[Test]
+	public void FindCommandLineTool_StableAndPrereleaseHaveSameCoreRevision_PrefersStable ()
+	{
+		var expectedSdkManager = CreateCommandLineTool ("stable", "sdkmanager", "22.0.0");
+		var expectedAvdManager = CreateCommandLineTool ("stable", "avdmanager", "22.0.0");
+		CreateCommandLineTool ("preview", "sdkmanager", "22.0.0 rc1");
+		CreateCommandLineTool ("preview", "avdmanager", "22.0.0 rc1");
+
+		using var manager = CreateSdkManager ();
+
+		Assert.That (manager.FindSdkManagerPath (), Is.EqualTo (expectedSdkManager));
+		Assert.That (
+			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
+			Is.EqualTo (expectedAvdManager));
+	}
+
+	[Test]
+	public void FindCommandLineTool_PrereleaseRevisionsHaveNumericSuffix_SelectsHighest ()
+	{
+		CreateCommandLineTool ("rc2", "sdkmanager", "22.0.0 rc2");
+		var expectedSdkManager = CreateCommandLineTool ("rc10", "sdkmanager", "22.0.0 rc10");
+
+		using var manager = CreateSdkManager ();
+
+		Assert.That (manager.FindSdkManagerPath (), Is.EqualTo (expectedSdkManager));
+	}
+
+	[Test]
+	public void FindCommandLineTool_LegacyToolsDirectory_UsedOnlyForSdkManager ()
+	{
+		var legacyDirectory = Path.Combine (SdkDirectory, "tools", "bin");
+		Directory.CreateDirectory (legacyDirectory);
+		var expectedSdkManager = Path.Combine (legacyDirectory, "sdkmanager" + ExecutableExtension);
+		File.WriteAllText (expectedSdkManager, "");
+		File.WriteAllText (Path.Combine (legacyDirectory, "avdmanager" + ExecutableExtension), "");
+
+		using var manager = CreateSdkManager ();
+
+		Assert.That (manager.FindSdkManagerPath (), Is.EqualTo (expectedSdkManager));
+		Assert.That (
+			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
+			Is.Null);
+	}
+
+	[Test]
+	public async Task EnsureLatestCommandLineToolsAsync_MissingManager_BootstrapsAndInstallsLatest ()
+	{
+		var bootstrapCalls = 0;
+		var installCalls = 0;
+		var progress = new ProgressCollector ();
+		using var manager = CreateSdkManager ();
+
+		var selected = await manager.EnsureLatestCommandLineToolsAsync (
+			SdkDirectory,
+			progress,
+			CancellationToken.None,
+			(targetPath, bootstrapProgress, cancellationToken) => {
+				cancellationToken.ThrowIfCancellationRequested ();
+				Assert.That (targetPath, Is.EqualTo (SdkDirectory));
+				bootstrapCalls++;
+				bootstrapProgress?.Report (new SdkBootstrapProgress (SdkBootstrapPhase.ReadingManifest));
+				bootstrapProgress?.Report (new SdkBootstrapProgress (SdkBootstrapPhase.Complete));
+				CreateCommandLineTool ("19.0", "sdkmanager", "19.0");
+				return Task.CompletedTask;
+			},
+			_ => CreatePackageList ("22.0"),
+			(packages, acceptLicenses, cancellationToken) => {
+				cancellationToken.ThrowIfCancellationRequested ();
+				string[] expectedPackages = [LatestPackage];
+				CollectionAssert.AreEqual (expectedPackages, packages.ToArray ());
+				Assert.That (acceptLicenses, Is.True);
+				installCalls++;
+				CreateCommandLineTool ("latest", "sdkmanager", "22.0");
+				return Task.CompletedTask;
+			});
+
+		Assert.That (selected.Revision, Is.EqualTo ("22.0"));
+		Assert.That (selected.Path, Does.Contain (Path.Combine ("latest", "bin")));
+		Assert.That (bootstrapCalls, Is.EqualTo (1));
+		Assert.That (installCalls, Is.EqualTo (1));
+		Assert.That (progress.Phases, Does.Contain (SdkBootstrapPhase.ReadingManifest));
+		Assert.That (progress.Phases, Does.Contain (SdkBootstrapPhase.CheckingForUpdates));
+		Assert.That (progress.Phases, Does.Contain (SdkBootstrapPhase.Installing));
+		Assert.That (progress.Phases, Does.Contain (SdkBootstrapPhase.Complete));
+		Assert.That (progress.Phases.Count (phase => phase == SdkBootstrapPhase.Complete), Is.EqualTo (1));
+	}
+
+	[Test]
+	public async Task EnsureLatestCommandLineToolsAsync_StaleManager_InstallsLatestWithoutBootstrap ()
+	{
+		CreateCommandLineTool ("19.0", "sdkmanager", "19.0");
+		var bootstrapCalls = 0;
+		var installCalls = 0;
+		using var manager = CreateSdkManager ();
+
+		var selected = await manager.EnsureLatestCommandLineToolsAsync (
+			SdkDirectory,
+			new ProgressCollector (),
+			CancellationToken.None,
+			(_, _, _) => {
+				bootstrapCalls++;
+				return Task.CompletedTask;
+			},
+			_ => CreatePackageList ("22.0"),
+			(_, _, _) => {
+				installCalls++;
+				CreateCommandLineTool ("latest", "sdkmanager", "22.0");
+				return Task.CompletedTask;
+			});
+
+		Assert.That (selected.Revision, Is.EqualTo ("22.0"));
+		Assert.That (bootstrapCalls, Is.Zero);
+		Assert.That (installCalls, Is.EqualTo (1));
+	}
+
+	[Test]
+	public async Task EnsureLatestCommandLineToolsAsync_CurrentManager_DoesNotInstall ()
+	{
+		CreateCommandLineTool ("latest", "sdkmanager", "22.0.0");
+		var bootstrapCalls = 0;
+		var installCalls = 0;
+		var progress = new ProgressCollector ();
+		using var manager = CreateSdkManager ();
+
+		var selected = await manager.EnsureLatestCommandLineToolsAsync (
+			SdkDirectory,
+			progress,
+			CancellationToken.None,
+			(_, _, _) => {
+				bootstrapCalls++;
+				return Task.CompletedTask;
+			},
+			_ => CreatePackageList ("22.0", isInstalled: true),
+			(_, _, _) => {
+				installCalls++;
+				return Task.CompletedTask;
+			});
+
+		Assert.That (selected.Revision, Is.EqualTo ("22.0.0"));
+		Assert.That (bootstrapCalls, Is.Zero);
+		Assert.That (installCalls, Is.Zero);
+		Assert.That (progress.Phases, Does.Not.Contain (SdkBootstrapPhase.Installing));
+	}
+
+	[Test]
+	public async Task EnsureLatestCommandLineToolsAsync_InstalledPackageHasAvailableUpdate_InstallsLatest ()
+	{
+		CreateCommandLineTool ("latest", "sdkmanager", "19.0");
+		var installCalls = 0;
+		using var manager = CreateSdkManager ();
+
+		var selected = await manager.EnsureLatestCommandLineToolsAsync (
+			SdkDirectory,
+			new ProgressCollector (),
+			CancellationToken.None,
+			(_, _, _) => Task.CompletedTask,
+			_ => {
+				IReadOnlyList<SdkPackage> installed = [new SdkPackage (LatestPackage, "19.0", IsInstalled: true)];
+				IReadOnlyList<SdkPackage> available = [new SdkPackage (LatestPackage, "22.0")];
+				return Task.FromResult ((installed, available));
+			},
+			(_, _, _) => {
+				installCalls++;
+				CreateCommandLineTool ("latest", "sdkmanager", "22.0");
+				return Task.CompletedTask;
+			});
+
+		Assert.That (selected.Revision, Is.EqualTo ("22.0"));
+		Assert.That (installCalls, Is.EqualTo (1));
+	}
+
+	[Test]
+	public void EnsureLatestCommandLineToolsAsync_MissingCatalogPackage_Throws ()
+	{
+		CreateCommandLineTool ("19.0", "sdkmanager", "19.0");
+		using var manager = CreateSdkManager ();
+
+		var exception = Assert.ThrowsAsync<InvalidOperationException> (() => manager.EnsureLatestCommandLineToolsAsync (
+			SdkDirectory,
+			new ProgressCollector (),
+			CancellationToken.None,
+			(_, _, _) => Task.CompletedTask,
+			_ => {
+				IReadOnlyList<SdkPackage> installed = [];
+				IReadOnlyList<SdkPackage> available = [];
+				return Task.FromResult ((installed, available));
+			},
+			(_, _, _) => Task.CompletedTask));
+
+		Assert.That (exception?.Message, Does.Contain ("Could not determine the latest"));
+	}
+
+	[Test]
+	public void EnsureLatestCommandLineToolsAsync_InstallDoesNotUpdateManager_Throws ()
+	{
+		CreateCommandLineTool ("19.0", "sdkmanager", "19.0");
+		var installCalls = 0;
+		using var manager = CreateSdkManager ();
+
+		var exception = Assert.ThrowsAsync<InvalidOperationException> (() => manager.EnsureLatestCommandLineToolsAsync (
+			SdkDirectory,
+			new ProgressCollector (),
+			CancellationToken.None,
+			(_, _, _) => Task.CompletedTask,
+			_ => CreatePackageList ("22.0"),
+			(_, _, _) => {
+				installCalls++;
+				return Task.CompletedTask;
+			}));
+
+		Assert.That (exception?.Message, Does.Contain ("older than the catalog revision"));
+		Assert.That (installCalls, Is.EqualTo (1));
+	}
+
+	[Test]
+	public void EnsureLatestCommandLineToolsAsync_BootstrapDoesNotInstallManager_Throws ()
+	{
+		using var manager = CreateSdkManager ();
+
+		var exception = Assert.ThrowsAsync<InvalidOperationException> (() => manager.EnsureLatestCommandLineToolsAsync (
+			SdkDirectory,
+			new ProgressCollector (),
+			CancellationToken.None,
+			(_, _, _) => Task.CompletedTask,
+			_ => CreatePackageList ("22.0"),
+			(_, _, _) => Task.CompletedTask));
+
+		Assert.That (exception?.Message, Does.Contain ("without installing sdkmanager"));
+	}
+
+	[Test]
+	public void EnsureLatestCommandLineToolsAsync_Canceled_PropagatesCancellation ()
+	{
+		using var manager = CreateSdkManager ();
+		using var cancellation = new CancellationTokenSource ();
+		cancellation.Cancel ();
+
+		Assert.ThrowsAsync<OperationCanceledException> (() => manager.EnsureLatestCommandLineToolsAsync (
+			SdkDirectory,
+			new ProgressCollector (),
+			cancellation.Token,
+			(_, _, _) => Task.CompletedTask,
+			_ => CreatePackageList ("22.0"),
+			(_, _, _) => Task.CompletedTask));
+	}
+
+	[Test]
+	public void EnsureLatestCommandLineToolsAsync_CanceledDuringInstall_PropagatesCancellation ()
+	{
+		CreateCommandLineTool ("19.0", "sdkmanager", "19.0");
+		using var manager = CreateSdkManager ();
+		using var cancellation = new CancellationTokenSource ();
+
+		Assert.ThrowsAsync<OperationCanceledException> (() => manager.EnsureLatestCommandLineToolsAsync (
+			SdkDirectory,
+			new ProgressCollector (),
+			cancellation.Token,
+			(_, _, _) => Task.CompletedTask,
+			_ => CreatePackageList ("22.0"),
+			(_, _, cancellationToken) => {
+				cancellation.Cancel ();
+				cancellationToken.ThrowIfCancellationRequested ();
+				return Task.CompletedTask;
+			}));
+	}
+
+	const string LatestPackage = "cmdline-tools;latest";
+
+	SdkManager CreateSdkManager ()
+	{
+		return new SdkManager {
+			AndroidSdkPath = SdkDirectory,
+		};
+	}
+
+	string CreateCommandLineTool (string directoryName, string toolName, string revision = null)
+	{
+		var commandLineToolsDirectory = Path.Combine (SdkDirectory, "cmdline-tools", directoryName);
+		var binDirectory = Path.Combine (commandLineToolsDirectory, "bin");
+		Directory.CreateDirectory (binDirectory);
+
+		var toolPath = Path.Combine (binDirectory, toolName + ExecutableExtension);
+		File.WriteAllText (toolPath, "");
+		if (revision is not null)
+			File.WriteAllText (Path.Combine (commandLineToolsDirectory, "source.properties"), $"Pkg.Revision = {revision}");
+		return toolPath;
+	}
+
+	static Task<(IReadOnlyList<SdkPackage> Installed, IReadOnlyList<SdkPackage> Available)> CreatePackageList (
+		string latestVersion,
+		bool isInstalled = false)
+	{
+		var package = new SdkPackage (LatestPackage, latestVersion, IsInstalled: isInstalled);
+		IReadOnlyList<SdkPackage> installed = isInstalled ? [package] : [];
+		IReadOnlyList<SdkPackage> available = isInstalled ? [] : [package];
+		return Task.FromResult ((installed, available));
+	}
+
+	sealed class ProgressCollector : IProgress<SdkBootstrapProgress>
+	{
+		public List<SdkBootstrapPhase> Phases { get; } = [];
+
+		public void Report (SdkBootstrapProgress value)
+		{
+			Phases.Add (value.Phase);
+		}
+	}
+}

--- a/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/CommandLineToolsResolverTests.cs
+++ b/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/CommandLineToolsResolverTests.cs
@@ -115,10 +115,10 @@ public class CommandLineToolsResolverTests
 	[Test]
 	public void FindCommandLineTool_StableAndPrereleaseHaveSameCoreRevision_PrefersStable ()
 	{
-		var expectedSdkManager = CreateCommandLineTool ("stable", "sdkmanager", "22.0.0");
-		var expectedAvdManager = CreateCommandLineTool ("stable", "avdmanager", "22.0.0");
-		CreateCommandLineTool ("preview", "sdkmanager", "22.0.0 rc1");
-		CreateCommandLineTool ("preview", "avdmanager", "22.0.0 rc1");
+		var expectedSdkManager = CreateCommandLineTool ("stable", "sdkmanager", "22.0");
+		var expectedAvdManager = CreateCommandLineTool ("stable", "avdmanager", "22.0");
+		CreateCommandLineTool ("preview", "sdkmanager", "22.0 rc1");
+		CreateCommandLineTool ("preview", "avdmanager", "22.0 rc1");
 
 		using var manager = CreateSdkManager ();
 
@@ -131,29 +131,12 @@ public class CommandLineToolsResolverTests
 	[Test]
 	public void FindCommandLineTool_PrereleaseRevisionsHaveNumericSuffix_SelectsHighest ()
 	{
-		CreateCommandLineTool ("rc2", "sdkmanager", "22.0.0 rc2");
-		var expectedSdkManager = CreateCommandLineTool ("rc10", "sdkmanager", "22.0.0 rc10");
+		CreateCommandLineTool ("rc2", "sdkmanager", "22.0 rc2");
+		var expectedSdkManager = CreateCommandLineTool ("rc10", "sdkmanager", "22.0 rc10");
 
 		using var manager = CreateSdkManager ();
 
 		Assert.That (manager.FindSdkManagerPath (), Is.EqualTo (expectedSdkManager));
-	}
-
-	[Test]
-	public void FindCommandLineTool_LegacyToolsDirectory_UsedOnlyForSdkManager ()
-	{
-		var legacyDirectory = Path.Combine (SdkDirectory, "tools", "bin");
-		Directory.CreateDirectory (legacyDirectory);
-		var expectedSdkManager = Path.Combine (legacyDirectory, "sdkmanager" + ExecutableExtension);
-		File.WriteAllText (expectedSdkManager, "");
-		File.WriteAllText (Path.Combine (legacyDirectory, "avdmanager" + ExecutableExtension), "");
-
-		using var manager = CreateSdkManager ();
-
-		Assert.That (manager.FindSdkManagerPath (), Is.EqualTo (expectedSdkManager));
-		Assert.That (
-			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
-			Is.Null);
 	}
 
 	[Test]
@@ -230,7 +213,7 @@ public class CommandLineToolsResolverTests
 	[Test]
 	public async Task EnsureLatestCommandLineToolsAsync_CurrentManager_DoesNotInstall ()
 	{
-		CreateCommandLineTool ("latest", "sdkmanager", "22.0.0");
+		CreateCommandLineTool ("latest", "sdkmanager", "22.0");
 		var bootstrapCalls = 0;
 		var installCalls = 0;
 		var progress = new ProgressCollector ();
@@ -250,7 +233,7 @@ public class CommandLineToolsResolverTests
 				return Task.CompletedTask;
 			});
 
-		Assert.That (selected.Revision, Is.EqualTo ("22.0.0"));
+		Assert.That (selected.Revision, Is.EqualTo ("22.0"));
 		Assert.That (bootstrapCalls, Is.Zero);
 		Assert.That (installCalls, Is.Zero);
 		Assert.That (progress.Phases, Does.Not.Contain (SdkBootstrapPhase.Installing));

--- a/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/SdkManagerTests.cs
+++ b/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/SdkManagerTests.cs
@@ -149,7 +149,7 @@ public class SdkManagerTests
 	}
 
 	[Test]
-	public void ParseSdkManagerList_ParsesInstalledAndAvailable ()
+	public void ParseSdkManagerList_ParsesInstalledAvailableAndUpdates ()
 	{
 		var output = @"Installed packages:
   Path                 | Version | Description                    | Location
@@ -166,14 +166,15 @@ Available Packages:
   system-images;android-35;google_apis;arm64-v8a | 14 | Google APIs ARM 64 v8a System Image
 
 Available Updates:
-  Path         | Installed | Available
-  platform-tools | 35.0.2  | 36.0.0
+  ID             | Installed | Available
+  -------        | --------- | ---------
+  platform-tools | 35.0.2    | 36.0.0
 ";
 
 		var (installed, available) = SdkManager.ParseSdkManagerList (output);
 
 		Assert.AreEqual (3, installed.Count, "Should have 3 installed packages");
-		Assert.AreEqual (3, available.Count, "Should have 3 available packages");
+		Assert.AreEqual (4, available.Count, "Should have 3 available packages and 1 update");
 
 		var platformTools = installed.FirstOrDefault (p => p.Path == "platform-tools");
 		Assert.IsNotNull (platformTools);
@@ -184,6 +185,11 @@ Available Updates:
 		Assert.IsNotNull (buildTools36);
 		Assert.AreEqual ("36.0.0", buildTools36!.Version);
 		Assert.IsFalse (buildTools36.IsInstalled);
+
+		var platformToolsUpdate = available.FirstOrDefault (p => p.Path == "platform-tools");
+		Assert.IsNotNull (platformToolsUpdate);
+		Assert.AreEqual ("36.0.0", platformToolsUpdate!.Version);
+		Assert.IsFalse (platformToolsUpdate.IsInstalled);
 	}
 
 	[Test]

--- a/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/SdkManagerTests.cs
+++ b/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/SdkManagerTests.cs
@@ -268,28 +268,6 @@ Available Updates:
 	}
 
 	[Test]
-	public void FindSdkManagerPath_LegacyToolsDir_Found ()
-	{
-		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-test-{Guid.NewGuid ()}");
-		try {
-			var binDir = Path.Combine (sdkDir, "tools", "bin");
-			Directory.CreateDirectory (binDir);
-
-			var sdkManagerName = OS.IsWindows ? "sdkmanager.bat" : "sdkmanager";
-			File.WriteAllText (Path.Combine (binDir, sdkManagerName), "#!/bin/sh\necho test");
-
-			manager.AndroidSdkPath = sdkDir;
-			var result = manager.FindSdkManagerPath ();
-
-			Assert.IsNotNull (result, "Should find sdkmanager in legacy tools/bin");
-		}
-		finally {
-			if (Directory.Exists (sdkDir))
-				Directory.Delete (sdkDir, recursive: true);
-		}
-	}
-
-	[Test]
 	public void FindSdkManagerPath_NoSdkManager_ReturnsNull ()
 	{
 		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-test-{Guid.NewGuid ()}");


### PR DESCRIPTION
## Summary

- resolve `sdkmanager`, `avdmanager`, and future command-line tools through one shared `Pkg.Revision`-aware resolver under `cmdline-tools`
- expose the selected manager path and revision, and conditionally install only `cmdline-tools;latest` when the installed manager is missing or stale
- share `source.properties` parsing with NDK discovery, parse available SDK updates correctly, and add coverage for precedence, fallbacks, prereleases, refresh, cancellation, and progress

## Testing

- `dotnet test external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj -c Release --no-restore --filter 'FullyQualifiedName~CommandLineToolsResolverTests|FullyQualifiedName~SdkManagerTests|FullyQualifiedName~AndroidSdkInfoTests'`
- `dotnet build external/xamarin-android-tools/Xamarin.Android.Tools.sln -c Release --no-restore`

Fixes #12137