### PR TITLE
[ci] cache Gradle distributions on MSBuild test agents

### DIFF
--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -631,6 +631,12 @@ stages:
         installTestSlicer: true
         use1ESTemplate: false
 
+    # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
+    # Gradle distribution and Maven dependencies on first use.
+    - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+      parameters:
+        xaSourcePath: $(System.DefaultWorkingDirectory)
+
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
@@ -676,6 +682,12 @@ stages:
         useAgentJdkPath: false
         installTestSlicer: true
         use1ESTemplate: false
+
+    # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
+    # Gradle distribution and Maven dependencies on first use.
+    - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+      parameters:
+        xaSourcePath: $(System.DefaultWorkingDirectory)
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -290,6 +290,12 @@ stages:
         installTestSlicer: true
         use1ESTemplate: false
 
+    # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
+    # Gradle distribution and Maven dependencies on first use.
+    - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+      parameters:
+        xaSourcePath: $(System.DefaultWorkingDirectory)
+
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
@@ -335,6 +341,12 @@ stages:
         useAgentJdkPath: false
         installTestSlicer: true
         use1ESTemplate: false
+
+    # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
+    # Gradle distribution and Maven dependencies on first use.
+    - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+      parameters:
+        xaSourcePath: $(System.DefaultWorkingDirectory)
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/cache-gradle.yaml
+++ b/build-tools/automation/yaml-templates/cache-gradle.yaml
@@ -18,7 +18,7 @@
 # See: https://learn.microsoft.com/azure/devops/pipelines/release/caching
 
 parameters:
-  xaSourcePath: $(System.DefaultWorkingDirectory)
+  xaSourcePath: $(System.DefaultWorkingDirectory)/android
 
 steps:
 - script: |

--- a/build-tools/automation/yaml-templates/cache-gradle.yaml
+++ b/build-tools/automation/yaml-templates/cache-gradle.yaml
@@ -1,16 +1,30 @@
 # Shared Gradle dependency cache template
 # Caches Gradle downloads between pipeline runs to avoid transient network
-# failures when resolving Maven dependencies.
+# failures when resolving Maven dependencies or when downloading the Gradle
+# distribution itself.
+#
+# Two caches are used, because they have different invalidation rules:
+#
+#   * $HOME/.gradle/caches        - resolved Maven dependencies. Keyed on the
+#                                   Gradle build files that declare them.
+#   * $HOME/.gradle/wrapper/dists - the Gradle distribution .zip downloaded by
+#                                   the Gradle wrapper. Keyed only on
+#                                   gradle-wrapper.properties.
+#
+# Without the second cache every agent re-downloads the distribution from
+# services.gradle.org (which redirects to github.com). A transient HTTP 5xx
+# there fails `gradlew` for every Gradle test running on that agent.
 #
 # See: https://learn.microsoft.com/azure/devops/pipelines/release/caching
 
 parameters:
-  xaSourcePath: $(System.DefaultWorkingDirectory)/android
+  xaSourcePath: $(System.DefaultWorkingDirectory)
 
 steps:
 - script: |
     git log -1 --format=%H external/Java.Interop > $(Agent.TempDirectory)/java-interop-submodule-hash.txt
     echo "##vso[task.setvariable variable=GRADLE_CACHE_DIR]$HOME/.gradle/caches"
+    echo "##vso[task.setvariable variable=GRADLE_DISTS_DIR]$HOME/.gradle/wrapper/dists"
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: prepare Gradle cache variables
   condition: ne(variables['Agent.OS'], 'Windows_NT')
@@ -19,6 +33,8 @@ steps:
     git log -1 --format=%H external/Java.Interop > $(Agent.TempDirectory)/java-interop-submodule-hash.txt
     $gradleCacheDir = Join-Path $env:USERPROFILE ".gradle\caches"
     Write-Host "##vso[task.setvariable variable=GRADLE_CACHE_DIR]$gradleCacheDir"
+    $gradleDistsDir = Join-Path $env:USERPROFILE ".gradle\wrapper\dists"
+    Write-Host "##vso[task.setvariable variable=GRADLE_DISTS_DIR]$gradleDistsDir"
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: prepare Gradle cache variables
   condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -30,3 +46,11 @@ steps:
     restoreKeys: |
       "gradle" | "v1" | "$(Agent.OS)"
     path: $(GRADLE_CACHE_DIR)
+
+- task: Cache@2
+  displayName: cache Gradle distributions
+  inputs:
+    key: '"gradle-dists" | "v1" | "$(Agent.OS)" | ${{ parameters.xaSourcePath }}/build-tools/gradle/gradle/wrapper/gradle-wrapper.properties'
+    restoreKeys: |
+      "gradle-dists" | "v1" | "$(Agent.OS)"
+    path: $(GRADLE_DISTS_DIR)

