### PR TITLE
[tests] Fix `TimeZoneInfoTests` fixture: add missing `[TestFixtureSource]`

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/TimeZoneInfoTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/TimeZoneInfoTests.cs
@@ -11,6 +11,7 @@ using Xamarin.ProjectTools;
 namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
+	[TestFixtureSource (nameof (Get_Fixture_Args))]
 	[Category ("TimeZoneInfo")]
 	[NonParallelizable]
 	public class TimeZoneInfoTests : DeviceTest


### PR DESCRIPTION
## Why

The `Test TimeZoneInfo` stage of the nightly pipeline fails completely: **all 197 tests x 3 lanes** fail with the identical error:

```
OneTimeSetUp: No suitable constructor was found
```

This is NUnit failing to construct the test fixture, not a device, emulator, or timezone problem.

## Root cause

`tests/MSBuildDeviceIntegration/Tests/TimeZoneInfoTests.cs` declares a `Get_Fixture_Args ()` provider method and a parameterized constructor:

```csharp
[TestFixture]                                      // parameterless
[Category ("TimeZoneInfo")]
[NonParallelizable]
public class TimeZoneInfoTests : DeviceTest
{
    static IEnumerable<object[]> Get_Fixture_Args ()  // never referenced
    ...
    public TimeZoneInfoTests (AndroidRuntime runtime) // requires an argument
```

but is annotated only with a bare `[TestFixture]`. The provider is never referenced, so NUnit tries the parameterless constructor, finds none, and fails `OneTimeSetUp` for every test in the fixture.

The sibling `LocalizationTests` uses the identical pattern and is annotated correctly with `[TestFixtureSource (nameof (Get_Fixture_Args))]`. This change makes `TimeZoneInfoTests` match it exactly.

This is a pre-existing bug on `main`. It stayed hidden because recent nightly builds were failing at `make prepare` before any test ran.

## Audit

A scripted scan of all 100 NUnit `[TestFixture]` classes under `tests/` looked for any fixture whose only constructors take parameters but which lacks `[TestFixtureSource]` / `[TestFixture(...)]`, plus any provider method that is defined but never referenced.

Against `main`, the scan reports exactly one hit:

```
BROKEN: tests\MSBuildDeviceIntegration\Tests\TimeZoneInfoTests.cs | TimeZoneInfoTests | ['AndroidRuntime runtime']
```

With this fix applied it reports `(none)`. Only four fixtures in the repo have parameterized constructors; the other three (`LocalizationTests`, `BundleToolTests`, `BundleToolNoAbiSplitTests`) already have correct `[TestFixtureSource]` attributes, and `JavaListTest` correctly uses `[TestFixture (typeof (...))]`.

The fixture args themselves are left unchanged: `Get_Fixture_Args ()` yields `CoreCLR` and `NativeAOT` with `isRelease = runtime == AndroidRuntime.NativeAOT`, which is identical to `LocalizationTests`. Worth noting for a follow-up that neither fixture covers `MonoVM`.

## Verification

These are device tests, so they cannot execute locally. Instead the fixture is proven to construct by having NUnit discover the tests without running them, using `dotnet vstest MSBuildDeviceIntegration.dll /ListFullyQualifiedTests`. (`dotnet test --list-tests` is not useful here because it prints method names with no fixture prefix.)

Before:

```
Xamarin.Android.Build.Tests.TimeZoneInfoTests.CheckTimeZoneInfoIsCorrectNode1("Africa/Abidjan")
Xamarin.Android.Build.Tests.TimeZoneInfoTests.CheckTimeZoneInfoIsCorrectNode1("Africa/Ceuta")
--- count --- 1182
--- runtime-suffixed count --- 0
```

After:

```
Xamarin.Android.Build.Tests.TimeZoneInfoTests(CoreCLR).CheckTimeZoneInfoIsCorrectNode1("Africa/Abidjan")
Xamarin.Android.Build.Tests.TimeZoneInfoTests(CoreCLR).CheckTimeZoneInfoIsCorrectNode1("Africa/Ceuta")
CoreCLR: 1182   NativeAOT: 1182   unsuffixed: 0
```

1182 unparameterized cases become 2364 across two correctly parameterized fixture instances, with zero unsuffixed cases remaining.

## Checklist

- [x] Useful description of *why the change is necessary*
- [ ] Links to issues fixed - N/A, found via nightly build 14775838
- [x] Unit tests - this change repairs existing tests; no new tests are appropriate