### PR TITLE
[ci] Add signing to the internal pipeline

### DIFF
--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -459,6 +459,7 @@ stages:
               "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
               "/p:OfficialBuildId=$(_BuildOfficialId)",
               "/p:DotNetSignType=$(_SignType)",
+              "/p:SignWorkloadMsis=true",
               "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
               "/p:RepositoryName=dotnet/android"
             )

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -55,8 +55,6 @@ variables:
     value: test
 - name: _BuildConfig
   value: Release
-- name: ArcadeDotNetSdkVersion
-  value: 11.0.100-preview.7.26355.102
 - name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE
   value: 'true'
 - name: DOTNET_SDK_VULNERABILITY_CHECK_DISABLE
@@ -339,23 +337,27 @@ stages:
           inputs:
             version: 8.0.x
 
-        - task: UseDotNet@2
-          displayName: Install .NET SDK for Arcade signing
-          inputs:
-            version: $(ArcadeDotNetSdkVersion)
-            includePreviewVersions: true
+        - pwsh: |
+            $signingLogs = "$(Build.StagingDirectory)\signing-logs"
+            New-Item $signingLogs -ItemType Directory -Force | Out-Null
+
+            & "$(Build.SourcesDirectory)\android\eng\install-dotnet.ps1" -configuration Release
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+
+            Write-Host "##vso[task.prependpath]$(Build.SourcesDirectory)\android\bin\Release\dotnet"
+          displayName: Install tracked .NET SDK for Arcade signing
 
         - pwsh: |
             $unsigned = "$(Build.StagingDirectory)\unsigned"
             $artifacts = "$(Build.SourcesDirectory)\android\artifacts"
             $shipping = Join-Path $artifacts "packages\Release\Shipping"
             $logs = Join-Path $artifacts "log\Release"
-            $signingLogs = "$(Build.StagingDirectory)\signing-logs"
 
             Remove-Item $artifacts -Recurse -Force -ErrorAction Ignore
             New-Item $shipping -ItemType Directory -Force | Out-Null
             New-Item $logs -ItemType Directory -Force | Out-Null
