### PR TITLE
[main] Bump System.CodeDom to 10.0.10

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,7 +3,7 @@
   <!-- NuGet Package Versions -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Win32.Registry"                     Version="5.0.0" />
-    <PackageReference Update="System.CodeDom"                               Version="10.0.8" />
+    <PackageReference Update="System.CodeDom"                               Version="10.0.10" />
     <PackageReference Update="Irony"                                        Version="1.5.3" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- backport #12143 onto `main`
- update the authoritative root `System.CodeDom` package pin from 10.0.8 to 10.0.10 while preserving main's newer surrounding package changes
- keep the existing centralization through `Directory.Build.targets`; both CodeDom consumers inherit this version and no duplicate CodeDom pins were found
- leave unrelated hard-coded 10.0.9 values unchanged

## Validation

- `dotnet restore src\Xamarin.Android.Tools.Aidl\Xamarin.Android.Tools.Aidl.csproj`
- `dotnet build src\Xamarin.Android.Tools.Aidl\Xamarin.Android.Tools.Aidl.csproj --no-restore --nologo --verbosity:minimal`