### PR TITLE
[Native] Remove unused printf debugging helper

### DIFF
--- a/src/native/common/include/shared/cpp-util.hh
+++ b/src/native/common/include/shared/cpp-util.hh
@@ -137,14 +137,6 @@ abort_if_negative_integer_argument (int arg, const char *arg_name, std::source_l
 	);
 }
 
-// Helper to use in "printf debugging". Normally not used in code anywhere. No code should be shipped with any
-// of the calls present.
-[[gnu::always_inline]]
-inline void pd_log_location (std::source_location sloc = std::source_location::current ()) noexcept
-{
-	log_warn (LOG_DEFAULT, "loc: {}:{} ('{}')", sloc.file_name (), sloc.line (), sloc.function_name ());
-}
-
 namespace xamarin::android
 {
 	template <typename T>

--- a/src/native/mono/shared/cpp-util.hh
+++ b/src/native/mono/shared/cpp-util.hh
@@ -138,13 +138,6 @@ abort_if_negative_integer_argument (int arg, const char *arg_name, std::source_l
 	);
 }
 
-// Helper to use in "printf debugging". Normally not used in code anywhere. No code should be shipped with any
-// of the calls present.
-force_inline inline void pd_log_location (std::source_location sloc = std::source_location::current ()) noexcept
-{
-	log_warn (LOG_DEFAULT, "loc: {}:{} ('{}')", sloc.file_name (), sloc.line (), sloc.function_name ());
-}
-
 namespace xamarin::android
 {
 	template <typename T>


### PR DESCRIPTION
## Summary

Remove the unused `pd_log_location()` printf-debugging helper from both native `cpp-util.hh` implementations.

A repository-wide search found no callers. Because the helper is inline and unused, it currently emits no code; retaining it only leaves dead `std::format`-style logging source available to be copied or accidentally used later.

## Changes

- remove `pd_log_location()` from the shared CoreCLR/NativeAOT header;
- remove the duplicate helper from the MonoVM header.

## Validation

- repository-wide search confirms there are no remaining declarations or callers;
- representative Android arm64 NativeAOT, CoreCLR, and MonoVM translation units compile with the repository-generated NDK commands;
- `git diff --check`.

Related to #12139.
