### PR TITLE
[build] fix `make prepare` on clean agents: empty `$(PkgMono_Unix)`

### DIFF
--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -14,7 +14,11 @@
          before Java.Interop's Prepare target scans for a JDK. Otherwise its JdkInfo task
          falls back to a system-installed JDK (e.g. the JDK 25 preinstalled on hosted
          macOS images), which can be incompatible with our Gradle version. -->
-    <MSBuild Projects="$(_Root)src\openjdk\openjdk.csproj" Properties="Configuration=$(Configuration)" Targets="Restore;Build" />
+    <!-- Build out of process so NuGet-generated props are evaluated after restore. -->
+    <Exec
+        Command="&quot;$(DotNetPreviewTool)&quot; build &quot;$(_Root)src\openjdk\openjdk.csproj&quot; -p:Configuration=$(Configuration) -bl:$(_BinlogPathPrefix)-openjdk.binlog"
+        WorkingDirectory="$(_Root)"
+    />
   </Target>
 
   <Target Name="PrepareJavaInterop"

--- a/build-tools/scripts/MonoUnixNative.targets
+++ b/build-tools/scripts/MonoUnixNative.targets
@@ -13,6 +13,16 @@
     <_MonoUnixOutputDylib>$(OutputPath)\libMono.Unix.dylib</_MonoUnixOutputDylib>
   </PropertyGroup>
 
+  <!-- `$(PkgMono_Unix)` comes from `obj\*.nuget.g.props`, so it is only set if the project was
+       evaluated after restore. Fail clearly instead of copying `/runtimes/...` paths. -->
+  <Target Name="_ValidateMonoUnixPackagePath"
+      BeforeTargets="PrepareForBuild;_MakeMonoUnixFatBinariesOSX">
+    <Error
+        Text="`%24(PkgMono_Unix)` is not set. Build this project with `dotnet build` so NuGet-generated props are evaluated after restore."
+        Condition=" '$(PkgMono_Unix)' == '' "
+    />
+  </Target>
+
   <Target Name="_MakeMonoUnixFatBinariesOSX"
       Inputs="@(_MonoUnixDylib)"
       Outputs="$(_MonoUnixOutputDylib)">

--- a/build-tools/scripts/Prepare.proj
+++ b/build-tools/scripts/Prepare.proj
@@ -19,15 +19,14 @@
         Text="The specified `%24(AndroidToolchainDirectory)` '$(AndroidToolchainDirectory)' contains a space. Android NDK commands do not support this. Please create a Configuration.Override.props file that sets the AndroidToolchainDirectory property to a different path."
         Condition=" '$(HostOS)' == 'Windows' And $(AndroidToolchainDirectory.Contains (' '))"
     />
-    <MSBuild
-        Projects="$(_TopDir)\build-tools\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj"
-        Targets="Restore;Build"
-        Properties="Configuration=$(Configuration)"
+    <!-- Build out of process so NuGet-generated props are evaluated after restore. -->
+    <Exec
+        Command="&quot;$(DotNetPreviewTool)&quot; build &quot;$(_TopDir)\build-tools\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj&quot; -p:Configuration=$(Configuration) -bl:$(_BinlogPathPrefix)-bootstrap-tasks.binlog"
+        WorkingDirectory="$(_TopDir)"
     />
-    <MSBuild
-        Projects="$(_TopDir)\src\workloads\workloads.csproj"
-        Targets="Restore;Build"
-        Properties="Configuration=$(Configuration)"
+    <Exec
+        Command="&quot;$(DotNetPreviewTool)&quot; build &quot;$(_TopDir)\src\workloads\workloads.csproj&quot; -p:Configuration=$(Configuration) -bl:$(_BinlogPathPrefix)-workloads.binlog"
+        WorkingDirectory="$(_TopDir)"
     />
     <CallTarget Targets="PrepareJavaInterop" />
     <MSBuild


### PR DESCRIPTION
## Summary

The `Xamarin.Android Nightly` build fails in `make jenkins` -> `make prepare`:

```
/Users/builder/.dotnet/sdk/10.0.302/Microsoft.Common.CurrentVersion.targets(5397,5):
  error MSB3030: Could not copy the file "/runtimes/linux-x64/native/libMono.Unix.so"
  because it was not found.
  [.../build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj]
```

The leading bare `/` shows `$(PkgMono_Unix)` evaluated to an empty string. The package content is present; the path property was simply never set.

## Root cause

`$(PkgMono_Unix)` comes from `GeneratePathProperty="true"` on the `Mono.Unix` `PackageReference` in `MSBuildReferences.projitems`. NuGet writes it into `obj\*.nuget.g.props`, which only a *fresh project evaluation* picks up. `build-tools/scripts/Prepare.proj` invoked BootstrapTasks with:

```xml
<MSBuild Projects="...BootstrapTasks.csproj" Targets="Restore;Build" />
```

The `MSBuild` task evaluates a project once and runs both targets against that single project instance, so unlike the `-restore` switch it never re-evaluates between `Restore` and `Build`. With no pre-existing `obj/`, the static `None` item in `MonoUnixNative.targets` therefore resolved to a root-relative path.

Before 94e483376 the `prepare` target ran `dotnet build Xamarin.Android.BootstrapTasks.sln`, whose implicit restore *does* re-evaluate — which is why this only regressed now, and only on clean agents. A warm `obj/` on a dev machine hides it.

## Fix

Build these projects out of process with `dotnet build`, matching the approach in #12199. The change to `Prepare.proj` here is identical to that PR's, so the two will not conflict. `dotnet build` restores in a separate evaluation and also writes a `.binlog` per project, so the next `make prepare` failure is diagnosable from CI artifacts.

`PrepareOpenJDK` in `DotNet.targets` gets the same treatment, since it had the identical latent bug.

Also adds `_ValidateMonoUnixPackagePath` to `MonoUnixNative.targets` so an unset `$(PkgMono_Unix)` reports what is actually wrong rather than an `MSB3030` on a nonsense path. It runs `BeforeTargets="PrepareForBuild"` so it fires before `_CopyOutOfDateSourceItemsToOutputDirectory` can attempt the copy.

## Testing

Verified locally with a clean `bin/` and `obj/`:

- The old `Targets="Restore;Build"` pattern reproduces the failure — `D:\runtimes\...` on Windows, the same empty-prefix bug as CI's `/runtimes/...`.
- With the guard in place, that same pattern now reports only:
  ```
  error : `$(PkgMono_Unix)` is not set. Build this project with `dotnet build` so
  NuGet-generated props are evaluated after restore.
  ```
- `dotnet build` of BootstrapTasks succeeds with 0 warnings and 0 errors, and copies the real `libMono.Unix.so` (120768 bytes, matching the file in the `Mono.Unix` package) plus `libMono.Unix.dylib`.