### PR TITLE
[CoreCLR] Stabilize Debug typemaps across C# rebuilds

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -460,7 +460,13 @@ namespace Android.Runtime {
 				} else if (RuntimeFeature.IsCoreClrRuntime) {
 					if (type.FullName is null)
 						return null;
-					ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, (IntPtr)mvidptr);
+					string? assemblyFullName = null;
+					if (RuntimeFeature.ManagedToJavaUsesAssemblyFullName) {
+						assemblyFullName = type.Assembly.FullName;
+						if (assemblyFullName is null)
+							return null;
+					}
+					ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, assemblyFullName, (IntPtr)mvidptr);
 				} else {
 					throw new NotSupportedException ("Internal error: unknown runtime not supported");
 				}

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -441,38 +441,39 @@ namespace Android.Runtime {
 				return TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName) ? jniName : null;
 			}
 
-			IntPtr ret;
-			if (RuntimeFeature.IsCoreClrRuntime && RuntimeFeature.ManagedToJavaUsesAssemblyFullName) {
-				// These typemaps are keyed on the assembly display name, so computing the MVID would be wasted work.
-				if (type.FullName is null)
-					return null;
-				string? assemblyFullName = type.Assembly.FullName;
-				if (assemblyFullName is null)
-					return null;
-				ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, assemblyFullName, IntPtr.Zero);
-			} else {
+			// These typemaps are keyed on the assembly display name, so computing the MVID would be wasted work.
+			bool useAssemblyFullName = RuntimeFeature.IsCoreClrRuntime && RuntimeFeature.ManagedToJavaUsesAssemblyFullName;
+
+			byte[]? mvid_data = null;
+			if (!useAssemblyFullName) {
 				if (mvid_bytes == null)
 					mvid_bytes = new byte[16];
 
 				var mvid = new Span<byte>(mvid_bytes);
-				byte[]? mvid_data = null;
 				if (!type.Module.ModuleVersionId.TryWriteBytes (mvid)) {
 					RuntimeNativeMethods.monodroid_log (LogLevel.Warn, LogCategories.Default, $"Failed to obtain module MVID using the fast method, falling back to the slow one");
 					mvid_data = type.Module.ModuleVersionId.ToByteArray ();
 				} else {
 					mvid_data = mvid_bytes;
 				}
+			}
 
-				fixed (byte* mvidptr = mvid_data) {
-					if (RuntimeFeature.IsMonoRuntime) {
-						ret = monovm_typemap_managed_to_java (type, mvidptr);
-					} else if (RuntimeFeature.IsCoreClrRuntime) {
-						if (type.FullName is null)
+			IntPtr ret;
+			fixed (byte* mvidptr = mvid_data) {
+				if (RuntimeFeature.IsMonoRuntime) {
+					ret = monovm_typemap_managed_to_java (type, mvidptr);
+				} else if (RuntimeFeature.IsCoreClrRuntime) {
+					if (type.FullName is null)
+						return null;
+					string? assemblyFullName = null;
+					if (useAssemblyFullName) {
+						assemblyFullName = type.Assembly.FullName;
+						if (assemblyFullName is null)
 							return null;
-						ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, null, (IntPtr)mvidptr);
-					} else {
-						throw new NotSupportedException ("Internal error: unknown runtime not supported");
 					}
+					ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, assemblyFullName, (IntPtr)mvidptr);
+				} else {
+					throw new NotSupportedException ("Internal error: unknown runtime not supported");
 				}
 			}
 

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -441,11 +441,9 @@ namespace Android.Runtime {
 				return TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName) ? jniName : null;
 			}
 
-			// These typemaps are keyed on the assembly display name, so computing the MVID would be wasted work.
-			bool useAssemblyFullName = RuntimeFeature.IsCoreClrRuntime && RuntimeFeature.ManagedToJavaUsesAssemblyFullName;
-
 			byte[]? mvid_data = null;
