### PR TITLE
[tests] Ignore MarshalMethodsAppRuns on CoreCLR

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/MarshalMethodsGCHangTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MarshalMethodsGCHangTests.cs
@@ -84,7 +84,7 @@ public class MainActivity : Activity
 ";
 
 	[Test]
-	[Ignore ("Marshal methods are only supported with MonoVM")]
+	[Ignore ("Marshal methods are not yet working on CoreCLR")]
 	public void MarshalMethodsAppRuns ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 	{
 		const bool isRelease = true;

--- a/tests/MSBuildDeviceIntegration/Tests/MarshalMethodsGCHangTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MarshalMethodsGCHangTests.cs
@@ -84,7 +84,7 @@ public class MainActivity : Activity
 ";
 
 	[Test]
-	[Ignore ("Marshal methods are not yet working on CoreCLR")]
+	[Ignore ("Marshal methods are not yet working on CoreCLR: https://github.com/dotnet/android/issues/12206")]
 	public void MarshalMethodsAppRuns ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 	{
 		const bool isRelease = true;

--- a/tests/MSBuildDeviceIntegration/Tests/MarshalMethodsGCHangTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MarshalMethodsGCHangTests.cs
@@ -84,6 +84,7 @@ public class MainActivity : Activity
 ";
 
 	[Test]
+	[Ignore ("Marshal methods are only supported with MonoVM")]
 	public void MarshalMethodsAppRuns ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 	{
 		const bool isRelease = true;


### PR DESCRIPTION
## Description

`MarshalMethodsAppRuns(CoreCLR)` repeatedly crashes in `Java_mono_android_TypeManager_n_activate` across unrelated CI builds because marshal methods are not yet working on CoreCLR.

Ignore the test for now while keeping it in place so CoreCLR coverage can be restored when the runtime support is ready. NativeAOT was already skipped by the test as unsupported.

Related to #12206. The issue should remain open to track restoring the test.

- [x] Useful description of why the change is necessary.
- [x] Links to the related issue.
- [x] Unit tests: not applicable; this change temporarily ignores a failing device test.