### PR TITLE
[NativeAOT] Preserve nested Java class names in trimmable ACW maps

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
@@ -29,10 +29,10 @@ public static class AcwMapWriter
 	public static void Write (TextWriter writer, IEnumerable<JavaPeerInfo> peers)
 	{
 		foreach (var peer in peers.OrderBy (p => p.ManagedTypeName, StringComparer.Ordinal)) {
-			string javaKey = peer.JavaName.Replace ('/', '.');
+			string javaKey = JniSignatureHelper.JniNameToJavaBinaryName (peer.JavaName);
 			string managedKey = peer.ManagedTypeName;
 			string partialAsmQualifiedName = $"{managedKey}, {peer.AssemblyName}";
-			string compatJniName = peer.CompatJniName.Replace ('/', '.');
+			string compatJniName = JniSignatureHelper.JniNameToJavaBinaryName (peer.CompatJniName);
 
 			// Line 1: PartialAssemblyQualifiedName;JavaKey
 			writer.Write (partialAsmQualifiedName);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 ///   Line 2: ManagedKey;JavaKey
 ///   Line 3: CompatJniName;JavaKey
 ///
-/// Java keys use dots (not slashes): e.g., "android.app.Activity"
+/// Java keys use dots for packages and preserve '$' for nested classes:
+/// e.g., "android.app.Activity" and "android.view.View$OnClickListener".
 /// </summary>
 public static class AcwMapWriter
 {
@@ -28,10 +29,10 @@ public static class AcwMapWriter
 	public static void Write (TextWriter writer, IEnumerable<JavaPeerInfo> peers)
 	{
 		foreach (var peer in peers.OrderBy (p => p.ManagedTypeName, StringComparer.Ordinal)) {
-			string javaKey = JniSignatureHelper.JniNameToJavaName (peer.JavaName);
+			string javaKey = peer.JavaName.Replace ('/', '.');
 			string managedKey = peer.ManagedTypeName;
 			string partialAsmQualifiedName = $"{managedKey}, {peer.AssemblyName}";
-			string compatJniName = JniSignatureHelper.JniNameToJavaName (peer.CompatJniName);
+			string compatJniName = peer.CompatJniName.Replace ('/', '.');
 
 			// Line 1: PartialAssemblyQualifiedName;JavaKey
 			writer.Write (partialAsmQualifiedName);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
@@ -208,7 +208,7 @@ static class AssemblyLevelElementBuilder
 
 		foreach (var peer in allPeers) {
 			if (peer.ManagedTypeName == managedName) {
-				app.SetAttributeValue (AndroidNs + xmlAttrName, peer.JavaName.Replace ('/', '.'));
+				app.SetAttributeValue (AndroidNs + xmlAttrName, JniSignatureHelper.JniNameToJavaBinaryName (peer.JavaName));
 				return;
 			}
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ComponentElementBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ComponentElementBuilder.cs
@@ -237,7 +237,7 @@ static class ComponentElementBuilder
 
 	internal static void UpdateApplicationElement (XElement app, JavaPeerInfo peer, int targetSdkVersion = 0)
 	{
-		string jniName = JniSignatureHelper.JniNameToJavaName (peer.JavaName);
+		string jniName = JniSignatureHelper.JniNameToJavaBinaryName (peer.JavaName);
 		app.SetAttributeValue (AttName, jniName);
 
 		var component = peer.ComponentAttribute;
@@ -249,7 +249,7 @@ static class ComponentElementBuilder
 
 	internal static void AddInstrumentation (XElement manifest, JavaPeerInfo peer, string packageName)
 	{
-		string jniName = JniSignatureHelper.JniNameToJavaName (peer.JavaName);
+		string jniName = JniSignatureHelper.JniNameToJavaBinaryName (peer.JavaName);
 		var element = new XElement ("instrumentation",
 			new XAttribute (AttName, jniName));
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
@@ -259,6 +259,17 @@ static class JniSignatureHelper
 	}
 
 	/// <summary>
+	/// Converts a JNI type name to a Java binary type name.
+	/// JNI and Java binary names use '$' for nested classes, but JNI uses '/' for packages.
+	/// e.g., "android/app/Activity" → "android.app.Activity"
+	/// e.g., "android/view/View$OnClickListener" → "android.view.View$OnClickListener"
+	/// </summary>
+	internal static string JniNameToJavaBinaryName (string jniName)
+	{
+		return jniName.Replace ('/', '.');
+	}
+
+	/// <summary>
 	/// Extracts the Java package name from a JNI type name.
 	/// e.g., "com/example/MainActivity" \u2192 "com.example"
 	/// Returns null for types without a package.

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
@@ -107,7 +107,7 @@ class ManifestGenerator
 		var managedToManifestNames = new Dictionary<string, string> (allPeers.Count, StringComparer.Ordinal);
 		foreach (var peer in allPeers) {
 			if (!string.IsNullOrEmpty (peer.ManagedTypeName)) {
-				managedToManifestNames [peer.ManagedTypeName] = JniSignatureHelper.JniNameToJavaName (peer.JavaName);
+				managedToManifestNames [peer.ManagedTypeName] = JniSignatureHelper.JniNameToJavaBinaryName (peer.JavaName);
 			}
 		}
 
@@ -128,7 +128,7 @@ class ManifestGenerator
 				continue;
 			}
 
-			string jniName = JniSignatureHelper.JniNameToJavaName (peer.JavaName);
+			string jniName = JniSignatureHelper.JniNameToJavaBinaryName (peer.JavaName);
 			if (existingTypes.Contains (jniName)) {
 				continue;
 			}
@@ -295,8 +295,8 @@ class ManifestGenerator
 		// Build mapping: fully-qualified compat Java name → CRC Java name
 		var compatToCrc = new Dictionary<string, string> (allPeers.Count, StringComparer.Ordinal);
 		foreach (var peer in allPeers) {
-			string javaName = JniSignatureHelper.JniNameToJavaName (peer.JavaName);
-			string compatName = JniSignatureHelper.JniNameToJavaName (peer.CompatJniName);
+			string javaName = JniSignatureHelper.JniNameToJavaBinaryName (peer.JavaName);
+			string compatName = JniSignatureHelper.JniNameToJavaBinaryName (peer.CompatJniName);
 			if (javaName != compatName) {
 				compatToCrc [compatName] = javaName;
 			}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -502,9 +502,7 @@ public class TrimmableTypeMapGenerator
 
 	static void AddJniLookupNames (Dictionary<string, List<JavaPeerInfo>> peersByDotName, string jniName, JavaPeerInfo peer)
 	{
-		var simpleName = JniSignatureHelper.GetJavaSimpleName (jniName);
-		var packageName = JniSignatureHelper.GetJavaPackageName (jniName);
-		var manifestName = packageName.IsNullOrEmpty () ? simpleName : packageName + "." + simpleName;
+		var manifestName = JniSignatureHelper.JniNameToJavaBinaryName (jniName);
 		AddPeerByDotName (peersByDotName, manifestName, peer);
 
 		var javaSourceName = JniSignatureHelper.JniNameToJavaName (jniName);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
@@ -254,7 +254,8 @@ namespace Xamarin.Android.Build.Tests {
 				    <Node Id="1" Label="Type metadata: [UnnamedProject]UnnamedProject.MainActivity" />
 				    <Node Id="2" Label="Type metadata: [Mono.Android]Android.App.Activity" />
 				    <Node Id="3" Label="Type metadata: [My.Assembly]Duplicate.Type" />
-				    <Node Id="4" Label="Unrelated node" />
+				    <Node Id="4" Label="Type metadata: [Xamarin.AndroidX.Activity]AndroidX.Activity.Result.Contract.ActivityResultContracts+TakePicture" />
+				    <Node Id="5" Label="Unrelated node" />
 				  </Nodes>
 				</DirectedGraph>
 				""");
@@ -262,6 +263,7 @@ namespace Xamarin.Android.Build.Tests {
 				UnnamedProject.MainActivity, UnnamedProject;crc64a1.MainActivity
 				Android.App.Activity, Mono.Android;android.app.Activity
 				Duplicate.Type, My.Assembly;my.app.Duplicate
+				AndroidX.Activity.Result.Contract.ActivityResultContracts+TakePicture, Xamarin.AndroidX.Activity;androidx.activity.result.contract.ActivityResultContracts$TakePicture
 				Duplicate.Type;wrong.Duplicate
 				Other.Type;other.Type
 				""");
@@ -279,6 +281,7 @@ namespace Xamarin.Android.Build.Tests {
 			StringAssert.Contains ("-keep class crc64a1.MainActivity { *; }", proguard);
 			StringAssert.Contains ("-keep class android.app.Activity { *; }", proguard);
 			StringAssert.Contains ("-keep class my.app.Duplicate { *; }", proguard);
+			StringAssert.Contains ("-keep class androidx.activity.result.contract.ActivityResultContracts$TakePicture { *; }", proguard);
 			StringAssert.DoesNotContain ("wrong.Duplicate", proguard);
 			StringAssert.DoesNotContain ("other.Type", proguard);
 		}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/AcwMapWriterTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/AcwMapWriterTests.cs
@@ -55,6 +55,22 @@ public class AcwMapWriterTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void Write_NestedJniClass_PreservesDollarSign ()
+	{
+		var peer = MakeMcwPeer (
+			"androidx/activity/result/contract/ActivityResultContracts$TakePicture",
+			"AndroidX.Activity.Result.Contract.ActivityResultContracts+TakePicture",
+			"Xamarin.AndroidX.Activity");
+
+		var lines = WriteLines (new [] { peer });
+
+		Assert.Equal (3, lines.Length);
+		Assert.Equal ("AndroidX.Activity.Result.Contract.ActivityResultContracts+TakePicture, Xamarin.AndroidX.Activity;androidx.activity.result.contract.ActivityResultContracts$TakePicture", lines [0]);
+		Assert.Equal ("AndroidX.Activity.Result.Contract.ActivityResultContracts+TakePicture;androidx.activity.result.contract.ActivityResultContracts$TakePicture", lines [1]);
+		Assert.Equal ("androidx.activity.result.contract.ActivityResultContracts$TakePicture;androidx.activity.result.contract.ActivityResultContracts$TakePicture", lines [2]);
+	}
+
+	[Fact]
 	public void Write_MultipleTypes_OrderedByManagedName ()
 	{
 		var peers = new [] {

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -45,6 +45,7 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 
 		[Theory]
 		[InlineData ("android/app/Activity", "android.app.Activity")]
+		[InlineData ("java/lang/Object", "java.lang.Object")]
 		[InlineData ("android/view/View$OnClickListener", "android.view.View$OnClickListener")]
 		public void JniNameToJavaBinaryName_ConvertsCorrectly (string jniName, string expected)
 		{

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -44,6 +44,14 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 		}
 
 		[Theory]
+		[InlineData ("android/app/Activity", "android.app.Activity")]
+		[InlineData ("android/view/View$OnClickListener", "android.view.View$OnClickListener")]
+		public void JniNameToJavaBinaryName_ConvertsCorrectly (string jniName, string expected)
+		{
+			Assert.Equal (expected, JniSignatureHelper.JniNameToJavaBinaryName (jniName));
+		}
+
+		[Theory]
 		[InlineData ("com/example/MainActivity", "com.example")]
 		[InlineData ("java/lang/Object", "java.lang")]
 		[InlineData ("TopLevelClass", null)]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
@@ -183,6 +183,20 @@ public class ManifestGeneratorTests
 	}
 
 	[Fact]
+	public void Activity_NestedClass_PreservesBinaryName ()
+	{
+		var gen = CreateDefaultGenerator ();
+		var peer = CreatePeer ("com/example/app/Outer$NestedActivity", new ComponentInfo {
+			Kind = ComponentKind.Activity,
+		});
+
+		var doc = GenerateAndLoad (gen, [peer]);
+		var activity = doc.Root?.Element ("application")?.Element ("activity");
+
+		Assert.Equal ("com.example.app.Outer$NestedActivity", (string?) activity?.Attribute (AttName));
+	}
+
+	[Fact]
 	public void Activity_WithProperties ()
 	{
 		var gen = CreateDefaultGenerator ();


### PR DESCRIPTION
## Description

NativeAOT trimmable typemaps wrote nested JNI class names to `acw-map.txt` using Java source notation. For example:

```text
androidx/activity/result/contract/ActivityResultContracts$TakePicture
```

became:

```text
androidx.activity.result.contract.ActivityResultContracts.TakePicture
```

`GenerateNativeAotProguardConfiguration` copied that value into an R8 keep rule, but R8 requires the Java binary name with `$`. The resulting rules matched no classes, and runtime lookup of `ActivityResultContracts$TakePicture` failed with `ClassNotFoundException`.

This was exposed downstream by dotnet/maui#36121 while consuming a dotnet/android build with trimmable typemaps and R8 enabled.

Preserve `$` in ACW-map Java keys by adding `JniNameToJavaBinaryName()`, which replaces JNI package `/` separators with `.` without changing nested-class separators. Use binary names consistently for ACW maps and Android manifest class names, while retaining Java source-name conversion for generated Java source and JNI descriptor rendering.

## Testing

- Added helper unit tests for top-level and nested JNI names.
- Added an `acw-map.txt` regression for `ActivityResultContracts$TakePicture`.
- Added a generated-manifest nested-class regression.
- Added a NativeAOT ProGuard assertion for the exact `$` keep rule.
- `Microsoft.Android.Sdk.TrimmableTypeMap.Tests`: 585 passed.
- `GenerateTrimmableTypeMapTests`: 13 passed.

----

- [x] Useful description of *why the change is necessary*.
- [x] Links to downstream failure.
- [x] Unit tests.