-			if (!useAssemblyFullName) {
+			// The Debug CoreCLR typemaps are keyed on the assembly display name, so computing the MVID would be wasted work.
+			if (!RuntimeFeature.IsCoreClrRuntime || !RuntimeFeature.ManagedToJavaUsesAssemblyFullName) {
 				if (mvid_bytes == null)
 					mvid_bytes = new byte[16];
 
@@ -466,7 +464,7 @@ namespace Android.Runtime {
 					if (type.FullName is null)
 						return null;
 					string? assemblyFullName = null;
-					if (useAssemblyFullName) {
+					if (RuntimeFeature.ManagedToJavaUsesAssemblyFullName) {
 						assemblyFullName = type.Assembly.FullName;
 						if (assemblyFullName is null)
 							return null;

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -463,12 +463,7 @@ namespace Android.Runtime {
 				} else if (RuntimeFeature.IsCoreClrRuntime) {
 					if (type.FullName is null)
 						return null;
-					string? assemblyFullName = null;
-					if (RuntimeFeature.ManagedToJavaUsesAssemblyFullName) {
-						assemblyFullName = type.Assembly.FullName;
-						if (assemblyFullName is null)
-							return null;
-					}
+					string? assemblyFullName = RuntimeFeature.ManagedToJavaUsesAssemblyFullName ? type.Assembly.FullName : null;
 					ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, assemblyFullName, (IntPtr)mvidptr);
 				} else {
 					throw new NotSupportedException ("Internal error: unknown runtime not supported");

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -441,34 +441,38 @@ namespace Android.Runtime {
 				return TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName) ? jniName : null;
 			}
 
-			if (mvid_bytes == null)
-				mvid_bytes = new byte[16];
-
-			var mvid = new Span<byte>(mvid_bytes);
-			byte[]? mvid_data = null;
-			if (!type.Module.ModuleVersionId.TryWriteBytes (mvid)) {
-				RuntimeNativeMethods.monodroid_log (LogLevel.Warn, LogCategories.Default, $"Failed to obtain module MVID using the fast method, falling back to the slow one");
-				mvid_data = type.Module.ModuleVersionId.ToByteArray ();
-			} else {
-				mvid_data = mvid_bytes;
-			}
-
 			IntPtr ret;
-			fixed (byte* mvidptr = mvid_data) {
-				if (RuntimeFeature.IsMonoRuntime) {
-					ret = monovm_typemap_managed_to_java (type, mvidptr);
-				} else if (RuntimeFeature.IsCoreClrRuntime) {
-					if (type.FullName is null)
-						return null;
-					string? assemblyFullName = null;
-					if (RuntimeFeature.ManagedToJavaUsesAssemblyFullName) {
-						assemblyFullName = type.Assembly.FullName;
-						if (assemblyFullName is null)
-							return null;
-					}
-					ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, assemblyFullName, (IntPtr)mvidptr);
+			if (RuntimeFeature.IsCoreClrRuntime && RuntimeFeature.ManagedToJavaUsesAssemblyFullName) {
+				// These typemaps are keyed on the assembly display name, so computing the MVID would be wasted work.
+				if (type.FullName is null)
+					return null;
+				string? assemblyFullName = type.Assembly.FullName;
+				if (assemblyFullName is null)
+					return null;
+				ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, assemblyFullName, IntPtr.Zero);
+			} else {
+				if (mvid_bytes == null)
+					mvid_bytes = new byte[16];
+
+				var mvid = new Span<byte>(mvid_bytes);
+				byte[]? mvid_data = null;
+				if (!type.Module.ModuleVersionId.TryWriteBytes (mvid)) {
+					RuntimeNativeMethods.monodroid_log (LogLevel.Warn, LogCategories.Default, $"Failed to obtain module MVID using the fast method, falling back to the slow one");
+					mvid_data = type.Module.ModuleVersionId.ToByteArray ();
 				} else {
-					throw new NotSupportedException ("Internal error: unknown runtime not supported");
+					mvid_data = mvid_bytes;
+				}
+
+				fixed (byte* mvidptr = mvid_data) {
+					if (RuntimeFeature.IsMonoRuntime) {
+						ret = monovm_typemap_managed_to_java (type, mvidptr);
+					} else if (RuntimeFeature.IsCoreClrRuntime) {
+						if (type.FullName is null)
+							return null;
+						ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, null, (IntPtr)mvidptr);
+					} else {
+						throw new NotSupportedException ("Internal error: unknown runtime not supported");
+					}
 				}
 			}
 

--- a/src/Mono.Android/Android.Runtime/RuntimeNativeMethods.cs
+++ b/src/Mono.Android/Android.Runtime/RuntimeNativeMethods.cs
@@ -115,7 +115,7 @@ namespace Android.Runtime
 
 		[LibraryImport (RuntimeConstants.InternalDllName, StringMarshalling = StringMarshalling.Utf8)]
 		[UnmanagedCallConv (CallConvs = new[] { typeof (CallConvCdecl) })]
-		internal static partial IntPtr clr_typemap_managed_to_java (string fullName, IntPtr mvid);
+		internal static partial IntPtr clr_typemap_managed_to_java (string fullName, string? assemblyFullName, IntPtr mvid);
 
 		[LibraryImport (RuntimeConstants.InternalDllName, StringMarshalling = StringMarshalling.Utf8)]
 		[UnmanagedCallConv (CallConvs = new[] { typeof (CallConvCdecl) })]

--- a/src/Mono.Android/Microsoft.Android.Runtime/RuntimeFeature.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/RuntimeFeature.cs
@@ -12,6 +12,7 @@ static class RuntimeFeature
 	const bool StartupHookSupportEnabledByDefault = true;
 	const bool TrimmableTypeMapEnabledByDefault = false;
 	const bool ObjectReferenceLoggingEnabledByDefault = false;
+	const bool ManagedToJavaUsesAssemblyFullNameEnabledByDefault = false;
 
 	const string FeatureSwitchPrefix = "Microsoft.Android.Runtime.RuntimeFeature.";
 	const string StartupHookProviderSwitch = "System.StartupHookProvider.IsSupported";
@@ -44,4 +45,9 @@ static class RuntimeFeature
 	[FeatureSwitchDefinition ($"{FeatureSwitchPrefix}{nameof (ObjectReferenceLogging)}")]
 	internal static bool ObjectReferenceLogging { get; } =
 		AppContext.TryGetSwitch ($"{FeatureSwitchPrefix}{nameof (ObjectReferenceLogging)}", out bool isEnabled) ? isEnabled : ObjectReferenceLoggingEnabledByDefault;
+
+	// Enabled for Debug builds, whose string-based typemaps support Fast Deployment without embedding assembly MVIDs.
+	[FeatureSwitchDefinition ($"{FeatureSwitchPrefix}{nameof (ManagedToJavaUsesAssemblyFullName)}")]
+	internal static bool ManagedToJavaUsesAssemblyFullName { get; } =
+		AppContext.TryGetSwitch ($"{FeatureSwitchPrefix}{nameof (ManagedToJavaUsesAssemblyFullName)}", out bool isEnabled) ? isEnabled : ManagedToJavaUsesAssemblyFullNameEnabledByDefault;
 }

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FindTypeMapObjectsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FindTypeMapObjectsStep.cs
@@ -37,7 +37,7 @@ public class FindTypeMapObjectsStep : BaseStep, IAssemblyModifierPipelineStep
 
 		var xml = new TypeMapObjectsXmlFile {
 			AssemblyName = assembly.Name.Name,
-			AssemblyFullName = Debug ? assembly.Name.FullName : null,
+			AssemblyFullName = Debug ? TypeMapCecilAdapter.GetRuntimeAssemblyFullName (assembly.Name) : null,
 			AssemblyMvid = assembly.MainModule.Mvid,
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FindTypeMapObjectsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FindTypeMapObjectsStep.cs
@@ -37,6 +37,7 @@ public class FindTypeMapObjectsStep : BaseStep, IAssemblyModifierPipelineStep
 
 		var xml = new TypeMapObjectsXmlFile {
 			AssemblyName = assembly.Name.Name,
+			AssemblyFullName = Debug ? assembly.Name.FullName : null,
 			AssemblyMvid = assembly.MainModule.Mvid,
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
@@ -34,6 +34,10 @@ This file contains the CoreCLR-specific MSBuild logic for .NET for Android.
         Value="false"
         Trim="true"
     />
+    <RuntimeHostConfigurationOption Include="Microsoft.Android.Runtime.RuntimeFeature.ManagedToJavaUsesAssemblyFullName"
+        Value="$(AndroidIncludeDebugSymbols)"
+        Trim="true"
+    />
   </ItemGroup>
 
   <Target Name="_CLRUseLocalRuntimePacks" AfterTargets="ResolveFrameworkReferences"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateEmptyTypemapStub.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateEmptyTypemapStub.cs
@@ -66,8 +66,8 @@ target triple = "{{triple}}"
 
 		if (Debug) {
 			return header + """
-%struct.TypeMap = type { i32, i32, ptr, ptr }
-%struct.TypeMapManagedTypeInfo = type { i64, i32, i32 }
+%struct.TypeMap = type { i32, ptr, ptr }
+%struct.TypeMapManagedTypeInfo = type { i32, i32 }
 
 @type_map = dso_local constant %struct.TypeMap zeroinitializer, align 8
 @type_map_managed_type_info = dso_local constant [0 x %struct.TypeMapManagedTypeInfo] zeroinitializer, align 8

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateEmptyTypemapStub.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateEmptyTypemapStub.cs
@@ -68,11 +68,9 @@ target triple = "{{triple}}"
 			return header + """
 %struct.TypeMap = type { i32, i32, ptr, ptr }
 %struct.TypeMapManagedTypeInfo = type { i64, i32, i32 }
-%struct.TypeMapAssembly = type { [16 x i8], i64, i64 }
 
 @type_map = dso_local constant %struct.TypeMap zeroinitializer, align 8
 @type_map_managed_type_info = dso_local constant [0 x %struct.TypeMapManagedTypeInfo] zeroinitializer, align 8
-@type_map_unique_assemblies = dso_local constant [0 x %struct.TypeMapAssembly] zeroinitializer, align 8
 @type_map_assembly_names = dso_local constant [1 x i8] zeroinitializer, align 1
 @type_map_managed_type_names = dso_local constant [1 x i8] zeroinitializer, align 1
 @type_map_java_type_names = dso_local constant [1 x i8] zeroinitializer, align 1

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1390,6 +1390,32 @@ namespace Lib2
 					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
 				}
 				AssertAssemblyFilesInFileWrites (proj, b, abi, runtime);
+
+				if (!isRelease && runtime == AndroidRuntime.CoreCLR) {
+					string projectDirectory = Path.Combine (Root, b.ProjectDirectory);
+					string intermediate = Path.Combine (projectDirectory, proj.IntermediateOutputPath, MonoAndroidHelper.AbiToRid (abi));
+					string typemap = Path.Combine (intermediate, "android", $"typemaps.{abi}.ll");
+					string apk = Directory.GetFiles (Path.Combine (projectDirectory, proj.OutputPath), "*-Signed.apk", SearchOption.AllDirectories).Single ();
+					DateTime typemapWriteTime = File.GetLastWriteTimeUtc (typemap);
+					DateTime apkWriteTime = File.GetLastWriteTimeUtc (apk);
+					string typemapHash = Files.HashFile (typemap);
+					string apkHash = Files.HashFile (apk);
+
+					// Change managed code without changing any Java type mappings.
+					proj.MainActivity = proj.MainActivity.Replace ("clicks", "CLICKS");
+					proj.Touch ("MainActivity.cs");
+					Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "fourth build should have succeeded.");
+
+					b.Output.AssertTargetIsNotSkipped ("CoreCompile");
+					b.Output.AssertTargetIsSkipped ("_CompileNativeAssemblySources");
+					b.Output.AssertTargetIsSkipped ("_CreateApplicationSharedLibraries");
+					b.Output.AssertTargetIsSkipped ("_BuildApkFastDev");
+					b.Output.AssertTargetIsSkipped ("_Sign");
+					Assert.AreEqual (typemapWriteTime, File.GetLastWriteTimeUtc (typemap), $"{typemap} should not be rewritten when its mappings have not changed.");
+					Assert.AreEqual (typemapHash, Files.HashFile (typemap), $"{typemap} contents should not change.");
+					Assert.AreEqual (apkWriteTime, File.GetLastWriteTimeUtc (apk), $"{apk} should not be rewritten for an incremental C# change.");
+					Assert.AreEqual (apkHash, Files.HashFile (apk), $"{apk} contents should not change.");
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LlvmIrGeneratorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LlvmIrGeneratorTests.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Utilities;
+using Mono.Cecil;
 using NUnit.Framework;
+using Xamarin.Android.Tasks;
 using Xamarin.Android.Tasks.LLVMIR;
 using Xamarin.Android.Tools;
 
@@ -78,6 +80,17 @@ namespace Xamarin.Android.Build.Tests.Tasks
 			Assert.That (output, Does.Not.Contain ("% )"), "Generated LLVM IR should not contain 'ptr noundef % )' pattern");
 			Assert.That (output, Does.Not.Contain ("%\t)"), "Generated LLVM IR should not contain 'ptr noundef %\\t)' pattern");
 			Assert.That (output, Does.Contain ("@test_function"), "Generated LLVM IR should contain the function name");
+		}
+
+		[Test]
+		public void TypeMapAssemblyFullNameUsesRuntimeEscaping ()
+		{
+			var assemblyName = new AssemblyNameDefinition ("Comma,Name", new Version (1, 2, 3, 4));
+
+			Assert.That (
+				TypeMapCecilAdapter.GetRuntimeAssemblyFullName (assemblyName),
+				Is.EqualTo (@"Comma\,Name, Version=1.2.3.4, Culture=neutral, PublicKeyToken=null")
+			);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LlvmIrGeneratorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LlvmIrGeneratorTests.cs
@@ -92,5 +92,16 @@ namespace Xamarin.Android.Build.Tests.Tasks
 				Is.EqualTo (@"Comma\,Name, Version=1.2.3.4, Culture=neutral, PublicKeyToken=null")
 			);
 		}
+
+		[Test]
+		public void TypeMapAssemblyFullNameMatchesStrongNamedRuntimeAssembly ()
+		{
+			string assemblyPath = typeof (TypeMapCecilAdapter).Assembly.Location;
+			using var assembly = AssemblyDefinition.ReadAssembly (assemblyPath);
+			string? runtimeFullName = System.Reflection.AssemblyName.GetAssemblyName (assemblyPath).FullName;
+
+			Assert.That (runtimeFullName, Does.Not.EndWith ("PublicKeyToken=null"));
+			Assert.That (TypeMapCecilAdapter.GetRuntimeAssemblyFullName (assembly.Name), Is.EqualTo (runtimeFullName));
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
 using Xamarin.Tools.Zip;
 
 namespace Xamarin.ProjectTools
@@ -170,8 +171,27 @@ namespace Xamarin.ProjectTools
 			return TimeSpan.Zero;
 		}
 
+		/// <summary>
+		/// Gets a value indicating whether the .apk was installed on the device by the last build.
+		/// </summary>
+		/// <remarks>
+		/// <para>This scans the build output for the <c>Installed Package</c> message written by the
+		/// <c>FastDeploy</c> and <c>FastDeploy2</c> tasks. Both write it with
+		/// <see cref="Microsoft.Build.Framework.MessageImportance.Low"/>, so it is only present in the
+		/// build output at <see cref="Microsoft.Build.Framework.LoggerVerbosity.Detailed"/> or higher.</para>
+		/// <para>At a lower verbosity this property would silently return <c>false</c> no matter what the
+		/// build did, which makes both <c>Assert.IsTrue</c> and <c>Assert.IsFalse</c> on it meaningless.
+		/// It therefore throws instead, so the test fails with an actionable message rather than a
+		/// misleading pass or an opaque assertion failure.</para>
+		/// </remarks>
+		/// <exception cref="InvalidOperationException">
+		/// <see cref="Builder"/> is running at a verbosity below
+		/// <see cref="Microsoft.Build.Framework.LoggerVerbosity.Detailed"/>.
+		/// </exception>
 		public bool IsApkInstalled {
 			get {
+				if (Builder.Verbosity < LoggerVerbosity.Detailed)
+					throw new InvalidOperationException ($"`{nameof (IsApkInstalled)}` requires `{nameof (Builder)}.{nameof (Builder.Verbosity)}` to be `{nameof (LoggerVerbosity.Detailed)}` or higher, but it is `{Builder.Verbosity}`. The `Installed Package` message it looks for is logged with `MessageImportance.Low`.");
 				foreach (var line in Builder.LastBuildOutput) {
 					if (line.Contains ("Installed Package") || line.Contains (" pm install "))
 						return true;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapCecilAdapter.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapCecilAdapter.cs
@@ -149,6 +149,7 @@ class TypeMapCecilAdapter
 			TypeDefinition = td,
 			SkipInJavaToManaged = ShouldSkipInJavaToManaged (td),
 			AssemblyName = td.Module.Assembly.Name.Name,
+			AssemblyFullName = td.Module.Assembly.Name.FullName,
 		};
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapCecilAdapter.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapCecilAdapter.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using Java.Interop.Tools.Cecil;
 using Mono.Cecil;
 
+using ReflectionAssemblyContentType = System.Reflection.AssemblyContentType;
+using ReflectionAssemblyName = System.Reflection.AssemblyName;
+using ReflectionAssemblyNameFlags = System.Reflection.AssemblyNameFlags;
 using ModuleReleaseData = Xamarin.Android.Tasks.TypeMapGenerator.ModuleReleaseData;
 using ReleaseGenerationState = Xamarin.Android.Tasks.TypeMapGenerator.ReleaseGenerationState;
 using TypeMapDebugEntry = Xamarin.Android.Tasks.TypeMapGenerator.TypeMapDebugEntry;
@@ -149,8 +152,23 @@ class TypeMapCecilAdapter
 			TypeDefinition = td,
 			SkipInJavaToManaged = ShouldSkipInJavaToManaged (td),
 			AssemblyName = td.Module.Assembly.Name.Name,
-			AssemblyFullName = td.Module.Assembly.Name.FullName,
+			AssemblyFullName = GetRuntimeAssemblyFullName (td.Module.Assembly.Name),
 		};
+	}
+
+	// Cecil's FullName does not escape assembly display names in the same way as Assembly.FullName.
+	public static string GetRuntimeAssemblyFullName (AssemblyNameReference assemblyName)
+	{
+		var runtimeAssemblyName = new ReflectionAssemblyName {
+			Name = assemblyName.Name,
+			Version = assemblyName.Version,
+			CultureName = assemblyName.Culture ?? "",
+			Flags = assemblyName.IsRetargetable ? ReflectionAssemblyNameFlags.Retargetable : ReflectionAssemblyNameFlags.None,
+			ContentType = assemblyName.IsWindowsRuntime ? ReflectionAssemblyContentType.WindowsRuntime : ReflectionAssemblyContentType.Default,
+		};
+		runtimeAssemblyName.SetPublicKeyToken (assemblyName.PublicKeyToken);
+
+		return runtimeAssemblyName.FullName ?? throw new InvalidOperationException ($"Unable to format assembly name '{assemblyName.Name}'.");
 	}
 
 	static string GetManagedTypeName (TypeDefinition td)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
@@ -64,6 +64,7 @@ namespace Xamarin.Android.Tasks
 			public bool SkipInJavaToManaged;
 			public TypeMapDebugEntry DuplicateForJavaToManaged;
 			public string AssemblyName;
+			public string AssemblyFullName;
 
 			// This field is only used by the Cecil adapter for temp storage while reading.
 			// It is not used to create the typemap.

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
@@ -23,6 +23,7 @@ class TypeMapObjectsXmlFile
 	static readonly TypeMapObjectsXmlFile unscanned = new TypeMapObjectsXmlFile { WasScanned = false };
 
 	public string? AssemblyName { get; set; }
+	public string? AssemblyFullName { get; set; }
 	public Guid AssemblyMvid { get; set; } = Guid.Empty;
 	public bool FoundJniNativeRegistration { get; set; }
 	public List<TypeMapDebugEntry> JavaToManagedDebugEntries { get; } = [];
@@ -57,6 +58,7 @@ class TypeMapObjectsXmlFile
 		xml.WriteStartElement ("api");
 		xml.WriteAttributeString ("type", HasDebugEntries ? "debug" : "release");
 		xml.WriteAttributeStringIfNotDefault ("assembly-name", AssemblyName);
+		xml.WriteAttributeStringIfNotDefault ("assembly-full-name", AssemblyFullName);
 
 		if (AssemblyMvid != Guid.Empty) {
 			xml.WriteAttributeString ("mvid", AssemblyMvid.ToString ("N"));
@@ -183,6 +185,7 @@ class TypeMapObjectsXmlFile
 			throw new InvalidOperationException ($"Missing required attribute 'type' in '{filename}'");
 
 		var assemblyName = reader.GetAttribute ("assembly-name");
+		var assemblyFullName = reader.GetAttribute ("assembly-full-name");
 		var mvidValue = reader.GetAttribute ("mvid");
 		var mvid = mvidValue.IsNullOrWhiteSpace () ? Guid.Empty : Guid.Parse (mvidValue);
 		var foundJniNativeRegistration = GetAttributeOrDefault (reader, "found-jni-native-registration", false);
@@ -190,6 +193,7 @@ class TypeMapObjectsXmlFile
 		var file = new TypeMapObjectsXmlFile {
 			WasScanned = true,
 			AssemblyName = assemblyName,
+			AssemblyFullName = assemblyFullName,
 			AssemblyMvid = mvid,
 			FoundJniNativeRegistration = foundJniNativeRegistration,
 		};
@@ -205,6 +209,7 @@ class TypeMapObjectsXmlFile
 	static void ImportDebugData (XmlReader reader, TypeMapObjectsXmlFile file)
 	{
 		var assemblyName = file.AssemblyName ?? string.Empty;
+		var assemblyFullName = file.AssemblyFullName ?? string.Empty;
 		var isMonoAndroid = assemblyName == "Mono.Android";
 
 		while (reader.Read ()) {
@@ -212,9 +217,9 @@ class TypeMapObjectsXmlFile
 				continue;
 
 			if (reader.Name == "java-to-managed")
-				ReadDebugEntries (reader, file.JavaToManagedDebugEntries, assemblyName, isMonoAndroid);
+				ReadDebugEntries (reader, file.JavaToManagedDebugEntries, assemblyName, assemblyFullName, isMonoAndroid);
 			else if (reader.Name == "managed-to-java")
-				ReadDebugEntries (reader, file.ManagedToJavaDebugEntries, assemblyName, isMonoAndroid);
+				ReadDebugEntries (reader, file.ManagedToJavaDebugEntries, assemblyName, assemblyFullName, isMonoAndroid);
 		}
 	}
 
@@ -268,7 +273,7 @@ class TypeMapObjectsXmlFile
 		File.Create (destination).Dispose ();
 	}
 
-	static TypeMapDebugEntry FromDebugEntryXml (XmlReader reader, string assemblyName, bool isMonoAndroid)
+	static TypeMapDebugEntry FromDebugEntryXml (XmlReader reader, string assemblyName, string assemblyFullName, bool isMonoAndroid)
 	{
 		return new TypeMapDebugEntry {
 			JavaName = reader.GetAttribute ("java-name") ?? string.Empty,
@@ -278,6 +283,7 @@ class TypeMapObjectsXmlFile
 			IsInvoker = GetAttributeOrDefault (reader, "is-invoker", false),
 			IsMonoAndroid = isMonoAndroid,
 			AssemblyName = assemblyName,
+			AssemblyFullName = assemblyFullName,
 		};
 	}
 
@@ -301,7 +307,7 @@ class TypeMapObjectsXmlFile
 		return (T) Convert.ChangeType (value, typeof (T), CultureInfo.InvariantCulture);
 	}
 
-	static void ReadDebugEntries (XmlReader reader, List<TypeMapDebugEntry> entries, string assemblyName, bool isMonoAndroid)
+	static void ReadDebugEntries (XmlReader reader, List<TypeMapDebugEntry> entries, string assemblyName, string assemblyFullName, bool isMonoAndroid)
 	{
 		if (reader.IsEmptyElement)
 			return;
@@ -313,7 +319,7 @@ class TypeMapObjectsXmlFile
 				return;
 
 			if (reader.NodeType == XmlNodeType.Element && reader.Name == "entry")
-				entries.Add (FromDebugEntryXml (reader, assemblyName, isMonoAndroid));
+				entries.Add (FromDebugEntryXml (reader, assemblyName, assemblyFullName, isMonoAndroid));
 		}
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
@@ -14,7 +14,6 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 
 	// These names MUST match src/native/clr/include/xamarin-app.hh
 	const string TypeMapSymbol = "type_map";
-	const string UniqueAssembliesSymbol = "type_map_unique_assemblies";
 	const string AssemblyNamesBlobSymbol = "type_map_assembly_names";
 	const string ManagedTypeNamesBlobSymbol = "type_map_managed_type_names";
 	const string JavaTypeNamesBlobSymbol = "type_map_java_type_names";
@@ -60,24 +59,6 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 
 			if (MonoAndroidHelper.StringEquals ("to", fieldName)) {
 				return $" to: '{entry.To}'";
-			}
-
-			return String.Empty;
-		}
-	}
-
-	sealed class TypeMapAssemblyContextDataProvider : NativeAssemblerStructContextDataProvider
-	{
-		public override string GetComment (object data, string fieldName)
-		{
-			var entry = EnsureType<TypeMapAssembly> (data);
-
-			if (MonoAndroidHelper.StringEquals ("module_uuid", fieldName)) {
-				return $" MVID: {entry.MVID}";
-			}
-
-			if (MonoAndroidHelper.StringEquals ("name_offset", fieldName)) {
-				return $" {entry.Name}";
 			}
 
 			return String.Empty;
@@ -153,7 +134,6 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 		public int    ManagedToJavaCount;
 
 		public uint   entry_count;
-		public ulong  unique_assemblies_count;
 
 		[NativeAssembler (UsesDataProvider = true), NativePointer (PointsToSymbol = "")]
 		public TypeMapEntry? java_to_managed = null;
@@ -162,34 +142,12 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 		public TypeMapEntry? managed_to_java = null;
 	};
 
-	// Order of fields and their type must correspond *exactly* to that in
-	// src/native/clr/include/xamarin-app.hh TypeMapAssembly structure
-	[NativeAssemblerStructContextDataProvider (typeof (TypeMapAssemblyContextDataProvider))]
-	sealed class TypeMapAssembly
-	{
-		[NativeAssembler (Ignore = true)]
-		public string Name = String.Empty;
-
-		[NativeAssembler (Ignore = true)]
-		public Guid MVID;
-
-		[NativeAssembler (UsesDataProvider = true, InlineArray = true, InlineArraySize = 16)]
-		public byte[] module_uuid = [];
-
-		public ulong name_length;
-
-		[NativeAssembler (UsesDataProvider = true)]
-		public ulong name_offset;
-	}
-
 	readonly TypeMapGenerator.ModuleDebugData data;
 	StructureInfo? typeMapEntryStructureInfo;
 	StructureInfo? typeMapStructureInfo;
-	StructureInfo? typeMapAssemblyStructureInfo;
 	StructureInfo? typeMapManagedTypeInfoStructureInfo;
 	List<StructureInstance<TypeMapEntry>> javaToManagedMap;
 	List<StructureInstance<TypeMapEntry>> managedToJavaMap;
-	List<StructureInstance<TypeMapAssembly>> uniqueAssemblies;
 	List<StructureInstance<TypeMapManagedTypeInfo>> managedTypeInfos;
 	StructureInstance<TypeMap>? type_map;
 
@@ -204,7 +162,6 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 
 		javaToManagedMap = new ();
 		managedToJavaMap = new ();
-		uniqueAssemblies = new ();
 		managedTypeInfos = new ();
 	}
 
