### PR TITLE
[build] Fix stabilized SDK workload manifest path

### DIFF
--- a/build-tools/create-packs/ConfigureLocalWorkload.targets
+++ b/build-tools/create-packs/ConfigureLocalWorkload.targets
@@ -82,7 +82,7 @@
       <_LocalSdkFeatureBand Condition=" '$(_LocalSdkFeatureBandPrefix)' != '' ">$(_LocalSdkFeatureBandPrefix)00</_LocalSdkFeatureBand>
       <_LocalSdkPrerelease>$([System.Text.RegularExpressions.Regex]::Match($(NETCoreSdkVersion), `(?&lt;=-)[^+]+`))</_LocalSdkPrerelease>
       <_LocalSdkPrereleaseFeatureBand>$([System.Text.RegularExpressions.Regex]::Match($(_LocalSdkPrerelease), `^[^.]+(\.[^.]+)?`))</_LocalSdkPrereleaseFeatureBand>
-      <_LocalSdkFeatureBand Condition=" '$(_LocalSdkPrerelease)' != '' and !$(_LocalSdkPrerelease.Contains('dev')) and !$(_LocalSdkPrerelease.Contains('ci')) and !$(_LocalSdkPrerelease.Contains('rtm')) ">$(_LocalSdkFeatureBand)-$(_LocalSdkPrereleaseFeatureBand)</_LocalSdkFeatureBand>
+      <_LocalSdkFeatureBand Condition=" '$(_LocalSdkFeatureBandPrefix)' != '' and '$(_LocalSdkPrerelease)' != '' and !$(_LocalSdkPrerelease.Contains('dev')) and !$(_LocalSdkPrerelease.Contains('ci')) and !$(_LocalSdkPrerelease.Contains('rtm')) ">$(_LocalSdkFeatureBand)-$(_LocalSdkPrereleaseFeatureBand)</_LocalSdkFeatureBand>
     </PropertyGroup>
 
     <Error Condition=" '$(_LocalSdkFeatureBand)' == '' " Text="Failed to determine the SDK feature band from NETCoreSdkVersion '$(NETCoreSdkVersion)'." />

--- a/build-tools/create-packs/ConfigureLocalWorkload.targets
+++ b/build-tools/create-packs/ConfigureLocalWorkload.targets
@@ -76,10 +76,23 @@
     </Task>
   </UsingTask>
 
-  <Target Name="InstallManifestAndDependencies"
-      DependsOnTargets="_GetDefaultPackageVersion">
+  <Target Name="_DetermineLocalSdkFeatureBand">
     <PropertyGroup>
-      <_LocalSdkManifestsFolder>$(BuildOutputDirectory)lib\sdk-manifests\$(DotNetSdkManifestsFolder)\</_LocalSdkManifestsFolder>
+      <_LocalSdkFeatureBandPrefix>$([System.Text.RegularExpressions.Regex]::Match($(NETCoreSdkVersion), `^\d+\.\d+\.\d`))</_LocalSdkFeatureBandPrefix>
+      <_LocalSdkFeatureBand Condition=" '$(_LocalSdkFeatureBandPrefix)' != '' ">$(_LocalSdkFeatureBandPrefix)00</_LocalSdkFeatureBand>
+      <_LocalSdkPrerelease>$([System.Text.RegularExpressions.Regex]::Match($(NETCoreSdkVersion), `(?&lt;=-)[^+]+`))</_LocalSdkPrerelease>
+      <_LocalSdkPrereleaseFeatureBand>$([System.Text.RegularExpressions.Regex]::Match($(_LocalSdkPrerelease), `^[^.]+(\.[^.]+)?`))</_LocalSdkPrereleaseFeatureBand>
+      <_LocalSdkFeatureBand Condition=" '$(_LocalSdkPrerelease)' != '' and !$(_LocalSdkPrerelease.Contains('dev')) and !$(_LocalSdkPrerelease.Contains('ci')) and !$(_LocalSdkPrerelease.Contains('rtm')) ">$(_LocalSdkFeatureBand)-$(_LocalSdkPrereleaseFeatureBand)</_LocalSdkFeatureBand>
+    </PropertyGroup>
+
+    <Error Condition=" '$(_LocalSdkFeatureBand)' == '' " Text="Failed to determine the SDK feature band from NETCoreSdkVersion '$(NETCoreSdkVersion)'." />
+  </Target>
+
+  <Target Name="InstallManifestAndDependencies"
+      DependsOnTargets="_GetDefaultPackageVersion;_DetermineLocalSdkFeatureBand">
+    <PropertyGroup>
+      <!-- Use the installed SDK version because stabilized SDK builds can retain a prerelease package version. -->
+      <_LocalSdkManifestsFolder>$(BuildOutputDirectory)lib\sdk-manifests\$(_LocalSdkFeatureBand)\</_LocalSdkManifestsFolder>
       <_LocalAndroidManifestFolder>$(_LocalSdkManifestsFolder)microsoft.net.sdk.android\$(AndroidPackVersionLong)\</_LocalAndroidManifestFolder>
       <_EmptyWorkloadDir>$(_LocalSdkManifestsFolder)android.deps.workload\0.0.1\</_EmptyWorkloadDir>
     </PropertyGroup>


### PR DESCRIPTION
----

[PR #12180](https://github.com/dotnet/android/pull/12180) exposed a mismatch in stabilized SDK builds: `MicrosoftNETSdkPackageVersion` remained `10.0.400-preview.0.26367.110`, while `dotnet-install` downloaded an SDK whose actual `NETCoreSdkVersion` and product directory were `10.0.400`. The package-derived loose manifest path was therefore `sdk-manifests/10.0.400-preview.0`, but the installed SDK searched `sdk-manifests/10.0.400`, so `dotnet workload install android-deps` could not discover the Android manifest.

Derive the local manifest feature band from `NETCoreSdkVersion`, matching the installed SDK's `SdkFeatureBand` behavior: round servicing patches to the X00 band, preserve the first two public prerelease components, and omit dev/ci/rtm prerelease labels. Emit a clear error when the feature band cannot be determined.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: required by [PR #12180](https://github.com/dotnet/android/pull/12180)
- [x] Unit tests: validated stable, servicing, preview, beta, dev, ci, rtm, and invalid forms with an MSBuild harness.