### PR TITLE
Fix PlatformTarget validation for RuntimeIdentifiers

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -63,8 +63,14 @@ _ResolveAssemblies MSBuild target.
     </ItemGroup>
   </Target>
 
+  <!-- RuntimeIdentifier is assigned in these inner builds, after the outer assembly has been compiled.
+       _CheckForInvalidConfigurationAndPlatform is a private MSBuild target, but there is no public
+       validation-only target. Microsoft.Common.targets explicitly directs custom targets that require
+       configuration validation to depend on it. This also avoids depending on the SDK's private
+       _CheckForMismatchingPlatform implementation target.
+       See https://github.com/dotnet/msbuild/blob/eae54023463db15e9a9081f35a959c9162797643/src/Tasks/Microsoft.Common.CurrentVersion.targets#L823-L836 -->
   <Target Name="_ComputeFilesToPublishForRuntimeIdentifiers"
-      DependsOnTargets="BuildOnlySettings;_FixupIntermediateAssembly;_PatchNuGetReferenceMetadata;ResolveReferences;ComputeFilesToPublish;$(_RunAotMaybe)"
+      DependsOnTargets="BuildOnlySettings;_CheckForInvalidConfigurationAndPlatform;_FixupIntermediateAssembly;_PatchNuGetReferenceMetadata;ResolveReferences;ComputeFilesToPublish;$(_RunAotMaybe)"
       Returns="@(ResolvedFileToPublish)">
       <ItemGroup>
         <ResolvedFileToPublish Remove="@(_SourceItemsToCopyToPublishDirectory)" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -102,6 +102,23 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void IncompatiblePlatformTargetAndRuntimeIdentifiersFailsBuild ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.TargetFrameworks = proj.TargetFramework;
+			proj.RemoveProperty ("TargetFramework");
+			proj.SetProperty ("Platforms", "AnyCPU;x64");
+			proj.SetProperty (KnownProperties.RuntimeIdentifiers, "android-arm64");
+
+			using var b = CreateApkBuilder ();
+			b.Target = "Build";
+			b.ThrowOnBuildFailure = false;
+			Assert.IsFalse (b.Build (proj, parameters: new [] { "Platform=x64" }), "Build should have failed.");
+			StringAssertEx.Contains ("NETSDK1032", b.LastBuildOutput);
+		}
+
+		[Test]
 		public void BuildBasicApplicationThenMoveIt ([Values] bool isRelease, [Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 		{
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {


### PR DESCRIPTION
----

Android's per-RID inner builds assign `RuntimeIdentifier` after the outer assembly has already been compiled. This allowed an x64 managed assembly to be reused for `android-arm64`, producing an application that built successfully but crashed at runtime.

Run the common MSBuild configuration validation hook before reusing the outer assembly so incompatible combinations fail with `NETSDK1032`. The target is private, but Microsoft.Common.targets explicitly directs custom targets requiring configuration validation to depend on it; the source comment includes a permanent link documenting that contract.

Fixes #12183

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [x] Unit tests

Tests:
- `IncompatiblePlatformTargetAndRuntimeIdentifiersFailsBuild`
- `BuildBasicApplicationThenMoveIt`