### PR TITLE
[CoreCLR] Invalidate time zone caches after device changes

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -218,6 +218,18 @@ stages:
 
     - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
 
+  - template: /build-tools/automation/yaml-templates/run-emulator-tests.yaml
+    parameters:
+      jobName: TimeZoneChangeTests
+      jobTimeout: 120
+      use1ESTemplate: false
+      testSteps:
+      - template: run-nunit-tests.yaml
+        parameters:
+          testRunTitle: TimeZoneChangeTests On Device - macOS
+          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
+          dotNetTestExtraArgs: --filter "Name=TimeZoneChangeClearsCachedTimeZoneInfo"
+
 
 # Localization test jobs
 - stage: test_locals

--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -220,7 +220,7 @@ namespace Android.Runtime {
 
 		// This is invoked by libmonodroid.so.
 		// DO NOT REMOVE
-		static void NotifyTimeZoneChanged ()
+		internal static void NotifyTimeZoneChanged ()
 		{
 			var thread            = Thread.CurrentThread;
 			var timeZoneClearInfo = new[]{

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -58,14 +58,12 @@ namespace Android.Runtime
 		}
 
 		[UnmanagedCallersOnly]
-		static int NotifyTimeZoneChanged ()
+		static void NotifyTimeZoneChanged ()
 		{
 			try {
 				AndroidEnvironment.NotifyTimeZoneChanged ();
-				return 0;
 			} catch (Exception e) {
 				Logger.Log (LogLevel.Error, "MonoAndroid", $"Exception while clearing time-zone caches: {e}");
-				return -1;
 			}
 		}
 
@@ -158,7 +156,7 @@ namespace Android.Runtime
 			RegisterTrimmableTypeMapNativeMethodsIfNeeded ();
 
 			args->propagateUncaughtExceptionFn = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, void>)&PropagateUncaughtException;
-			args->notifyTimeZoneChangedFn = (IntPtr)(delegate* unmanaged<int>)&NotifyTimeZoneChanged;
+			args->notifyTimeZoneChangedFn = (IntPtr)(delegate* unmanaged<void>)&NotifyTimeZoneChanged;
 
 			if (!RuntimeFeature.TrimmableTypeMap) {
 				args->registerJniNativesFn = GetRegisterJniNativesFnPtr ();

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -36,6 +36,7 @@ namespace Android.Runtime
 			public IntPtr          grefGCUserPeerable;
 			public IntPtr          propagateUncaughtExceptionFn;
 			public IntPtr          registerJniNativesFn;
+			public IntPtr          notifyTimeZoneChangedFn;
 		}
 #pragma warning restore 0649
 
@@ -54,6 +55,18 @@ namespace Android.Runtime
 		static void PropagateUncaughtException (IntPtr env, IntPtr javaThread, IntPtr javaException)
 		{
 			JNIEnv.PropagateUncaughtException (env, javaThread, javaException);
+		}
+
+		[UnmanagedCallersOnly]
+		static int NotifyTimeZoneChanged ()
+		{
+			try {
+				AndroidEnvironment.NotifyTimeZoneChanged ();
+				return 0;
+			} catch (Exception e) {
+				Logger.Log (LogLevel.Error, "MonoAndroid", $"Exception while clearing time-zone caches: {e}");
+				return -1;
+			}
 		}
 
 		[UnmanagedCallersOnly]
@@ -145,6 +158,7 @@ namespace Android.Runtime
 			RegisterTrimmableTypeMapNativeMethodsIfNeeded ();
 
 			args->propagateUncaughtExceptionFn = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, void>)&PropagateUncaughtException;