@@ -225,14 +182,19 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 		// in a callback during code generation
 
 		foreach (TypeMapGenerator.TypeMapDebugEntry entry in data.ManagedToJavaMap) {
-			(int managedTypeNameOffset, int _) = managedTypeNames.Add (entry.ManagedName);
+			if (!entry.ManagedName.EndsWith (entry.AssemblyName, StringComparison.Ordinal)) {
+				throw new InvalidOperationException ($"Internal error: managed type name '{entry.ManagedName}' does not end with assembly name '{entry.AssemblyName}'.");
+			}
+
+			string managedName = entry.ManagedName.Substring (0, entry.ManagedName.Length - entry.AssemblyName.Length) + entry.AssemblyFullName;
+			(int managedTypeNameOffset, int _) = managedTypeNames.Add (managedName);
 			(int javaTypeNameOffset, int _) = javaTypeNames.Add (entry.JavaName);
 			var m2j = new TypeMapEntry {
-				From = entry.ManagedName,
+				From = managedName,
 				To = entry.JavaName,
 
 				from = (uint)managedTypeNameOffset,
-				from_hash = TypeMapHelper.HashNameForCLR (entry.ManagedName),
+				from_hash = TypeMapHelper.HashNameForCLR (managedName),
 				to = (uint)javaTypeNameOffset,
 			};
 			managedToJavaMap.Add (new StructureInstance<TypeMapEntry> (typeMapEntryStructureInfo, m2j));
@@ -252,31 +214,10 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 		});
 
 		var assemblyNamesBlob = new LlvmIrStringBlob ();
