### PR TITLE
[TrimmableTypeMap] Improve incremental build performance

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
@@ -36,15 +36,14 @@ CoreCompile
 _ReadGeneratedTrimmableTypeMapAssemblies    (reads typemap-assemblies.txt)
 _PrepareTrimmableNativeConfigAssemblies     (feeds _GeneratePackageManagerJava)
 _PrepareTrimmableTypeMapAssemblies          (feeds packaging / assembly store)
-_CollectTrimmableTypeMapJavaFiles           (globs the JCW *.java)
-_GenerateJavaStubs                          (copies JCWs into android/src, manifest, acw-map)
+_GenerateJavaStubs                          (prepares manifest and native config)
    └─► _CompileJava ─► _CompileToDalvik ─► packaging
 ```
 
 `_GenerateJavaStubs` **overrides** the legacy target of the same name from
-`BuildOrder.targets`; in the trimmable path the JCWs already exist, so this
-target only copies them into `$(IntermediateOutputPath)android/src` and wires up
-the manifest, `acw-map.txt`, and native config.
+`BuildOrder.targets`; in the trimmable path the JCWs already exist and are
+compiled in place from the generator output directory. This target wires up
+the manifest and native config.
 
 For `CoreCLR` + `PublishTrimmed=true`, a second pass
 (`_GeneratePostTrimTrimmableTypeMapJavaSources`, in the CoreCLR targets)
@@ -64,8 +63,8 @@ reliable timestamp sentinel.
 `_GenerateTrimmableTypeMap` declares:
 
 ```xml
-Inputs="@(ReferencePath);@(PrivateSdkAssemblies);@(FrameworkAssemblies);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
-Outputs="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll;$(_TypeMapAssembliesListFile);$(_TrimmableTypeMapOutputStamp)"
+Inputs="@(ReferencePath);@(PrivateSdkAssemblies);@(FrameworkAssemblies);...;$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
+Outputs="$(_TrimmableTypeMapOutputStamp)"
 ```
 
 The generated TypeMap DLLs are written with `Files.CopyIfStreamChanged`, so an
@@ -76,7 +75,7 @@ it on every build. To avoid this, the target unconditionally `Touch`es a
 dedicated stamp:
 
 ```xml
-<Touch Files="@(_GeneratedTypeMapAssemblies);$(_TypeMapAssembliesListFile);$(_TrimmableTypeMapOutputStamp)" AlwaysCreate="true" />
+<Touch Files="$(_TrimmableTypeMapOutputStamp)" AlwaysCreate="true" />
 ```
 
 so the stamp is always newer than the inputs after a run, and the target is
@@ -86,54 +85,56 @@ correctly **skipped** when none of the inputs changed.
 > inputs — including `@(PrivateSdkAssemblies)` and `@(FrameworkAssemblies)` —
 > otherwise a change in one of them would not trigger regeneration.
 
-### 2. `_GenerateJavaStubs` keys off the stamp
+### 2. `_GenerateJavaStubs` keys off both producer stamps
 
 ```xml
-Inputs="$(_TrimmableTypeMapOutputStamp);@(_EnvironmentFiles)"
+Inputs="$(_TrimmableTypeMapOutputStamp);$(_TrimmableJavaSourceStamp);@(_EnvironmentFiles)"
 Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp"
 ```
 
-The stamp captures "the generator ran because its inputs changed" and is left
-stable when the generator is skipped, so the JCW copy into `android/src` only
-re-runs when something relevant actually changed. The copy uses
-`SkipUnchangedFiles="true"` so unchanged JCWs do not churn downstream Java
-compilation. For `CoreCLR` + `PublishTrimmed`, the JCWs are sourced from the
-`linked-java` directory produced by `_GeneratePostTrimTrimmableTypeMapJavaSources`,
-which is itself incremental; the stamp remains the sentinel so a no-op build
-still skips `_GenerateJavaStubs`.
+The pre-trim stamp covers the generated manifest and other shared outputs. For
+`CoreCLR` + `PublishTrimmed`, `_TrimmableJavaSourceStamp` is the post-trim stamp
+and covers the linked JCW set. Both remain stable when their producer is
+skipped, so a no-op build still skips `_GenerateJavaStubs` while a manifest-only
+change is not lost just because the linked assemblies stayed unchanged.
+
+The pre-trim CoreCLR pass deliberately does not write the final `acw-map.txt`
+or `ApplicationRegistration.java` in trimmed builds. Those files are owned by
+the post-trim pass; sharing their paths allowed a manifest-only pre-trim run to
+overwrite the linked versions while the post-trim target remained up-to-date.
 
 ### 3. Stale generated Java sources are pruned (both passes)
 
 When a managed type is removed — or trimmed away on the `PublishTrimmed` path —
-its JCW must not linger in `android/src`, where it would otherwise be compiled
-and packaged. Both generator passes report the JCWs they no longer produce as
-`DeletedJavaFiles` (with `RelativePath` metadata), and the owning target mirrors
-each deletion into the `android/src` copy and, if anything was deleted, deletes
-`$(_AndroidCompileJavaStampFile)` so `_CompileJava` re-runs and drops the stale
-`.class` outputs:
+its JCW must not linger in the generator directory, where it would otherwise
+be compiled and packaged. Both generator passes report the JCWs they no longer
+produce as `DeletedJavaFiles` (with `RelativePath` metadata). If anything was
+deleted, the owning target deletes `$(_AndroidCompileJavaStampFile)` so
+`_CompileJava` re-runs and drops the stale `.class` outputs:
 
 ```xml
