### PR TITLE
Update Gradle projects with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,8 @@ updates:
       interval: "weekly"
   - package-ecosystem: "gradle"
     directories:
+      - "/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle"
+      - "/external/Java.Interop/tools/java-source-utils"
       - "/src/r8"
       - "/src/manifestmerger"
       - "/src/proguard-android"


### PR DESCRIPTION
----

Two Gradle builds under `external/Java.Interop` were outside Dependabot's configured directories, so their Kotlin, JavaParser, and JUnit dependencies could not receive automated updates. Add both project roots to the existing weekly Gradle update configuration while leaving shared Gradle scripts and embedded templates excluded.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed: N/A
- [ ] Unit tests: N/A (configuration-only change)