+		data.UniqueAssemblies.Sort ((a, b) => String.Compare (a.Name, b.Name, StringComparison.Ordinal));
 		foreach (TypeMapGenerator.TypeMapDebugAssembly asm in data.UniqueAssemblies) {
-			(int assemblyNameOffset, int assemblyNameLength) = assemblyNamesBlob.Add (asm.Name);
-
-			var entry = new TypeMapAssembly {
-				Name = asm.Name,
-				MVID = asm.MVID,
-
-				module_uuid = asm.MVIDBytes,
-				name_length = (ulong)assemblyNameLength, // without the trailing NUL
-				name_offset = (ulong)assemblyNameOffset,
-			};
-			uniqueAssemblies.Add (new StructureInstance<TypeMapAssembly> (typeMapAssemblyStructureInfo, entry));
+			assemblyNamesBlob.Add (asm.Name);
 		}
-
-		uniqueAssemblies.Sort ((StructureInstance<TypeMapAssembly> a, StructureInstance<TypeMapAssembly> b) => {
-			if (a.Instance == null) {
-				return b.Instance == null ? 0 : -1;
-			}
-
-			if (b.Instance == null) {
-				return 1;
-			}
-
-			return a.Instance.module_uuid.AsSpan ().SequenceCompareTo (b.Instance.module_uuid);
-		});
 
 		var managedTypeInfos = new List<StructureInstance<TypeMapManagedTypeInfo>> ();
 		// Java-to-managed maps don't use hashes since many mappings have multiple instances