-<Delete Files="@(_DeletedCopiedJavaFiles)" />
-<Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_DeletedCopiedJavaFiles->Count())' != '0' " />
+<Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_DeletedJavaFiles->Count())' != '0' " />
 ```
 
-The two passes compute the deleted set differently because of how each manages
-its output directory:
+Both passes update their output directories in place:
 
 - **Pre-trim** (`_GenerateTrimmableTypeMap`, writing `typemap/java`): the task
   scans the output directory and deletes any `*.java` the current pass did not
   produce.
 - **Post-trim** (`_GeneratePostTrimTrimmableTypeMapJavaSources`, writing
-  `typemap/linked-java` with `CleanJavaSourceOutputDirectory=true`): the
-  directory is wiped before regeneration, so the task snapshots the previous
-  `*.java` set *before* the wipe and reports `previous − regenerated`. This keeps
-  the deletion precise — only files the generator itself previously produced are
-  ever removed from `android/src`, never unrelated sources such as
-  `ApplicationRegistration.java`.
+  `typemap/linked-java`): the task updates files by content and prunes stale
+  `*.java` files in place. Unchanged JCWs keep their timestamps, so a managed
+  method-body change does not force `javac` and D8 to rebuild identical Java
+  output.
 
-The invariant is two-directional: **`android/src` contains exactly the JCWs the
-active pass produces** — no missing files (copied via `_GenerateJavaStubs`) and
-no stale files (pruned via `DeletedJavaFiles`).
+The invariant is two-directional: the active generator directory contains
+exactly the JCWs that should be compiled — no missing files and no stale files.
+The post-trim pass persists its expected Java paths in
+`typemap/linked-java-files.txt`. Before using the post-trim stamp, an always-run
+validation target compares that list with the files on disk and invalidates the
+stamp if a source is missing or unexpected, or if the ACW map or application
+registration source is missing. If generation logs an error, stale pruning is
+suppressed so a partial result cannot delete the last known-good output set.
 
 ### 4. Dynamic `FileWrites` are re-emitted on no-op builds
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
@@ -155,9 +155,14 @@ CoreCLR packages managed assemblies, so `_RemoveRegisterAttributeCoreClr`
 copies the resolved assembly set into the shrunk/package locations. The target
 uses the resolved assemblies, assembly-set hash, build properties, and project
 imports as inputs and a stamp as its output. Missing destination assemblies
-invalidate the stamp. Projects with `*.dll.config` files retain the previous
-always-run behavior until those files can be modeled as a reliable one-to-one
-transform.
+invalidate the stamp.
+
+`*.dll.config` files are deliberately *not* copied alongside the shrunk
+assemblies. .NET for Android does not support assembly configuration files (see
+[OneDotNet.md](../../Documentation/guides/OneDotNet.md)): the `config_data`
+field carried by the assembly store is never handed to the runtime — it only
+appears in a `log_debug` message — so copying the files added an unavoidable
+always-run step for no observable behavior.
 
 NativeAOT keeps a separate always-run `_RemoveRegisterAttributeNativeAot`
 target. Its project-local destination remap must execute on every build so a

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
@@ -141,12 +141,30 @@ suppressed so a partial result cannot delete the last known-good output set.
 The set of generated assemblies and JCWs is data-dependent, so a build that
 *skips* `_GenerateTrimmableTypeMap` never executes the `ItemGroup` that registers
 those files in `@(FileWrites)`. `_RecordTrimmableTypeMapFileWrites` re-reads the
-generated outputs from `typemap-assemblies.txt` (and globs the JCWs) and
-re-emits them — plus the stamp — into `@(FileWrites)` *before* MSBuild's
-`IncrementalClean`, so the outputs are not seen as orphaned and deleted between
-incremental builds.
+generated outputs from `typemap-assemblies.txt`, `java-files.txt`, and
+`linked-java-files.txt`, then re-emits them — plus the stamps — into
+`@(FileWrites)` *before* MSBuild's `IncrementalClean`. This avoids recursively
+globbing both Java trees on every no-op build. When upgrading an existing
+`obj` directory that predates either Java list, the record target temporarily
+falls back to the corresponding directory glob so the old outputs survive
+`IncrementalClean` long enough for generation to backfill the list.
 
-### 5. The generator does not run in design-time builds, and runs once
+### 5. CoreCLR skips unchanged shrunk-assembly copies
+
+CoreCLR packages managed assemblies, so `_RemoveRegisterAttributeCoreClr`
+copies the resolved assembly set into the shrunk/package locations. The target
+uses the resolved assemblies, assembly-set hash, build properties, and project
+imports as inputs and a stamp as its output. Missing destination assemblies
+invalidate the stamp. Projects with `*.dll.config` files retain the previous
+always-run behavior until those files can be modeled as a reliable one-to-one
+transform.
+
+NativeAOT keeps a separate always-run `_RemoveRegisterAttributeNativeAot`
+target. Its project-local destination remap must execute on every build so a
+skipped target cannot point `_ShrunkAssemblies` back into the shared runtime
+pack and reintroduce cross-build races.
+
+### 6. The generator does not run in design-time builds, and runs once
 
 `_GenerateTrimmableTypeMap` is gated on `'$(DesignTimeBuild)' != 'true'`: in a
 design-time build, project references may resolve to target paths that are not

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -282,17 +282,30 @@
     Runs in the inner build after ILLink but before ReadyToRun/crossgen2 compilation,
     so R2R images are generated from the already-modified assemblies.
   -->
-  <Target Name="_PostTrimmingPipeline"
-      AfterTargets="ILLink"
+  <Target Name="_CollectPostTrimmingAssemblies"
       Condition=" '$(PublishTrimmed)' == 'true' ">
     <ItemGroup>
+      <_PostTrimmingAssembly Remove="@(_PostTrimmingAssembly)" />
       <_PostTrimmingAssembly Include="@(ResolvedFileToPublish)" Condition=" '%(Extension)' == '.dll' and '%(ResolvedFileToPublish.PostprocessAssembly)' == 'true' " />
     </ItemGroup>
+  </Target>
+
+  <Target Name="_PostTrimmingPipeline"
+      AfterTargets="ILLink"
+      DependsOnTargets="_CollectPostTrimmingAssemblies"
+      Condition=" '$(PublishTrimmed)' == 'true' "
+      Inputs="@(_PostTrimmingAssembly);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
+      Outputs="$(_AndroidStampDirectory)_PostTrimmingPipeline.stamp">
     <PostTrimmingPipeline
         Assemblies="@(_PostTrimmingAssembly)"
         AddKeepAlives="$(AndroidAddKeepAlives)"
         AndroidLinkResources="$(AndroidLinkResources)"
         Deterministic="$(Deterministic)" />
+    <MakeDir Directories="$(_AndroidStampDirectory)" />
+    <Touch Files="$(_AndroidStampDirectory)_PostTrimmingPipeline.stamp" AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_AndroidStampDirectory)_PostTrimmingPipeline.stamp" />
+    </ItemGroup>
   </Target>
 
   <!-- Inject _TypeMapKind into the property cache -->
@@ -304,6 +317,7 @@
     </PropertyGroup>
     <ItemGroup>
       <_PropertyCacheItems Include="TypeMapKind=$(_TypeMapKind)" />
+      <_PropertyCacheItems Include="Deterministic=$(Deterministic)" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
@@ -65,12 +65,45 @@
     </ItemGroup>
   </Target>
 
+  <!-- The stamp is the timestamp sentinel because generated files use content-based writes and
+       can legitimately be older than their inputs. If IncrementalClean or a manual cleanup removes
+       a real output but leaves the stamp, invalidate the stamp so the producer restores the complete
+       post-trim output set instead of letting _GenerateJavaStubs create an empty acw-map placeholder. -->
+  <Target Name="_InvalidatePostTrimTrimmableTypeMapStampIfOutputsMissing"
+      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(PublishTrimmed)' == 'true' and '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' ">
+    <ItemGroup>
+      <_ExpectedPostTrimJavaFile Remove="@(_ExpectedPostTrimJavaFile)" />
+      <_ActualPostTrimJavaFile Remove="@(_ActualPostTrimJavaFile)" />
+      <_MissingPostTrimJavaFile Remove="@(_MissingPostTrimJavaFile)" />
+      <_UnexpectedPostTrimJavaFile Remove="@(_UnexpectedPostTrimJavaFile)" />
+    </ItemGroup>
+    <ReadLinesFromFile
+        File="$(_PostTrimTypeMapJavaFilesList)"
+        Condition="Exists('$(_PostTrimTypeMapJavaFilesList)')">
+      <Output TaskParameter="Lines" ItemName="_ExpectedPostTrimJavaFile" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_ActualPostTrimJavaFile Include="$(_PostTrimTypeMapJavaOutputDirectory)/**/*.java" />
+      <_MissingPostTrimJavaFile Include="@(_ExpectedPostTrimJavaFile)" Condition="!Exists('%(_ExpectedPostTrimJavaFile.Identity)')" />
+      <_UnexpectedPostTrimJavaFile Include="@(_ActualPostTrimJavaFile)" Exclude="@(_ExpectedPostTrimJavaFile)" />
+    </ItemGroup>
+    <Delete
+        Files="$(_PostTrimTrimmableTypeMapJavaStamp)"
+        Condition="Exists('$(_PostTrimTrimmableTypeMapJavaStamp)') and (!Exists('$(_PostTrimTypeMapJavaOutputDirectory)') or !Exists('$(_PostTrimTypeMapJavaFilesList)') or '@(_MissingPostTrimJavaFile->Count())' != '0' or '@(_UnexpectedPostTrimJavaFile->Count())' != '0' or !Exists('$(IntermediateOutputPath)acw-map.txt') or !Exists('$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java'))" />
+    <ItemGroup>
+      <_ExpectedPostTrimJavaFile Remove="@(_ExpectedPostTrimJavaFile)" />
+      <_ActualPostTrimJavaFile Remove="@(_ActualPostTrimJavaFile)" />
+      <_MissingPostTrimJavaFile Remove="@(_MissingPostTrimJavaFile)" />
+      <_UnexpectedPostTrimJavaFile Remove="@(_UnexpectedPostTrimJavaFile)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_GeneratePostTrimTrimmableTypeMapJavaSources"
       Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(PublishTrimmed)' == 'true' and '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' "
-      DependsOnTargets="_ComputePostTrimTrimmableTypeMapInputs"
+      DependsOnTargets="_ComputePostTrimTrimmableTypeMapInputs;_InvalidatePostTrimTrimmableTypeMapStampIfOutputsMissing"
       AfterTargets="_ResolveAssemblies"
       BeforeTargets="_GenerateJavaStubs;_CompileJava;_CompileToDalvik"
-      Inputs="@(_PostTrimTrimmableTypeMapInputAssemblies)"
+      Inputs="@(_PostTrimTrimmableTypeMapInputAssemblies);$(_ResolvedUserAssembliesHashFile);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
       Outputs="$(_PostTrimTrimmableTypeMapJavaStamp)">
 
     <GenerateTrimmableTypeMap
@@ -82,37 +115,37 @@
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         PackageNamingPolicy="$(_TrimmableTypeMapPackageNamingPolicy)"
         GenerateTypeMapAssemblies="false"
-        CleanJavaSourceOutputDirectory="true"
+        CleanJavaSourceOutputDirectory="false"
         AcwMapOutputFile="$(IntermediateOutputPath)acw-map.txt"
         ApplicationRegistrationOutputFile="$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java">
       <Output TaskParameter="GeneratedJavaFiles" ItemName="_PostTrimGeneratedJavaFiles" />
       <Output TaskParameter="DeletedJavaFiles" ItemName="_PostTrimDeletedJavaFiles" />
     </GenerateTrimmableTypeMap>
 
-    <!-- Mirror any JCWs the post-trim pass no longer produces (e.g. trimmed-away types) into
-         the android/src copies so a stale .java (and stale .class) is not left behind. Busting
-         the Java compile stamp forces _CompileJava to drop the corresponding class output. -->
-    <ItemGroup>
-      <_PostTrimDeletedCopiedJavaFiles Remove="@(_PostTrimDeletedCopiedJavaFiles)" />
-      <_PostTrimDeletedCopiedJavaFiles Include="@(_PostTrimDeletedJavaFiles->'$(IntermediateOutputPath)android/src/%(RelativePath)')" />
-    </ItemGroup>
-    <Delete Files="@(_PostTrimDeletedCopiedJavaFiles)" />
-    <Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_PostTrimDeletedCopiedJavaFiles->Count())' != '0' " />
+    <WriteLinesToFile
+        File="$(_PostTrimTypeMapJavaFilesList)"
+        Lines="@(_PostTrimGeneratedJavaFiles)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true" />
+
+    <!-- The task updates linked-java in place, preserving timestamps for unchanged JCWs, and
+         reports any sources it pruned (e.g. trimmed-away types). Busting the Java compile stamp
+         for removals forces _CompileJava to drop the corresponding class output. -->
+    <Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_PostTrimDeletedJavaFiles->Count())' != '0' " />
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(_PostTrimTrimmableTypeMapJavaStamp)'))" />
     <Touch Files="$(_PostTrimTrimmableTypeMapJavaStamp)" AlwaysCreate="true" />
 
     <ItemGroup>
       <FileWrites Remove="@(_PostTrimDeletedJavaFiles)" />
-      <FileWrites Remove="@(_PostTrimDeletedCopiedJavaFiles)" />
       <FileWrites Include="@(_PostTrimGeneratedJavaFiles)" />
+      <FileWrites Include="$(_PostTrimTypeMapJavaFilesList)" />
       <FileWrites Include="$(IntermediateOutputPath)acw-map.txt" />
       <FileWrites Include="$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java" />
       <FileWrites Include="$(_PostTrimTrimmableTypeMapJavaStamp)" />
       <_PostTrimTrimmableTypeMapInputAssemblies Remove="@(_PostTrimTrimmableTypeMapInputAssemblies)" />
       <_PostTrimGeneratedJavaFiles Remove="@(_PostTrimGeneratedJavaFiles)" />
       <_PostTrimDeletedJavaFiles Remove="@(_PostTrimDeletedJavaFiles)" />
-      <_PostTrimDeletedCopiedJavaFiles Remove="@(_PostTrimDeletedCopiedJavaFiles)" />
     </ItemGroup>
   </Target>
   <!-- After ILLink trims per-assembly _X.TypeMap assemblies whose target Java binding was unused,

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
@@ -85,7 +85,7 @@
     <ItemGroup>
       <_ActualPostTrimJavaFile Include="$(_PostTrimTypeMapJavaOutputDirectory)/**/*.java" />
       <_MissingPostTrimJavaFile Include="@(_ExpectedPostTrimJavaFile)" Condition="!Exists('%(_ExpectedPostTrimJavaFile.Identity)')" />
-      <_UnexpectedPostTrimJavaFile Include="@(_ActualPostTrimJavaFile)" Exclude="@(_ExpectedPostTrimJavaFile)" />
+      <_UnexpectedPostTrimJavaFile Include="@(_ActualPostTrimJavaFile->'%(FullPath)')" Exclude="@(_ExpectedPostTrimJavaFile)" />
     </ItemGroup>
     <Delete
         Files="$(_PostTrimTrimmableTypeMapJavaStamp)"
@@ -124,7 +124,7 @@
 
     <WriteLinesToFile
         File="$(_PostTrimTypeMapJavaFilesList)"
-        Lines="@(_PostTrimGeneratedJavaFiles)"
+        Lines="@(_PostTrimGeneratedJavaFiles->'%(FullPath)')"
         Overwrite="true"
         WriteOnlyWhenDifferent="true" />
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
@@ -14,9 +14,9 @@
   <!-- Add TypeMap DLLs to ILLink input. ILLink natively understands TypeMapAttribute<T>. -->
   <Target Name="_AddTrimmableTypeMapToLinker"
       BeforeTargets="PrepareForILLink;_RunILLink"
-      DependsOnTargets="_GenerateTrimmableTypeMap">
+      DependsOnTargets="_ReadGeneratedTrimmableTypeMapAssemblies">
     <ItemGroup>
-      <ManagedAssemblyToLink Include="$(_TypeMapOutputDirectory)*.dll">
+      <ManagedAssemblyToLink Include="@(_GeneratedTypeMapAssembliesFromList)">
         <DestinationSubPath>%(Filename)%(Extension)</DestinationSubPath>
         <IsTrimmable>true</IsTrimmable>
       </ManagedAssemblyToLink>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -27,11 +27,17 @@
     <_PostTrimTypeMapJavaBaseOutputDir Condition=" '$(_OuterIntermediateOutputPath)' != '' ">$(IntermediateOutputPath)</_PostTrimTypeMapJavaBaseOutputDir>
     <_PostTrimTypeMapJavaBaseOutputDir Condition=" '$(_PostTrimTypeMapJavaBaseOutputDir)' == '' ">$(_TypeMapBaseOutputDir)</_PostTrimTypeMapJavaBaseOutputDir>
     <_PostTrimTypeMapJavaOutputDirectory>$(_PostTrimTypeMapJavaBaseOutputDir)typemap/linked-java</_PostTrimTypeMapJavaOutputDirectory>
+    <_PostTrimTypeMapJavaFilesList>$(_PostTrimTypeMapJavaBaseOutputDir)typemap/linked-java-files.txt</_PostTrimTypeMapJavaFilesList>
     <_PostTrimTypeMapFirstRuntimeIdentifier Condition=" '$(RuntimeIdentifiers)' != '' ">$([System.String]::Copy('$(RuntimeIdentifiers)').Split(';')[0])</_PostTrimTypeMapFirstRuntimeIdentifier>
     <_PostTrimTypeMapFirstRuntimeIdentifier Condition=" '$(_PostTrimTypeMapFirstRuntimeIdentifier)' == '' ">$(RuntimeIdentifier)</_PostTrimTypeMapFirstRuntimeIdentifier>
     <_TypeMapJavaStubsSourceDirectory Condition=" '$(_TypeMapJavaStubsSourceDirectory)' == '' and '$(_AndroidRuntime)' == 'CoreCLR' and '$(PublishTrimmed)' == 'true' ">$(_PostTrimTypeMapJavaOutputDirectory)</_TypeMapJavaStubsSourceDirectory>
     <_TypeMapJavaStubsSourceDirectory Condition=" '$(_TypeMapJavaStubsSourceDirectory)' == '' ">$(_TypeMapJavaOutputDirectory)</_TypeMapJavaStubsSourceDirectory>
     <_PostTrimTrimmableTypeMapJavaStamp>$(_PostTrimTypeMapJavaBaseOutputDir)stamp/_GeneratePostTrimTrimmableTypeMapJavaSources.stamp</_PostTrimTrimmableTypeMapJavaStamp>
+    <!-- CoreCLR trimmed builds regenerate these files from the linked assemblies. Keep the
+         pre-trim pass from overwriting those final post-trim outputs when only an unrelated
+         generator input (for example AndroidManifest.xml) changes. -->
+    <_PreTrimTypeMapAcwMapOutputFile Condition=" '$(_AndroidRuntime)' != 'CoreCLR' or '$(PublishTrimmed)' != 'true' ">$(IntermediateOutputPath)acw-map.txt</_PreTrimTypeMapAcwMapOutputFile>
+    <_PreTrimTypeMapApplicationRegistrationOutputFile Condition=" '$(_AndroidRuntime)' != 'CoreCLR' or '$(PublishTrimmed)' != 'true' ">$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java</_PreTrimTypeMapApplicationRegistrationOutputFile>
     <!-- Stamp file touched on every _GenerateTrimmableTypeMap run. It is a stable
          incremental sentinel: the generated TypeMap DLLs are only rewritten when their
          content changes (CopyIfStreamChanged), so their timestamps cannot be used as
@@ -159,8 +165,8 @@
         ApplicationJavaClass="$(AndroidApplicationJavaClass)"
         ErrorOnCustomJavaObject="$(AndroidErrorOnCustomJavaObject)"
         GeneratedAssembliesListFile="$(_TypeMapAssembliesListFile)"
-        AcwMapOutputFile="$(IntermediateOutputPath)acw-map.txt"
-        ApplicationRegistrationOutputFile="$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java">
+        AcwMapOutputFile="$(_PreTrimTypeMapAcwMapOutputFile)"
+        ApplicationRegistrationOutputFile="$(_PreTrimTypeMapApplicationRegistrationOutputFile)">
       <Output TaskParameter="GeneratedAssemblies" ItemName="_GeneratedTypeMapAssemblies" />
       <Output TaskParameter="GeneratedJavaFiles" ItemName="_GeneratedJavaFiles" />
       <Output TaskParameter="DeletedJavaFiles" ItemName="_DeletedJavaFiles" />
@@ -185,8 +191,8 @@
       <FileWrites Include="$(_TypeMapAssembliesListFile)" />
       <FileWrites Include="$(_TrimmableTypeMapOutputStamp)" />
       <FileWrites Include="$(_TypeMapBaseOutputDir)AndroidManifest.xml" />
-      <FileWrites Include="$(IntermediateOutputPath)acw-map.txt" />
-      <FileWrites Include="$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java" />
+      <FileWrites Include="$(_PreTrimTypeMapAcwMapOutputFile)" Condition=" '$(_PreTrimTypeMapAcwMapOutputFile)' != '' " />
+      <FileWrites Include="$(_PreTrimTypeMapApplicationRegistrationOutputFile)" Condition=" '$(_PreTrimTypeMapApplicationRegistrationOutputFile)' != '' " />
     </ItemGroup>
   </Target>
 
@@ -241,6 +247,7 @@
       <FileWrites Include="@(_GeneratedTypeMapAssembliesForFileWrites)" />
       <FileWrites Include="@(_TypeMapJavaFilesForFileWrites)" />
       <FileWrites Include="@(_TypeMapPostTrimJavaFilesForFileWrites)" />
+      <FileWrites Include="$(_PostTrimTypeMapJavaFilesList)" Condition="Exists('$(_PostTrimTypeMapJavaFilesList)')" />
       <FileWrites Include="$(_PostTrimTrimmableTypeMapJavaStamp)" Condition="Exists('$(_PostTrimTrimmableTypeMapJavaStamp)')" />
       <FileWrites Include="$(_TypeMapAssembliesListFile)" />
       <FileWrites Include="$(_TrimmableTypeMapOutputStamp)" Condition="Exists('$(_TrimmableTypeMapOutputStamp)')" />
@@ -351,19 +358,18 @@
   <!--
     _GenerateJavaStubs: overrides the legacy target from BuildOrder.targets.
     In the trimmable path, TypeMap generation already happened in _GenerateTrimmableTypeMap,
-    so this target only handles JCW file copying, manifest, assembly store setup, and native config.
+    so this target only handles the manifest, assembly store setup, and native config.
     We keep the name _GenerateJavaStubs because BuildOrder.targets references it.
 
-    Inputs uses the TypeMap output stamp as a focused sentinel — _GenerateTrimmableTypeMap
-    touches it whenever any of its own inputs (assemblies, manifest, etc.) change, and is
-    skipped (leaving the stamp stable) on no-op builds. The Copy below then updates
-    android/src only for Java sources whose content changed.
+    Inputs uses both generator stamps. The pre-trim stamp covers the generated manifest and
+    other shared outputs, while _TrimmableJavaSourceStamp covers the selected JCW set (the
+    post-trim stamp for trimmed CoreCLR builds). Both remain stable on no-op builds.
     We keep _GetGenerateJavaStubsInputs in DependsOnTargets so that downstream targets
     (_GetGeneratePackageManagerJavaInputs) can still read @(_GenerateJavaStubsInputs).
   -->
   <Target Name="_GenerateJavaStubs"
       DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;_GetGenerateJavaStubsInputs;_DefineBuildTargetAbis;_PrepareNativeAssemblySources"
-      Inputs="$(_TrimmableJavaSourceStamp);@(_EnvironmentFiles)"
+      Inputs="$(_TrimmableTypeMapOutputStamp);$(_TrimmableJavaSourceStamp);@(_EnvironmentFiles)"
       Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
 
     <!-- The generated Java Callable Wrappers are compiled in place from

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -27,6 +27,7 @@
     <_TypeMapJavaFilesList>$(_TypeMapOutputDirectory)java-files.txt</_TypeMapJavaFilesList>
     <_PostTrimTypeMapJavaBaseOutputDir Condition=" '$(_OuterIntermediateOutputPath)' != '' ">$(IntermediateOutputPath)</_PostTrimTypeMapJavaBaseOutputDir>
     <_PostTrimTypeMapJavaBaseOutputDir Condition=" '$(_PostTrimTypeMapJavaBaseOutputDir)' == '' ">$(_TypeMapBaseOutputDir)</_PostTrimTypeMapJavaBaseOutputDir>
+    <_PostTrimTypeMapJavaBaseOutputDir>$(_PostTrimTypeMapJavaBaseOutputDir.Replace('\','/'))</_PostTrimTypeMapJavaBaseOutputDir>
     <_PostTrimTypeMapJavaOutputDirectory>$(_PostTrimTypeMapJavaBaseOutputDir)typemap/linked-java</_PostTrimTypeMapJavaOutputDirectory>
     <_PostTrimTypeMapJavaFilesList>$(_PostTrimTypeMapJavaBaseOutputDir)typemap/linked-java-files.txt</_PostTrimTypeMapJavaFilesList>
     <_PostTrimTypeMapFirstRuntimeIdentifier Condition=" '$(RuntimeIdentifiers)' != '' ">$([System.String]::Copy('$(RuntimeIdentifiers)').Split(';')[0])</_PostTrimTypeMapFirstRuntimeIdentifier>
@@ -179,7 +180,7 @@
 
     <WriteLinesToFile
         File="$(_TypeMapJavaFilesList)"
-        Lines="@(_GeneratedJavaFiles)"
+        Lines="@(_GeneratedJavaFiles->'%(FullPath)')"
         Overwrite="true"
         WriteOnlyWhenDifferent="true" />
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -24,6 +24,7 @@
     <_TypeMapOutputDirectory>$(_TypeMapBaseOutputDir)typemap/</_TypeMapOutputDirectory>
     <_TypeMapJavaOutputDirectory>$(_TypeMapBaseOutputDir)typemap/java</_TypeMapJavaOutputDirectory>
     <_TypeMapAssembliesListFile>$(_TypeMapOutputDirectory)typemap-assemblies.txt</_TypeMapAssembliesListFile>
+    <_TypeMapJavaFilesList>$(_TypeMapOutputDirectory)java-files.txt</_TypeMapJavaFilesList>
     <_PostTrimTypeMapJavaBaseOutputDir Condition=" '$(_OuterIntermediateOutputPath)' != '' ">$(IntermediateOutputPath)</_PostTrimTypeMapJavaBaseOutputDir>
     <_PostTrimTypeMapJavaBaseOutputDir Condition=" '$(_PostTrimTypeMapJavaBaseOutputDir)' == '' ">$(_TypeMapBaseOutputDir)</_PostTrimTypeMapJavaBaseOutputDir>
     <_PostTrimTypeMapJavaOutputDirectory>$(_PostTrimTypeMapJavaBaseOutputDir)typemap/linked-java</_PostTrimTypeMapJavaOutputDirectory>
@@ -44,6 +45,9 @@
          Outputs without making the target run on every build. The stamp is always
          touched, so the target is correctly skipped when none of its Inputs changed. -->
     <_TrimmableTypeMapOutputStamp>$(_TypeMapOutputDirectory)_GenerateTrimmableTypeMap.stamp</_TrimmableTypeMapOutputStamp>
+    <_TrimmableRemoveRegisterFlag>$(_AndroidStampDirectory)_RemoveRegisterAttribute.stamp</_TrimmableRemoveRegisterFlag>
+    <_TrimmableRemoveRegisterTarget Condition=" '$(_AndroidRuntime)' == 'CoreCLR' ">_RemoveRegisterAttributeCoreClr</_TrimmableRemoveRegisterTarget>
+    <_TrimmableRemoveRegisterTarget Condition=" '$(_AndroidRuntime)' == 'NativeAOT' ">_RemoveRegisterAttributeNativeAot</_TrimmableRemoveRegisterTarget>
     <!-- Sentinel for _GenerateJavaStubs: the post-trim Java stamp when JCWs are regenerated
          from the linked assemblies (CoreCLR + PublishTrimmed), otherwise the generator stamp.
          Both are touched only when their producing target actually runs, so _GenerateJavaStubs
@@ -173,6 +177,12 @@
       <Output TaskParameter="AdditionalProviderSources" ItemName="_AdditionalProviderSources" />
     </GenerateTrimmableTypeMap>
 
+    <WriteLinesToFile
+        File="$(_TypeMapJavaFilesList)"
+        Lines="@(_GeneratedJavaFiles)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true" />
+
     <!-- If the generator removed a Java source, bust the Java compile stamp so _CompileJava
          re-runs (it fully cleans its class output each run, dropping the stale .class). The
          JCWs are compiled in place, so there are no android/src copies to delete. -->
@@ -189,6 +199,7 @@
       <FileWrites Include="@(_GeneratedTypeMapAssemblies)" />
       <FileWrites Include="@(_GeneratedJavaFiles)" />
       <FileWrites Include="$(_TypeMapAssembliesListFile)" />
+      <FileWrites Include="$(_TypeMapJavaFilesList)" />
       <FileWrites Include="$(_TrimmableTypeMapOutputStamp)" />
       <FileWrites Include="$(_TypeMapBaseOutputDir)AndroidManifest.xml" />
       <FileWrites Include="$(_PreTrimTypeMapAcwMapOutputFile)" Condition=" '$(_PreTrimTypeMapAcwMapOutputFile)' != '' " />
@@ -236,13 +247,25 @@
     <ReadLinesFromFile File="$(_TypeMapAssembliesListFile)">
       <Output TaskParameter="Lines" ItemName="_GeneratedTypeMapAssembliesForFileWrites" />
     </ReadLinesFromFile>
+    <ReadLinesFromFile
+        File="$(_TypeMapJavaFilesList)"
+        Condition="Exists('$(_TypeMapJavaFilesList)')">
+      <Output TaskParameter="Lines" ItemName="_TypeMapJavaFilesForFileWrites" />
+    </ReadLinesFromFile>
+    <ReadLinesFromFile
+        File="$(_PostTrimTypeMapJavaFilesList)"
+        Condition="Exists('$(_PostTrimTypeMapJavaFilesList)')">
+      <Output TaskParameter="Lines" ItemName="_TypeMapPostTrimJavaFilesForFileWrites" />
+    </ReadLinesFromFile>
     <ItemGroup>
-      <_TypeMapJavaFilesForFileWrites Include="$(_TypeMapJavaOutputDirectory)/**/*.java" />
-      <!-- For CoreCLR + PublishTrimmed the JCWs come from the post-trim `linked-java` directory.
-           _GeneratePostTrimTrimmableTypeMapJavaSources is now incremental, so re-emit its outputs
-           here too; otherwise IncrementalClean deletes linked-java on builds where post-trim is
-           skipped. The glob is empty for configurations that have no post-trim pass. -->
-      <_TypeMapPostTrimJavaFilesForFileWrites Include="$(_PostTrimTypeMapJavaOutputDirectory)/**/*.java" />
+      <!-- Backfill FileWrites from the directory when upgrading an existing obj tree that
+           predates java-files.txt and skips _GenerateTrimmableTypeMap on its first no-op build. -->
+      <_TypeMapJavaFilesForFileWrites
+          Include="$(_TypeMapJavaOutputDirectory)/**/*.java"
+          Condition="!Exists('$(_TypeMapJavaFilesList)')" />
+      <_TypeMapPostTrimJavaFilesForFileWrites
+          Include="$(_PostTrimTypeMapJavaOutputDirectory)/**/*.java"
+          Condition="!Exists('$(_PostTrimTypeMapJavaFilesList)')" />
 
       <FileWrites Include="@(_GeneratedTypeMapAssembliesForFileWrites)" />
       <FileWrites Include="@(_TypeMapJavaFilesForFileWrites)" />
@@ -250,6 +273,7 @@
       <FileWrites Include="$(_PostTrimTypeMapJavaFilesList)" Condition="Exists('$(_PostTrimTypeMapJavaFilesList)')" />
       <FileWrites Include="$(_PostTrimTrimmableTypeMapJavaStamp)" Condition="Exists('$(_PostTrimTrimmableTypeMapJavaStamp)')" />
       <FileWrites Include="$(_TypeMapAssembliesListFile)" />
+      <FileWrites Include="$(_TypeMapJavaFilesList)" Condition="Exists('$(_TypeMapJavaFilesList)')" />
       <FileWrites Include="$(_TrimmableTypeMapOutputStamp)" Condition="Exists('$(_TrimmableTypeMapOutputStamp)')" />
       <FileWrites Include="$(_TypeMapBaseOutputDir)AndroidManifest.xml" Condition="Exists('$(_TypeMapBaseOutputDir)AndroidManifest.xml')" />
       <FileWrites Include="$(IntermediateOutputPath)AndroidManifest.xml" Condition="Exists('$(IntermediateOutputPath)AndroidManifest.xml')" />
@@ -335,9 +359,53 @@
     CoreCLR (and any other trimmable runtime) keeps the base behavior because it still
     packages the managed assemblies and therefore needs the shrunk copies in place.
   -->
-  <Target Name="_RemoveRegisterAttribute"
-      DependsOnTargets="_PrepareAssemblies"
+  <Target Name="_PrepareTrimmableRemoveRegisterAttribute"
+      DependsOnTargets="_PrepareAssemblies;_PrepareTrimmableTypeMapAssemblies"
       Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidIncludeDebugSymbols)' != 'true'">
+    <ItemGroup>
+      <_TrimmableResolvedAssemblyConfigInput Remove="@(_TrimmableResolvedAssemblyConfigInput)" />
+      <_TrimmableResolvedAssemblyConfigInput Include="@(_ResolvedAssemblies->'%(Identity).config')" />
+      <_TrimmableResolvedAssemblyConfigInput Remove="@(_TrimmableResolvedAssemblyConfigInput)" Condition="!Exists('%(_TrimmableResolvedAssemblyConfigInput.Identity)')" />
+      <_MissingTrimmableShrunkAssembly Remove="@(_MissingTrimmableShrunkAssembly)" />
+      <_MissingTrimmableShrunkAssembly
+          Include="@(_ShrunkAssemblies)"
+          Condition=" '$(_AndroidRuntime)' == 'CoreCLR' and !Exists('%(_ShrunkAssemblies.Identity)') " />
+    </ItemGroup>
+    <Delete
+        Files="$(_TrimmableRemoveRegisterFlag)"
+        Condition=" '@(_MissingTrimmableShrunkAssembly->Count())' != '0' " />
+    <PropertyGroup>
+      <!-- Keep config-file projects on the previous always-run path until source/destination
+           config files can be modeled as a reliable one-to-one incremental transform. -->
+      <_TrimmableRemoveRegisterAlwaysRunInput
+          Condition=" '@(_TrimmableResolvedAssemblyConfigInput->Count())' != '0' ">$(IntermediateOutputPath)__always_copy_trimmable_assembly_configs__</_TrimmableRemoveRegisterAlwaysRunInput>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_RemoveRegisterAttribute"
+      DependsOnTargets="_PrepareTrimmableRemoveRegisterAttribute;$(_TrimmableRemoveRegisterTarget)"
+      Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidIncludeDebugSymbols)' != 'true'" />
+
+  <Target Name="_RemoveRegisterAttributeCoreClr"
+      Condition=" '$(_AndroidRuntime)' == 'CoreCLR' "
+      Inputs="@(_ResolvedAssemblies);$(_ResolvedUserAssembliesHashFile);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects);$(_TrimmableRemoveRegisterAlwaysRunInput)"
+      Outputs="$(_TrimmableRemoveRegisterFlag)">
+    <CopyIfChanged
+      SourceFiles="@(_ResolvedAssemblies)"
+      DestinationFiles="@(_ShrunkAssemblies)" />
+    <CopyIfChanged
+      SourceFiles="@(_ResolvedAssemblies->'%(Identity).config')"
+      DestinationFiles="@(_ShrunkAssemblies->'%(Identity).config')" />
+    <MakeDir Directories="$(MonoAndroidIntermediateAssemblyDir)shrunk" />
+    <MakeDir Directories="$(_AndroidStampDirectory)" />
+    <Touch Files="$(_TrimmableRemoveRegisterFlag)" AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_TrimmableRemoveRegisterFlag)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_RemoveRegisterAttributeNativeAot"
+      Condition=" '$(_AndroidRuntime)' == 'NativeAOT' ">
     <ItemGroup Condition=" '$(_AndroidRuntime)' == 'NativeAOT' ">
       <_ShrunkAssemblies Remove="@(_ShrunkAssemblies)" />
       <_ShrunkAssemblies Include="@(_ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(DestinationSubPath)')" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -359,14 +359,17 @@
 
     CoreCLR (and any other trimmable runtime) keeps the base behavior because it still
     packages the managed assemblies and therefore needs the shrunk copies in place.
+
+    Unlike the base target, `*.dll.config` files are not copied next to the shrunk
+    assemblies. Assembly configuration files are not supported by .NET for Android
+    (see Documentation/guides/OneDotNet.md); the assembly store's `config_data` is
+    never handed to the runtime, so the copy only forced this target to run on every
+    build.
   -->
   <Target Name="_PrepareTrimmableRemoveRegisterAttribute"
       DependsOnTargets="_PrepareAssemblies;_PrepareTrimmableTypeMapAssemblies"
       Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidIncludeDebugSymbols)' != 'true'">
     <ItemGroup>
-      <_TrimmableResolvedAssemblyConfigInput Remove="@(_TrimmableResolvedAssemblyConfigInput)" />
-      <_TrimmableResolvedAssemblyConfigInput Include="@(_ResolvedAssemblies->'%(Identity).config')" />
-      <_TrimmableResolvedAssemblyConfigInput Remove="@(_TrimmableResolvedAssemblyConfigInput)" Condition="!Exists('%(_TrimmableResolvedAssemblyConfigInput.Identity)')" />
       <_MissingTrimmableShrunkAssembly Remove="@(_MissingTrimmableShrunkAssembly)" />
       <_MissingTrimmableShrunkAssembly
           Include="@(_ShrunkAssemblies)"
@@ -375,12 +378,6 @@
     <Delete
         Files="$(_TrimmableRemoveRegisterFlag)"
         Condition=" '@(_MissingTrimmableShrunkAssembly->Count())' != '0' " />
-    <PropertyGroup>
-      <!-- Keep config-file projects on the previous always-run path until source/destination
-           config files can be modeled as a reliable one-to-one incremental transform. -->
-      <_TrimmableRemoveRegisterAlwaysRunInput
-          Condition=" '@(_TrimmableResolvedAssemblyConfigInput->Count())' != '0' ">$(IntermediateOutputPath)__always_copy_trimmable_assembly_configs__</_TrimmableRemoveRegisterAlwaysRunInput>
-    </PropertyGroup>
   </Target>
 
   <Target Name="_RemoveRegisterAttribute"
@@ -389,14 +386,11 @@
 
   <Target Name="_RemoveRegisterAttributeCoreClr"
       Condition=" '$(_AndroidRuntime)' == 'CoreCLR' "
-      Inputs="@(_ResolvedAssemblies);$(_ResolvedUserAssembliesHashFile);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects);$(_TrimmableRemoveRegisterAlwaysRunInput)"
+      Inputs="@(_ResolvedAssemblies);$(_ResolvedUserAssembliesHashFile);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
       Outputs="$(_TrimmableRemoveRegisterFlag)">
     <CopyIfChanged
       SourceFiles="@(_ResolvedAssemblies)"
       DestinationFiles="@(_ShrunkAssemblies)" />
-    <CopyIfChanged
-      SourceFiles="@(_ResolvedAssemblies->'%(Identity).config')"
-      DestinationFiles="@(_ShrunkAssemblies->'%(Identity).config')" />
     <MakeDir Directories="$(MonoAndroidIntermediateAssemblyDir)shrunk" />
     <MakeDir Directories="$(_AndroidStampDirectory)" />
     <Touch Files="$(_TrimmableRemoveRegisterFlag)" AlwaysCreate="true" />
@@ -418,9 +412,6 @@
     <CopyIfChanged
       SourceFiles="@(_ResolvedAssemblies)"
       DestinationFiles="@(_ShrunkAssemblies)" />
-    <CopyIfChanged
-      SourceFiles="@(_ResolvedAssemblies->'%(Identity).config')"
-      DestinationFiles="@(_ShrunkAssemblies->'%(Identity).config')" />
     <MakeDir Directories="$(MonoAndroidIntermediateAssemblyDir)shrunk" />
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -409,30 +409,27 @@ public class GenerateTrimmableTypeMap : AndroidTask
 
 	// Removes generated Java sources from a previous build that the current generation pass
 	// no longer produces (for example when a managed type is removed or trimmed away). Returns
-	// the deleted files (with a RelativePath metadata) so the targets can mirror the deletion
-	// into the android/src copies and force a Java recompilation.
+	// the deleted files (with RelativePath metadata) so the targets can force Java recompilation.
 	//
-	// When the output directory was wiped before generation (CleanJavaSourceOutputDirectory, used
-	// by the post-trim pass), the stale files are already gone from disk; the previous contents
-	// are supplied via priorJavaSnapshot and the difference against the freshly generated set is
-	// reported. Otherwise the directory is scanned and any file the current pass did not produce
-	// is deleted.
+	// When the output directory was wiped before generation (CleanJavaSourceOutputDirectory), the
+	// stale files are already gone from disk; the previous contents are supplied via
+	// priorJavaSnapshot and the difference against the freshly generated set is reported.
+	// Otherwise the directory is scanned and any file the current pass did not produce is deleted.
 	ITaskItem [] DeleteStaleJavaSources (IReadOnlyCollection<ITaskItem> generatedJavaFiles, string[]? priorJavaSnapshot)
 	{
+		// GeneratedJavaFiles can be incomplete after an error (for example XA4255 when a
+		// pre-trim source is missing). The build will fail, but keep the last known-good output
+		// set intact rather than pruning files based on a partial result.
+		if (Log.HasLoggedErrors) {
+			return [];
+		}
+
 		var expectedFiles = new HashSet<string> (
 			generatedJavaFiles.Select (i => Path.GetFullPath (i.ItemSpec)),
 			Path.DirectorySeparatorChar == '\\' ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
 		var deleted = new List<ITaskItem> ();
 
 		if (priorJavaSnapshot is not null) {
-			// If generation logged errors (e.g. a generated source was missing from the input
-			// directory, XA4255), GeneratedJavaFiles may be incomplete, so the prior-minus-current
-			// diff could wrongly flag a still-valid source as deleted. The build fails on logged
-			// errors anyway; skip pruning to avoid removing a file that should remain.
-			if (Log.HasLoggedErrors) {
-				return [];
-			}
-
 			foreach (var path in priorJavaSnapshot) {
 				var fullPath = Path.GetFullPath (path);
 				if (expectedFiles.Contains (fullPath)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1861,6 +1861,9 @@ namespace Lib2
 				Assert.IsTrue (b.Build (proj), "first build should succeed");
 				b.Output.AssertTargetIsNotSkipped ("_RunAfterILLinkAdditionalSteps");
 				b.Output.AssertTargetIsNotSkipped ("_AfterILLinkAdditionalSteps");
+				if (runtime == AndroidRuntime.CoreCLR) {
+					b.Output.AssertTargetIsNotSkipped ("_PostTrimmingPipeline");
+				}
 
 				// Verify afterlink/ output directory was created with per-ABI subdirectories containing assemblies
 				var afterlinkDir = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "afterlink");
@@ -1876,6 +1879,9 @@ namespace Lib2
 				b.Output.AssertTargetIsSkipped ("_RunAfterILLinkAdditionalSteps");
 				// The outer target must always run to update assembly itemgroups for downstream targets
 				b.Output.AssertTargetIsNotSkipped ("_AfterILLinkAdditionalSteps");
+				if (runtime == AndroidRuntime.CoreCLR) {
+					b.Output.AssertTargetIsSkipped ("_PostTrimmingPipeline");
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
@@ -111,6 +111,45 @@ namespace Xamarin.Android.Build.Tests {
 		}
 
 		[Test]
+		public void Execute_MissingJavaSource_DoesNotPruneExistingOutput ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var outputDir = Path.Combine (Root, path, "typemap");
+			var javaInputDir = Path.Combine (Root, path, "java");
+			var javaOutputDir = Path.Combine (Root, path, "linked-java");
+
+			var monoAndroidItem = FindMonoAndroidDll ();
+			if (monoAndroidItem is null) {
+				Assert.Ignore ("Mono.Android.dll not found; skipping.");
+				return;
+			}
+
+			var firstTask = CreateTask (new [] { monoAndroidItem }, outputDir, javaInputDir);
+			Assert.IsTrue (firstTask.Execute (), "First run should generate Java inputs.");
+			Assert.IsNotEmpty (firstTask.GeneratedJavaFiles, "Test setup should generate Java sources.");
+
+			var missingInput = firstTask.GeneratedJavaFiles [0].ItemSpec;
+			var relativePath = Path.GetRelativePath (javaInputDir, missingInput);
+			var existingOutput = Path.Combine (javaOutputDir, relativePath);
+			var existingOutputDirectory = Path.GetDirectoryName (existingOutput);
+			if (existingOutputDirectory is null) {
+				throw new InvalidOperationException ("Could not determine the linked Java output directory.");
+			}
+			Directory.CreateDirectory (existingOutputDirectory);
+			File.Copy (missingInput, existingOutput);
+			File.Delete (missingInput);
+
+			var errors = new List<BuildErrorEventArgs> ();
+			var secondTask = CreateTask (new [] { monoAndroidItem }, outputDir, javaOutputDir, errors: errors);
+			secondTask.JavaSourceInputDirectory = javaInputDir;
+			secondTask.GenerateTypeMapAssemblies = false;
+
+			Assert.IsFalse (secondTask.Execute (), "The missing pre-trim Java source should fail with XA4255.");
+			Assert.IsTrue (errors.Any (e => e.Code == "XA4255"), "The task should report the missing Java source.");
+			FileAssert.Exists (existingOutput, "A failing in-place update should preserve the last known-good linked Java source.");
+		}
+
+		[Test]
 		public void Execute_WritesGeneratedAssembliesListFile ()
 		{
 			var path = Path.Combine ("temp", TestName);
@@ -356,10 +395,11 @@ namespace Xamarin.Android.Build.Tests {
 		}
 
 		GenerateTrimmableTypeMap CreateTask (ITaskItem [] assemblies, string outputDir, string javaDir,
-			IList<BuildMessageEventArgs>? messages = null, IList<BuildWarningEventArgs>? warnings = null, string tfv = "v11.0")
+			IList<BuildMessageEventArgs>? messages = null, IList<BuildWarningEventArgs>? warnings = null,
+			IList<BuildErrorEventArgs>? errors = null, string tfv = "v11.0")
 		{
 			return new GenerateTrimmableTypeMap {
-				BuildEngine = new MockBuildEngine (TestContext.Out, warnings: warnings, messages: messages),
+				BuildEngine = new MockBuildEngine (TestContext.Out, errors: errors, warnings: warnings, messages: messages),
 				ResolvedAssemblies = assemblies,
 				OutputDirectory = outputDir,
 				JavaSourceOutputDirectory = javaDir,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -258,8 +258,8 @@ namespace Xamarin.Android.Build.Tests {
 			File.WriteAllBytes (staleCompiledClass, []);
 
 			// Force the post-trim Java generation to re-run by removing its stamp (without a source
-			// change, which would trigger an unrelated incremental CrossGen rebuild). It wipes and
-			// regenerates linked-java (dropping the stale JCW); the JCWs are compiled in place, so
+			// change, which would trigger an unrelated incremental CrossGen rebuild). It updates
+			// linked-java in place (dropping the stale JCW); the JCWs are compiled in place, so
 			// busting the compile stamp must drop the stale .class too.
 			var postTrimStamp = builder.Output.GetIntermediaryPath (Path.Combine ("stamp", "_GeneratePostTrimTrimmableTypeMapJavaSources.stamp"));
 			FileAssert.Exists (postTrimStamp, "First build should have written the post-trim Java stamp.");
@@ -296,6 +296,96 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "No-op rebuild should have succeeded.");
 			builder.Output.AssertTargetIsSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
 			builder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
+
+			var acwMap = builder.Output.GetIntermediaryPath ("acw-map.txt");
+			FileAssert.Exists (acwMap, "First build should have generated the post-trim ACW map.");
+			var linkedJava = Directory.GetFiles (
+				builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "linked-java")),
+				"*.java",
+				SearchOption.AllDirectories).First ();
+			File.Delete (acwMap);
+			File.Delete (linkedJava);
+
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Missing-output recovery build should have succeeded.");
+			builder.Output.AssertTargetIsNotSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
+			FileAssert.Exists (acwMap, "Post-trim generation should restore a missing ACW map even when linked assemblies are unchanged.");
+			FileAssert.Exists (linkedJava, "Post-trim generation should restore a missing linked Java source even when linked assemblies are unchanged.");
+			Assert.That (new FileInfo (acwMap).Length, Is.GreaterThan (0), "The restored ACW map should contain the linked mappings.");
+		}
+
+		[Test]
+		public void Build_WithTrimmableTypeMap_PublishTrimmed_IncrementalChangesAvoidUnnecessaryJavaWork ()
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
+
+			var linkedJavaDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "linked-java"));
+			var linkedJavaBefore = Directory.GetFiles (linkedJavaDirectory, "*.java", SearchOption.AllDirectories)
+				.ToDictionary (
+					path => Path.GetRelativePath (linkedJavaDirectory, path),
+					path => (Hash: ComputeFileHash (path), WriteTime: File.GetLastWriteTimeUtc (path)),
+					StringComparer.Ordinal);
+			Assert.IsNotEmpty (linkedJavaBefore, "First build should have generated post-trim Java sources.");
+
+			var updatedMainActivity = proj.DefaultMainActivity.Replace (
+				"//${AFTER_ONCREATE}",
+				"System.Console.WriteLine (\"Managed-only incremental change.\");");
+			Assert.AreNotEqual (proj.DefaultMainActivity, updatedMainActivity, "Test setup should update the managed MainActivity body.");
+			proj.MainActivity = updatedMainActivity;
+			proj.Touch ("MainActivity.cs");
+
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Managed-only rebuild should have succeeded.");
+			builder.Output.AssertTargetIsNotSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
+			builder.Output.AssertTargetIsSkipped ("_CompileJava");
+			builder.Output.AssertTargetIsSkipped ("_CompileToDalvik");
+
+			var linkedJavaAfter = Directory.GetFiles (linkedJavaDirectory, "*.java", SearchOption.AllDirectories)
+				.ToDictionary (
+					path => Path.GetRelativePath (linkedJavaDirectory, path),
+					path => (Hash: ComputeFileHash (path), WriteTime: File.GetLastWriteTimeUtc (path)),
+					StringComparer.Ordinal);
+			CollectionAssert.AreEquivalent (linkedJavaBefore.Keys, linkedJavaAfter.Keys, "A managed method-body change should not alter the JCW set.");
+			foreach (var pair in linkedJavaBefore) {
+				var current = linkedJavaAfter [pair.Key];
+				Assert.IsTrue (pair.Value.Hash.SequenceEqual (current.Hash), $"{pair.Key} content should be unchanged.");
+				Assert.AreEqual (pair.Value.WriteTime, current.WriteTime, $"{pair.Key} timestamp should remain stable.");
+			}
+
+			var acwMap = builder.Output.GetIntermediaryPath ("acw-map.txt");
+			var applicationRegistration = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src", "net", "dot", "android", "ApplicationRegistration.java"));
+			var postTrimAcwMap = ComputeFileHash (acwMap);
+			var postTrimApplicationRegistration = ComputeFileHash (applicationRegistration);
+
+			var updatedManifest = proj.AndroidManifest.Replace (
+				"</manifest>",
+				"<uses-permission android:name=\"android.permission.CAMERA\" /></manifest>");
+			Assert.AreNotEqual (proj.AndroidManifest, updatedManifest, "Test setup should update AndroidManifest.xml.");
+			proj.AndroidManifest = updatedManifest;
+			proj.Touch ("Properties\\AndroidManifest.xml");
+
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true), "Manifest-only rebuild should have succeeded.");
+			builder.Output.AssertTargetIsNotSkipped ("_GenerateTrimmableTypeMap");
+			builder.Output.AssertTargetIsSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
+			builder.Output.AssertTargetIsNotSkipped ("_GenerateJavaStubs");
+			builder.Output.AssertTargetIsSkipped ("_CompileJava");
+			builder.Output.AssertTargetIsSkipped ("_CompileToDalvik");
+			Assert.IsTrue (postTrimAcwMap.SequenceEqual (ComputeFileHash (acwMap)), "The pre-trim pass should not overwrite the linked acw-map.txt.");
+			Assert.IsTrue (
+				postTrimApplicationRegistration.SequenceEqual (ComputeFileHash (applicationRegistration)),
+				"The pre-trim pass should not overwrite the linked ApplicationRegistration.java.");
+
+			var mergedManifest = builder.Output.GetIntermediaryPath (Path.Combine ("android", "AndroidManifest.xml"));
+			StringAssert.Contains ("android.permission.CAMERA", File.ReadAllText (mergedManifest), "The manifest-only change should flow into the packaged manifest.");
 		}
 
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -61,8 +61,76 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (
 				builder.Output.IsTargetSkipped ("_GenerateJavaStubs"),
 				"_GenerateJavaStubs should be skipped on incremental build.");
+			if (isRelease && runtime == AndroidRuntime.CoreCLR) {
+				builder.Output.AssertTargetIsSkipped ("_RemoveRegisterAttributeCoreClr");
+			}
+			if (isRelease && runtime == AndroidRuntime.NativeAOT) {
+				builder.Output.AssertTargetIsNotSkipped ("_RemoveRegisterAttributeNativeAot");
+			}
 			foreach (var typemapDll in typemapDlls) {
 				FileAssert.Exists (typemapDll, $"No-op builds should preserve generated typemap assembly {typemapDll} when _GenerateTrimmableTypeMap is skipped.");
+			}
+		}
+
+		[Test]
+		public void Build_WithTrimmableTypeMap_MissingJavaListPreservesGeneratedJava ()
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: false)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
+
+			var typemapDirectory = builder.Output.GetIntermediaryPath ("typemap");
+			var javaDirectory = Path.Combine (typemapDirectory, "java");
+			var javaFiles = Directory.GetFiles (javaDirectory, "*.java", SearchOption.AllDirectories);
+			var javaFilesList = Path.Combine (typemapDirectory, "java-files.txt");
+			Assert.IsNotEmpty (javaFiles, "First build should have generated pre-trim Java sources.");
+			FileAssert.Exists (javaFilesList, "First build should have persisted the pre-trim Java file list.");
+			File.Delete (javaFilesList);
+
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "No-op build should have succeeded.");
+			builder.Output.AssertTargetIsSkipped ("_GenerateTrimmableTypeMap");
+			foreach (var javaFile in javaFiles) {
+				FileAssert.Exists (javaFile, $"IncrementalClean should preserve {javaFile} when upgrading an obj directory without java-files.txt.");
+			}
+		}
+
+		[Test]
+		public void Build_WithTrimmableTypeMap_PublishTrimmed_MissingLinkedJavaListRegenerates ()
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
+
+			var typemapDirectory = builder.Output.GetIntermediaryPath ("typemap");
+			var linkedJavaDirectory = Path.Combine (typemapDirectory, "linked-java");
+			var linkedJavaFiles = Directory.GetFiles (linkedJavaDirectory, "*.java", SearchOption.AllDirectories);
+			var linkedJavaFilesList = Path.Combine (typemapDirectory, "linked-java-files.txt");
+			Assert.IsNotEmpty (linkedJavaFiles, "First build should have generated post-trim Java sources.");
+			FileAssert.Exists (linkedJavaFilesList, "First build should have persisted the post-trim Java file list.");
+			File.Delete (linkedJavaFilesList);
+
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Migration rebuild should have succeeded.");
+			builder.Output.AssertTargetIsNotSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
+			builder.Output.AssertTargetIsSkipped ("_CompileJava");
+			FileAssert.Exists (linkedJavaFilesList, "Post-trim generation should recreate linked-java-files.txt.");
+			foreach (var javaFile in linkedJavaFiles) {
+				FileAssert.Exists (javaFile, $"IncrementalClean should preserve {javaFile} until post-trim generation recreates its list.");
 			}
 		}
 
@@ -346,6 +414,7 @@ namespace Xamarin.Android.Build.Tests {
 
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Managed-only rebuild should have succeeded.");
 			builder.Output.AssertTargetIsNotSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
+			builder.Output.AssertTargetIsNotSkipped ("_RemoveRegisterAttributeCoreClr");
 			builder.Output.AssertTargetIsSkipped ("_CompileJava");
 			builder.Output.AssertTargetIsSkipped ("_CompileToDalvik");
 
@@ -377,6 +446,7 @@ namespace Xamarin.Android.Build.Tests {
 			builder.Output.AssertTargetIsNotSkipped ("_GenerateTrimmableTypeMap");
 			builder.Output.AssertTargetIsSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
 			builder.Output.AssertTargetIsNotSkipped ("_GenerateJavaStubs");
+			builder.Output.AssertTargetIsSkipped ("_RemoveRegisterAttributeCoreClr");
 			builder.Output.AssertTargetIsSkipped ("_CompileJava");
 			builder.Output.AssertTargetIsSkipped ("_CompileToDalvik");
 			Assert.IsTrue (postTrimAcwMap.SequenceEqual (ComputeFileHash (acwMap)), "The pre-trim pass should not overwrite the linked acw-map.txt.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -92,6 +92,9 @@ namespace Xamarin.Android.Build.Tests {
 			var javaFilesList = Path.Combine (typemapDirectory, "java-files.txt");
 			Assert.IsNotEmpty (javaFiles, "First build should have generated pre-trim Java sources.");
 			FileAssert.Exists (javaFilesList, "First build should have persisted the pre-trim Java file list.");
+			foreach (var path in File.ReadAllLines (javaFilesList)) {
+				Assert.IsTrue (Path.IsPathFullyQualified (path), $"The persisted Java path should be fully qualified: {path}");
+			}
 			File.Delete (javaFilesList);
 
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "No-op build should have succeeded.");
@@ -123,6 +126,9 @@ namespace Xamarin.Android.Build.Tests {
 			var linkedJavaFilesList = Path.Combine (typemapDirectory, "linked-java-files.txt");
 			Assert.IsNotEmpty (linkedJavaFiles, "First build should have generated post-trim Java sources.");
 			FileAssert.Exists (linkedJavaFilesList, "First build should have persisted the post-trim Java file list.");
+			foreach (var path in File.ReadAllLines (linkedJavaFilesList)) {
+				Assert.IsTrue (Path.IsPathFullyQualified (path), $"The persisted linked Java path should be fully qualified: {path}");
+			}
 			File.Delete (linkedJavaFilesList);
 
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Migration rebuild should have succeeded.");


### PR DESCRIPTION
## Summary

- update post-trim JCWs in place so unchanged Java sources keep stable timestamps
- give linked `acw-map.txt` and `ApplicationRegistration.java` a single post-trim owner
- make `_GenerateJavaStubs` react independently to pre-trim manifest changes and post-trim Java changes
- persist and validate the expected linked-Java output set, recovering missing or stale files
- preserve last known-good linked JCWs when generation fails
- make the legacy `llvm-ir` post-trimming assembly pipeline incremental
- reuse persisted TypeMap and Java output lists instead of wildcard/glob discovery
- persist and compare fully qualified Java paths so the lists compare correctly on Windows
- skip unchanged CoreCLR shrunk-assembly copies while preserving NativeAOT's always-run remap
- stop copying `*.dll.config` files next to the shrunk assemblies, since assembly configuration files are not supported

## Motivation

On a Release CoreCLR `dotnet new maui --sample-content` app, an ordinary managed source touch caused the trimmable path to delete and recreate all 566 linked JCWs. Their new timestamps forced javac and D8 to rebuild identical output:

| Scenario | `llvm-ir` | Trimmable before | This PR |
| --- | ---: | ---: | ---: |
| C# source touch | 50.73s | 68.32s | 52.31s |
| Android manifest touch | 5.63s | 39.74s | 10.97s |

With the generic universal-APK no-op fix from #12230 applied, the additional
trimmable-specific no-op changes in this PR reduce repeated `dotnet build`
from 4.58 seconds to approximately 3.0-3.5 seconds:

| Change | Real time |
| --- | ---: |
| #12230 only | 4.58s |
| Use `typemap-assemblies.txt` for ILLink inputs | 4.02s |
| Reuse post-trim Java list for `FileWrites` | 3.93s |
| Persist/reuse pre-trim Java list | 3.85s |
| Incremental CoreCLR shrunk-assembly copy | ~3.0-3.5s |

The manifest case also exposed an output-ownership bug. The pre-trim pass overwrote the final post-trim files while the post-trim target remained up to date:

| Output | Correct post-trim | Overwriting pre-trim |
| --- | ---: | ---: |
| `acw-map.txt` | 660,756 B / 6,186 lines | 4,927,847 B / 49,665 lines |
| `ApplicationRegistration.java` | 341 B / 12 lines | 413 B / 13 lines |

The overwritten registration source additionally registered `android.app.Application`, and its changed timestamp triggered javac and D8.

## Implementation

- CoreCLR trimmed pre-generation no longer writes the final ACW map or application-registration source.
- The post-trim pass uses content-based in-place updates instead of wiping `linked-java`.
- `_GenerateJavaStubs` depends on both producer stamps: pre-trim for the manifest/shared outputs and post-trim for linked JCWs.
- `linked-java-files.txt` records the expected JCW set. Missing or unexpected Java files, a missing ACW map, or a missing registration source invalidate the post-trim stamp.
- Stale pruning is suppressed after generation errors so a partial result cannot delete the previous valid output set.
- `_PostTrimmingPipeline` now has explicit inputs/outputs while a separate collector target continues to repopulate its dynamic assembly items.
- `_AddTrimmableTypeMapToLinker` consumes `typemap-assemblies.txt` instead of wildcarding the output directory.
- `java-files.txt` and `linked-java-files.txt` drive no-op `FileWrites`; migration fallbacks preserve outputs from older `obj` trees.
- Both Java lists persist `%(FullPath)` and the post-trim output base directory is normalized to forward slashes. Otherwise the recorded relative/backslash paths never matched the globbed actual paths on Windows, so every build saw the whole expected set as `_UnexpectedPostTrimJavaFile` and invalidated the stamp.
- CoreCLR uses an incremental shrunk-assembly copy target. NativeAOT retains the original always-run project-local remap/copy path.
- The trimmable path no longer copies `@(_ResolvedAssemblies->'%(Identity).config')` into the shrunk locations. Optional source files cannot be modeled as a reliable one-to-one incremental transform, and the copy has no observable effect: assembly configuration files are unsupported in .NET for Android (see [`OneDotNet.md`](https://github.com/dotnet/android/blob/main/Documentation/guides/OneDotNet.md#net-configuration-files)), and the assembly store's `config_data` is never assigned from the store nor handed to the runtime — its only use in `assembly-store.cc` / `embedded-assemblies.cc` is a `log_debug` message that always prints `nullptr`. Dropping it makes `_RemoveRegisterAttributeCoreClr` a clean one-to-one transform for every project instead of forcing config-file projects onto an always-run path.

## Validation

- Debug solution build
- `Build_WithTrimmableTypeMap_PublishTrimmed_IncrementalChangesAvoidUnnecessaryJavaWork`
- `Build_WithTrimmableTypeMap_PublishTrimmed_PostTrimJavaGenerationIsIncremental`
- `Build_WithTrimmableTypeMap_PublishTrimmed_DeletesStaleLinkedJavaWhenLinkedJavaShrinks`
- `Execute_MissingJavaSource_DoesNotPruneExistingOutput`
- `Build_WithTrimmableTypeMap_MissingJavaListPreservesGeneratedJava`
- `Build_WithTrimmableTypeMap_PublishTrimmed_MissingLinkedJavaListRegenerates`
- parameterized `Build_WithTrimmableTypeMap_IncrementalBuild`
- `AfterILLinkAdditionalStepsIsSkippedOnSecondBuild`
- `BuildBasicApplicationCheckConfigFiles`, `AppProjectTargetsDoNotBreak`
- API 36 arm64 emulator: both trimmable and `llvm-ir` apps launched and survived 100 Monkey events

## Follow-up

Clean trimmable builds still carry 85 managed TypeMap DLLs through ILLink, `ProcessAssemblies`, compression, and packaging; 49 are empty stubs. Reducing that file fan-out is a separate, larger optimization.

The `llvm-ir` path in `Microsoft.Android.Sdk.TypeMap.LlvmIr.targets` still copies `*.dll.config` files for the same non-reason; that copy can be removed separately.

Related to https://github.com/dotnet/android/issues/12184
