### PR TITLE
[tests] Isolate parallel Kotlin Gradle state

### DIFF
--- a/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle.targets
+++ b/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle.targets
@@ -24,6 +24,8 @@
   <PropertyGroup>
     <_KotlinGradleProjectDir>$(MSBuildThisFileDirectory)kotlin-gradle</_KotlinGradleProjectDir>
     <_TestKotlinGradleOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\$(IntermediateOutputPath)kotlin-gradle\classes'))</_TestKotlinGradleOutputDir>
+    <_TestKotlinGradleBuildDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\$(IntermediateOutputPath)kotlin-gradle\build'))</_TestKotlinGradleBuildDir>
+    <_TestKotlinGradleProjectCacheDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\$(IntermediateOutputPath)kotlin-gradle\project-cache'))</_TestKotlinGradleProjectCacheDir>
     <!--
         This target is imported by two projects (Xamarin.Android.Tools.Bytecode-Tests
         and generator-Tests) that build in parallel during the solution build. Gradle is
@@ -32,7 +34,9 @@
         user home (~/.gradle) they race over the same daemon registry and loopback ports,
         which manifests as "Timeout waiting to connect to the Gradle daemon" on slower CI
         agents. Point GRADLE_USER_HOME at each project's own obj/ directory so the two
-        daemons are fully isolated; it also gets cleaned up with the rest of obj/.
+        daemons are fully isolated. The Gradle build and project-cache directories also
+        contain mutable state, so keep those in the importing project's obj/ directory.
+        This also ensures all generated state is removed by Clean.
     -->
     <_KotlinGradleUserHome Condition=" '$(_KotlinGradleUserHome)' == '' ">$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\$(IntermediateOutputPath)kotlin-gradle\.gradle'))</_KotlinGradleUserHome>
   </PropertyGroup>
@@ -41,7 +45,7 @@
         BeforeTargets="BeforeCompile"
         Inputs="@(TestKotlinGradleSource)"
         Outputs="@(TestKotlinGradleOutput)">
-    <Exec Command="&quot;$(GradleWPath)&quot; $(GradleArgs) -p &quot;$(_KotlinGradleProjectDir)&quot; -PkotlinClassesDir=&quot;$(_TestKotlinGradleOutputDir)&quot; classes"
+    <Exec Command="&quot;$(GradleWPath)&quot; $(GradleArgs) --project-cache-dir &quot;$(_TestKotlinGradleProjectCacheDir)&quot; -p &quot;$(_KotlinGradleProjectDir)&quot; -PkotlinBuildDir=&quot;$(_TestKotlinGradleBuildDir)&quot; -PkotlinClassesDir=&quot;$(_TestKotlinGradleOutputDir)&quot; classes"
           EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome);GRADLE_USER_HOME=$(_KotlinGradleUserHome)" />
   </Target>
 

--- a/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/build.gradle.kts
+++ b/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     kotlin("jvm") version "2.4.10"
 }
 
+layout.buildDirectory.set(file((findProperty("kotlinBuildDir") as String?) ?: "$rootDir/build"))
+
 // Don't pin a jvmToolchain -- it would force Gradle to auto-provision a
 // matching JDK and fail in CI environments without download repositories
 // configured. Use whatever JDK the caller already set in JAVA_HOME (the


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [ ] Unit tests

## Description

Java.Interop solution builds run the Kotlin fixture from two test projects in parallel. Although their Gradle user homes and class outputs were already separate, they still shared the fixture's mutable Gradle build directory and project cache. This intermittently corrupted Kotlin compiler snapshots on Windows and plugin configuration state on macOS.

Keep each invocation's build directory and Gradle project cache under the importing project's `obj` directory. This fully isolates parallel builds while preserving the existing direct-Gradle defaults.

## Testing

`dotnet build external\Java.Interop\Java.Interop.sln -c Release` with the local JDK tool properties configured. Both Kotlin Gradle invocations completed concurrently.