@@ -315,7 +256,6 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 			ManagedToJavaCount = data.ManagedToJavaMap == null ? 0 : data.ManagedToJavaMap.Count,
 
 			entry_count = data.EntryCount,
-			unique_assemblies_count = (ulong)data.UniqueAssemblies.Count,
 		};
 		type_map = new StructureInstance<TypeMap> (typeMapStructureInfo, map);
 
@@ -323,7 +263,6 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 		module.AddGlobalVariable (ManagedToJavaSymbol, managedToJavaMap, LlvmIrVariableOptions.LocalConstant);
 		module.AddGlobalVariable (JavaToManagedSymbol, javaToManagedMap, LlvmIrVariableOptions.LocalConstant);
 		module.AddGlobalVariable (TypeMapManagedTypeInfoSymbol, managedTypeInfos, LlvmIrVariableOptions.GlobalConstant);
-		module.AddGlobalVariable (UniqueAssembliesSymbol, uniqueAssemblies, LlvmIrVariableOptions.GlobalConstant);
 		module.AddGlobalVariable (AssemblyNamesBlobSymbol, assemblyNamesBlob, LlvmIrVariableOptions.GlobalConstant);
 		module.AddGlobalVariable (ManagedTypeNamesBlobSymbol, managedTypeNames, LlvmIrVariableOptions.GlobalConstant);
 		module.AddGlobalVariable (JavaTypeNamesBlobSymbol, javaTypeNames, LlvmIrVariableOptions.GlobalConstant);