-            New-Item $signingLogs -ItemType Directory -Force | Out-Null
 
             $packages = @(Get-ChildItem $unsigned -Filter "*.nupkg" -File -Recurse)
             if ($packages.Count -eq 0) {

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -482,6 +482,38 @@ stages:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
         - pwsh: |
+            $properties = @(
+              "/p:RepositoryEngineeringDir=$(ArcadeAdapterRoot)\eng\",
+              "/p:AndroidRepoRoot=$(Build.SourcesDirectory)\android",
+              "/p:AndroidSignList=$(AndroidSignList)",
+              "/p:ArtifactsDir=$(Build.SourcesDirectory)\android\artifacts\",
+              "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
+              "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
+              "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
+              "/p:OfficialBuildId=$(_BuildOfficialId)",
+              "/p:DotNetSignType=$(_SignType)",
+              "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
+              "/p:RepositoryName=dotnet/android"
+            )
+
+            & "$(ArcadeAdapterRoot)\eng\common\build.ps1" `
+              -configuration Release `
+              -msbuildEngine dotnet `
+              -projects "$(ArcadeAdapterRoot)\Workloads.proj" `
+              -sign `
+              -ci `
+              -warnAsError:$false `
+              -binaryLogName "$(Build.StagingDirectory)\signing-logs\sign-msi-nugets.binlog" `
+              @properties
+          displayName: Sign workload MSI NuGet packages with Arcade
+          env:
+            BUILD_REPOSITORY_NAME: dotnet/android
+            BUILD_REPOSITORY_URI: https://github.com/dotnet/android
+            NUGET_CONFIG: $(Build.SourcesDirectory)\android\NuGet.config
+            NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+        - pwsh: |
             $shipping = "$(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping"
             $inputNames = @(Get-Content "$(Build.StagingDirectory)\unsigned-package-names.json" -Raw | ConvertFrom-Json)
             foreach ($name in $inputNames) {

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -339,27 +339,23 @@ stages:
           inputs:
             version: 8.0.x
 
-        - pwsh: |
-            $signingLogs = "$(Build.StagingDirectory)\signing-logs"
-            New-Item $signingLogs -ItemType Directory -Force | Out-Null
-
-            & "$(Build.SourcesDirectory)\android\eng\install-dotnet.ps1" -configuration Release
-            if ($LASTEXITCODE -ne 0) {
-              exit $LASTEXITCODE
-            }
-
-            Write-Host "##vso[task.prependpath]$(Build.SourcesDirectory)\android\bin\Release\dotnet"
-          displayName: Install tracked .NET SDK for Arcade signing
+        - task: UseDotNet@2
+          displayName: Install .NET SDK for Arcade signing
+          inputs:
+            version: $(DotNetSdkVersion).x
+            includePreviewVersions: true
 
         - pwsh: |
             $unsigned = "$(Build.StagingDirectory)\unsigned"
             $artifacts = "$(Build.SourcesDirectory)\android\artifacts"
             $shipping = Join-Path $artifacts "packages\Release\Shipping"
             $logs = Join-Path $artifacts "log\Release"
+            $signingLogs = "$(Build.StagingDirectory)\signing-logs"
 
             Remove-Item $artifacts -Recurse -Force -ErrorAction Ignore
             New-Item $shipping -ItemType Directory -Force | Out-Null
             New-Item $logs -ItemType Directory -Force | Out-Null
+            New-Item $signingLogs -ItemType Directory -Force | Out-Null
 
             $packages = @(Get-ChildItem $unsigned -Filter "*.nupkg" -File -Recurse)
             if ($packages.Count -eq 0) {

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -373,7 +373,19 @@ stages:
             if (-not $signList) {
               throw "The build did not publish SignList.xml."
             }
-            Write-Host "##vso[task.setvariable variable=AndroidSignList]$($signList.FullName)"
+
+            [xml] $arcadeSignList = Get-Content $signList.FullName
+            foreach ($item in $arcadeSignList.SelectNodes("/Project/ItemGroup/*[@Include]")) {
+              $include = $item.GetAttribute("Include")
+              if ($item.LocalName -eq "MacDeveloperSign" -or $item.LocalName -eq "MacDeveloperSignHarden") {
+                $include = [IO.Path]::GetFileName($include.Replace("/", "\"))
+              }
+              $include = $include.Replace("%", "%25").Replace("*", "%2A").Replace("?", "%3F").Replace(";", "%3B")
+              $item.SetAttribute("Include", $include)
+            }
+            $arcadeSignListPath = "$(Build.StagingDirectory)\ArcadeSignList.xml"
+            $arcadeSignList.Save($arcadeSignListPath)
+            Write-Host "##vso[task.setvariable variable=AndroidSignList]$arcadeSignListPath"
 
             $signVerify = Get-ChildItem $unsigned -Filter "SignVerifyIgnore.txt" -File -Recurse | Select-Object -First 1
             if (-not $signVerify) {

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -10,10 +10,9 @@
 # branch policies for main, release/*, and feature/*. Azure Repos does not
 # support YAML `pr` triggers.
 #
-# Signing is intentionally NOT enabled yet. We will eventually release &
-# sign from here; when we do, convert this to `extends` the 1ES
-# `MicroBuild.1ES.Official.yml` template and flip the `use1ESTemplate`
-# parameters below to `true` (see azure-pipelines.yaml for reference).
+# Signing uses the in-repo Arcade templates and adapter under
+# build-tools/automation/dnceng. Do not add a Xamarin.yaml-templates
+# repository resource: dnceng/internal cannot access that repository.
 
 name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 
@@ -46,6 +45,20 @@ resources:
 # Global variables
 variables:
 - template: /build-tools/automation/yaml-templates/variables.yaml@self
+- name: _TeamName
+  value: Maui
+- ${{ if and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: _SignType
+    value: real
+- ${{ else }}:
+  - name: _SignType
+    value: test
+- name: _BuildConfig
+  value: Release
+- name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE
+  value: 'true'
+- name: DOTNET_SDK_VULNERABILITY_CHECK_DISABLE
+  value: 'true'
 # Override for internal pipeline
 - name: DefaultJavaSdkMajorVersion
   value: 21
@@ -269,6 +282,228 @@ stages:
         use1ESTemplate: false
 
     - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+
+# Signing and Visual Studio workload insertion artifacts
+- stage: dotnet_prepare_release
+  displayName: Prepare .NET Release
+  dependsOn:
+  - mac_build
+  - linux_build
+  condition: and(
+      succeeded(),
+      ne(variables['Build.Reason'], 'PullRequest'),
+      ne(variables['Build.Reason'], 'Schedule')
+    )
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml@self
+    parameters:
+      runAsPublic: false
+      enableMicrobuild: true
+      microbuildUseESRP: ${{ and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ne(variables['Build.Reason'], 'PullRequest')) }}
+      jobs:
+      - job: prepare_release
+        displayName: Sign NuGets and workload MSIs
+        timeoutInMinutes: 240
+        pool:
+          name: $(NetCoreInternalPoolName)
+          demands:
+          - ImageOverride -equals $(WindowsPoolImageNetCoreInternal)
+        workspace:
+          clean: all
+        steps:
+        - checkout: self
+          clean: true
+          fetchDepth: 1
+          fetchTags: false
+          path: s/android
+
+        - checkout: android-tools
+          path: s/android-tools
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download unsigned macOS and Windows packages
+          inputs:
+            artifactName: $(NuGetArtifactName)
+            downloadPath: $(Build.StagingDirectory)\unsigned\mac-win
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download unsigned Linux packages
+          inputs:
+            artifactName: $(LinuxNuGetArtifactName)
+            downloadPath: $(Build.StagingDirectory)\unsigned\linux
+
+        - task: UseDotNet@2
+          displayName: Install .NET 8 SDK for SwixBuild
+          inputs:
+            version: 8.0.x
+
+        - task: UseDotNet@2
+          displayName: Install .NET SDK for Arcade signing
+          inputs:
+            version: $(DotNetSdkVersion).x
+            includePreviewVersions: true
+
+        - pwsh: |
+            $unsigned = "$(Build.StagingDirectory)\unsigned"
+            $artifacts = "$(Build.SourcesDirectory)\android\artifacts"
+            $shipping = Join-Path $artifacts "packages\Release\Shipping"
+            $logs = Join-Path $artifacts "log\Release"
+
+            Remove-Item $artifacts -Recurse -Force -ErrorAction Ignore
+            New-Item $shipping -ItemType Directory -Force | Out-Null
+            New-Item $logs -ItemType Directory -Force | Out-Null
+
+            $packages = @(Get-ChildItem $unsigned -Filter "*.nupkg" -File -Recurse)
+            if ($packages.Count -eq 0) {
+              throw "The build did not publish any NuGet packages."
+            }
+            Copy-Item $packages.FullName $shipping
+
+            $workloadProps = Get-ChildItem $unsigned -Filter "vs-workload.props" -File -Recurse | Select-Object -First 1
+            if (-not $workloadProps) {
+              throw "The build did not publish vs-workload.props."
+            }
+            Copy-Item $workloadProps.FullName $shipping
+
+            $signList = Get-ChildItem $unsigned -Filter "SignList.xml" -File -Recurse | Select-Object -First 1
+            if (-not $signList) {
+              throw "The build did not publish SignList.xml."
+            }
+            Write-Host "##vso[task.setvariable variable=AndroidSignList]$($signList.FullName)"
+
+            $signVerify = Get-ChildItem $unsigned -Filter "SignVerifyIgnore.txt" -File -Recurse | Select-Object -First 1
+            if (-not $signVerify) {
+              throw "The build did not publish SignVerifyIgnore.txt."
+            }
+            Copy-Item $signVerify.FullName "$(Build.StagingDirectory)\SignVerifyIgnore.txt"
+
+            $inputNames = $packages.Name | Sort-Object -Unique
+            $inputNames | ConvertTo-Json | Set-Content "$(Build.StagingDirectory)\unsigned-package-names.json"
+
+            $shortHash = "$(Build.SourceVersion)".Substring(0, 7)
+            Write-Host "##vso[task.setvariable variable=BUILD_SOURCEVERSIONSHORT]$shortHash"
+          displayName: Normalize unsigned artifacts for Arcade
+
+        - pwsh: |
+            $adapter = "$(Agent.TempDirectory)\android-arcade"
+            Remove-Item $adapter -Recurse -Force -ErrorAction Ignore
+            Copy-Item "$(Build.SourcesDirectory)\android\build-tools\automation\dnceng\arcade" $adapter -Recurse
+            Copy-Item "$(Build.SourcesDirectory)\android\eng\common" "$adapter\eng\common" -Recurse
+
+            $globalJson = Get-Content "$(Build.SourcesDirectory)\android\global.json" -Raw | ConvertFrom-Json -AsHashtable
+            $globalJson["tools"] = [ordered]@{
+              dotnet = (& dotnet --version)
+            }
+            $globalJson | ConvertTo-Json -Depth 5 | Set-Content "$adapter\global.json"
+
+            Write-Host "##vso[task.setvariable variable=ArcadeAdapterRoot]$adapter"
+          displayName: Prepare isolated Arcade adapter
+
+        - pwsh: |
+            $properties = @(
+              "/p:RepositoryEngineeringDir=$(ArcadeAdapterRoot)\eng\",
+              "/p:AndroidRepoRoot=$(Build.SourcesDirectory)\android",
+              "/p:AndroidSignList=$(AndroidSignList)",
+              "/p:ArtifactsDir=$(Build.SourcesDirectory)\android\artifacts\",
+              "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
+              "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
+              "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
+              "/p:OfficialBuildId=$(Build.BuildNumber)",
+              "/p:DotNetSignType=$(_SignType)",
+              "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
+              "/p:RepositoryName=dotnet/android"
+            )
+
+            & "$(ArcadeAdapterRoot)\eng\common\build.ps1" `
+              -configuration Release `
+              -msbuildEngine dotnet `
+              -projects "$(ArcadeAdapterRoot)\Workloads.proj" `
+              -restore `
+              -sign `
+              -ci `
+              -warnAsError:$false `
+              -excludeCIBinarylog `
+              @properties
+          displayName: Sign prebuilt NuGet packages with Arcade
+          env:
+            BUILD_REPOSITORY_NAME: dotnet/android
+            BUILD_REPOSITORY_URI: https://github.com/dotnet/android
+            NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+        - pwsh: |
+            $properties = @(
+              "/p:RepositoryEngineeringDir=$(ArcadeAdapterRoot)\eng\",
+              "/p:AndroidRepoRoot=$(Build.SourcesDirectory)\android",
+              "/p:AndroidSignList=$(AndroidSignList)",
+              "/p:ArtifactsDir=$(Build.SourcesDirectory)\android\artifacts\",
+              "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
+              "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
+              "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
+              "/p:OfficialBuildId=$(Build.BuildNumber)",
+              "/p:DotNetSignType=$(_SignType)",
+              "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
+              "/p:RepositoryName=dotnet/android"
+            )
+
+            & "$(ArcadeAdapterRoot)\eng\common\build.ps1" `
+              -configuration Release `
+              -msbuildEngine dotnet `
+              -projects "$(ArcadeAdapterRoot)\Workloads.proj" `
+              -build `
+              -sign `
+              -ci `
+              -warnAsError:$false `
+              @properties
+          displayName: Build and sign workload MSIs with Arcade
+          env:
+            BUILD_REPOSITORY_NAME: dotnet/android
+            BUILD_REPOSITORY_URI: https://github.com/dotnet/android
+            NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+        - pwsh: |
+            $shipping = "$(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping"
+            $inputNames = @(Get-Content "$(Build.StagingDirectory)\unsigned-package-names.json" -Raw | ConvertFrom-Json)
+            foreach ($name in $inputNames) {
+              if (-not (Test-Path (Join-Path $shipping $name) -PathType Leaf)) {
+                throw "Signed output is missing '$name'."
+              }
+            }
+
+            $msiPackages = @(Get-ChildItem $shipping -Filter "*.nupkg" -File |
+              Where-Object { $_.Name -notin $inputNames })
+            if ($msiPackages.Count -eq 0) {
+              throw "The workload build did not generate any MSI NuGet packages."
+            }
+
+            $msiDirectory = "$(Build.StagingDirectory)\msi-nupkgs"
+            New-Item $msiDirectory -ItemType Directory -Force | Out-Null
+            Copy-Item $msiPackages.FullName $msiDirectory
+          displayName: Validate signed package outputs
+
+        - task: MicroBuildCodesignVerify@3
+          displayName: Verify signed workload artifacts
+          inputs:
+            TargetFolders: |
+              $(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping\manifests
+              $(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping\manifests-packs
+              $(Build.StagingDirectory)\msi-nupkgs
+            ExcludeSNVerify: true
+            ApprovalListPathForCerts: $(Build.StagingDirectory)\SignVerifyIgnore.txt
+
+        - task: PublishPipelineArtifact@1
+          displayName: Publish signed NuGet packages
+          inputs:
+            artifactName: nuget-signed
+            targetPath: $(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping
+
+        - task: PublishPipelineArtifact@1
+          displayName: Publish signing logs
+          condition: succeededOrFailed()
+          inputs:
+            artifactName: signing-logs-$(System.StageAttempt)-$(System.JobAttempt)
+            targetPath: $(Build.SourcesDirectory)\android\artifacts\log\Release
 
 # MSBuild Tests Stage
 - stage: msbuild_dotnet

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -375,14 +375,65 @@ stages:
             }
 
             [xml] $arcadeSignList = Get-Content $signList.FullName
-            foreach ($item in $arcadeSignList.SelectNodes("/Project/ItemGroup/*[@Include]")) {
-              $include = $item.GetAttribute("Include")
-              if ($item.LocalName -eq "MacDeveloperSign" -or $item.LocalName -eq "MacDeveloperSignHarden") {
-                $include = [IO.Path]::GetFileName($include.Replace("/", "\"))
+            $packageEntries = foreach ($package in $packages) {
+              $archive = [IO.Compression.ZipFile]::OpenRead($package.FullName)
+              try {
+                foreach ($entry in $archive.Entries) {
+                  [pscustomobject]@{
+                    FullName = $entry.FullName.Replace("\", "/")
+                    Name = $entry.Name
+                  }
+                }
+              } finally {
+                $archive.Dispose()
               }
-              $include = $include.Replace("%", "%25").Replace("*", "%2A").Replace("?", "%3F").Replace(";", "%3B")
-              $item.SetAttribute("Include", $include)
             }
+
+            foreach ($item in @($arcadeSignList.SelectNodes("/Project/ItemGroup/*[@Include]"))) {
+              $include = $item.GetAttribute("Include").Replace("\", "/")
+              if ($include.Contains("*") -or $include.Contains("?")) {
+                $matchedEntries = if ($include.Contains("/")) {
+                  @($packageEntries | Where-Object { $_.FullName -like $include -or $_.FullName -like "*/$include" })
+                } else {
+                  @($packageEntries | Where-Object { $_.Name -like $include })
+                }
+                $names = @($matchedEntries.Name | Where-Object { $_ } | Sort-Object -Unique)
+                if ($names.Count -eq 0) {
+                  throw "Signing pattern '$include' did not match any package entries."
+                }
+                foreach ($name in $names) {
+                  $expandedItem = $item.Clone()
+                  $escapedName = $name.Replace("%", "%25").Replace(";", "%3B")
+                  $expandedItem.SetAttribute("Include", $escapedName)
+                  [void] $item.ParentNode.InsertBefore($expandedItem, $item)
+                }
+                [void] $item.ParentNode.RemoveChild($item)
+              } else {
+                if ($item.LocalName -eq "MacDeveloperSign" -or $item.LocalName -eq "MacDeveloperSignHarden") {
+                  $include = [IO.Path]::GetFileName($include)
+                }
+                $include = $include.Replace("%", "%25").Replace(";", "%3B")
+                $item.SetAttribute("Include", $include)
+              }
+            }
+
+            $skipNames = @($arcadeSignList.SelectNodes("/Project/ItemGroup/Skip") | ForEach-Object Include)
+            foreach ($item in @($arcadeSignList.SelectNodes("/Project/ItemGroup/MacDeveloperSign | /Project/ItemGroup/MacDeveloperSignHarden"))) {
+              if ($item.GetAttribute("Include") -in $skipNames) {
+                [void] $item.ParentNode.RemoveChild($item)
+              }
+            }
+
+            $certificatesByName = @{}
+            foreach ($item in $arcadeSignList.SelectNodes("/Project/ItemGroup/ThirdParty | /Project/ItemGroup/ThirdPartyScript | /Project/ItemGroup/MacDeveloperSign | /Project/ItemGroup/MacDeveloperSignHarden")) {
+              $name = $item.GetAttribute("Include")
+              $certificateGroup = $item.LocalName
+              if ($certificatesByName.ContainsKey($name) -and $certificatesByName[$name] -ne $certificateGroup) {
+                throw "Signing entry '$name' is assigned to both '$($certificatesByName[$name])' and '$certificateGroup'."
+              }
+              $certificatesByName[$name] = $certificateGroup
+            }
+
             $arcadeSignListPath = "$(Build.StagingDirectory)\ArcadeSignList.xml"
             $arcadeSignList.Save($arcadeSignListPath)
             Write-Host "##vso[task.setvariable variable=AndroidSignList]$arcadeSignListPath"

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -340,7 +340,7 @@ stages:
         - task: UseDotNet@2
           displayName: Install .NET SDK for Arcade signing
           inputs:
-            version: $(DotNetSdkVersion).x
+            version: 11.0.x
             includePreviewVersions: true
 
         - pwsh: |

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -428,6 +428,7 @@ stages:
           env:
             BUILD_REPOSITORY_NAME: dotnet/android
             BUILD_REPOSITORY_URI: https://github.com/dotnet/android
+            NUGET_CONFIG: $(Build.SourcesDirectory)\android\NuGet.config
             NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
@@ -459,6 +460,7 @@ stages:
           env:
             BUILD_REPOSITORY_NAME: dotnet/android
             BUILD_REPOSITORY_URI: https://github.com/dotnet/android
+            NUGET_CONFIG: $(Build.SourcesDirectory)\android\NuGet.config
             NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -56,7 +56,7 @@ variables:
 - name: _BuildConfig
   value: Release
 - name: ArcadeDotNetSdkVersion
-  value: 11.0
+  value: 11.0.100-preview.7.26355.102
 - name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE
   value: 'true'
 - name: DOTNET_SDK_VULNERABILITY_CHECK_DISABLE
@@ -342,7 +342,7 @@ stages:
         - task: UseDotNet@2
           displayName: Install .NET SDK for Arcade signing
           inputs:
-            version: $(ArcadeDotNetSdkVersion).x
+            version: $(ArcadeDotNetSdkVersion)
             includePreviewVersions: true
 
         - pwsh: |
@@ -350,10 +350,12 @@ stages:
             $artifacts = "$(Build.SourcesDirectory)\android\artifacts"
             $shipping = Join-Path $artifacts "packages\Release\Shipping"
             $logs = Join-Path $artifacts "log\Release"
+            $signingLogs = "$(Build.StagingDirectory)\signing-logs"
 
             Remove-Item $artifacts -Recurse -Force -ErrorAction Ignore
             New-Item $shipping -ItemType Directory -Force | Out-Null
             New-Item $logs -ItemType Directory -Force | Out-Null
+            New-Item $signingLogs -ItemType Directory -Force | Out-Null
 
             $packages = @(Get-ChildItem $unsigned -Filter "*.nupkg" -File -Recurse)
             if ($packages.Count -eq 0) {
@@ -424,7 +426,7 @@ stages:
               -sign `
               -ci `
               -warnAsError:$false `
-              -excludeCIBinarylog `
+              -binaryLogName "$(Build.StagingDirectory)\signing-logs\sign-nugets.binlog" `
               @properties
           displayName: Sign prebuilt NuGet packages with Arcade
           env:
@@ -457,6 +459,7 @@ stages:
               -sign `
               -ci `
               -warnAsError:$false `
+              -binaryLogName "$(Build.StagingDirectory)\signing-logs\workload-msis.binlog" `
               @properties
           displayName: Build and sign workload MSIs with Arcade
           env:
@@ -504,10 +507,10 @@ stages:
 
         - task: PublishPipelineArtifact@1
           displayName: Publish signing logs
-          condition: succeededOrFailed()
+          condition: always()
           inputs:
             artifactName: signing-logs-$(System.StageAttempt)-$(System.JobAttempt)
-            targetPath: $(Build.SourcesDirectory)\android\artifacts\log\Release
+            targetPath: $(Build.StagingDirectory)\signing-logs
 
 # MSBuild Tests Stage
 - stage: msbuild_dotnet

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -55,6 +55,8 @@ variables:
     value: test
 - name: _BuildConfig
   value: Release
+- name: _BuildOfficialId
+  value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1)) ]
 - name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE
   value: 'true'
 - name: DOTNET_SDK_VULNERABILITY_CHECK_DISABLE
@@ -414,7 +416,7 @@ stages:
               "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
               "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
               "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
-              "/p:OfficialBuildId=$(Build.BuildNumber)",
+              "/p:OfficialBuildId=$(_BuildOfficialId)",
               "/p:DotNetSignType=$(_SignType)",
               "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
               "/p:RepositoryName=dotnet/android"
@@ -447,7 +449,7 @@ stages:
               "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
               "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
               "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
-              "/p:OfficialBuildId=$(Build.BuildNumber)",
+              "/p:OfficialBuildId=$(_BuildOfficialId)",
               "/p:DotNetSignType=$(_SignType)",
               "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
               "/p:RepositoryName=dotnet/android"

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -55,6 +55,8 @@ variables:
     value: test
 - name: _BuildConfig
   value: Release
+- name: ArcadeDotNetSdkVersion
+  value: 11.0
 - name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE
   value: 'true'
 - name: DOTNET_SDK_VULNERABILITY_CHECK_DISABLE
@@ -340,7 +342,7 @@ stages:
         - task: UseDotNet@2
           displayName: Install .NET SDK for Arcade signing
           inputs:
-            version: 11.0.x
+            version: $(ArcadeDotNetSdkVersion).x
             includePreviewVersions: true
 
         - pwsh: |

--- a/build-tools/automation/dnceng/arcade/Workloads.proj
+++ b/build-tools/automation/dnceng/arcade/Workloads.proj
@@ -159,9 +159,6 @@
       <Output TaskParameter="SwixProjects" ItemName="_SwixProjects" />
     </CreateVisualStudioWorkload>
     <ItemGroup>
-      <FilesToSign Include="$(OutputPath)**\*.msi">
-        <Authenticode>Microsoft400</Authenticode>
-      </FilesToSign>
       <_WorkloadOutputLines Include="&lt;Project&gt;" />
       <_WorkloadOutputLines Include="  &lt;ItemGroup&gt;" />
       <_WorkloadOutputLines Include="@(_WorkloadMsis->'    &lt;_WorkloadMsis Include=&quot;%(Identity)&quot; PackageProject=&quot;%(PackageProject)&quot; /&gt;')" />

--- a/build-tools/automation/dnceng/arcade/Workloads.proj
+++ b/build-tools/automation/dnceng/arcade/Workloads.proj
@@ -16,6 +16,7 @@
     <ArtifactsShippingPackagesDir>$(ArtifactsPackagesDir)Shipping\</ArtifactsShippingPackagesDir>
     <ArtifactsLogDir>$(_ArtifactsDir)log\Release\</ArtifactsLogDir>
     <WorkloadMsiLogDirectory>$(ArtifactsLogDir)workload-msi</WorkloadMsiLogDirectory>
+    <IntermediateOutputPath>$(_ArtifactsDir)obj\Release\</IntermediateOutputPath>
     <OutputPath>$(_ArtifactsDir)workload-msi\</OutputPath>
     <VsmanProject>$(MSBuildThisFileDirectory)vsman\Workload.vsmanproj</VsmanProject>
     <ManifestOutputPath>$(ArtifactsShippingPackagesDir)\manifests</ManifestOutputPath>

--- a/build-tools/automation/dnceng/arcade/Workloads.proj
+++ b/build-tools/automation/dnceng/arcade/Workloads.proj
@@ -1,0 +1,209 @@
+<Project DefaultTargets="Restore;Build">
+  <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <AndroidRepoRoot Condition="'$(AndroidRepoRoot)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..', '..', '..'))</AndroidRepoRoot>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <_ArtifactsDir>$([MSBuild]::EnsureTrailingSlash('$(ArtifactsDir)'))</_ArtifactsDir>
+    <ArtifactsPackagesDir>$(_ArtifactsDir)packages\Release\</ArtifactsPackagesDir>
+    <ArtifactsShippingPackagesDir>$(ArtifactsPackagesDir)Shipping\</ArtifactsShippingPackagesDir>
+    <ArtifactsLogDir>$(_ArtifactsDir)log\Release\</ArtifactsLogDir>
+    <WorkloadMsiLogDirectory>$(ArtifactsLogDir)workload-msi</WorkloadMsiLogDirectory>
+    <OutputPath>$(_ArtifactsDir)workload-msi\</OutputPath>
+    <VsmanProject>$(MSBuildThisFileDirectory)vsman\Workload.vsmanproj</VsmanProject>
+    <ManifestOutputPath>$(ArtifactsShippingPackagesDir)\manifests</ManifestOutputPath>
+    <PreviewManifestOutputPath>$(ArtifactsShippingPackagesDir)\manifests-pre</PreviewManifestOutputPath>
+    <PackManifestOutputPath>$(ArtifactsShippingPackagesDir)\manifests-packs</PackManifestOutputPath>
+    <MsiNuGetOutputPath>$(ArtifactsShippingPackagesDir)</MsiNuGetOutputPath>
+    <NuGetPackagePath Condition="'$(NuGetPackagePath)' == ''">$(ArtifactsShippingPackagesDir)</NuGetPackagePath>
+    <WorkloadMsiGenProps Condition="'$(WorkloadMsiGenProps)' == ''">$(ArtifactsShippingPackagesDir)\vs-workload.props</WorkloadMsiGenProps>
+    <ArcadePackageVersion>11.0.0-beta.26325.102</ArcadePackageVersion>
+    <SwixBuildPackageVersion>1.1.922</SwixBuildPackageVersion>
+    <MicrosoftWixToolsetSdkVersion>6.0.3-dotnet.4</MicrosoftWixToolsetSdkVersion>
+    <WixHeatPackageVersion>6.0.3-dotnet.4</WixHeatPackageVersion>
+    <WixExtensionsPackageVersion>6.0.3-dotnet.4</WixExtensionsPackageVersion>
+    <VSWherePackageVersion>3.1.7</VSWherePackageVersion>
+    <BundledNETCoreAppTargetFramework Condition="'$(BundledNETCoreAppTargetFramework)' == ''">net$(BundledNETCoreAppTargetFrameworkVersion)</BundledNETCoreAppTargetFramework>
+    <DropBuildNumber Condition="'$(BUILD_SOURCEVERSIONSHORT)' == ''">$(BUILD_BUILDID)</DropBuildNumber>
+    <DropBuildNumber Condition="'$(BUILD_SOURCEVERSIONSHORT)' != ''">$(BUILD_SOURCEVERSIONSHORT)/$(BUILD_BUILDID)</DropBuildNumber>
+    <SwixTargetsPath>$(PkgMicrosoft_VisualStudioEng_MicroBuild_Plugins_SwixBuild)\build\Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild.targets</SwixTargetsPath>
+    <WixExe>$(PkgMicrosoft_Wix)\tools\net6.0\any\wix.exe</WixExe>
+    <HeatExe>$(PkgMicrosoft_WixToolset_Heat)\tools\net472\x64\heat.exe</HeatExe>
+    <WixExtensionsDir>wixext6</WixExtensionsDir>
+  </PropertyGroup>
+
+  <Import Project="$(WorkloadMsiGenProps)" Condition="Exists('$(WorkloadMsiGenProps)')" />
+
+  <PropertyGroup>
+    <CreateWorkloadPackGroups Condition="'$(CreateWorkloadPackGroups)' == ''">false</CreateWorkloadPackGroups>
+    <SkipRedundantMsiCreation Condition="'$(SkipRedundantMsiCreation)' == ''">false</SkipRedundantMsiCreation>
+    <IsOutOfSupportInVisualStudio Condition="'$(IsOutOfSupportInVisualStudio)' == ''">false</IsOutOfSupportInVisualStudio>
+    <EnableSideBySideManifests Condition="'$(EnableSideBySideManifests)' == ''">false</EnableSideBySideManifests>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(ArcadePackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Workloads" Version="$(ArcadePackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild" Version="$(SwixBuildPackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Wix" Version="$(MicrosoftWixToolsetSdkVersion)" ExcludeAssets="all" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WixToolset.Heat" Version="$(WixHeatPackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WixToolset.Dependency.wixext" Version="$(WixExtensionsPackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WixToolset.Util.wixext" Version="$(WixExtensionsPackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WixToolset.UI.wixext" Version="$(WixExtensionsPackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="vswhere" Version="$(VSWherePackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <WixExtensions Include="$(PkgMicrosoft_WixToolset_UI_wixext)\$(WixExtensionsDir)\WixToolset.UI.wixext.dll" />
+    <WixExtensions Include="$(PkgMicrosoft_WixToolset_Dependency_wixext)\$(WixExtensionsDir)\WixToolset.Dependency.wixext.dll" />
+    <WixExtensions Include="$(PkgMicrosoft_WixToolset_Util_wixext)\$(WixExtensionsDir)\WixToolset.Util.wixext.dll" />
+  </ItemGroup>
+
+  <UsingTask TaskName="GenerateCurrentVersion" AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\tools\net\Microsoft.DotNet.Build.Tasks.Installers.dll" />
+  <UsingTask TaskName="GenerateMsiVersion" AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\tools\net\Microsoft.DotNet.Build.Tasks.Installers.dll" />
+  <UsingTask TaskName="CreateVisualStudioWorkload" AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Workloads)\tools\net\Microsoft.DotNet.Build.Tasks.Workloads.dll" />
+
+  <Target Name="_SetStableMsiVersions">
+    <ItemGroup>
+      <WorkloadPackages Condition="'%(WorkloadPackages.Identity)' == '%(Identity)' and '%(WorkloadPackages.MsiVersion)' == ''">
+        <_PreviewMatch>$([System.Text.RegularExpressions.Regex]::Match(%(WorkloadPackages.Identity), `\-(preview|rc|ci.+).\d+`))</_PreviewMatch>
+        <_NuGetVersion>$([System.Version]::Parse('%(WorkloadPackages.Version)').Major).$([System.Version]::Parse('%(WorkloadPackages.Version)').Minor).$([System.Version]::Parse('%(WorkloadPackages.Version)').Build)</_NuGetVersion>
+      </WorkloadPackages>
+      <WorkloadPackages Condition="'%(WorkloadPackages.Identity)' == '%(Identity)' and '%(WorkloadPackages.MsiVersion)' == '' and ('%(WorkloadPackages._PreviewMatch)' == '' or '%(WorkloadPackages.UseNuGetVersionAsMsiVersion)' == 'true')">
+        <MsiVersion>%(WorkloadPackages._NuGetVersion)</MsiVersion>
+      </WorkloadPackages>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_SetPreviewMsiVersions" Outputs="%(WorkloadPackages.Identity)">
+    <PropertyGroup>
+      <VersionPadding Condition="'$(VersionPadding)' == ''">5</VersionPadding>
+      <VersionComparisonDate Condition="'$(VersionComparisonDate)' == ''">1996-04-01</VersionComparisonDate>
+    </PropertyGroup>
+    <GenerateCurrentVersion
+        SeedDate="$([System.DateTime]::UtcNow.ToString(yyyy-MM-dd))"
+        OfficialBuildId="$([System.DateTime]::UtcNow.ToString(yyyyMMdd)).$([System.Version]::Parse('%(WorkloadPackages.Version)').Revision)"
+        ComparisonDate="$(VersionComparisonDate)"
+        Padding="$(VersionPadding)">
+      <Output TaskParameter="GeneratedVersion" PropertyName="_BuildNumberMajor" />
+      <Output TaskParameter="GeneratedRevision" PropertyName="_BuildNumberMinor" />
+    </GenerateCurrentVersion>
+    <GenerateMsiVersion
+        Major="$([System.Version]::Parse('%(WorkloadPackages.Version)').Major)"
+        Minor="$([System.Version]::Parse('%(WorkloadPackages.Version)').Minor)"
+        Patch="$([System.Version]::Parse('%(WorkloadPackages.Version)').Build)"
+        BuildNumberMajor="$(_BuildNumberMajor)"
+        BuildNumberMinor="$(_BuildNumberMinor)">
+      <Output TaskParameter="MsiVersion" PropertyName="_GeneratedMsiVersion" />
+    </GenerateMsiVersion>
+    <ItemGroup>
+      <WorkloadPackages Condition="'%(WorkloadPackages.Identity)' == '%(Identity)' and '%(WorkloadPackages.MsiVersion)' == ''">
+        <MsiVersion>$(_GeneratedMsiVersion)</MsiVersion>
+      </WorkloadPackages>
+    </ItemGroup>
+    <PropertyGroup>
+      <_GeneratedMsiVersion />
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_FindMSBuild">
+    <PropertyGroup>
+      <_VSWherePath>$([MSBuild]::NormalizePath('$(Pkgvswhere)', 'tools', 'vswhere.exe'))</_VSWherePath>
+    </PropertyGroup>
+    <Exec Command="&quot;$(_VSWherePath)&quot; -latest -prerelease -property installationPath -requires Microsoft.Component.MSBuild"
+        ConsoleToMsBuild="true"
+        StandardErrorImportance="high">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_VSInstallDirectory" />
+    </Exec>
+    <PropertyGroup>
+      <_DesktopMSBuildPath>$(_VSInstallDirectory)\MSBuild\Current\Bin\MSBuild.exe</_DesktopMSBuildPath>
+    </PropertyGroup>
+    <Error Condition="'$(_VSInstallDirectory)' == ''" Text="Could not locate a Visual Studio installation with MSBuild." />
+    <Error Condition="!Exists('$(_DesktopMSBuildPath)')" Text="Desktop MSBuild was not found at '$(_DesktopMSBuildPath)'." />
+    <MakeDir Directories="$(WorkloadMsiLogDirectory)" />
+    <Exec
+        Command="&quot;$(_DesktopMSBuildPath)&quot; &quot;$(VsmanProject)&quot; /nologo /v:minimal /nr:false /t:Restore /p:SwixBuildTargets=&quot;$(SwixTargetsPath)&quot; /p:WorkloadMsiGenProps=&quot;$(WorkloadMsiGenProps)&quot; /p:RestoreConfigFile=&quot;$(RestoreConfigFile)&quot; -bl:&quot;$(WorkloadMsiLogDirectory)\vsman-restore.binlog&quot;"
+        WorkingDirectory="$(MSBuildThisFileDirectory)vsman" />
+  </Target>
+
+  <Target Name="_GenerateAndSignMsis"
+      DependsOnTargets="_SetStableMsiVersions;_SetPreviewMsiVersions;_FindMSBuild"
+      BeforeTargets="SignFiles">
+    <CreateVisualStudioWorkload
+        AllowMissingPacks="true"
+        BaseIntermediateOutputPath="$(IntermediateOutputPath)"
+        BaseOutputPath="$(OutputPath)"
+        ComponentResources="@(ComponentResources)"
+        CreateWorkloadPackGroups="$(CreateWorkloadPackGroups)"
+        EnableSideBySideManifests="$(EnableSideBySideManifests)"
+        HeatExe="$(HeatExe)"
+        IsOutOfSupportInVisualStudio="$(IsOutOfSupportInVisualStudio)"
+        PackageSource="$(NuGetPackagePath)"
+        ShortNames="@(ShortNames)"
+        SkipRedundantMsiCreation="$(SkipRedundantMsiCreation)"
+        WixExe="$(WixExe)"
+        WixExtensions="@(WixExtensions)"
+        WorkloadManifestPackageFiles="@(WorkloadPackages)">
+      <Output TaskParameter="Msis" ItemName="_WorkloadMsis" />
+      <Output TaskParameter="SwixProjects" ItemName="_SwixProjects" />
+    </CreateVisualStudioWorkload>
+    <ItemGroup>
+      <FilesToSign Include="$(OutputPath)**\*.msi">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CreateInsertionArtifacts" AfterTargets="SignFiles">
+    <MSBuild
+        Projects="%(_WorkloadMsis.PackageProject)"
+        Targets="Restore;Pack"
+        Properties="OutputPath=$(MsiNuGetOutputPath);BundledNETCoreAppTargetFramework=$(BundledNETCoreAppTargetFramework)" />
+    <ItemGroup>
+      <_PackProjects Include="@(_SwixProjects)" Condition="'%(PackageType)' == 'msi-pack'"
+          ManifestOutputPath="$(PackManifestOutputPath)"
+          LogGroup="packs"
+          ZipFile="Workload.VSDrop.$(TargetName).packs.zip" />
+      <_ComponentProjects Include="@(_SwixProjects)" Condition="'%(PackageType)' == 'msi-manifest' or '%(PackageType)' == 'manifest-package-group' or ('%(PackageType)' == 'component' and '%(IsPreview)' != 'true')"
+          ManifestOutputPath="$(ManifestOutputPath)"
+          LogGroup="components"
+          ZipFile="Workload.VSDrop.$(TargetName).components.zip" />
+      <_PreviewComponentProjects Include="@(_SwixProjects)" Condition="'%(PackageType)' == 'msi-manifest' or '%(PackageType)' == 'manifest-package-group' or ('%(PackageType)' == 'component' and '%(IsPreview)' == 'true')"
+          ManifestOutputPath="$(PreviewManifestOutputPath)"
+          LogGroup="components-pre"
+          ZipFile="Workload.VSDrop.$(TargetName)-pre.components.zip" />
+      <_InsertionProjects Include="@(_PackProjects);@(_ComponentProjects);@(_PreviewComponentProjects)" />
+    </ItemGroup>
+    <Exec Command="&quot;$(_DesktopMSBuildPath)&quot; &quot;%(_InsertionProjects.Identity)&quot; /nologo /v:minimal /nr:false /p:SwixBuildTargets=&quot;$(SwixTargetsPath)&quot; /p:ManifestOutputPath=&quot;%(_InsertionProjects.ManifestOutputPath)&quot; -bl:&quot;$(WorkloadMsiLogDirectory)\swix-%(_InsertionProjects.LogGroup)-%(_InsertionProjects.Filename).binlog&quot;" />
+    <ItemGroup>
+      <_Drop Include="%(_InsertionProjects.ZipFile)" SourceDirectory="%(ManifestOutputPath)" />
+      <_DropMetadata Include="$(ManifestBuildVersion);$(BUILD_REPOSITORY_NAME);$(BUILD_SOURCEBRANCH)" />
+    </ItemGroup>
+    <WriteLinesToFile File="%(_Drop.SourceDirectory)\.metadata" Lines="@(_DropMetadata)" Overwrite="true" />
+    <ZipDirectory Overwrite="true" SourceDirectory="%(_Drop.SourceDirectory)" DestinationFile="$(ArtifactsShippingPackagesDir)\%(_Drop.Identity)" />
+    <PropertyGroup>
+      <_VsmanArguments>&quot;$(_DesktopMSBuildPath)&quot; &quot;$(VsmanProject)&quot; /nologo /v:normal /nr:false /t:GenerateSetupManifest /p:SwixBuildTargets=&quot;$(SwixTargetsPath)&quot; /p:WorkloadMsiGenProps=&quot;$(WorkloadMsiGenProps)&quot;</_VsmanArguments>
+    </PropertyGroup>
+    <Exec Command="$(_VsmanArguments) /p:ManifestOutputPath=&quot;$(ManifestOutputPath)&quot; /p:TargetName=&quot;$(TargetName).components&quot; /p:ManifestBuildNumber=&quot;$(DropBuildNumber)/vs-components&quot; -bl:&quot;$(WorkloadMsiLogDirectory)\vsman-components.binlog&quot;" WorkingDirectory="$(MSBuildThisFileDirectory)vsman" />
+    <Exec Command="$(_VsmanArguments) /p:ManifestOutputPath=&quot;$(PreviewManifestOutputPath)&quot; /p:TargetName=&quot;$(TargetName).components.pre&quot; /p:ManifestBuildNumber=&quot;$(DropBuildNumber)/vs-components&quot; -bl:&quot;$(WorkloadMsiLogDirectory)\vsman-components-pre.binlog&quot;" WorkingDirectory="$(MSBuildThisFileDirectory)vsman" />
+    <ItemGroup>
+      <_PreviewManifests Include="$(PreviewManifestOutputPath)\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_PreviewManifests)" DestinationFolder="$(ManifestOutputPath)" />
+    <Exec Command="$(_VsmanArguments) /p:ManifestOutputPath=&quot;$(PackManifestOutputPath)&quot; /p:TargetName=&quot;$(TargetName).packs&quot; /p:ManifestBuildNumber=&quot;$(DropBuildNumber)/vs-packs&quot; -bl:&quot;$(WorkloadMsiLogDirectory)\vsman-packs.binlog&quot;" WorkingDirectory="$(MSBuildThisFileDirectory)vsman" />
+  </Target>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+  <PropertyGroup>
+    <BuildDependsOn>_GenerateAndSignMsis;AfterBuild</BuildDependsOn>
+  </PropertyGroup>
+</Project>

--- a/build-tools/automation/dnceng/arcade/Workloads.proj
+++ b/build-tools/automation/dnceng/arcade/Workloads.proj
@@ -167,7 +167,7 @@
     <MSBuild
         Projects="%(_WorkloadMsis.PackageProject)"
         Targets="Restore;Pack"
-        Properties="OutputPath=$(MsiNuGetOutputPath);BundledNETCoreAppTargetFramework=$(BundledNETCoreAppTargetFramework)" />
+        Properties="OutputPath=$(MsiNuGetOutputPath);PackageOutputPath=$(MsiNuGetOutputPath);BundledNETCoreAppTargetFramework=$(BundledNETCoreAppTargetFramework)" />
     <ItemGroup>
       <_PackProjects Include="@(_SwixProjects)" Condition="'%(PackageType)' == 'msi-pack'"
           ManifestOutputPath="$(PackManifestOutputPath)"

--- a/build-tools/automation/dnceng/arcade/Workloads.proj
+++ b/build-tools/automation/dnceng/arcade/Workloads.proj
@@ -18,6 +18,7 @@
     <WorkloadMsiLogDirectory>$(ArtifactsLogDir)workload-msi</WorkloadMsiLogDirectory>
     <IntermediateOutputPath>$(_ArtifactsDir)obj\Release\</IntermediateOutputPath>
     <OutputPath>$(_ArtifactsDir)workload-msi\</OutputPath>
+    <WorkloadOutputsProps>$(IntermediateOutputPath)WorkloadOutputs.props</WorkloadOutputsProps>
     <VsmanProject>$(MSBuildThisFileDirectory)vsman\Workload.vsmanproj</VsmanProject>
     <ManifestOutputPath>$(ArtifactsShippingPackagesDir)\manifests</ManifestOutputPath>
     <PreviewManifestOutputPath>$(ArtifactsShippingPackagesDir)\manifests-pre</PreviewManifestOutputPath>
@@ -41,6 +42,7 @@
   </PropertyGroup>
 
   <Import Project="$(WorkloadMsiGenProps)" Condition="Exists('$(WorkloadMsiGenProps)')" />
+  <Import Project="$(WorkloadOutputsProps)" Condition="Exists('$(WorkloadOutputsProps)')" />
 
   <PropertyGroup>
     <CreateWorkloadPackGroups Condition="'$(CreateWorkloadPackGroups)' == ''">false</CreateWorkloadPackGroups>
@@ -160,10 +162,19 @@
       <FilesToSign Include="$(OutputPath)**\*.msi">
         <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
+      <_WorkloadOutputLines Include="&lt;Project&gt;" />
+      <_WorkloadOutputLines Include="  &lt;ItemGroup&gt;" />
+      <_WorkloadOutputLines Include="@(_WorkloadMsis->'    &lt;_WorkloadMsis Include=&quot;%(Identity)&quot; PackageProject=&quot;%(PackageProject)&quot; /&gt;')" />
+      <_WorkloadOutputLines Include="@(_SwixProjects->'    &lt;_SwixProjects Include=&quot;%(Identity)&quot; PackageType=&quot;%(PackageType)&quot; IsPreview=&quot;%(IsPreview)&quot; /&gt;')" />
+      <_WorkloadOutputLines Include="  &lt;/ItemGroup&gt;" />
+      <_WorkloadOutputLines Include="&lt;/Project&gt;" />
     </ItemGroup>
+    <WriteLinesToFile File="$(WorkloadOutputsProps)" Lines="@(_WorkloadOutputLines)" Overwrite="true" />
   </Target>
 
-  <Target Name="_CreateInsertionArtifacts" AfterTargets="SignFiles">
+  <Target Name="_CreateInsertionArtifacts" DependsOnTargets="_FindMSBuild">
+    <Error Condition="'@(_WorkloadMsis)' == ''" Text="No persisted workload MSI outputs were found." />
+    <Error Condition="'@(_SwixProjects)' == ''" Text="No persisted workload insertion projects were found." />
     <MSBuild
         Projects="%(_WorkloadMsis.PackageProject)"
         Targets="Restore;Pack"

--- a/build-tools/automation/dnceng/arcade/eng/AfterSigning.targets
+++ b/build-tools/automation/dnceng/arcade/eng/AfterSigning.targets
@@ -1,0 +1,7 @@
+<Project>
+  <Target Name="CreateWorkloadInsertionArtifacts" BeforeTargets="Build">
+    <MSBuild
+        Projects="$(RepositoryEngineeringDir)..\Workloads.proj"
+        Targets="_CreateInsertionArtifacts" />
+  </Target>
+</Project>

--- a/build-tools/automation/dnceng/arcade/eng/Signing.props
+++ b/build-tools/automation/dnceng/arcade/eng/Signing.props
@@ -9,6 +9,7 @@
   <ItemGroup>
     <StrongNameSignInfo Remove="@(StrongNameSignInfo)" />
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)\*.nupkg" />
+    <ItemsToSign Include="$(ArtifactsDir)workload-msi\msi\*.msi" Condition="'$(SignWorkloadMsis)' == 'true'" />
 
     <FileSignInfo Include="@(Skip)" CertificateName="None" />
     <FileSignInfo Include="@(ThirdParty)" CertificateName="3PartySHA2" />

--- a/build-tools/automation/dnceng/arcade/eng/Signing.props
+++ b/build-tools/automation/dnceng/arcade/eng/Signing.props
@@ -1,0 +1,26 @@
+<Project>
+  <PropertyGroup>
+    <EnableDefaultArtifacts>false</EnableDefaultArtifacts>
+    <UseDotNetCertificate>false</UseDotNetCertificate>
+  </PropertyGroup>
+
+  <Import Project="$(AndroidSignList)" Condition="Exists('$(AndroidSignList)')" />
+
+  <ItemGroup>
+    <StrongNameSignInfo Remove="@(StrongNameSignInfo)" />
+    <ItemsToSign Include="$(ArtifactsShippingPackagesDir)\*.nupkg" />
+
+    <FileSignInfo Include="@(Skip)" CertificateName="None" />
+    <FileSignInfo Include="@(ThirdParty)" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="@(ThirdPartyScript)" CertificateName="3PartyScriptsSHA2" />
+    <FileSignInfo Include="@(MacDeveloperSign)" CertificateName="MacDeveloperVNext" />
+    <FileSignInfo Include="@(MacDeveloperSignHarden)" CertificateName="MacDeveloperVNextHarden" />
+
+    <FileExtensionSignInfo Remove=".jar;.msi;.nupkg" />
+    <FileExtensionSignInfo Include=".jar" CertificateName="MicrosoftJARSHA2" />
+    <FileExtensionSignInfo Include=".msi" CertificateName="Microsoft400" />
+    <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
+
+    <ItemsToSkip3rdPartyCheck Include="@(FirstParty)" />
+  </ItemGroup>
+</Project>

--- a/build-tools/automation/dnceng/arcade/vsman/Workload.vsmanproj
+++ b/build-tools/automation/dnceng/arcade/vsman/Workload.vsmanproj
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DebugSymbols>false</DebugSymbols>
+    <IsShippingAssembly>false</IsShippingAssembly>
+    <PublishWindowsPdb>false</PublishWindowsPdb>
+    <TargetType>build-manifest</TargetType>
+    <FinalizeManifest>true</FinalizeManifest>
+    <FinalizeSkipLayout>false</FinalizeSkipLayout>
+    <ProductName>DotNetOptionalWorkloads</ProductName>
+    <ProductFamily>vs</ProductFamily>
+    <ProductFamilyVersion Condition="$(ProductFamilyVersion) == ''">42.42.42</ProductFamilyVersion>
+    <ComputeRelativeUrls>true</ComputeRelativeUrls>
+    <OutputPath>$(ManifestOutputPath)</OutputPath>
+  </PropertyGroup>
+
+  <Import Project="$(WorkloadMsiGenProps)" />
+
+  <PropertyGroup>
+    <TargetName Condition="'$(ManifestNameSuffix)' != ''">$(TargetName).$(ManifestNameSuffix)</TargetName>
+    <ManifestName Condition="'$(ManifestName)' == ''">$(TargetName)</ManifestName>
+    <ManifestTeamProject Condition="'$(ManifestTeamProject)' == ''">$(SYSTEM_TEAMPROJECT)</ManifestTeamProject>
+    <ManifestRepositoryName Condition="'$(ManifestRepositoryName)' == ''">$(BUILD_REPOSITORY_NAME)</ManifestRepositoryName>
+    <ManifestBuildBranch Condition="'$(ManifestBuildBranch)' == ''">$(BUILD_SOURCEBRANCHNAME)</ManifestBuildBranch>
+    <ManifestBuildNumber Condition="'$(ManifestBuildNumber)' == ''">$(BUILD_BUILDID)</ManifestBuildNumber>
+    <ManifestDropNameRoot>Products/$(ManifestTeamProject)/$(ManifestRepositoryName)/$(ManifestBuildBranch)</ManifestDropNameRoot>
+    <ManifestDropName Condition="'$(ManifestNameSuffix)' == ''">$(ManifestDropNameRoot)/$(ManifestBuildNumber)</ManifestDropName>
+    <ManifestDropName Condition="'$(ManifestNameSuffix)' != ''">$(ManifestDropNameRoot)/$(ManifestNameSuffix)/$(ManifestBuildNumber)</ManifestDropName>
+    <ManifestPublishUrl>https://vsdrop.corp.microsoft.com/file/v1/$(ManifestDropName);</ManifestPublishUrl>
+    <ManifestIntermediateOutputPath>$(OutputPath)\obj\$(MSBuildProject)</ManifestIntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MergeManifest Include="$(ManifestOutputPath)\*.json">
+      <RelativeUrl>/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\CHS\*.json">
+      <RelativeUrl>/CHS/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\CHT\*.json">
+      <RelativeUrl>/CHT/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\CSY\*.json">
+      <RelativeUrl>/CSY/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\DEU\*.json">
+      <RelativeUrl>/DEU/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\ENU\*.json">
+      <RelativeUrl>/ENU/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\ESN\*.json">
+      <RelativeUrl>/ESN/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\FRA\*.json">
+      <RelativeUrl>/FRA/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\ITA\*.json">
+      <RelativeUrl>/ITA/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\JPN\*.json">
+      <RelativeUrl>/JPN/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\KOR\*.json">
+      <RelativeUrl>/KOR/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\PLK\*.json">
+      <RelativeUrl>/PLK/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\PTB\*.json">
+      <RelativeUrl>/PTB/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\RUS\*.json">
+      <RelativeUrl>/RUS/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\TRK\*.json">
+      <RelativeUrl>/TRK/</RelativeUrl>
+    </MergeManifest>
+  </ItemGroup>
+
+  <Import Project="$(SwixBuildTargets)" />
+</Project>

--- a/build-tools/automation/dnceng/arcade/vsman/Workload.vsmanproj
+++ b/build-tools/automation/dnceng/arcade/vsman/Workload.vsmanproj
@@ -28,7 +28,7 @@
     <ManifestDropName Condition="'$(ManifestNameSuffix)' == ''">$(ManifestDropNameRoot)/$(ManifestBuildNumber)</ManifestDropName>
     <ManifestDropName Condition="'$(ManifestNameSuffix)' != ''">$(ManifestDropNameRoot)/$(ManifestNameSuffix)/$(ManifestBuildNumber)</ManifestDropName>
     <ManifestPublishUrl>https://vsdrop.corp.microsoft.com/file/v1/$(ManifestDropName);</ManifestPublishUrl>
-    <ManifestIntermediateOutputPath>$(OutputPath)\obj\$(MSBuildProject)</ManifestIntermediateOutputPath>
+    <ManifestIntermediateOutputPath>$(OutputPath)\obj\$(MSBuildProjectName)</ManifestIntermediateOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build-tools/automation/dnceng/arcade/vsman/global.json
+++ b/build-tools/automation/dnceng/arcade/vsman/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.400",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary

Adds an in-repo Arcade signing flow to `azure-pipelines-internal.yaml` without using `Xamarin.yaml-templates`, which is inaccessible from `dnceng-internal` and is being phased out.

The new **Prepare .NET Release** stage:

- downloads and normalizes the unsigned Windows, macOS, and Linux packages
- applies the existing `SignList.xml` certificate mappings through Arcade
- signs the original NuGet packages and generated workload MSIs
- packages the signed MSIs into NuGets
- generates Visual Studio component and pack insertion artifacts after MSI signing
- signs the generated MSI NuGets and verifies the final outputs
- always publishes signing binlogs for diagnostics

Real signing is limited to non-PR `release/*` builds. Other manually queued builds use test signing. PR and scheduled builds skip the stage.

## DevDiv comparison

Compared the successful internal outputs from [build 3024411](https://dev.azure.com/dnceng/internal/_build/results?buildId=3024411) with DevDiv [build 14688220](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14688220&view=results):

- all 63 NuGet packages validate with the same `VS Bld Lab` test-signing certificate
- the 18 base package IDs match exactly
- the 45 generated MSI NuGet package IDs match exactly
- all 45 embedded MSIs validate with the same test-signing certificate
- package payload layouts match, aside from expected generated metadata names and content-derived MSI filenames
- the same three VS insertion archives are produced with matching entry counts

The artifact organization intentionally differs. DevDiv separates Linux and macOS/Windows signed packages, converted package artifacts, and VS blobs into multiple drops. The internal pipeline publishes these retained outputs together in `nuget-signed`. Nothing currently consumes those internal artifact names, and this change does not publish to Darc/Maestro.

## Validation

The **Prepare .NET Release** stage, including package validation and `MicroBuildCodesignVerify`, succeeded in internal build 3024411.