+			args->notifyTimeZoneChangedFn = (IntPtr)(delegate* unmanaged<int>)&NotifyTimeZoneChanged;
 
 			if (!RuntimeFeature.TrimmableTypeMap) {
 				args->registerJniNativesFn = GetRegisterJniNativesFnPtr ();

--- a/src/native/clr/host/host-jni.cc
+++ b/src/native/clr/host/host-jni.cc
@@ -55,5 +55,5 @@ JNICALL Java_mono_android_Runtime_propagateUncaughtException (JNIEnv *env, [[may
 JNIEXPORT void
 JNICALL Java_mono_android_Runtime_notifyTimeZoneChanged ([[maybe_unused]] JNIEnv *env, [[maybe_unused]] jclass klass)
 {
-	// TODO: implement or remove
+	Host::notify_time_zone_changed ();
 }

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -478,7 +478,9 @@ void Host::Java_mono_android_Runtime_initInternal (
 	// trimmable typemap path (the method is trimmed; registration is handled in managed code).
 	jnienv_register_jni_natives = init.registerJniNativesFn;
 	jnienv_propagate_uncaught_exception = init.propagateUncaughtExceptionFn;
+	jnienv_notify_time_zone_changed = init.notifyTimeZoneChangedFn;
 	abort_unless (jnienv_propagate_uncaught_exception != nullptr, "Failed to obtain unmanaged-callers-only function pointer to the PropagateUncaughtException method.");
+	abort_unless (jnienv_notify_time_zone_changed != nullptr, "Failed to obtain unmanaged-callers-only function pointer to the NotifyTimeZoneChanged method.");
 
 	if (FastTiming::enabled ()) [[unlikely]] {
 		internal_timing.end_event (); // native to managed
@@ -553,4 +555,17 @@ void Host::propagate_uncaught_exception (JNIEnv *env, jobject javaThread, jthrow
 	}
 
 	jnienv_propagate_uncaught_exception (env, javaThread, javaException);
+}
+
+void Host::notify_time_zone_changed () noexcept
+{
+	if (jnienv_notify_time_zone_changed == nullptr) {
+		log_warn (LOG_DEFAULT, "notify_time_zone_changed called before JNIEnvInit.NotifyTimeZoneChanged was initialized"sv);
+		return;
+	}
+
+	int32_t result = jnienv_notify_time_zone_changed ();
+	if (result != 0) {
+		log_warn (LOG_DEFAULT, "JNIEnvInit.NotifyTimeZoneChanged failed with result {}"sv, result);
+	}
 }

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -564,8 +564,5 @@ void Host::notify_time_zone_changed () noexcept
 		return;
 	}
 
-	int32_t result = jnienv_notify_time_zone_changed ();
-	if (result != 0) {
-		log_warnf (LOG_DEFAULT, "JNIEnvInit.NotifyTimeZoneChanged failed with result %d", result);
-	}
+	jnienv_notify_time_zone_changed ();
 }

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -560,12 +560,12 @@ void Host::propagate_uncaught_exception (JNIEnv *env, jobject javaThread, jthrow
 void Host::notify_time_zone_changed () noexcept
 {
 	if (jnienv_notify_time_zone_changed == nullptr) {
-		log_warn (LOG_DEFAULT, "notify_time_zone_changed called before JNIEnvInit.NotifyTimeZoneChanged was initialized"sv);
+		log_warnf (LOG_DEFAULT, "notify_time_zone_changed called before JNIEnvInit.NotifyTimeZoneChanged was initialized");
 		return;
 	}
 
 	int32_t result = jnienv_notify_time_zone_changed ();
 	if (result != 0) {
-		log_warn (LOG_DEFAULT, "JNIEnvInit.NotifyTimeZoneChanged failed with result {}"sv, result);
+		log_warnf (LOG_DEFAULT, "JNIEnvInit.NotifyTimeZoneChanged failed with result %d", result);
 	}
 }

--- a/src/native/clr/include/host/host.hh
+++ b/src/native/clr/include/host/host.hh
@@ -22,6 +22,7 @@ namespace xamarin::android {
 		static void Java_mono_android_Runtime_register (JNIEnv *env, jstring managedType, jclass nativeClass, jstring methods) noexcept;
 		static void Java_mono_android_Runtime_registerNatives (JNIEnv *env, jclass nativeClass) noexcept;
 		static void propagate_uncaught_exception (JNIEnv *env, jobject javaThread, jthrowable javaException) noexcept;
+		static void notify_time_zone_changed () noexcept;
 
 		static auto get_timing () -> std::shared_ptr<Timing>
 		{
@@ -58,6 +59,7 @@ namespace xamarin::android {
 		static inline bool found_assembly_store = false;
 		static inline jnienv_register_jni_natives_fn jnienv_register_jni_natives = nullptr;
 		static inline jnienv_propagate_uncaught_exception_fn jnienv_propagate_uncaught_exception = nullptr;
+		static inline jnienv_notify_time_zone_changed_fn jnienv_notify_time_zone_changed = nullptr;
 
 		static inline jclass java_TimeZone = nullptr;
 

--- a/src/native/common/include/managed-interface.hh
+++ b/src/native/common/include/managed-interface.hh
@@ -16,6 +16,7 @@ namespace xamarin::android {
 
 	using jnienv_propagate_uncaught_exception_fn = void (*)(JNIEnv *env, jobject javaThread, jthrowable javaException);
 	using jnienv_register_jni_natives_fn = void (*)(const jchar *typeName_ptr, int32_t typeName_len, jclass jniClass, const jchar *methods_ptr, int32_t methods_len);
+	using jnienv_notify_time_zone_changed_fn = int32_t (*)();
 
 	// NOTE: Keep this in sync with managed side in src/Mono.Android/Android.Runtime/JNIEnvInit.cs
 	struct JnienvInitializeArgs {
@@ -37,6 +38,7 @@ namespace xamarin::android {
 		jobject         grefGCUserPeerable;
 		jnienv_propagate_uncaught_exception_fn propagateUncaughtExceptionFn;
 		jnienv_register_jni_natives_fn registerJniNativesFn;
+		jnienv_notify_time_zone_changed_fn notifyTimeZoneChangedFn;
 	};
 
 	// Keep the enum values in sync with those in src/Mono.Android/AndroidRuntime/BoundExceptionType.cs

--- a/src/native/common/include/managed-interface.hh
+++ b/src/native/common/include/managed-interface.hh
@@ -16,7 +16,7 @@ namespace xamarin::android {
 
 	using jnienv_propagate_uncaught_exception_fn = void (*)(JNIEnv *env, jobject javaThread, jthrowable javaException);
 	using jnienv_register_jni_natives_fn = void (*)(const jchar *typeName_ptr, int32_t typeName_len, jclass jniClass, const jchar *methods_ptr, int32_t methods_len);
-	using jnienv_notify_time_zone_changed_fn = int32_t (*)();
+	using jnienv_notify_time_zone_changed_fn = void (*)();
 
 	// NOTE: Keep this in sync with managed side in src/Mono.Android/Android.Runtime/JNIEnvInit.cs
 	struct JnienvInitializeArgs {

--- a/tests/MSBuildDeviceIntegration/Tests/TimeZoneInfoTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/TimeZoneInfoTests.cs
@@ -259,4 +259,113 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (logLine.Contains (expectedLogcatOutput), $"Line '{logLine}' did not contain '{expectedLogcatOutput}'");
 		}
 	}
+
+	[TestFixture (AndroidRuntime.MonoVM)]
+	[TestFixture (AndroidRuntime.CoreCLR)]
+	[Category ("TimeZoneInfo")]
+	[NonParallelizable]
+	public class TimeZoneChangeTests : DeviceTest
+	{
+		const string InitialTimeZone = "America/New_York";
+		const string ChangedTimeZone = "America/Los_Angeles";
+
+		readonly AndroidRuntime runtime;
+		ProjectBuilder builder;
+		XamarinAndroidApplicationProject proj;
+		string originalAutoTimeZone;
+		string originalTimeZone;
+
+		public TimeZoneChangeTests (AndroidRuntime runtime)
+		{
+			this.runtime = runtime;
+		}
+
+		[OneTimeSetUp]
+		public void BeforeAllTests ()
+		{
+			AssertHasDevices ();
+
+			originalAutoTimeZone = RunAdbCommand ("shell settings get global auto_time_zone").Trim ();
+			originalTimeZone = RunAdbCommand ("shell getprop persist.sys.timezone").Trim ();
+			RunAdbCommand ("shell settings put global auto_time_zone 0");
+			SetTimeZone (InitialTimeZone);
+
+			proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (runtime, "TimeZoneChangeTests"));
+			proj.SetRuntime (runtime);
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", """
+				if (button == null) {
+					throw new InvalidOperationException ("Could not find the test button.");
+				}
+
+				Console.WriteLine ($"TimeZoneChangeTests.Initial={TimeZoneInfo.Local.Id}");
+				button.Click += delegate {
+					Console.WriteLine ($"TimeZoneChangeTests.Changed={TimeZoneInfo.Local.Id}");
+				};
+			""");
+
+			builder = CreateApkBuilder (Path.Combine ("temp", TestName));
+			builder.BuildLogFile = "timezone-change-install.log";
+			Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
+		}
+
+		[OneTimeTearDown]
+		protected override void AfterAllTests ()
+		{
+			if (proj != null) {
+				RunAdbCommand ($"shell am force-stop --user all {proj.PackageName}");
+			}
+			if (!string.IsNullOrEmpty (originalTimeZone)) {
+				SetTimeZone (originalTimeZone);
+			}
+			if (!string.IsNullOrEmpty (originalAutoTimeZone)) {
+				RunAdbCommand ($"shell settings put global auto_time_zone {originalAutoTimeZone}");
+			}
+		}
+
+		[Test]
+		public void TimeZoneChangeClearsCachedTimeZoneInfo ()
+		{
+			ClearAdbLogcat ();
+			StartActivityAndAssert (proj);
+
+			string initialLog = $"TimeZoneChangeTests.Initial={InitialTimeZone}";
+			Assert.IsTrue (
+				MonitorAdbLogcat (
+					line => line.Contains (initialLog),
+					Path.Combine (Root, builder.ProjectDirectory, "timezone-change-initial.log"),
+					45
+				),
+				$"App output did not contain '{initialLog}'"
+			);
+
+			ClearAdbLogcat ();
+			SetTimeZone (ChangedTimeZone);
+			Thread.Sleep (1000);
+			Assert.IsTrue (ClickButton (proj.PackageName, "myButton", "HELLO WORLD, CLICK ME!"), "Test button should have been clicked.");
+
+			string changedLog = $"TimeZoneChangeTests.Changed={ChangedTimeZone}";
+			Assert.IsTrue (
+				MonitorAdbLogcat (
+					line => line.Contains (changedLog),
+					Path.Combine (Root, builder.ProjectDirectory, "timezone-change-updated.log"),
+					45
+				),
+				$"App output did not contain '{changedLog}'"
+			);
+		}
+
+		static void SetTimeZone (string timeZone)
+		{
+			string deviceTimeZone = "";
+			for (int attempt = 0; attempt < 5; attempt++) {
+				RunAdbCommand ($"shell cmd alarm set-timezone \"{timeZone}\"");
+				deviceTimeZone = RunAdbCommand ("shell getprop persist.sys.timezone").Trim ();
+				if (deviceTimeZone == timeZone) {
+					break;
+				}
+			}
+
+			Assert.AreEqual (timeZone, deviceTimeZone, $"The command to set the device timezone to {timeZone} failed. Current device timezone is {deviceTimeZone}");
+		}
+	}
 }

--- a/tests/MSBuildDeviceIntegration/Tests/TimeZoneInfoTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/TimeZoneInfoTests.cs
@@ -260,7 +260,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 	}
 
-	[TestFixture (AndroidRuntime.MonoVM)]
 	[TestFixture (AndroidRuntime.CoreCLR)]
 	[Category ("TimeZoneInfo")]
 	[NonParallelizable]

--- a/tests/MSBuildDeviceIntegration/Tests/TimeZoneInfoTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/TimeZoneInfoTests.cs
@@ -310,14 +310,18 @@ namespace Xamarin.Android.Build.Tests
 		[OneTimeTearDown]
 		protected override void AfterAllTests ()
 		{
-			if (proj != null) {
-				RunAdbCommand ($"shell am force-stop --user all {proj.PackageName}");
-			}
-			if (!string.IsNullOrEmpty (originalTimeZone)) {
-				SetTimeZone (originalTimeZone);
-			}
-			if (!string.IsNullOrEmpty (originalAutoTimeZone)) {
-				RunAdbCommand ($"shell settings put global auto_time_zone {originalAutoTimeZone}");
+			try {
+				if (proj != null) {
+					RunAdbCommand ($"shell am force-stop --user all {proj.PackageName}");
+				}
+				if (!string.IsNullOrEmpty (originalTimeZone)) {
+					SetTimeZone (originalTimeZone);
+				}
+				if (!string.IsNullOrEmpty (originalAutoTimeZone)) {
+					RunAdbCommand ($"shell settings put global auto_time_zone {originalAutoTimeZone}");
+				}
+			} finally {
+				base.AfterAllTests ();
 			}
 		}
 


### PR DESCRIPTION
Android registers a receiver for `ACTION_TIMEZONE_CHANGED`, but the CoreCLR JNI entry point was empty. As a result, a running CoreCLR application continued using the cached `TimeZoneInfo.Local` value after the device time zone changed.

Route the notification through the existing `JNIEnvInit.Initialize` unmanaged-callers-only callback table and invoke `AndroidEnvironment.NotifyTimeZoneChanged()` from an attached CoreCLR reverse P/Invoke transition. The managed wrapper catches unexpected exceptions before they cross the native boundary.

Add a CoreCLR live-process regression test and schedule it only in the dedicated nightly time-zone stage so PR validation does not mutate emulator time-zone state.

----

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [x] Unit tests