### PR TITLE
[Native] Remove unused field weak_handle

### DIFF
--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniObjectReferenceControlBlock.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniObjectReferenceControlBlock.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Java.Interop;
 
+[StructLayout (LayoutKind.Sequential)]
 internal struct JniObjectReferenceControlBlock {
 	public	IntPtr  handle;
 	public  int     handle_type;

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniObjectReferenceControlBlock.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniObjectReferenceControlBlock.cs
@@ -6,7 +6,6 @@ namespace Java.Interop;
 internal struct JniObjectReferenceControlBlock {
 	public	IntPtr  handle;
 	public  int     handle_type;
-	public  IntPtr  weak_handle;
 	public  int     refs_added;
 
 	public  static  readonly    int Size    = Marshal.SizeOf<JniObjectReferenceControlBlock>();

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
@@ -312,16 +312,14 @@ static class JavaMarshalRegisteredPeers
 			}
 		}
 
-#pragma warning disable CS0649 // Field 'JavaMarshalRegisteredPeers.HandleContext.JniObjectReferenceControlBlock.*' is never assigned to, and will always have its default value 0
 		// This is an internal mirror of the Java.Interop.JniObjectReferenceControlBlock
+		[StructLayout (LayoutKind.Sequential)]
 		private struct JniObjectReferenceControlBlock
 		{
 			public IntPtr handle;
 			public int handle_type;
-			public IntPtr weak_handle;
 			public int refs_added;
 		}
-#pragma warning restore CS0649
 
 		public static GCHandle GetAssociatedGCHandle (HandleContext* context)
 		{

--- a/src/native/clr/include/host/gc-bridge.hh
+++ b/src/native/clr/include/host/gc-bridge.hh
@@ -10,7 +10,6 @@ struct JniObjectReferenceControlBlock
 {
 	jobject handle;
 	int handle_type;
-	jobject weak_handle;
 	int refs_added;
 };
 

--- a/src/native/mono/monodroid/osbridge.cc
+++ b/src/native/mono/monodroid/osbridge.cc
@@ -79,7 +79,6 @@ OSBridge::clear_mono_java_gc_bridge_info ()
 		}
 		control_block->handle = nullptr;
 		control_block->handle_type = 0;
-		control_block->weak_handle = nullptr;
 		control_block->refs_added = 0;
 	}
 }
@@ -506,16 +505,10 @@ OSBridge::take_global_ref_jni (JNIEnv *env, MonoObject *obj)
 			_monodroid_gref_inc ();
 		}
 	} else if (Logger::gc_spew_enabled ()) [[unlikely]] {
-		void   *key_handle  = nullptr;
-		if (control_block->weak_handle != nullptr) {
-			key_handle = control_block->weak_handle;
-		}
-
 		MonoClass *klass = mono_object_get_class (obj);
 		char *message = Util::monodroid_strdup_printf (
-				"handle %p/W; key_handle %p; MCW type: `%s.%s`: was collected by a Java GC",
+				"handle %p/W; MCW type: `%s.%s`: was collected by a Java GC",
 				weak,
-				key_handle,
 				mono_class_get_namespace (klass),
 				mono_class_get_name (klass));
 		_monodroid_gref_log (message);
@@ -1013,21 +1006,16 @@ OSBridge::gc_cross_references (int num_sccs, MonoGCBridgeSCC **sccs, int num_xre
 
 				JniObjectReferenceControlBlock *control_block = get_gc_control_block_for_object (obj);
 				jobject handle      = 0;
-				void   *key_handle  = nullptr;
 				if (control_block != nullptr) {
 					handle = control_block->handle;
-					if (control_block->weak_handle != nullptr) {
-						key_handle = control_block->weak_handle;
-					}
 				}
 				MonoClass *klass = mono_object_get_class (obj);
 				log_info (LOG_GC,
-					"\tobj {:p} [{}::{}] handle {:p} key_handle {:p}",
+					"\tobj {:p} [{}::{}] handle {:p}",
 					reinterpret_cast<void*>(obj),
 					optional_string (mono_class_get_namespace (klass)),
 					optional_string (mono_class_get_name (klass)),
-					reinterpret_cast<void*>(handle),
-					key_handle
+					reinterpret_cast<void*>(handle)
 				);
 			}
 		}

--- a/src/native/mono/monodroid/osbridge.hh
+++ b/src/native/mono/monodroid/osbridge.hh
@@ -46,7 +46,6 @@ namespace xamarin::android::internal
 		{
 			jobject handle;
 			int     handle_type;
-			jobject weak_handle;
 			int     refs_added;
 		};
 


### PR DESCRIPTION
This field on `JniObjectReferenceControlBlock` was never written to. The only time it was read was for debug logging.
This shrinks the size of the control block from [32 to 16 bytes](https://godbolt.org/z/eMYddx14T) on 64-bit platforms.

While I was at it, I added the the `StructLayout` attribute to the `JniObjectReferenceControlBlock` in C#. This makes the warning suppression for CS0649 no longer necessary.

----

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [ ] Unit tests
