### PR TITLE
[build] Default interpreter only for MonoVM

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -73,7 +73,7 @@
   <!--  User-facing configuration-specific defaults -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
-    <UseInterpreter Condition=" '$(UseInterpreter)' == '' and '$(AndroidUseInterpreter)' == '' and '$(UseMonoRuntime)' == 'true' ">true</UseInterpreter>
+    <UseInterpreter Condition=" '$(UseInterpreter)' == '' and '$(AndroidUseInterpreter)' == '' and '$(_AndroidRuntime)' == 'MonoVM' ">true</UseInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">true</EmbedAssembliesIntoApk>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -73,7 +73,7 @@
   <!--  User-facing configuration-specific defaults -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
-    <UseInterpreter Condition=" '$(UseInterpreter)' == '' and '$(AndroidUseInterpreter)' == '' ">true</UseInterpreter>
+    <UseInterpreter Condition=" '$(UseInterpreter)' == '' and '$(AndroidUseInterpreter)' == '' and '$(UseMonoRuntime)' == 'true' ">true</UseInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">true</EmbedAssembliesIntoApk>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1687,17 +1687,16 @@ namespace UnnamedProject
 			var ret = new List<object[]> ();
 
 			foreach (AndroidRuntime runtime in new[] { AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT }) {
-				AddTestData (true, "LowercaseMD5", "", runtime, runtime == AndroidRuntime.CoreCLR);
-				AddTestData (true, "LowercaseCrc64", "", runtime, false);
-				AddTestData (false, "", "127.0.0.1:9000,suspend,connect", runtime, false);
+				AddTestData ("LowercaseMD5", "", runtime, runtime == AndroidRuntime.CoreCLR);
+				AddTestData ("LowercaseCrc64", "", runtime, false);
+				AddTestData ("", "127.0.0.1:9000,suspend,connect", runtime, false);
 			}
 
 			return ret;
 
-			void AddTestData (bool useInterpreter, string packageNamingPolicy, string diagnosticConfiguration, AndroidRuntime runtime, bool enableCrashReport)
+			void AddTestData (string packageNamingPolicy, string diagnosticConfiguration, AndroidRuntime runtime, bool enableCrashReport)
 			{
 				ret.Add (new object[] {
-					useInterpreter,
 					packageNamingPolicy,
 					diagnosticConfiguration,
 					runtime,
@@ -1708,34 +1707,23 @@ namespace UnnamedProject
 
 		[Test]
 		[TestCaseSource (nameof (Get_EnvironmentVariablesData))]
-		public void EnvironmentVariables (bool useInterpreter, string packageNamingPolicy, string diagnosticConfiguration, AndroidRuntime runtime, bool enableCrashReport)
+		public void EnvironmentVariables (string packageNamingPolicy, string diagnosticConfiguration, AndroidRuntime runtime, bool enableCrashReport)
 		{
-			// NativeAOT supports neither the interpreter nor debug builds, but what we test here is
-			// environment file creation and contents, and that's relevant to NativeAOT too
+			// NativeAOT does not support debug builds, but environment file creation and contents are relevant to NativeAOT too.
 			bool isRelease = runtime == AndroidRuntime.NativeAOT;
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
 
-			if (runtime == AndroidRuntime.NativeAOT) {
-				if (packageNamingPolicy == "LowercaseMD5") {
-					Assert.Ignore ("NativeAOT does not support the 'LowercaseMD5' package naming policy.");
-					return;
-				}
-
-				// TODO: investigate and fix this. For some reason, `DOTNET_MODIFIABLE_ASSEMBLIES=Debug` is not
-				// in the environment variables file
-				if (useInterpreter && packageNamingPolicy == "LowercaseCrc64" && diagnosticConfiguration == "") {
-					Assert.Ignore ("NativeAOT doesn't put the DOTNET_MODIFIABLE_ASSEMBLIES=Debug variable in the environment file.");
-					return;
-				}
+			if (runtime == AndroidRuntime.NativeAOT && packageNamingPolicy == "LowercaseMD5") {
+				Assert.Ignore ("NativeAOT does not support the 'LowercaseMD5' package naming policy.");
+				return;
 			}
 
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
 			proj.SetRuntime (runtime);
-			proj.SetProperty ("UseInterpreter", useInterpreter.ToString ());
 			proj.SetProperty ("EnableCrashReport", enableCrashReport.ToString ());
 			if (!string.IsNullOrEmpty (packageNamingPolicy))
 				proj.SetProperty ("AndroidPackageNamingPolicy", packageNamingPolicy);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1748,7 +1748,7 @@ namespace UnnamedProject
 				var values = new List<string> {
 					"mono.enable_assembly_preload=0",
 				};
-				if (useInterpreter)
+				if (!isRelease)
 					values.Add ("DOTNET_MODIFIABLE_ASSEMBLIES=Debug");
 				if (!string.IsNullOrEmpty (diagnosticConfiguration))
 					values.Add ($"DOTNET_DiagnosticPorts={diagnosticConfiguration}");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1651,7 +1651,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GenerateEnvironmentFiles" DependsOnTargets="_AndroidConfigureHotReloadEnvironment">
   <ItemGroup>
     <_GeneratedAndroidEnvironment Include="mono.enable_assembly_preload=0" Condition=" '$(AndroidEnablePreloadAssemblies)' != 'True' " />
-    <_GeneratedAndroidEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES=Debug" Condition=" '$(AndroidIncludeDebugSymbols)' == 'true' and '$(AndroidUseInterpreter)' == 'true' " />
+    <_GeneratedAndroidEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES=Debug" Condition=" '$(AndroidIncludeDebugSymbols)' == 'true' " />
     <_GeneratedAndroidEnvironment Include="DOTNET_DiagnosticPorts=$(DiagnosticConfiguration)" Condition=" '$(DiagnosticConfiguration)' != '' " />
     <_GeneratedAndroidEnvironment Include="DOTNET_EnableCrashReport=1" Condition=" '$(EnableCrashReport)' == 'true' and '$(UseMonoRuntime)' != 'true' " />
     <!-- RuntimeEnvironmentVariable items come from 'dotnet run -e NAME=VALUE' -->

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2212,14 +2212,12 @@ MONO_GC_PARAMS=bridge-implementation=new",
 					logcatOutput,
 					"The Environment variable \"DOTNET_DiagnosticPorts\" was not set to expected value \"127.0.0.1:9000,connect,nosuspend\"."
 			);
-			// NOTE: set when $(UseInterpreter) is true, default for Debug mode
-			if (!isRelease) {
-				StringAssert.Contains (
-						"DOTNET_MODIFIABLE_ASSEMBLIES=Debug",
-						logcatOutput,
-						"The Environment variable \"DOTNET_MODIFIABLE_ASSEMBLIES\" was not set."
-				);
-			}
+			// NOTE: set when $(UseInterpreter) is true, which is not the default for CoreCLR
+			StringAssert.DoesNotContain (
+					"DOTNET_MODIFIABLE_ASSEMBLIES=Debug",
+					logcatOutput,
+					"The Environment variable \"DOTNET_MODIFIABLE_ASSEMBLIES\" was unexpectedly set."
+			);
 		}
 
 		[Test]

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2163,9 +2163,6 @@ MONO_GC_PARAMS=bridge-implementation=new",
 				}
 			};
 			proj.SetRuntime (runtime);
-			if (!isRelease) {
-				proj.SetProperty ("UseInterpreter", "true");
-			}
 			proj.SetProperty ("DiagnosticAddress", "127.0.0.1");
 			proj.SetProperty ("DiagnosticPort", "9000");
 			proj.SetProperty ("DiagnosticSuspend", "false");
@@ -2215,7 +2212,7 @@ MONO_GC_PARAMS=bridge-implementation=new",
 					logcatOutput,
 					"The Environment variable \"DOTNET_DiagnosticPorts\" was not set to expected value \"127.0.0.1:9000,connect,nosuspend\"."
 			);