--- a/build-tools/automation/yaml-templates/cache-gradle.yaml
+++ b/build-tools/automation/yaml-templates/cache-gradle.yaml
@@ -50,7 +50,9 @@ steps:
 - task: Cache@2
   displayName: cache Gradle distributions
   inputs:
+    # No `restoreKeys` fallback: a partial restore would bring back a
+    # distribution the wrapper cannot use, and Cache@2 would then save the old
+    # and new distributions together under the new key, growing the cache on
+    # every version bump. An exact-key miss re-downloads only the new version.
     key: '"gradle-dists" | "v1" | "$(Agent.OS)" | ${{ parameters.xaSourcePath }}/build-tools/gradle/gradle/wrapper/gradle-wrapper.properties'
-    restoreKeys: |
-      "gradle-dists" | "v1" | "$(Agent.OS)"
     path: $(GRADLE_DISTS_DIR)

--- a/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
@@ -43,12 +43,6 @@ jobs:
       commit: ${{ parameters.commit }}
       use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
-  # AndroidGradleProjectTests invoke the Gradle wrapper, which downloads the
-  # Gradle distribution and Maven dependencies on first use.
-  - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
-    parameters:
-      xaSourcePath: ${{ parameters.xaSourcePath }}
-
   - task: DownloadPipelineArtifact@2
     inputs:
       artifactName: $(TestAssembliesArtifactName)

--- a/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
@@ -43,6 +43,12 @@ jobs:
       commit: ${{ parameters.commit }}
       use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
+  # AndroidGradleProjectTests invoke the Gradle wrapper, which downloads the
+  # Gradle distribution and Maven dependencies on first use.
+  - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+    parameters:
+      xaSourcePath: ${{ parameters.xaSourcePath }}
+
   - task: DownloadPipelineArtifact@2
     inputs:
       artifactName: $(TestAssembliesArtifactName)


### PR DESCRIPTION
## Summary

Internal build [3030679](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030679) had six `AndroidGradleProjectTests` failures spread across two macOS test agents (`Xamarin.Android.Build.Tests - macOS-9` and `macOS-10`). Every one reported:

```
error XAGRDL1000: Executable 'gradlew' not found in project directory
'.../temp/gradle/BuildAppNativeAOT/'
```

The real failure was upstream, in the Gradle wrapper invoked by `AndroidGradleProject.Create()`:

```
Running: .../build-tools/gradle/gradlew init --dsl kotlin ... --no-daemon
Exception in thread "main" java.io.IOException: Server returned HTTP response code: 504 for URL:
  https://github.com/gradle/gradle-distributions/releases/download/v9.4.1/gradle-9.4.1-bin.zip
Exit Code: 1
```

`services.gradle.org` redirects distribution downloads to GitHub releases, and GitHub returned a transient **504** on those two agents. Every Gradle test on those agents failed; the same test cases passed on all other shards.

Two things made a single transient 504 fatal:

* `cache-gradle.yaml` only cached `$HOME/.gradle/caches`. The Gradle wrapper stores downloaded distributions in `$HOME/.gradle/wrapper/dists`, which was never cached — so every agent re-downloaded the distribution from GitHub on every run.
* `run-msbuild-tests.yaml` did not include `cache-gradle.yaml` at all, even though `AndroidGradleProjectTests` runs the Gradle wrapper there. The MSBuild test agents had no Gradle caching whatsoever.

## Changes

* `cache-gradle.yaml` gains a second `Cache@2` task for `$HOME/.gradle/wrapper/dists`, keyed only on `build-tools/gradle/gradle/wrapper/gradle-wrapper.properties` since that file alone determines the distribution version. The existing dependency cache keeps its broader key.
* `run-msbuild-tests.yaml` now includes `cache-gradle.yaml`, after `setup-test-environment.yaml` (which performs the checkout the cache key globs against).

## Notes

This is complementary to #12199. That PR removes the `gradle init` call and the extra 9.3.1 distribution download, but the repo wrapper's own distribution (9.4.1) is still fetched from `services.gradle.org` on first use, so caching it is still needed.

The Linux `Xamarin.Android.Build.Tests` jobs are filtered to `BuildTest`/`PackagingTest`/`XASdkTests`/`AndroidDependenciesTests` and do not run `AndroidGradleProjectTests`, so they are left alone.

## Testing

* Both templates parse as valid YAML.
* Caching behavior is only observable on CI; the effect should be a `cache Gradle distributions` hit on subsequent MSBuild test runs.