### PR TITLE
[tests] Restore GetObjectArray coverage

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Runtime/JnienvArrayMarshaling.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Runtime/JnienvArrayMarshaling.cs
@@ -323,7 +323,7 @@ namespace Android.RuntimeTests {
 		}
 
 		[Test]
-		[Ignore ("Fails on CoreCLR: https://github.com/dotnet/android/issues/10973")]
+		[Category ("JNIObjectArray")]
 		public void GetObjectArray ()
 		{
 			using (var byteArray = new Java.Lang.Object (JNIEnv.NewArray (new byte[]{1,2,3}), JniHandleOwnership.TransferLocalRef)) {
@@ -338,8 +338,8 @@ namespace Android.RuntimeTests {
 						JniHandleOwnership.TransferLocalRef)) {
 				object[] values = JNIEnv.GetObjectArray (objectArray.Handle, new[]{typeof(Context), typeof (int)});
 				Assert.AreEqual (3, values.Length);
-				Assert.IsTrue (object.ReferenceEquals (values [0], Application.Context));
-				Assert.IsTrue (values [1] is int);
+				Assert.AreSame (Application.Context, values [0], $"Expected existing Context peer, got {values [0]?.GetType ()}.");
+				Assert.IsInstanceOf<int> (values [1], $"Expected converted Int32, got {values [1]?.GetType ()}: {values [1]}.");
 				Assert.AreEqual (42, (int)values [1]);
 				Assert.AreEqual ("string", values [2].ToString ());
 			}


### PR DESCRIPTION
The `JNIEnv.GetObjectArray` regression test was globally ignored after a historical CoreCLR failure in #10973, leaving primitive conversion, Java peer identity, and mixed object-array marshaling uncovered on every runtime. The focused test now passes on current CoreCLR Release, so this restores it and adds clearer assertion diagnostics for peer identity and numeric conversion failures.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: #10973
- [x] Unit tests: `Android.RuntimeTests.JnienvArrayMarshaling.GetObjectArray` passed 1/1 on CoreCLR Release (`android-arm64`, Pixel 5/API 34).