### PR TITLE
[tests] Restore Java.Interop value manager coverage

### DIFF
--- a/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.NET.csproj
+++ b/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.NET.csproj
@@ -42,11 +42,13 @@
     <Compile Remove="$(JavaInteropTestDirectory)Java.Interop\InvokeVirtualFromConstructorTests.cs" />
   </ItemGroup>
 
-  <!-- Some of tests included in the files below fail on CoreCLR. This is PROBABLY caused by managed typemaps, which 
-       will be replaced at some point by a different implementation. Until then, these tests can remain disabled. -->
-  <!-- TODO: put these back when new typemap implementation is available -->
-  <ItemGroup>
+  <!-- AndroidValueManager is the MonoVM value manager; CoreCLR and NativeAOT use different implementations. -->
+  <ItemGroup Condition=" '$(UseMonoRuntime)' != 'true' ">
     <Compile Remove="Java.InteropTests\AndroidValueManagerContractTests.cs" />
+  </ItemGroup>
+
+  <!-- ReflectionJniValueManager is unsupported by the trimmable typemap value manager. See dotnet/android#12221. -->
+  <ItemGroup Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' ">
     <Compile Remove="$(JavaInteropTestDirectory)Java.Interop\JniRuntime.JniValueManagerTests.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [x] Unit tests

Two Java.Interop test fixtures were unconditionally removed after CoreCLR became the default runtime, which also prevented tests compatible with CoreCLR from running.

Condition the removals on the implementations under test:

- Run `JniRuntimeJniValueManagerTests` with the default typemap, while retaining its focused trimmable exclusion because `ReflectionJniValueManager` is unsupported there.
- Compile `AndroidValueManagerContractTests` only for MonoVM because CoreCLR uses `JavaMarshalValueManager` and the trimmable path uses `TrimmableTypeMapValueManager`.

The trimmable limitation is tracked by dotnet/android#12221.

Validation:

- Java.Interop host build
- Focused host value-manager tests: 24 passed
- CoreCLR default-typemap device suite: 1,001 total, 0 failed
- CoreCLR trimmable device suite: 661 total, 0 failed