### PR TITLE
[tests] Skip .NET 10 NativeAOT compatibility coverage

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1953,10 +1953,11 @@ namespace UnnamedProject
 		}
 
 		[Test]
+		// .NET 10 NativeAOT was experimental and is not covered by previous-version compatibility tests.
 		public void DotNetInstallAndRunMinorAPILevels (
 				[Values] bool isRelease,
 				[Values ("net10.0-android36.1")] string targetFramework,
-				[Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
+				[Values (AndroidRuntime.CoreCLR)] AndroidRuntime runtime)
 		{
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;


### PR DESCRIPTION
## Summary

- remove NativeAOT from the `DotNetInstallAndRunMinorAPILevels` runtime matrix
- retain CoreCLR coverage for `net10.0-android36.1`
- document that .NET 10 NativeAOT was experimental and is not a previous-version compatibility target

## Rationale

The current .NET 11 workload manifest routes this `net10.0-android36.1` application to the previously shipped Android 36.1.69 and NativeAOT 10.0.9 packs. Consequently, the NativeAOT case cannot exercise current-branch NativeAOT changes and currently hits the known duplicate-libunwind failure with NDK r29.

.NET 10 NativeAOT was experimental, so current PRs should not be gated on backward compatibility for that implementation.

## Validation

- `./dotnet-local.sh build tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj -c Debug -v:minimal --no-restore`
