### PR TITLE
[ci] Run public pipeline nightly

### DIFF
--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -6,6 +6,14 @@ name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 
 trigger: none
 
+schedules:
+- cron: "0 6 * * *"
+  displayName: Run nightly at 6:00 UTC
+  branches:
+    include:
+    - main
+  always: true
+
 pr:
   branches:
     include:


### PR DESCRIPTION
----

Component Governance alerts can become stale when the public pipeline does not run regularly. Schedule the `dnceng-public` pipeline from `main` every night at 06:00 UTC, using `always: true` so it runs even when there are no source changes.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed (N/A)
- [ ] Unit tests (N/A - YAML scheduling change)