### PR TITLE
[tests] Use dotnet-public for CI package resolution

### DIFF
--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -130,7 +130,7 @@ extends:
           inputs:
             forceReinstallCredentialProvider: true
 
-        - script: dotnet tool update -v:n boots --version 1.1.0.36 --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" --global
+        - script: dotnet tool update -v:n boots --version 1.1.0.36 --global
           displayName: Install boots
 
         - script: boots https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-6.12.0.188.macos10.xamarin.universal.pkg

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -130,7 +130,7 @@ extends:
           inputs:
             forceReinstallCredentialProvider: true
 
-        - script: dotnet tool update -v:n boots --version 1.1.0.36 --add-source "https://api.nuget.org/v3/index.json" --global
+        - script: dotnet tool update -v:n boots --version 1.1.0.36 --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" --global
           displayName: Install boots
 
         - script: boots https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-6.12.0.188.macos10.xamarin.universal.pkg

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -34,10 +34,6 @@ namespace Xamarin.Android.Build.Tests
 				ProjectName = "Test Me",
 				RootNamespace = "Test.Me",
 				EnableDefaultItems = true,
-				ExtraNuGetConfigSources = {
-					// Microsoft.AspNetCore.Components.WebView is not in dotnet-public
-					"https://api.nuget.org/v3/index.json",
-				},
 				PackageReferences = {
 					new Package { Id = "Xamarin.AndroidX.AppCompat", Version = "1.7.1.3" },
 					// Using * here, so we explicitly get newer packages

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Android.Build.Tests
 	[TestFixture]
 	public class FilterAssembliesTests : BaseTest
 	{
+		const string DotNetPublicPackageBaseAddress = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/flat2";
+
 		string tempDirectory;
 
 		[SetUp]
@@ -31,6 +33,12 @@ namespace Xamarin.Android.Build.Tests
 
 		Task<string> DownloadFromNuGet (string url, string filename = "") =>
 			Task.Factory.StartNew (() => new DownloadedCache ().GetAsFile (url, filename));
+
+		static string GetPackageUrl (string packageId, string version)
+		{
+			var lowercaseId = packageId.ToLowerInvariant ();
+			return $"{DotNetPublicPackageBaseAddress}/{lowercaseId}/{version}/{lowercaseId}.{version}.nupkg";
+		}
 
 		async Task<string []> GetAssembliesFromNuGet (string url, string filename, string path)
 		{
@@ -65,7 +73,7 @@ namespace Xamarin.Android.Build.Tests
 		public async Task CircleImageView ()
 		{
 			var assemblies = await GetAssembliesFromNuGet (
-				"https://www.nuget.org/api/v2/package/Refractored.Controls.CircleImageView/1.0.1",
+				GetPackageUrl ("Refractored.Controls.CircleImageView", "1.0.1"),
 				"Refractored.Controls.CircleImageView.1.0.1.nupkg",
 				"lib/MonoAndroid10/");
 			var actual = Run (assemblies);
@@ -77,7 +85,7 @@ namespace Xamarin.Android.Build.Tests
 		public async Task XamarinForms ()
 		{
 			var assemblies = await GetAssembliesFromNuGet (
-				"https://www.nuget.org/api/v2/package/Xamarin.Forms/3.6.0.220655",
+				GetPackageUrl ("Xamarin.Forms", "3.6.0.220655"),
 				"Xamarin.Forms.3.6.0.220655.nupkg",
 				"lib/MonoAndroid90/");
 			var actual = Run (assemblies);
@@ -93,7 +101,7 @@ namespace Xamarin.Android.Build.Tests
 		public async Task GuavaListenableFuture ()
 		{
 			var assemblies = await GetAssembliesFromNuGet (
-				"https://www.nuget.org/api/v2/package/Xamarin.Google.Guava.ListenableFuture/1.0.0",
+				GetPackageUrl ("Xamarin.Google.Guava.ListenableFuture", "1.0.0"),
 				"Xamarin.Google.Guava.ListenableFuture.1.0.0.nupkg",
 				"lib/MonoAndroid50/");
 			var actual = Run (assemblies);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
@@ -37,7 +37,15 @@ namespace Xamarin.Android.Build.Tests
 		static string GetPackageUrl (string packageId, string version)
 		{
 			var lowercaseId = packageId.ToLowerInvariant ();
-			return $"{DotNetPublicPackageBaseAddress}/{lowercaseId}/{version}/{lowercaseId}.{version}.nupkg";
+			var lowercaseVersion = version.ToLowerInvariant ();
+			return $"{DotNetPublicPackageBaseAddress}/{lowercaseId}/{lowercaseVersion}/{lowercaseId}.{lowercaseVersion}.nupkg";
+		}
+
+		[Test]
+		public void PackageUrlIsLowercase ()
+		{
+			var actual = GetPackageUrl ("Package.ID", "1.0.0-RC1");
+			Assert.AreEqual ($"{DotNetPublicPackageBaseAddress}/package.id/1.0.0-rc1/package.id.1.0.0-rc1.nupkg", actual);
 		}
 
 		async Task<string []> GetAssembliesFromNuGet (string url, string filename, string path)

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1286,6 +1286,7 @@ namespace Library1 {
 			proj.SetRuntime (runtime);
 
 			// NOTE: workaround for netcoreapp3.0 dependency being included along with monoandroid8.0
+			// See: https://www.nuget.org/packages/SQLitePCLRaw.bundle_green/2.0.3
 			proj.PackageReferences.Add (new Package {
 				Id = "SQLitePCLRaw.provider.dynamic_cdecl",
 				Version = "2.0.3",

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1286,7 +1286,6 @@ namespace Library1 {
 			proj.SetRuntime (runtime);
 
 			// NOTE: workaround for netcoreapp3.0 dependency being included along with monoandroid8.0
-			// See: https://www.nuget.org/packages/SQLitePCLRaw.bundle_green/2.0.3
 			proj.PackageReferences.Add (new Package {
 				Id = "SQLitePCLRaw.provider.dynamic_cdecl",
 				Version = "2.0.3",
@@ -2526,9 +2525,6 @@ public class FacebookSdk {{
 
 			var proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (runtime)) {
 				IsRelease = isRelease,
-				ExtraNuGetConfigSources = {
-					"https://api.nuget.org/v3/index.json",
-				},
 				OtherBuildItems = {
 					new AndroidItem.TransformFile ("Transforms\\Metadata.xml") {
 						TextContent = () => $@"<metadata><attr path=""/api/package[@name='{gradleModule.PackageName}']"" name=""managedName"">Facebook</attr></metadata>",


### PR DESCRIPTION
----

CFSClean reports network-isolation warnings when tests and CI tooling resolve packages directly from public NuGet endpoints. Route those package downloads through the existing dnceng `dotnet-public` Azure Artifacts feed and rely on the repository `NuGet.config` for generated test projects and the API-docs tool installation.

Direct `.nupkg` test downloads now use the feed's V3 package base address, while obsolete `ExtraNuGetConfigSources` public overrides are removed. No fallback to nuget.org is retained.

`Xamarin.Google.Android.InstallReferrer` 1.1.2.6 is not currently mirrored to `dotnet-public`; `InstallAndRunTests.GradleFBProj` will require that package to be mirrored.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [x] Unit tests

Validation:
- `FilterAssembliesTests`: 4 passed
- Forced no-cache restore of the generated `DotNetBuild` project using its generated `NuGet.config`
- `boots` 1.1.0.36 installation using the repository `NuGet.config`
- Test and automation endpoint scan for `api.nuget.org`, `www.nuget.org`, and `globalcdn.nuget.org`