### PR TITLE
[ci] Avoid emulator locale restart

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -99,7 +99,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return false;
 
 			var port = string.IsNullOrEmpty (Port) ? "" : $"-port {Port}";
-			var arguments = $"{Arguments ?? string.Empty} -verbose -detect-image-hang -logcat-output \"{LogcatFile}\" -no-audio -no-snapshot -cache-size 512 -change-locale en-US -timezone \"Etc/UTC\" {port} -avd {ImageName}";
+			var arguments = $"{Arguments ?? string.Empty} -verbose -detect-image-hang -logcat-output \"{LogcatFile}\" -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" {port} -avd {ImageName}";
 			Log.LogMessage ($"Tool {emulator} execution started with arguments: {arguments}");
 			var psi = new ProcessStartInfo () {
 				FileName                = emulator,

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -99,7 +99,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return false;
 
 			var port = string.IsNullOrEmpty (Port) ? "" : $"-port {Port}";
-			var arguments = $"{Arguments ?? string.Empty} -verbose -detect-image-hang -logcat-output \"{LogcatFile}\" -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" {port} -avd {ImageName}";
+			var arguments = $"{Arguments ?? ""} -verbose -detect-image-hang -logcat-output \"{LogcatFile}\" -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" {port} -avd {ImageName}";
 			Log.LogMessage ($"Tool {emulator} execution started with arguments: {arguments}");
 			var psi = new ProcessStartInfo () {
 				FileName                = emulator,


### PR DESCRIPTION
----

The `-change-locale en-US` emulator option restarts Android services after the initial boot readiness checks have completed. APK installation can overlap that restart and fail Fast Deployment with `XA0137` because the package data directory temporarily does not exist.

Use the Android system image's default `en-US` locale instead. Nightly localization tests remain unaffected because they explicitly set each locale under test.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: [Azure DevOps failure](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1513332&view=logs&jobId=c603587c-45e1-580d-a0f5-ab650547d049&j=c603587c-45e1-580d-a0f5-ab650547d049&t=ec735307-de95-567a-9eff-9b6e145590ba)
- [x] Unit tests: Existing `Xamarin.Android.Tools.BootstrapTasks` build.