@@ -331,7 +270,6 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 
 	void MapStructures (LlvmIrModule module)
 	{
-		typeMapAssemblyStructureInfo = module.MapStructure<TypeMapAssembly> ();
 		typeMapEntryStructureInfo = module.MapStructure<TypeMapEntry> ();
 		typeMapStructureInfo = module.MapStructure<TypeMap> ();
 		typeMapManagedTypeInfoStructureInfo = module.MapStructure<TypeMapManagedTypeInfo> ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
@@ -182,6 +182,10 @@ class TypeMappingDebugNativeAssemblyGeneratorCLR : LlvmIrComposer
 		// in a callback during code generation
 
 		foreach (TypeMapGenerator.TypeMapDebugEntry entry in data.ManagedToJavaMap) {
+			if (String.IsNullOrEmpty (entry.AssemblyFullName)) {
+				throw new InvalidOperationException ($"Internal error: assembly full name is missing for managed type '{entry.ManagedName}'.");
+			}
+
 			if (!entry.ManagedName.EndsWith (entry.AssemblyName, StringComparison.Ordinal)) {
 				throw new InvalidOperationException ($"Internal error: managed type name '{entry.ManagedName}' does not end with assembly name '{entry.AssemblyName}'.");
 			}

--- a/src/native/clr/host/internal-pinvokes-clr.cc
+++ b/src/native/clr/host/internal-pinvokes-clr.cc
@@ -9,9 +9,13 @@
 
 using namespace xamarin::android;
 
-const char* clr_typemap_managed_to_java (const char *typeName, const uint8_t *mvid) noexcept
+const char* clr_typemap_managed_to_java (const char *typeName, const char *assemblyFullName, const uint8_t *mvid) noexcept
 {
+#if defined(RELEASE)
 	return TypeMapper::managed_to_java (typeName, mvid);
+#else
+	return TypeMapper::managed_to_java (typeName, assemblyFullName);
+#endif
 }
 
 bool clr_typemap_java_to_managed (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept

--- a/src/native/clr/host/internal-pinvokes-clr.cc
+++ b/src/native/clr/host/internal-pinvokes-clr.cc
@@ -9,7 +9,11 @@
 
 using namespace xamarin::android;
 
-const char* clr_typemap_managed_to_java (const char *typeName, const char *assemblyFullName, const uint8_t *mvid) noexcept
+const char* clr_typemap_managed_to_java (
+	const char *typeName,
+	[[maybe_unused]] const char *assemblyFullName,
+	[[maybe_unused]] const uint8_t *mvid
+) noexcept
 {
 #if defined(RELEASE)
 	return TypeMapper::managed_to_java (typeName, mvid);

--- a/src/native/clr/host/typemap.cc
+++ b/src/native/clr/host/typemap.cc
@@ -150,26 +150,14 @@ auto TypeMapper::index_to_name (ssize_t idx, const char* typeName, const TypeMap
 }
 
 [[gnu::always_inline, gnu::flatten]]
-auto TypeMapper::managed_to_java_debug (const char *typeName, const uint8_t *mvid) noexcept -> const char*
+auto TypeMapper::managed_to_java_debug (const char *typeName, const char *assemblyFullName) noexcept -> const char*
 {
 	dynamic_local_path_string full_type_name;
 	full_type_name.append (typeName);
+	full_type_name.append (", "sv);
+	full_type_name.append (assemblyFullName);
 
-	auto equal = [](TypeMapAssembly const& entry, const uint8_t *key) -> bool { return memcmp (entry.module_uuid, key, sizeof(entry.module_uuid)) == 0; };
-	auto less_than = [](TypeMapAssembly const& entry, const uint8_t *key) -> bool { return memcmp (entry.module_uuid, key, sizeof(entry.module_uuid)) < 0; };
-	ssize_t idx = Search::binary_search<TypeMapAssembly, const uint8_t*, equal, less_than> (mvid, type_map_unique_assemblies, type_map.unique_assemblies_count);
-
-	if (idx >= 0) [[likely]] {
-		TypeMapAssembly const& assm = type_map_unique_assemblies[idx];
-		full_type_name.append (", "sv);
-
-		// We explicitly trust the build process here, with regards to validity of offsets
-		full_type_name.append (&type_map_assembly_names[assm.name_offset], assm.name_length);
-	} else {
-		log_warn (LOG_ASSEMBLY, "typemap: unable to look up assembly name for type '{}', trying without it."sv, typeName);
-	}
-
-	idx = find_index_by_hash (full_type_name.get (), type_map.managed_to_java, type_map_managed_type_names, MANAGED, JAVA);
+	ssize_t idx = find_index_by_hash (full_type_name.get (), type_map.managed_to_java, type_map_managed_type_names, MANAGED, JAVA);
 
 	return index_to_name (idx, full_type_name.get (), type_map.managed_to_java, type_map_java_type_names, MANAGED, JAVA);
 }
@@ -320,7 +308,11 @@ auto TypeMapper::managed_to_java_release (const char *typeName, const uint8_t *m
 #endif // def RELEASE
 
 [[gnu::flatten]]
+#if defined(RELEASE)
 auto TypeMapper::managed_to_java (const char *typeName, const uint8_t *mvid) noexcept -> const char*
+#else
+auto TypeMapper::managed_to_java (const char *typeName, const char *assemblyFullName) noexcept -> const char*
+#endif
 {
 	log_debug (LOG_ASSEMBLY, "managed_to_java: looking up type '{}'"sv, optional_string (typeName));
 	if (FastTiming::enabled ()) [[unlikely]] {
@@ -332,14 +324,15 @@ auto TypeMapper::managed_to_java (const char *typeName, const uint8_t *mvid) noe
 		return nullptr;
 	}
 
-	auto do_map = [&typeName, &mvid]() -> const char* {
 #if defined(RELEASE)
-		return managed_to_java_release (typeName, mvid);
+	const char *ret = managed_to_java_release (typeName, mvid);
 #else
-		return managed_to_java_debug (typeName, mvid);
+	if (assemblyFullName == nullptr) [[unlikely]] {
+		log_warn (LOG_ASSEMBLY, "typemap: assembly name not specified in typemap_managed_to_java"sv);
+		return nullptr;
+	}
+	const char *ret = managed_to_java_debug (typeName, assemblyFullName);
 #endif
-	};
-	const char *ret = do_map ();
 
 	if (FastTiming::enabled ()) [[unlikely]] {
 		internal_timing.end_event ();

--- a/src/native/clr/host/typemap.cc
+++ b/src/native/clr/host/typemap.cc
@@ -328,7 +328,7 @@ auto TypeMapper::managed_to_java (const char *typeName, const char *assemblyFull
 	const char *ret = managed_to_java_release (typeName, mvid);
 #else
 	if (assemblyFullName == nullptr) [[unlikely]] {
-		log_warn (LOG_ASSEMBLY, "typemap: assembly name not specified in typemap_managed_to_java"sv);
+		log_warn (LOG_ASSEMBLY, "typemap: assembly full name not specified in typemap_managed_to_java"sv);
 		return nullptr;
 	}
 	const char *ret = managed_to_java_debug (typeName, assemblyFullName);

--- a/src/native/clr/host/typemap.cc
+++ b/src/native/clr/host/typemap.cc
@@ -328,7 +328,7 @@ auto TypeMapper::managed_to_java (const char *typeName, const char *assemblyFull
 	const char *ret = managed_to_java_release (typeName, mvid);
 #else
 	if (assemblyFullName == nullptr) [[unlikely]] {
-		log_warn (LOG_ASSEMBLY, "typemap: assembly full name not specified in typemap_managed_to_java"sv);
+		log_warnf (LOG_ASSEMBLY, "typemap: assembly full name not specified in typemap_managed_to_java");
 		return nullptr;
 	}
 	const char *ret = managed_to_java_debug (typeName, assemblyFullName);

--- a/src/native/clr/include/host/typemap.hh
+++ b/src/native/clr/include/host/typemap.hh
@@ -13,7 +13,11 @@ namespace xamarin::android {
 		static constexpr std::string_view JAVA { "Java" };
 
 	public:
+#if defined(RELEASE)
 		static auto managed_to_java (const char *typeName, const uint8_t *mvid) noexcept -> const char*;
+#else
+		static auto managed_to_java (const char *typeName, const char *assemblyFullName) noexcept -> const char*;
+#endif
 		static auto java_to_managed (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept -> bool;
 
 	private:
@@ -29,7 +33,7 @@ namespace xamarin::android {
 		static auto index_to_name (ssize_t index, const char *typeName, const TypeMapEntry *map, const char (&name_map)[], std::string_view const& from_name, std::string_view const& to_name) -> const char*;
 		static auto find_index_by_hash (const char *typeName, const TypeMapEntry *map, const char (&name_map)[], std::string_view const& from_name, std::string_view const& to_name) noexcept -> ssize_t;
 		static auto find_index_by_name (const char *typeName, const TypeMapEntry *map, const char (&name_map)[], std::string_view const& from_name, std::string_view const& to_name) noexcept -> ssize_t;
-		static auto managed_to_java_debug (const char *typeName, const uint8_t *mvid) noexcept -> const char*;
+		static auto managed_to_java_debug (const char *typeName, const char *assemblyFullName) noexcept -> const char*;
 		static auto java_to_managed_debug (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept -> bool;
 #endif
 	};

--- a/src/native/clr/include/runtime-base/internal-pinvokes.hh
+++ b/src/native/clr/include/runtime-base/internal-pinvokes.hh
@@ -15,7 +15,7 @@ extern "C" {
 	void _monodroid_gref_log (const char *message) noexcept;
 	int _monodroid_gref_log_new (jobject curHandle, char curType, jobject newHandle, char newType, const char *threadName, int threadId, const char *from, int from_writable) noexcept;
 	void _monodroid_gref_log_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable) noexcept;
-	const char* clr_typemap_managed_to_java (const char *typeName, const uint8_t *mvid) noexcept;
+	const char* clr_typemap_managed_to_java (const char *typeName, const char *assemblyFullName, const uint8_t *mvid) noexcept;
 	bool clr_typemap_java_to_managed (const char *java_type_name, char const** assembly_name, uint32_t *managed_type_token_id) noexcept;
 	BridgeProcessingFtn clr_initialize_gc_bridge (
 		BridgeProcessingStartedFtn bridge_processing_started_callback,

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -60,17 +60,8 @@ struct TypeMapManagedTypeInfo
 struct TypeMap
 {
 	uint32_t             entry_count;
-	uint64_t             unique_assemblies_count;
 	const TypeMapEntry  *java_to_managed;
 	const TypeMapEntry  *managed_to_java;
-};
-
-// MUST match src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
-struct TypeMapAssembly
-{
-	uint8_t module_uuid[16];
-	uint64_t name_length;
-	uint64_t name_offset; // into the assembly names blob
 };
 #else
 struct TypeMapModuleEntry
@@ -295,7 +286,6 @@ extern "C" {
 #if defined (DEBUG)
 	[[gnu::visibility("default")]] extern const TypeMap type_map; // MUST match src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGeneratorCLR.cs
 	[[gnu::visibility("default")]] extern const TypeMapManagedTypeInfo type_map_managed_type_info[];
-	[[gnu::visibility("default")]] extern const TypeMapAssembly type_map_unique_assemblies[];
 	[[gnu::visibility("default")]] extern const char type_map_assembly_names[];
 	[[gnu::visibility("default")]] extern const char type_map_managed_type_names[];
 	[[gnu::visibility("default")]] extern const char type_map_java_type_names[];

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -14,13 +14,11 @@ static TypeMapEntry managed_to_java[] = {};
 // MUST match src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
 const TypeMap type_map = {
 	.entry_count = 0,
-	.unique_assemblies_count = 0,
 	.java_to_managed = java_to_managed,
 	.managed_to_java = managed_to_java,
 };
 
 const TypeMapManagedTypeInfo type_map_managed_type_info[] = {};
-const TypeMapAssembly type_map_unique_assemblies[] = {};
 const char type_map_assembly_names[] = {};
 const char type_map_managed_type_names[] = {};
 const char type_map_java_type_names[] = {};

--- a/src/native/nativeaot/host/internal-pinvoke-stubs.cc
+++ b/src/native/nativeaot/host/internal-pinvoke-stubs.cc
@@ -18,6 +18,7 @@ namespace {
 
 const char* clr_typemap_managed_to_java (
 	[[maybe_unused]] const char *typeName,
+	[[maybe_unused]] const char *assemblyFullName,
 	[[maybe_unused]] const uint8_t *mvid) noexcept
 {
 	pinvoke_unreachable ();

--- a/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
@@ -183,7 +183,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.Touch ("MainActivity.cs");
 			// make sure that the fastdev log tells that the relevant dll is updated but NOT for others.
 			Assert.IsTrue (b.Install (proj, doNotCleanupOnUpdate: true, saveProject: false), "install should have succeeded.");
-			Assert.IsTrue (b.Output.IsApkInstalled, "app apk was not installed");
+			Assert.IsFalse (b.Output.IsApkInstalled, "app apk was reinstalled");
 			Assert.IsTrue (b.LastBuildOutput.Any (l => l.Contains ("UnnamedProject.dll") && l.Contains ("NotifySync CopyFile")), "app dll not uploaded");
 
 			var assemblies = new[] {

--- a/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
@@ -41,14 +41,17 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void FastDeployUpdatesTypeMapAfterAssemblyEdit ()
 		{
+			const string logcatMessage = "FAST_DEPLOY_TYPEMAP_TEST_MESSAGE";
+
 			var proj = new XamarinAndroidApplicationProject {
 				PackageName = "com.xamarin.fastdeploy_typemap",
 			};
 			proj.SetDefaultTargetDevice ();
 			proj.SetProperty ("_AndroidFastDevStrategy", "FastDeploy");
 
-			// Whenever the set of Java-callable types changes, the Java stubs, the typemap, the native
-			// libraries embedding it, and the .apk containing them all have to be regenerated.
+			// Fast deployment only syncs managed assemblies, so anything that changes the set of
+			// Java-callable types has to go through a new .apk: new Java stubs, a new .dex, a new
+			// type map inside libxamarin-app.so, and therefore a new signed package.
 			var typeMapTargets = new [] {
 				"_GenerateJavaStubs",
 				"_CompileJava",
@@ -63,9 +66,6 @@ namespace Xamarin.Android.Build.Tests
 
 			// 1. Initial build and deployment, with only MainActivity.
 			Assert.IsTrue (builder.Install (proj), "Initial install should have succeeded.");
-			foreach (var target in typeMapTargets) {
-				builder.Output.AssertTargetIsNotSkipped (target, occurrence: 1);
-			}
 			Assert.IsTrue (builder.Output.IsApkInstalled, "The .apk should have been installed by the initial build.");
 			AssertActivityStarts ("MainActivity", "initial-launch.log");
 
@@ -76,17 +76,47 @@ namespace Xamarin.Android.Build.Tests
 					[Activity (Label = "Fast Deploy Result")]
 					public sealed class SecondActivity : Activity
 					{
+						protected override void OnCreate (Bundle bundle)
+						{
+							base.OnCreate (bundle);
+							//${SECOND_ACTIVITY_ONCREATE}
+						}
 					}
 					""");
 			proj.Touch ("MainActivity.cs");
-			Assert.IsTrue (builder.Install (proj, doNotCleanupOnUpdate: true, saveProject: false), "Incremental install should have succeeded.");
+			Assert.IsTrue (builder.Install (proj, doNotCleanupOnUpdate: true, saveProject: false), "Install of the new activity should have succeeded.");
 
 			builder.Output.AssertTargetIsNotSkipped ("CoreCompile", occurrence: 2);
 			foreach (var target in typeMapTargets) {
 				builder.Output.AssertTargetIsNotSkipped (target, occurrence: 2);
 			}
 			Assert.IsTrue (builder.Output.IsApkInstalled, "The .apk should have been reinstalled after adding a new activity.");
-			AssertActivityStarts ("SecondActivity", "incremental-launch.log");
+			AssertActivityStarts ("SecondActivity", "new-activity-launch.log");
+
+			// 3. A C#-only change that leaves the Java-callable types alone. The type map is unchanged,
+			// so the .apk is neither rebuilt nor reinstalled and only the assembly is fast deployed.
+			proj.MainActivity = proj.MainActivity.Replace ("//${SECOND_ACTIVITY_ONCREATE}", $"Console.WriteLine (\"{logcatMessage}\");");
+			proj.Touch ("MainActivity.cs");
+			Assert.IsTrue (builder.Install (proj, doNotCleanupOnUpdate: true, saveProject: false), "Incremental install should have succeeded.");
+
+			builder.Output.AssertTargetIsNotSkipped ("CoreCompile", occurrence: 3);
+			foreach (var target in new [] { "_CompileNativeAssemblySources", "_CreateApplicationSharedLibraries", "_BuildApkFastDev", "_Sign" }) {
+				builder.Output.AssertTargetIsSkipped (target, occurrence: 3);
+			}
+			Assert.IsFalse (builder.Output.IsApkInstalled, "The .apk should not be reinstalled for a C#-only change.");
+
+			ClearAdbLogcat ();
+			Assert.IsTrue (
+				MonitorAdbLogcat (
+					line => line.Contains (logcatMessage),
+					Path.Combine (Root, builder.ProjectDirectory, "incremental-launch.log"),
+					ActivityStartTimeoutInSeconds,
+					onMonitoringStarted: () => {
+						AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
+					}
+				),
+				$"`{logcatMessage}` should have been logged by the fast deployed assembly."
+			);
 
 			Assert.IsTrue (builder.Uninstall (proj), "Uninstall should have succeeded.");
 

--- a/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
@@ -63,6 +63,10 @@ namespace Xamarin.Android.Build.Tests
 			};
 
 			using var builder = CreateApkBuilder ();
+			// `IsApkInstalled` looks for the "Installed Package" message that `FastDeploy` logs via
+			// `LogDebugMessageWithTiming()`, which is `MessageImportance.Low` and therefore invisible
+			// at the default `Normal` verbosity.
+			builder.Verbosity = LoggerVerbosity.Detailed;
 
 			// 1. Initial build and deployment, with only MainActivity.
 			Assert.IsTrue (builder.Install (proj), "Initial install should have succeeded.");

--- a/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
@@ -65,9 +65,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 
 			using var builder = CreateApkBuilder ();
-			// `IsApkInstalled` looks for the "Installed Package" message that `FastDeploy` logs via
-			// `LogDebugMessageWithTiming()`, which is `MessageImportance.Low` and therefore invisible
-			// at the default `Normal` verbosity.
+			// `IsApkInstalled` requires detailed verbosity, see its documentation.
 			builder.Verbosity = LoggerVerbosity.Detailed;
 
 			// 1. Initial build and deployment, with only MainActivity.

--- a/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
@@ -46,6 +46,30 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.SetDefaultTargetDevice ();
 			proj.SetProperty ("_AndroidFastDevStrategy", "FastDeploy");
+
+			// Whenever the set of Java-callable types changes, the Java stubs, the typemap, the native
+			// libraries embedding it, and the .apk containing them all have to be regenerated.
+			var typeMapTargets = new [] {
+				"_GenerateJavaStubs",
+				"_CompileJava",
+				"_CompileToDalvik",
+				"_CompileNativeAssemblySources",
+				"_CreateApplicationSharedLibraries",
+				"_BuildApkFastDev",
+				"_Sign",
+			};
+
+			using var builder = CreateApkBuilder ();
+
+			// 1. Initial build and deployment, with only MainActivity.
+			Assert.IsTrue (builder.Install (proj), "Initial install should have succeeded.");
+			foreach (var target in typeMapTargets) {
+				builder.Output.AssertTargetIsNotSkipped (target, occurrence: 1);
+			}
+			Assert.IsTrue (builder.Output.IsApkInstalled, "The .apk should have been installed by the initial build.");
+			AssertActivityStarts ("MainActivity", "initial-launch.log");
+
+			// 2. A C#-only change that adds a new Java-callable type, so the type map *must* be updated.
 			proj.MainActivity = proj.DefaultMainActivity
 				.Replace ("//${AFTER_ONCREATE}", "StartActivity (new Android.Content.Intent (this, typeof (SecondActivity)));")
 				.Replace ("//${AFTER_MAINACTIVITY}", """
@@ -54,29 +78,30 @@ namespace Xamarin.Android.Build.Tests
 					{
 					}
 					""");
-
-			using var builder = CreateApkBuilder ();
-			Assert.IsTrue (builder.Install (proj), "Initial install should have succeeded.");
-			AssertSecondActivityStarts ("initial-launch.log");
-
-			proj.MainActivity += "// Incremental C# edit.";
 			proj.Touch ("MainActivity.cs");
 			Assert.IsTrue (builder.Install (proj, doNotCleanupOnUpdate: true, saveProject: false), "Incremental install should have succeeded.");
-			AssertSecondActivityStarts ("incremental-launch.log");
+
+			builder.Output.AssertTargetIsNotSkipped ("CoreCompile", occurrence: 2);
+			foreach (var target in typeMapTargets) {
+				builder.Output.AssertTargetIsNotSkipped (target, occurrence: 2);
+			}
+			Assert.IsTrue (builder.Output.IsApkInstalled, "The .apk should have been reinstalled after adding a new activity.");
+			AssertActivityStarts ("SecondActivity", "incremental-launch.log");
+
 			Assert.IsTrue (builder.Uninstall (proj), "Uninstall should have succeeded.");
 
-			void AssertSecondActivityStarts (string logFileName)
+			void AssertActivityStarts (string activityName, string logFileName)
 			{
 				ClearAdbLogcat ();
 				AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
 				Assert.IsTrue (
 					WaitForActivityToStart (
 						proj.PackageName,
-						"SecondActivity",
+						activityName,
 						Path.Combine (Root, builder.ProjectDirectory, logFileName),
 						ActivityStartTimeoutInSeconds
 					),
-					"SecondActivity should have started."
+					$"{activityName} should have started."
 				);
 			}
 		}

--- a/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
@@ -39,15 +39,17 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void FastDeployUpdatesTypeMapAfterAssemblyEdit ()
+		[TestCase ("FastDeploy")]
+		[TestCase ("FastDeploy2")]
+		public void FastDeployUpdatesTypeMapAfterAssemblyEdit (string strategy)
 		{
 			const string logcatMessage = "FAST_DEPLOY_TYPEMAP_TEST_MESSAGE";
 
 			var proj = new XamarinAndroidApplicationProject {
-				PackageName = "com.xamarin.fastdeploy_typemap",
+				PackageName = $"com.xamarin.fastdeploy_typemap_{strategy.ToLowerInvariant ()}",
 			};
 			proj.SetDefaultTargetDevice ();
-			proj.SetProperty ("_AndroidFastDevStrategy", "FastDeploy");
+			proj.SetProperty ("_AndroidFastDevStrategy", strategy);
 
 			// Fast deployment only syncs managed assemblies, so anything that changes the set of
 			// Java-callable types has to go through a new .apk: new Java stubs, a new .dex, a new


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: N/A
- [x] Unit tests

CoreCLR Debug typemaps embedded application assembly MVIDs. Because an MVID changes on every compilation, a C#-only rebuild rewrote the native typemap even when no Java mappings had changed. That cascaded into native compilation, APK rebuilding, and re-signing on every Fast Deployment cycle.

This changes Debug managed-to-Java entries to key on stable assembly full names and removes the Debug MVID table entirely. Release continues to use its MVID-based lookup, and a trimmer feature switch prevents `Assembly.FullName` retrieval and marshalling from being rooted in Release builds.

## Runtime

`clr_typemap_managed_to_java` now takes an assembly display name alongside the type name, and `TypeMapper::managed_to_java` is split on `RELEASE` so each configuration only sees the parameter it uses. When `$(RuntimeFeature.ManagedToJavaUsesAssemblyFullName)` is enabled, `JNIEnv.TypemapManagedToJava` skips computing the MVID altogether rather than computing it and discarding it. A null display name is left for the native side to report, which keeps a single diagnostic path for all callers.

`TypeMapCecilAdapter.GetRuntimeAssemblyFullName` reproduces reflection's escaping and `PublicKeyToken` formatting so that the build-time name matches what `Assembly.FullName` returns at runtime; a mismatch here would silently break every lookup.

## Tests

`IncrementalBuildTest` performs a C#-only change on the CoreCLR Debug path and asserts the typemap and signed APK are byte-for-byte unchanged, and that `_CompileNativeAssemblySources`, `_CreateApplicationSharedLibraries`, `_BuildApkFastDev`, and `_Sign` are all skipped.

`FastDeployUpdatesTypeMapAfterAssemblyEdit` is a device test covering three deployments, parameterized over both `FastDeploy` and `FastDeploy2`:

1. Deploy with only `MainActivity`.
2. Add a `SecondActivity`. This is a C#-only edit, but it introduces a new Java-callable type. Fast deployment only syncs managed assemblies, so the Java stubs, `.dex`, typemap, APK and signature must all be rebuilt and the package reinstalled. This confirms a typemap-affecting C# change is picked up automatically, with no clean required.
3. Add a `Console.WriteLine()` to `SecondActivity.OnCreate()`. No Java-callable types change, so the packaging and signing targets are skipped and the APK is not reinstalled. The message is asserted in `logcat` to prove the updated assembly really was deployed rather than merely that nothing was rebuilt.

`BuildOutput.IsApkInstalled` now throws below `LoggerVerbosity.Detailed`. It scans for an `Installed Package` message logged at `MessageImportance.Low`, so at a lower verbosity it silently returned `false` no matter what the build did — which broke the new test on CI and had been quietly making some pre-existing `Assert.IsFalse` calls vacuous.