-			// NOTE: set when $(UseInterpreter) is true
+			// NOTE: set when the debug version of libmonodroid.so is used
 			if (!isRelease) {
 				StringAssert.Contains (
 						"DOTNET_MODIFIABLE_ASSEMBLIES=Debug",

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2212,7 +2212,7 @@ MONO_GC_PARAMS=bridge-implementation=new",
 					logcatOutput,
 					"The Environment variable \"DOTNET_DiagnosticPorts\" was not set to expected value \"127.0.0.1:9000,connect,nosuspend\"."
 			);
-			// NOTE: set when the debug version of libmonodroid.so is used
+			// NOTE: set when $(AndroidIncludeDebugSymbols) is true
 			if (!isRelease) {
 				StringAssert.Contains (
 						"DOTNET_MODIFIABLE_ASSEMBLIES=Debug",

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2163,6 +2163,9 @@ MONO_GC_PARAMS=bridge-implementation=new",
 				}
 			};
 			proj.SetRuntime (runtime);
+			if (!isRelease) {
+				proj.SetProperty ("UseInterpreter", "true");
+			}
 			proj.SetProperty ("DiagnosticAddress", "127.0.0.1");
 			proj.SetProperty ("DiagnosticPort", "9000");
 			proj.SetProperty ("DiagnosticSuspend", "false");
@@ -2212,12 +2215,14 @@ MONO_GC_PARAMS=bridge-implementation=new",
 					logcatOutput,
 					"The Environment variable \"DOTNET_DiagnosticPorts\" was not set to expected value \"127.0.0.1:9000,connect,nosuspend\"."
 			);
-			// NOTE: set when $(UseInterpreter) is true, which is not the default for CoreCLR
-			StringAssert.DoesNotContain (
-					"DOTNET_MODIFIABLE_ASSEMBLIES=Debug",
-					logcatOutput,
-					"The Environment variable \"DOTNET_MODIFIABLE_ASSEMBLIES\" was unexpectedly set."
-			);
+			// NOTE: set when $(UseInterpreter) is true
+			if (!isRelease) {
+				StringAssert.Contains (
+						"DOTNET_MODIFIABLE_ASSEMBLIES=Debug",
+						logcatOutput,
+						"The Environment variable \"DOTNET_MODIFIABLE_ASSEMBLIES\" was not set."
+				);
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
CoreCLR Debug builds currently inherit `UseInterpreter=true`, but Android does not require the interpreter for hot reload. Default `UseInterpreter` only when `$(_AndroidRuntime) == 'MonoVM'`.

Hot reload still requires `DOTNET_MODIFIABLE_ASSEMBLIES=Debug` for Android Debug builds, including CoreCLR. Generate it whenever `$(AndroidIncludeDebugSymbols)` is true, independent of `UseInterpreter`.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: N/A
- [x] Unit tests: Updated environment-file expectations and retained on-device verification of `DOTNET_MODIFIABLE_ASSEMBLIES=Debug` for CoreCLR Debug.