### PR TITLE
`$(AndroidPackVersionSuffix)=rc.1`

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,6 +44,6 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>37.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/11.0.1xx-preview7

We branched for .NET 11 Preview 7 from d7f90faa into `release/11.0.1xx-preview7`; the main branch is now .NET 11 RC 1. This updates the Android pack suffix from `preview.7` to `rc.1`.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: N/A
- [x] Unit tests: N/A (version metadata only)