### PR TITLE
[xabt] Fix Windows long path directory removal

### DIFF
--- a/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Android.Build.Tasks
 		public static string ToLongPath (string fullPath)
 		{
 			// On non-Windows platforms, return the path unchanged
-			if (Path.DirectorySeparatorChar != '\\') {
+			if (Path.DirectorySeparatorChar != '\\' || fullPath.StartsWith (LongPathPrefix, StringComparison.Ordinal)) {
 				return fullPath;
 			}
 			return LongPathPrefix + fullPath;

--- a/external/xamarin-android-tools/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/external/xamarin-android-tools/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -41,6 +41,21 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		}
 
 		[Test]
+		public void ToLongPathIsIdempotent ()
+		{
+			if (!IsWindows) {
+				Assert.Ignore ("Long path prefixes only apply on Windows.");
+				return;
+			}
+
+			var path = Path.GetFullPath (tempDir);
+			var longPath = Files.ToLongPath (path);
+
+			Assert.AreEqual (Files.LongPathPrefix + path, longPath, "Long path prefix should be added.");
+			Assert.AreEqual (longPath, Files.ToLongPath (longPath), "Long path prefix should not be added twice.");
+		}
+
+		[Test]
 		public void CopyIfStringChanged ()
 		{
 			Directory.CreateDirectory (tempDir);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -72,14 +72,14 @@ namespace Xamarin.Android.Tasks
 							// only do the set writable on the second attempt
 							if (retryCount == 1)
 								Files.SetDirectoryWriteable (fullPath);
-							Directory.Delete (fullPath, true);
+							DeleteDirectory (fullPath, true);
 							temporaryRemovedDirectories.Add (directory);
 							break;
 						} catch (Exception e) {
 							switch (e) {
 								case DirectoryNotFoundException:
 									if (OS.IsWindows) {
-										fullPath = Files.ToLongPath (fullPath);
+										fullPath = Files.ToLongPath (fullPath.TrimEnd (Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
 										Log.LogDebugMessage ("Trying long path: " + fullPath);
 										break;
 									}
@@ -108,6 +108,9 @@ namespace Xamarin.Android.Tasks
 
 			return !Log.HasLoggedErrors;
 		}
+
+		// This is needed for tests.
+		internal Action<string, bool> DeleteDirectory { get; set; } = Directory.Delete;
 
 		[Required]
 		public ITaskItem [] Directories { get; set; } = [];

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -79,8 +79,10 @@ namespace Xamarin.Android.Tasks
 							switch (e) {
 								case DirectoryNotFoundException:
 									if (OS.IsWindows) {
-										fullPath = Files.ToLongPath (fullPath.TrimEnd (Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-										Log.LogDebugMessage ("Trying long path: " + fullPath);
+										if (!fullPath.StartsWith (Files.LongPathPrefix, StringComparison.Ordinal)) {
+											fullPath = Files.ToLongPath (fullPath.TrimEnd (Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+											Log.LogDebugMessage ("Trying long path: " + fullPath);
+										}
 										break;
 									}
 									throw;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -79,10 +79,8 @@ namespace Xamarin.Android.Tasks
 							switch (e) {
 								case DirectoryNotFoundException:
 									if (OS.IsWindows) {
-										if (!fullPath.StartsWith (Files.LongPathPrefix, StringComparison.Ordinal)) {
-											fullPath = Files.ToLongPath (fullPath.TrimEnd (Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-											Log.LogDebugMessage ("Trying long path: " + fullPath);
-										}
+										fullPath = Files.ToLongPath (fullPath.TrimEnd (Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+										Log.LogDebugMessage ("Trying long path: " + fullPath);
 										break;
 									}
 									throw;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -79,6 +79,7 @@ namespace Xamarin.Android.Tasks
 							switch (e) {
 								case DirectoryNotFoundException:
 									if (OS.IsWindows) {
+										// .NET Framework rejects \\?\ paths with a trailing directory separator.
 										fullPath = Files.ToLongPath (fullPath.TrimEnd (Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
 										Log.LogDebugMessage ("Trying long path: " + fullPath);
 										break;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
@@ -93,6 +93,33 @@ namespace Xamarin.Android.Build.Tests
 			DirectoryAssert.DoesNotExist (tempDirectory);
 		}
 
+		[Test]
+		public void LongPathWithTrailingDirectorySeparator ()
+		{
+			if (!IsWindows) {
+				Assert.Ignore ("MAX_PATH only applies on Windows.");
+				return;
+			}
+
+			NewFile (fileName: "foo".PadRight (MaxFileName, 'N'));
+			var deletedPaths = new List<string> ();
+			var task = CreateTask ();
+			task.Directories = new [] { new TaskItem (tempDirectory + Path.DirectorySeparatorChar) };
+			task.RetryAttempts = 1;
+			task.RetryDelayMs = 0;
+			task.DeleteDirectory = (path, recursive) => {
+				deletedPaths.Add (path);
+				if (deletedPaths.Count == 1)
+					throw new DirectoryNotFoundException ("Simulated MAX_PATH failure.");
+				Directory.Delete (path, recursive);
+			};
+
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (1, task.RemovedDirectories.Length, "Changes should have been made.");
+			Assert.AreEqual (Files.ToLongPath (tempDirectory), deletedPaths [1], "Long path should not have a trailing directory separator.");
+			DirectoryAssert.DoesNotExist (tempDirectory);
+		}
+
 		[Test, Category ("SmokeTests")]
 		public void DirectoryInUse ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
@@ -105,18 +105,20 @@ namespace Xamarin.Android.Build.Tests
 			var deletedPaths = new List<string> ();
 			var task = CreateTask ();
 			task.Directories = new [] { new TaskItem (tempDirectory + Path.DirectorySeparatorChar) };
-			task.RetryAttempts = 1;
+			task.RetryAttempts = 2;
 			task.RetryDelayMs = 0;
 			task.DeleteDirectory = (path, recursive) => {
 				deletedPaths.Add (path);
-				if (deletedPaths.Count == 1)
+				if (deletedPaths.Count <= 2)
 					throw new DirectoryNotFoundException ("Simulated MAX_PATH failure.");
 				Directory.Delete (path, recursive);
 			};
 
 			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
 			Assert.AreEqual (1, task.RemovedDirectories.Length, "Changes should have been made.");
+			Assert.AreEqual (3, deletedPaths.Count, "Delete should have been attempted three times.");
 			Assert.AreEqual (Files.ToLongPath (tempDirectory), deletedPaths [1], "Long path should not have a trailing directory separator.");
+			Assert.AreEqual (deletedPaths [1], deletedPaths [2], "Long path should not be prefixed more than once.");
 			DirectoryAssert.DoesNotExist (tempDirectory);
 		}
 


### PR DESCRIPTION
----

Visual Studio's .NET Framework MSBuild host can report XARDF7024 while deleting generated Java classes whose paths exceed `MAX_PATH`. The retry preserved the trailing directory separator from the MSBuild property, producing an extended path that .NET Framework rejects with `ERROR_INVALID_NAME`.

Normalize the directory path before retrying and make `Files.ToLongPath()` idempotent so repeated failures cannot add the `\\?\` prefix more than once. Direct unit coverage verifies both the shared helper and consecutive `RemoveDirFixed` retries.

Fixes #12207

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [x] Unit tests