### PR TITLE
[Xamarin.Android.Build.Tasks] mostly R2R the main assembly

### DIFF
--- a/.github/instructions/msbuild.instructions.md
+++ b/.github/instructions/msbuild.instructions.md
@@ -1,0 +1,189 @@
+---
+applyTo: "**/*.targets,**/*.props,**/*.proj,**/*.csproj"
+---
+
+# MSBuild conventions
+
+Rules for authoring MSBuild targets, wherever they live — `.targets`, `.props`, `.proj`, and the
+18 `.csproj` files in this repo that declare their own `<Target>`. They matter most for the product
+targets under `src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/` and
+`src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets`, which ship to customers.
+
+## Every target that produces a file must be incremental
+
+Any target invoking a task that writes a file needs `Inputs` and `Outputs`. A target without them
+re-runs on every build, which shows up directly in customer inner-loop build times.
+
+```xml
+<Target Name="_AndroidGenerateSomething"
+    AfterTargets="_SomeUpstreamTarget"
+    DependsOnTargets="_AndroidGenerateSomethingInputs"
+    Inputs="@(_AndroidSomethingInput)"
+    Outputs="$(_AndroidSomethingOutput)">
+  <GenerateSomething Input="@(_AndroidSomethingInput)" OutputFile="$(_AndroidSomethingOutput)" />
+</Target>
+```
+
+### `Outputs` should be the real output file
+
+Write the output file directly from the task and use that file as `Outputs`. Do **not** reach for a
+temp file + `Files.CopyIfChanged` + a stamp file unless there is a concrete reason the timestamp
+must be preserved (e.g. the file feeds another incremental target that would otherwise cascade).
+
+`CopyIfChanged` deliberately leaves the timestamp alone when content is unchanged, which means the
+real output can never serve as `Outputs` — you are then forced to invent a
+`$(...)Stamp` file, `<MakeDir/>` it, `<Touch/>` it, and add it to `@(FileWrites)`. That is a lot of
+machinery to buy back something you did not need. Prefer the simple version.
+
+## Compute `Inputs` in a `<TargetName>Inputs` target
+
+Do not compute the input `ItemGroup` inside the target that consumes it — `Inputs` is evaluated
+before the target body runs, so the item group would be empty on the first evaluation. Put it in a
+separate target pulled in via `DependsOnTargets`, named `<TargetName>Inputs`:
+
+```xml
+<Target Name="_AndroidGenerateSomethingInputs">
+  <ItemGroup>
+    <_AndroidSomethingInput Include="@(_SomeBigList)" Condition=" '%(Filename)' == '$(TargetName)' " />
+  </ItemGroup>
+</Target>
+```
+
+`DependsOnTargets` targets run **before** the parent target's `Condition`, `Inputs`, and `Outputs`
+are evaluated, so this works.
+
+### Output paths belong in the same target
+
+`$(TargetName)`, `$(TargetFileName)`, `$(IntermediateOutputPath)`, `$(OutDir)` and friends are
+**not final** when our `.targets` files are evaluated — `$(TargetName)` is often blank, and
+`$(IntermediateOutputPath)` has not yet had the RID/TFM subdirectory appended. A top-level
+`<PropertyGroup>` computing an output path from them silently produces garbage such as
+`obj\Release\.mibc` instead of `obj\Release\net11.0\android-arm64\MyApp.mibc`.
+
+Compute output paths in a `<PropertyGroup>` inside the `<TargetName>Inputs` target alongside the
+input items. `DependsOnTargets` guarantees it runs before the parent's `Outputs` is evaluated.
+
+```xml
+<Target Name="_AndroidGenerateSomethingInputs">
+  <PropertyGroup>
+    <_AndroidSomethingOutput>$(IntermediateOutputPath)$(TargetName).ext</_AndroidSomethingOutput>
+  </PropertyGroup>
+  <ItemGroup>
+    ...
+  </ItemGroup>
+</Target>
+```
+
+### `Inputs` must be the actual inputs, not a superset
+
+Never list a whole upstream item group as `Inputs` when the task only consumes one item from it.
+Doing so makes the target re-run whenever *any* unrelated file in that list changes. Filter first,
+then use the filtered item group as `Inputs`.
+
+Filter in MSBuild — using `%(Filename)` batching and `@(X->Distinct())` — rather than
+passing everything to the task and filtering in C#. Prefer the simplest well-known property for the
+comparison (`%(Filename)` vs `$(TargetName)`, not `%(Filename)%(Extension)` vs `$(TargetFileName)`).
+Keep the task's surface area minimal; a task that takes `[Required] string MainAssembly` is easier
+to reason about and unit test than one that takes an `ITaskItem[]` plus a filter property.
+
+## Item groups in a skipped target *are* still evaluated
+
+If a target is skipped as **up to date** (its `Inputs` are older than its `Outputs`), MSBuild still
+evaluates the `<ItemGroup>` and `<PropertyGroup>` elements inside it. Downstream targets see those
+items. So do **not** split item population into a second `AfterTargets` target "so it still runs on
+incremental builds" — that is unnecessary indirection.
+
+```xml
+<Target Name="_AndroidGenerateSomething" Inputs="..." Outputs="...">
+  <GenerateSomething ... />
+  <!-- Still evaluated when the target is skipped as up to date. -->
+  <ItemGroup Condition=" Exists('$(_AndroidSomethingOutput)') ">
+    <_SomeConsumerList Include="$(_AndroidSomethingOutput)" />
+    <FileWrites Include="$(_AndroidSomethingOutput)" />
+  </ItemGroup>
+</Target>
+```
+
+This is **not** true for a target skipped by `Condition="false"` — that skips the entire target
+body, item groups included.
+
+## Read late-set properties from a target `Condition`, never at evaluation time
+
+Properties set by NuGet `buildTransitive` `.targets` (from packages like `Microsoft.Maui.Controls`)
+are assigned **after** our `.targets` are evaluated. A top-level `<PropertyGroup>` that reads such a
+property will see it blank.
+
+```xml
+<!-- WRONG: $(PublishReadyToRunCrossgen2ExtraArgs) may not be set yet. -->
+<PropertyGroup>
+  <_AndroidDoThing Condition=" $(PublishReadyToRunCrossgen2ExtraArgs.Contains('...')) ">true</_AndroidDoThing>
+</PropertyGroup>
+
+<!-- RIGHT: evaluated when the target runs, after everything is assigned. -->
+<Target Name="_AndroidDoThing" Condition=" $(PublishReadyToRunCrossgen2ExtraArgs.Contains('...')) ">
+```
+
+A helper property that merely aliases a condition is usually not worth it — inline the check in the
+target's `Condition`.
+
+## A target's `Condition` is evaluated *before* its `DependsOnTargets`
+
+So a `Condition` can never read a property that one of its dependencies sets — the dependency is
+never built. This is tempting when a decision has several inputs and you want to resolve it into a
+single property in the `Inputs` helper target; it silently never runs.
+
+Giving the helper the same `AfterTargets`/`BeforeTargets` hooks does work (targets sharing a hook
+run in declaration order), but it makes correctness depend on declaration order. Prefer keeping the
+whole decision inline in the `Condition`, even when it needs nested parentheses.
+
+## Test item emptiness with `->Count()`
+
+`'@(SomeItem)' == ''` batches the whole list into a string just to see whether it is empty. Use
+`'@(SomeItem->Count())' == '0'` instead.
+
+## Don't invent public properties
+
+Prefer keying off properties that already exist. Do not add a public `$(AndroidFooBar)` opt-in/
+opt-out knob unless a customer genuinely needs it — every public property is documentation,
+localization, and a compatibility commitment.
+
+When an internal escape hatch is needed (typically so a test can force a codepath), add a
+**private** `$(_Android*)` property that is **blank by default** — no `<PropertyGroup>` default for
+it anywhere — and `or` it into the existing condition:
+
+```xml
+Condition=" '$(PublishReadyToRun)' == 'true' and '$(_AndroidReadyToRunMainAssembly)' != 'false' and ('$(_AndroidReadyToRunMainAssembly)' == 'true' or ($(PublishReadyToRunCrossgen2ExtraArgs.Contains('--partial')) and '@(PublishReadyToRunPgoFiles->Count())' == '0')) "
+```
+
+Give the hatch three states rather than two: `true` forces the codepath on, `false` forces it off,
+and blank means "decide automatically". A force-on-only hatch leaves no way to build the baseline
+it is meant to be compared against.
+
+Public properties go in `Documentation/docs-mobile/building-apps/build-properties.md`; private
+`_`-prefixed ones must not.
+
+## Naming
+
+* Private targets, properties, and items are `_Android`-prefixed: `_AndroidGenerateMibcProfile`,
+  `$(_AndroidMibcProfile)`, `@(_AndroidMibcMainAssembly)`.
+* An `Inputs`-computing helper target is `<TargetName>Inputs`, not `_AndroidPrepareXxx` or similar.
+* Names should say what the thing *is*, not how it is used.
+
+## `--` is illegal inside an XML comment
+
+Writing `--partial`, `--map`, or any `--` sequence inside an `<!-- ... -->` block produces an XML
+parse error. Escape it, reword it, or move it out of the comment. Always validate after editing:
+
+```powershell
+try { [xml]$x = Get-Content path\to\File.targets; "ok" } catch { "INVALID: $($_.Exception.Message)" }
+```
+
+## Other verified semantics
+
+* If `Inputs` evaluates to empty and `Outputs` is non-empty, MSBuild skips the target for having no
+  inputs. Guard accordingly if an empty input list is legitimate.
+* `$(UndefinedProperty.Contains('x'))` safely evaluates to `false`; no null check is needed.
+* `@(X->Distinct())` is a valid item function and is the right way to dedupe overlapping item lists.
+* Add generated files to `@(FileWrites)` so `Clean` removes them.
+* Use `TaskFactory="TaskHostFactory"` and `Runtime="NET"` on `<UsingTask/>` for **internal**
+  build-time tasks (`xa-prep-tasks`, `BootstrapTasks`) only — never on tasks shipped to customers.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
@@ -7,6 +7,8 @@ This file contains the CoreCLR-specific MSBuild logic for .NET for Android.
 -->
 <Project>
 
+  <UsingTask TaskName="Xamarin.Android.Tasks.GenerateMibcProfile" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+
   <!-- Default property values for CoreCLR -->
   <PropertyGroup>
     <_AndroidRuntimePackRuntime>CoreCLR</_AndroidRuntimePackRuntime>
@@ -47,6 +49,71 @@ This file contains the CoreCLR-specific MSBuild logic for .NET for Android.
       <ResolvedRuntimePack
           PackageDirectory="$(_DotnetRuntimeRepo)/artifacts/bin/microsoft.netcore.app.runtime.$(RuntimeIdentifier)/$(_DotNetRuntimeConfiguration)"
           Condition=" '%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' And Exists('$(_DotnetRuntimeRepo)/artifacts/bin/microsoft.netcore.app.runtime.$(RuntimeIdentifier)/$(_DotNetRuntimeConfiguration)') " />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    The crossgen2 "partial" switch restricts ReadyToRun compilation to the methods found in the
+    profile data passed via "mibc".  That is a good trade for framework assemblies, but it means
+    none of the application's own code gets precompiled unless it appears in a profile.
+
+    Generate a MIBC profile naming the methods of the main app assembly so that it is
+    ReadyToRun compiled, while the rest of the app remains partially compiled.
+
+    Everything below deliberately sticks to public MSBuild names.  `ILLink` and
+    `CreateReadyToRunImages` bracket the window where the trimmed assembly exists but crossgen2
+    has not run yet, and `@(PublishReadyToRunPgoFiles)` is the supported way to hand a profile to
+    crossgen2; `_PrepareForReadyToRunCompilation` copies it into its own private item group.
+
+    `$(_AndroidReadyToRunMainAssembly)` decides whether the profile is generated, in order:
+
+      1. An explicit `true` or `false` always wins.
+      2. Otherwise off when the app supplies its own `@(PublishReadyToRunPgoFiles)`.
+      3. Otherwise on when crossgen2 is running in partial mode.
+
+    An app that supplies its own profile, e.g. one recorded from a real startup trace with
+    `dotnet-pgo`, has already said exactly what it wants compiled, and the whole point of partial
+    mode is to compile only that.  Naming every method of the app assembly on top of it would
+    swamp that profile, so leave those builds alone.  Note this deliberately keys off the public
+    item: MAUI's own framework profiles go into `@(_ReadyToRunPgoFiles)`, so they do not
+    suppress this.
+  -->
+  <!-- $(TargetName) and $(IntermediateOutputPath) are not final until well after this file is
+       evaluated, so both the profile path and the main assembly are computed inside a target. -->
+  <Target Name="_AndroidGenerateMibcProfileInputs">
+    <PropertyGroup>
+      <_AndroidMibcProfile>$(IntermediateOutputPath)$(TargetName).mibc</_AndroidMibcProfile>
+      <!--
+        The main app assembly exactly as crossgen2 will see it.  ILLink writes the trimmed
+        assembly to $(IntermediateLinkDir), and this runs after it.  Without trimming
+        ($(AndroidLinkMode) of `None`, an explicit $(PublishTrimmed) of `false`, or
+        $(RunILLink) of `false`) ILLink never runs and crossgen2 compiles the compiler output
+        instead.  This mirrors when ILLink actually runs rather than probing for the trimmed
+        file, so a stale `linked` directory from an earlier build cannot be picked up.
+      -->
+      <_AndroidMibcMainAssembly Condition=" '$(PublishTrimmed)' == 'true' and '$(RunILLink)' != 'false' ">$(IntermediateLinkDir)$(TargetName)$(TargetExt)</_AndroidMibcMainAssembly>
+      <_AndroidMibcMainAssembly Condition=" '$(_AndroidMibcMainAssembly)' == '' ">@(IntermediateAssembly->'%(FullPath)')</_AndroidMibcMainAssembly>
+    </PropertyGroup>
+  </Target>
+
+  <!-- The decision is inline rather than resolved into a property by the target above, because
+       MSBuild evaluates a target's Condition *before* building its DependsOnTargets, so a
+       Condition can never read a property one of them sets. -->
+  <Target Name="_AndroidGenerateMibcProfile"
+      AfterTargets="ILLink"
+      BeforeTargets="CreateReadyToRunImages"
+      DependsOnTargets="_AndroidGenerateMibcProfileInputs"
+      Condition=" '$(PublishReadyToRun)' == 'true' and '$(_AndroidReadyToRunMainAssembly)' != 'false' and ('$(_AndroidReadyToRunMainAssembly)' == 'true' or ($(PublishReadyToRunCrossgen2ExtraArgs.Contains('--partial')) and '@(PublishReadyToRunPgoFiles->Count())' == '0')) "
+      Inputs="$(_AndroidMibcMainAssembly)"
+      Outputs="$(_AndroidMibcProfile)">
+    <GenerateMibcProfile
+        MainAssembly="$(_AndroidMibcMainAssembly)"
+        OutputFile="$(_AndroidMibcProfile)" />
+    <!-- MSBuild still evaluates ItemGroup/PropertyGroup elements of a target skipped as up to
+         date, so @(PublishReadyToRunPgoFiles) is populated on incremental builds too. -->
+    <ItemGroup Condition=" Exists('$(_AndroidMibcProfile)') ">
+      <PublishReadyToRunPgoFiles Include="$(_AndroidMibcProfile)" />
+      <FileWrites Include="$(_AndroidMibcProfile)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMibcProfile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateMibcProfile.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+using System.IO;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.Tasks;
+
+/// <summary>
+/// Generates a MIBC profile listing the methods of the "main app assembly" so that
+/// <c>crossgen2</c> in partial mode still ReadyToRun compiles it.
+///
+/// This runs after ILLink has trimmed the application, but before crossgen2 runs, so the profile
+/// only ever contains methods that survived trimming.
+/// </summary>
+public class GenerateMibcProfile : AndroidTask
+{
+	public override string TaskPrefix => "GMP";
+
+	/// <summary>
+	/// The "main app assembly", after trimming.
+	/// </summary>
+	[Required]
+	public string MainAssembly { get; set; } = "";
+
+	/// <summary>Path of the <c>.mibc</c> file to write.</summary>
+	[Required]
+	public string OutputFile { get; set; } = "";
+
+	public override bool RunTask ()
+	{
+		if (!File.Exists (MainAssembly)) {
+			Log.LogDebugMessage ($"Skipping MIBC profile generation, '{MainAssembly}' does not exist.");
+			return !Log.HasLoggedErrors;
+		}
+
+		int methods = MibcProfileWriter.Write ([MainAssembly], OutputFile, message => Log.LogDebugMessage ("{0}", message));
+		Log.LogDebugMessage ($"Wrote {methods} method(s) to '{OutputFile}'.");
+
+		return !Log.HasLoggedErrors;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateMibcProfileTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateMibcProfileTests.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests {
+	[TestFixture]
+	[Parallelizable (ParallelScope.Children)]
+	public class GenerateMibcProfileTests : BaseTest {
+
+		static string InputAssembly => typeof (GenerateMibcProfile).Assembly.Location;
+
+		GenerateMibcProfile CreateTask (string outputFile, string? mainAssembly = null) =>
+			new GenerateMibcProfile {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				MainAssembly = mainAssembly ?? InputAssembly,
+				OutputFile = outputFile,
+			};
+
+		[Test]
+		public void Execute_WritesZippedManagedPE ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory (path);
+			var outputFile = Path.Combine (path, "test.mibc");
+
+			var task = CreateTask (outputFile);
+			Assert.IsTrue (task.Execute (), "Task should succeed.");
+
+			FileAssert.Exists (outputFile);
+
+			// A MIBC file is a zip archive with a single "<file name>.dll" entry.
+			using var archive = ZipFile.OpenRead (outputFile);
+			Assert.AreEqual (1, archive.Entries.Count, "Expected a single entry.");
+			var entry = archive.Entries [0];
+			Assert.AreEqual ("test.mibc.dll", entry.Name);
+
+			var buffer = new MemoryStream ();
+			using (var entryStream = entry.Open ())
+				entryStream.CopyTo (buffer);
+			buffer.Position = 0;
+
+			using var peReader = new PEReader (buffer);
+			Assert.IsTrue (peReader.HasMetadata, "The entry should be a managed PE.");
+			var reader = peReader.GetMetadataReader ();
+
+			// crossgen2 looks up a global method named "AssemblyDictionary".
+			var globalMethods = reader.GetTypeDefinition (reader.TypeDefinitions.First ())
+				.GetMethods ()
+				.Select (h => reader.GetString (reader.GetMethodDefinition (h).Name))
+				.ToArray ();
+			CollectionAssert.Contains (globalMethods, "AssemblyDictionary");
+
+			// One group method per assembly, named after the assembly it describes.
+			var assemblyName = Path.GetFileNameWithoutExtension (InputAssembly);
+			CollectionAssert.Contains (globalMethods, $"Assemblies_{assemblyName}_1");
+		}
+
+		[Test]
+		public void Execute_IsDeterministic ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory (path);
+			var outputFile = Path.Combine (path, "test.mibc");
+
+			Assert.IsTrue (CreateTask (outputFile).Execute (), "First run should succeed.");
+			var bytes = File.ReadAllBytes (outputFile);
+
+			Assert.IsTrue (CreateTask (outputFile).Execute (), "Second run should succeed.");
+			CollectionAssert.AreEqual (bytes, File.ReadAllBytes (outputFile), "Output should be byte-identical.");
+		}
+
+		[Test]
+		public void Execute_MissingAssembly_WritesNothing ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory (path);
+			var outputFile = Path.Combine (path, "test.mibc");
+
+			var task = CreateTask (outputFile, mainAssembly: Path.Combine (path, "DoesNotExist.dll"));
+			Assert.IsTrue (task.Execute (), "Task should succeed.");
+
+			FileAssert.DoesNotExist (outputFile);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MibcProfileWriter.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MibcProfileWriter.cs
@@ -1,0 +1,578 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.IO.Hashing;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+namespace Xamarin.Android.Tasks;
+
+/// <summary>
+/// Writes a MIBC (Managed Instrumented Binary Code) profile that lists every compilable method
+/// of one or more input assemblies.
+///
+/// When <c>crossgen2</c> is invoked with <c>--partial</c> it only precompiles methods that appear
+/// in the profile data supplied via <c>--mibc</c>.  Feeding it a profile naming the methods of the
+/// "main app assembly" therefore ReadyToRun compiles that assembly, minus the generic code excluded
+/// below, while the rest of the application remains partially compiled.
+///
+/// The set of methods emitted here intentionally mirrors what crossgen2's
+/// <c>ReadyToRunLibraryRootProvider</c> would have rooted for a full (non-partial) compilation:
+///
+///   * abstract methods, <c>[MethodImpl(InternalCall)]</c> methods and runtime-provided bodies
+///     (such as delegate <c>Invoke</c>) are skipped, and
+///   * methods in a generic context (declared by a generic type, or generic themselves) are
+///     skipped.  crossgen2 compiles those as shared code instantiated over <c>System.__Canon</c>,
+///     which a profile can only name via that runtime implementation detail.  The main app
+///     assembly of a project template contains no such methods, so they are left to the JIT.
+///
+/// A MIBC file is a zip archive containing a single managed PE named <c>&lt;filename&gt;.dll</c>.
+/// The PE holds global methods:
+///
+///   * <c>AssemblyDictionary</c>: <c>ldstr "&lt;assembly name&gt;;"; ldtoken &lt;group method&gt;; pop</c>
+///   * one group method per assembly: <c>ldtoken &lt;method&gt;; pop</c> per profiled method
+/// </summary>
+class MibcProfileWriter
+{
+	/// <summary>
+	/// Earliest timestamp representable in a zip entry: the DOS date format stores the year as an
+	/// offset from 1980, so anything earlier throws.  There is no constant for this in the BCL --
+	/// <c>System.IO.Compression.ZipHelper.ValidZipDate_YearMin</c> is internal.
+	/// </summary>
+	static readonly DateTimeOffset ZipEpoch = new DateTimeOffset (1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	readonly MetadataBuilder metadata = new MetadataBuilder ();
+	readonly BlobBuilder ilBuilder = new BlobBuilder ();
+	readonly MethodBodyStreamEncoder methodBodies;
+	readonly Action<string>? log;
+
+	readonly Dictionary<string, AssemblyReferenceHandle> assemblyRefs = new Dictionary<string, AssemblyReferenceHandle> (StringComparer.Ordinal);
+	// Keyed by metadata token from the assembly currently being scanned; cleared per assembly.
+	readonly Dictionary<int, EntityHandle> typeRefs = new Dictionary<int, EntityHandle> ();
+
+	MibcProfileWriter (Action<string>? log)
+	{
+		this.log = log;
+		methodBodies = new MethodBodyStreamEncoder (ilBuilder);
+	}
+
+	/// <summary>
+	/// Scans <paramref name="assemblies"/> and writes a MIBC profile to <paramref name="outputPath"/>.
+	/// </summary>
+	/// <param name="assemblies">Paths of the managed assemblies to include, in full.</param>
+	/// <param name="outputPath">
+	/// Destination file.  A <c>.dll</c> extension writes the raw (uncompressed) PE, anything else
+	/// (normally <c>.mibc</c>) writes the zip-compressed form.
+	/// </param>
+	/// <param name="log">Optional callback receiving diagnostic messages.</param>
+	/// <returns>The number of methods written into the profile.</returns>
+	public static int Write (IEnumerable<string> assemblies, string outputPath, Action<string>? log = null)
+	{
+		if (assemblies is null)
+			throw new ArgumentNullException (nameof (assemblies));
+		if (outputPath is null)
+			throw new ArgumentNullException (nameof (outputPath));
+
+		return new MibcProfileWriter (log).WriteCore (assemblies, outputPath);
+	}
+
+	int WriteCore (IEnumerable<string> assemblies, string outputPath)
+	{
+		ReservedBlob<GuidHandle> mvid = metadata.ReserveGuid ();
+
+		metadata.AddModule (
+			generation: 0,
+			moduleName: metadata.GetOrAddString (Path.GetFileName (outputPath)),
+			mvid: mvid.Handle,
+			encId: default,
+			encBaseId: default);
+
+		metadata.AddAssembly (
+			name: metadata.GetOrAddString (Path.GetFileNameWithoutExtension (outputPath)),
+			version: new Version (1, 0, 0, 0),
+			culture: default,
+			publicKey: default,
+			flags: 0,
+			hashAlgorithm: AssemblyHashAlgorithm.None);
+
+		// <Module> type, required to host the global methods.
+		metadata.AddTypeDefinition (
+			attributes: default,
+			@namespace: default,
+			name: metadata.GetOrAddString ("<Module>"),
+			baseType: default,
+			fieldList: MetadataTokens.FieldDefinitionHandle (1),
+			methodList: MetadataTokens.MethodDefinitionHandle (1));
+
+		var voidSignature = new BlobBuilder ();
+		new BlobEncoder (voidSignature)
+			.MethodSignature (isInstanceMethod: false)
+			.Parameters (0, r => r.Void (), _ => { });
+		BlobHandle voidSignatureHandle = metadata.GetOrAddBlob (voidSignature);
+
+		var groups = new List<(string Name, MethodDefinitionHandle Handle)> ();
+		var fingerprint = new StringBuilder ();
+		int totalMethods = 0;
+		int groupIndex = 0;
+
+		foreach (string assembly in assemblies) {
+			groupIndex++;
+			var group = new BlobBuilder ();
+			var il = new InstructionEncoder (group);
+
+			(string assemblyName, int methodCount) = AddAssembly (assembly, il, fingerprint);
+			totalMethods += methodCount;
+			log?.Invoke ($"Added {methodCount} method(s) from '{assembly}' to the MIBC profile.");
+			if (methodCount == 0)
+				continue;
+
+			MethodDefinitionHandle handle = AddGlobalMethod ($"Assemblies_{assemblyName}_{groupIndex}", il, voidSignatureHandle);
+
+			// The group name lists every assembly referenced by the group, ';' separated, with the
+			// defining assembly first.  Our groups only ever reference their own assembly.
+			groups.Add ((assemblyName + ";", handle));
+		}
+
+		var dictionary = new BlobBuilder ();
+		var dictionaryIL = new InstructionEncoder (dictionary);
+		foreach ((string name, MethodDefinitionHandle handle) in groups) {
+			dictionaryIL.LoadString (metadata.GetOrAddUserString (name));
+			EmitToken (dictionaryIL, handle);
+		}
+
+		AddGlobalMethod ("AssemblyDictionary", dictionaryIL, voidSignatureHandle);
+
+		BlobContentId contentId = ContentId (fingerprint.ToString ());
+		new BlobWriter (mvid.Content).WriteGuid (contentId.Guid);
+
+		WritePE (outputPath, contentId);
+		return totalMethods;
+	}
+
+	/// <summary>
+	/// Adds a global <c>static void</c> method holding <paramref name="il"/>, terminating it with
+	/// <c>ret</c>.
+	/// </summary>
+	MethodDefinitionHandle AddGlobalMethod (string name, InstructionEncoder il, BlobHandle signature)
+	{
+		il.OpCode (ILOpCode.Ret);
+		return metadata.AddMethodDefinition (
+			MethodAttributes.Public | MethodAttributes.Static,
+			MethodImplAttributes.IL,
+			metadata.GetOrAddString (name),
+			signature,
+			methodBodies.AddMethodBody (il, maxStack: 8),
+			parameterList: MetadataTokens.ParameterHandle (1));
+	}
+
+	/// <summary>
+	/// A MIBC profile names an entity by pushing its token and discarding it; the IL is never run.
+	/// </summary>
+	static void EmitToken (InstructionEncoder il, EntityHandle handle)
+	{
+		il.OpCode (ILOpCode.Ldtoken);
+		il.Token (handle);
+		il.OpCode (ILOpCode.Pop);
+	}
+
+	/// <summary>
+	/// Emits <c>ldtoken</c>/<c>pop</c> pairs for every compilable method of <paramref name="path"/>
+	/// and appends that assembly's identity to <paramref name="fingerprint"/>.  Any method left out
+	/// is logged individually.
+	/// </summary>
+	(string Name, int MethodCount) AddAssembly (string path, InstructionEncoder il, StringBuilder fingerprint)
+	{
+		int methodCount = 0;
+
+		using var stream = File.OpenRead (path);
+		using var peReader = new PEReader (stream);
+
+		MetadataReader reader = peReader.GetMetadataReader ();
+		typeRefs.Clear ();
+
+		AssemblyDefinition assembly = reader.GetAssemblyDefinition ();
+		string assemblyName = reader.GetString (assembly.Name);
+		AssemblyReferenceHandle assemblyRef = GetOrAddAssemblyReference (reader, assembly);
+
+		fingerprint.Append (assemblyName).Append ('|')
+			.Append (reader.GetGuid (reader.GetModuleDefinition ().Mvid).ToString ("N")).Append ('\n');
+
+		string Describe (TypeDefinition type, MethodDefinition method) =>
+			$"{assemblyName}!{reader.GetString (type.Name)}.{reader.GetString (method.Name)}";
+
+		foreach (TypeDefinitionHandle typeHandle in reader.TypeDefinitions) {
+			TypeDefinition type = reader.GetTypeDefinition (typeHandle);
+
+			// Nested types re-declare the generic parameters of their enclosing types, so this
+			// also excludes types nested inside a generic type.
+			bool genericType = type.GetGenericParameters ().Count > 0;
+			EntityHandle owner = genericType ? default : GetTypeReference (reader, assemblyRef, typeHandle);
+
+			foreach (MethodDefinitionHandle methodHandle in type.GetMethods ()) {
+				MethodDefinition method = reader.GetMethodDefinition (methodHandle);
+				if (!IsCompilable (method))
+					continue;
+
+				if (genericType || method.GetGenericParameters ().Count > 0) {
+					log?.Invoke ($"Skipping '{Describe (type, method)}', methods in a generic context are left to the JIT.");
+					continue;
+				}
+
+				EntityHandle target;
+				try {
+					target = metadata.AddMemberReference (
+						owner,
+						metadata.GetOrAddString (reader.GetString (method.Name)),
+						metadata.GetOrAddBlob (TranslateMethodSignature (reader, assemblyRef, method.Signature)));
+				} catch (BadImageFormatException e) {
+					// A signature we cannot translate only costs us that one method, so keep
+					// going, but do not do it silently.
+					log?.Invoke ($"Skipping '{Describe (type, method)}', its signature could not be read: {e.Message}");
+					continue;
+				}
+
+				EmitToken (il, target);
+				methodCount++;
+			}
+		}
+
+		return (assemblyName, methodCount);
+	}
+
+	/// <summary>
+	/// Mirrors the filtering done by crossgen2's <c>ReadyToRunLibraryRootProvider</c>: abstract and
+	/// <c>InternalCall</c> methods are skipped, as are runtime-provided bodies such as delegate
+	/// <c>Invoke</c>.  P/Invokes are kept, because crossgen2 does compile their marshalling stubs.
+	/// </summary>
+	static bool IsCompilable (MethodDefinition method)
+	{
+		if ((method.Attributes & MethodAttributes.Abstract) != 0)
+			return false;
+		if ((method.ImplAttributes & MethodImplAttributes.CodeTypeMask) != MethodImplAttributes.IL)
+			return false;
+		if ((method.ImplAttributes & MethodImplAttributes.InternalCall) != 0)
+			return false;
+		if (method.RelativeVirtualAddress == 0 && (method.Attributes & MethodAttributes.PinvokeImpl) == 0)
+			return false;
+		return true;
+	}
+
+	byte []? GetPublicKeyToken (MetadataReader reader, AssemblyDefinition assembly)
+	{
+		if (assembly.PublicKey.IsNil)
+			return null;
+
+		byte [] publicKey = reader.GetBlobBytes (assembly.PublicKey);
+		if (publicKey.Length == 0)
+			return null;
+		if (publicKey.Length <= 8)
+			return publicKey;
+
+		var name = new AssemblyName ();
+		name.SetPublicKey (publicKey);
+		return name.GetPublicKeyToken ();
+	}
+
+	/// <summary>
+	/// Adds an <c>AssemblyRef</c> for the assembly being scanned.  <c>AssemblyDef</c> stores the
+	/// full public key, which has to be reduced to a token first.
+	/// </summary>
+	AssemblyReferenceHandle GetOrAddAssemblyReference (MetadataReader reader, AssemblyDefinition assembly) =>
+		GetOrAddAssemblyReference (
+			reader,
+			reader.GetString (assembly.Name),
+			assembly.Version,
+			assembly.Culture,
+			GetPublicKeyToken (reader, assembly));
+
+	/// <summary>
+	/// Adds an <c>AssemblyRef</c> mirroring one of the source assembly's own references, whose
+	/// <c>PublicKeyOrToken</c> is already in the form we need.
+	/// </summary>
+	AssemblyReferenceHandle GetOrAddAssemblyReference (MetadataReader reader, AssemblyReference assembly) =>
+		GetOrAddAssemblyReference (
+			reader,
+			reader.GetString (assembly.Name),
+			assembly.Version,
+			assembly.Culture,
+			assembly.PublicKeyOrToken.IsNil ? null : reader.GetBlobBytes (assembly.PublicKeyOrToken));
+
+	AssemblyReferenceHandle GetOrAddAssemblyReference (MetadataReader reader, string name, Version version, StringHandle culture, byte []? publicKeyToken)
+	{
+		byte [] token = publicKeyToken ?? [];
+		string cultureName = culture.IsNil ? "" : reader.GetString (culture);
+
+		string key = $"{name},{version},{cultureName},{Convert.ToBase64String (token)}";
+		if (assemblyRefs.TryGetValue (key, out AssemblyReferenceHandle handle))
+			return handle;
+
+		handle = metadata.AddAssemblyReference (
+			name: metadata.GetOrAddString (name),
+			version: version,
+			culture: CopyString (reader, culture),
+			publicKeyOrToken: token.Length > 0 ? metadata.GetOrAddBlob (token) : default,
+			flags: 0,
+			hashValue: default);
+		assemblyRefs [key] = handle;
+		return handle;
+	}
+
+	/// <summary>Copies a string from the assembly being scanned into the MIBC module.</summary>
+	StringHandle CopyString (MetadataReader reader, StringHandle source) =>
+		source.IsNil ? default : metadata.GetOrAddString (reader.GetString (source));
+
+	/// <summary>
+	/// Maps a <c>TypeDef</c>/<c>TypeRef</c>/<c>TypeSpec</c> from the source assembly onto an
+	/// equivalent entity in the MIBC module.
+	/// </summary>
+	EntityHandle GetTypeReference (MetadataReader reader, AssemblyReferenceHandle assemblyRef, EntityHandle source)
+	{
+		int token = MetadataTokens.GetToken (source);
+		if (typeRefs.TryGetValue (token, out EntityHandle handle))
+			return handle;
+
+		switch (source.Kind) {
+			case HandleKind.TypeDefinition: {
+					TypeDefinition type = reader.GetTypeDefinition ((TypeDefinitionHandle) source);
+					EntityHandle scope = type.IsNested
+						? GetTypeReference (reader, assemblyRef, type.GetDeclaringType ())
+						: assemblyRef;
+					handle = metadata.AddTypeReference (
+						scope,
+						CopyString (reader, type.Namespace),
+						CopyString (reader, type.Name));
+					break;
+				}
+			case HandleKind.TypeReference: {
+					TypeReference type = reader.GetTypeReference ((TypeReferenceHandle) source);
+					handle = metadata.AddTypeReference (
+						GetResolutionScope (reader, assemblyRef, type.ResolutionScope),
+						CopyString (reader, type.Namespace),
+						CopyString (reader, type.Name));
+					break;
+				}
+			case HandleKind.TypeSpecification: {
+					TypeSpecification type = reader.GetTypeSpecification ((TypeSpecificationHandle) source);
+					var blob = new BlobBuilder ();
+					BlobReader signature = reader.GetBlobReader (type.Signature);
+					TranslateType (reader, assemblyRef, ref signature, blob);
+					handle = metadata.AddTypeSpecification (metadata.GetOrAddBlob (blob));
+					break;
+				}
+			default:
+				throw new BadImageFormatException ($"Unexpected type handle kind '{source.Kind}'.");
+		}
+
+		typeRefs [token] = handle;
+		return handle;
+	}
+
+	EntityHandle GetResolutionScope (MetadataReader reader, AssemblyReferenceHandle assemblyRef, EntityHandle scope)
+	{
+		switch (scope.Kind) {
+			case HandleKind.AssemblyReference:
+				return GetOrAddAssemblyReference (reader, reader.GetAssemblyReference ((AssemblyReferenceHandle) scope));
+			case HandleKind.TypeReference:
+				return GetTypeReference (reader, assemblyRef, scope);
+			default:
+				// ModuleDefinition/ModuleReference: the type lives in the assembly being scanned.
+				return assemblyRef;
+		}
+	}
+
+	BlobBuilder TranslateMethodSignature (MetadataReader reader, AssemblyReferenceHandle assemblyRef, BlobHandle source)
+	{
+		var result = new BlobBuilder ();
+		BlobReader signature = reader.GetBlobReader (source);
+		TranslateMethodSignature (reader, assemblyRef, ref signature, result);
+		return result;
+	}
+
+	/// <summary>
+	/// Copies a <c>MethodDefSig</c>/<c>MethodRefSig</c>: the calling convention, the generic arity
+	/// if there is one, the parameter count, the return type and finally the parameters.  A
+	/// <c>FnPtr</c> element inside a signature is followed by one of these too.
+	/// </summary>
+	void TranslateMethodSignature (MetadataReader reader, AssemblyReferenceHandle assemblyRef, ref BlobReader signature, BlobBuilder result)
+	{
+		byte header = signature.ReadByte ();
+		result.WriteByte (header);
+
+		if (((SignatureAttributes) header & SignatureAttributes.Generic) != 0)
+			CopyCompressedInteger (ref signature, result);
+
+		int parameterCount = CopyCompressedInteger (ref signature, result);
+
+		TranslateType (reader, assemblyRef, ref signature, result);
+		for (int i = 0; i < parameterCount; i++)
+			TranslateType (reader, assemblyRef, ref signature, result);
+	}
+
+	/// <summary>
+	/// Copies one <c>Type</c> production of an ECMA-335 signature blob, rewriting the embedded
+	/// <c>TypeDefOrRefOrSpec</c> tokens so that they are valid in the MIBC module.
+	/// </summary>
+	void TranslateType (MetadataReader reader, AssemblyReferenceHandle assemblyRef, ref BlobReader signature, BlobBuilder result)
+	{
+		while (true) {
+			byte raw = signature.ReadByte ();
+			result.WriteByte (raw);
+
+			// ELEMENT_TYPE_VALUETYPE/CLASS are the only two values System.Reflection.Metadata
+			// models with SignatureTypeKind rather than SignatureTypeCode.
+			if (raw == (byte) SignatureTypeKind.ValueType || raw == (byte) SignatureTypeKind.Class) {
+				TranslateTypeToken (reader, assemblyRef, ref signature, result);
+				return;
+			}
+
+			switch ((SignatureTypeCode) raw) {
+				// Leaf types, nothing else to copy.
+				case SignatureTypeCode.Void:
+				case SignatureTypeCode.Boolean:
+				case SignatureTypeCode.Char:
+				case SignatureTypeCode.SByte:
+				case SignatureTypeCode.Byte:
+				case SignatureTypeCode.Int16:
+				case SignatureTypeCode.UInt16:
+				case SignatureTypeCode.Int32:
+				case SignatureTypeCode.UInt32:
+				case SignatureTypeCode.Int64:
+				case SignatureTypeCode.UInt64:
+				case SignatureTypeCode.Single:
+				case SignatureTypeCode.Double:
+				case SignatureTypeCode.String:
+				case SignatureTypeCode.IntPtr:
+				case SignatureTypeCode.UIntPtr:
+				case SignatureTypeCode.Object:
+				case SignatureTypeCode.TypedReference:
+					return;
+
+				// Prefixes: keep copying the type that follows.
+				case SignatureTypeCode.Pointer:
+				case SignatureTypeCode.ByReference:
+				case SignatureTypeCode.SZArray:
+				case SignatureTypeCode.Pinned:
+				case SignatureTypeCode.Sentinel:
+					continue;
+
+				case SignatureTypeCode.RequiredModifier:
+				case SignatureTypeCode.OptionalModifier:
+					TranslateTypeToken (reader, assemblyRef, ref signature, result);
+					continue;
+
+				case SignatureTypeCode.Array: {
+						TranslateType (reader, assemblyRef, ref signature, result);
+						CopyCompressedInteger (ref signature, result);                  // rank
+						int sizeCount = CopyCompressedInteger (ref signature, result);
+						for (int i = 0; i < sizeCount; i++)
+							CopyCompressedInteger (ref signature, result);
+						int lowerBoundCount = CopyCompressedInteger (ref signature, result);
+						for (int i = 0; i < lowerBoundCount; i++)
+							CopyCompressedSignedInteger (ref signature, result);
+						return;
+					}
+
+				case SignatureTypeCode.GenericTypeInstance: {
+						result.WriteByte (signature.ReadByte ());                       // CLASS or VALUETYPE
+						TranslateTypeToken (reader, assemblyRef, ref signature, result);
+						int argumentCount = CopyCompressedInteger (ref signature, result);
+						for (int i = 0; i < argumentCount; i++)
+							TranslateType (reader, assemblyRef, ref signature, result);
+						return;
+					}
+
+				case SignatureTypeCode.FunctionPointer:
+					TranslateMethodSignature (reader, assemblyRef, ref signature, result);
+					return;
+
+				default:
+					throw new BadImageFormatException ($"Unexpected signature element type '0x{raw:x2}'.");
+			}
+		}
+	}
+
+	void TranslateTypeToken (MetadataReader reader, AssemblyReferenceHandle assemblyRef, ref BlobReader signature, BlobBuilder result)
+	{
+		EntityHandle source = signature.ReadTypeHandle ();
+		result.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (GetTypeReference (reader, assemblyRef, source)));
+	}
+
+	static int CopyCompressedInteger (ref BlobReader signature, BlobBuilder result)
+	{
+		int value = signature.ReadCompressedInteger ();
+		result.WriteCompressedInteger (value);
+		return value;
+	}
+
+	static void CopyCompressedSignedInteger (ref BlobReader signature, BlobBuilder result)
+	{
+		result.WriteCompressedSignedInteger (signature.ReadCompressedSignedInteger ());
+	}
+
+	void WritePE (string outputPath, BlobContentId contentId)
+	{
+		var peBuilder = new ManagedPEBuilder (
+			new PEHeaderBuilder (imageCharacteristics: Characteristics.Dll),
+			new MetadataRootBuilder (metadata),
+			ilBuilder,
+			deterministicIdProvider: _ => contentId);
+
+		var peBlob = new BlobBuilder ();
+		peBuilder.Serialize (peBlob);
+
+		string? directory = Path.GetDirectoryName (outputPath);
+		if (!directory.IsNullOrEmpty ())
+			Directory.CreateDirectory (directory);
+
+		if (string.Equals (Path.GetExtension (outputPath), ".dll", StringComparison.OrdinalIgnoreCase)) {
+			using var file = File.Create (outputPath);
+			peBlob.WriteContentTo (file);
+			return;
+		}
+
+		using var archiveStream = File.Create (outputPath);
+		using var archive = new ZipArchive (archiveStream, ZipArchiveMode.Create);
+		// crossgen2 looks for an entry named "<mibc file name>.dll".
+		ZipArchiveEntry entry = archive.CreateEntry (Path.GetFileName (outputPath) + ".dll", CompressionLevel.Optimal);
+		// Keep the archive deterministic; the default is DateTime.Now.
+		entry.LastWriteTime = ZipEpoch;
+		using var entryStream = entry.Open ();
+		peBlob.WriteContentTo (entryStream);
+	}
+
+	/// <summary>
+	/// Derives a stable MVID and timestamp from the profile contents so that unchanged inputs
+	/// produce byte-identical output and downstream incremental builds are not invalidated.
+	/// </summary>
+	/// <param name="fingerprint">
+	/// One <c>name|mvid</c> line per input assembly, as built by <see cref="AddAssembly"/>.  The
+	/// input MVIDs are hashed rather than reused directly: a module's MVID has to be unique to
+	/// that module (ECMA-335 II.22.30), and the profile is not the assembly it profiles.
+	/// </param>
+	static BlobContentId ContentId (string fingerprint)
+	{
+		// This is only a content fingerprint, so a non cryptographic hash is fine, and unlike
+		// System.Security.Cryptography the System.IO.Hashing APIs are span based on netstandard2.0.
+		int byteCount = Encoding.UTF8.GetByteCount (fingerprint);
+		Span<byte> bytes = byteCount <= TypeMapHelper.StackallocThresholdBytes
+			? stackalloc byte [byteCount]
+			: new byte [byteCount];
+		TypeMapHelper.GetBytes (fingerprint, Encoding.UTF8, bytes);
+
+		// BlobContentId.FromHash turns hash bytes into an MVID and timestamp for us, including the
+		// RFC 4122 version and variant bits and the byte order of the Guid fields.  It reads 20
+		// bytes: 0..16 become the MVID and 16..20 become the timestamp.  XxHash128 only produces
+		// 16, so the timestamp slot repeats the first four rather than hashing the input again.
+		// This cannot be a stackalloc: FromHash only overloads on byte[] and ImmutableArray<byte>.
+		var hash = new byte [20];
+		XxHash128.Hash (bytes, hash.AsSpan (0, 16));
+		hash.AsSpan (0, 4).CopyTo (hash.AsSpan (16));
+		return BlobContentId.FromHash (hash);
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapHelper.cs
@@ -7,6 +7,13 @@ namespace Xamarin.Android.Tasks;
 static class TypeMapHelper
 {
 	/// <summary>
+	/// The largest buffer callers of <see cref="GetBytes"/> should <c>stackalloc</c> before falling
+	/// back to the heap.  Matches the threshold used elsewhere in the SDK, e.g.
+	/// <c>ScannerHashingHelper</c> in Microsoft.Android.Sdk.TrimmableTypeMap.
+	/// </summary>
+	public const int StackallocThresholdBytes = 256;
+
+	/// <summary>
 	/// Hash the given Java type name for use in java-to-managed typemap array (MonoVM version)
 	/// </summary>
 	public static ulong HashJavaName (string name, bool is64Bit)
@@ -23,21 +30,37 @@ static class TypeMapHelper
 	/// <summary>
 	/// Hash the given type name for use in CoreCLR native typemap arrays.
 	/// </summary>
-	public static unsafe uint HashNameForCLR (string name)
+	public static uint HashNameForCLR (string name)
 	{
 		if (name.Length == 0) {
 			return UInt32.MaxValue;
 		}
 
 		int byteCount = Encoding.UTF8.GetByteCount (name);
-		Span<byte> buffer = byteCount <= 256
+		Span<byte> buffer = byteCount <= StackallocThresholdBytes
 			? stackalloc byte [byteCount]
 			: new byte [byteCount];
-		fixed (char* pChars = name)
-		fixed (byte* pBuffer = buffer) {
-			Encoding.UTF8.GetBytes (pChars, name.Length, pBuffer, byteCount);
-		}
+		GetBytes (name, Encoding.UTF8, buffer);
 		return Crc32.HashToUInt32 (buffer);
+	}
+
+	/// <summary>
+	/// Encodes <paramref name="value"/> into <paramref name="buffer"/>, which must be at least
+	/// <c>encoding.GetByteCount (value)</c> bytes long.  Callers allocate the buffer themselves so
+	/// that short strings can use <c>stackalloc</c>.
+	/// </summary>
+	// The unsafe Encoding.GetBytes(char*, int, byte*, int) overload is used because the
+	// Span-based overload requires netstandard2.1+.
+	public static unsafe void GetBytes (string value, Encoding encoding, Span<byte> buffer)
+	{
+		if (value.Length == 0) {
+			return;
+		}
+
+		fixed (char* pChars = value)
+		fixed (byte* pBuffer = buffer) {
+			encoding.GetBytes (pChars, value.Length, pBuffer, buffer.Length);
+		}
 	}
 
 	/// <summary>
@@ -54,18 +77,13 @@ static class TypeMapHelper
 
 	// Java type names are always ASCII and typically 20-100 characters,
 	// so the encoded byte count is well within stackalloc limits.
-	// The unsafe Encoding.GetBytes(char*, int, byte*, int) overload is
-	// used because the Span-based overload requires netstandard2.1+.
-	static unsafe ulong HashString (string name, Encoding encoding, bool is64Bit)
+	static ulong HashString (string name, Encoding encoding, bool is64Bit)
 	{
 		int byteCount = encoding.GetByteCount (name);
-		Span<byte> buffer = byteCount <= 256
+		Span<byte> buffer = byteCount <= StackallocThresholdBytes
 			? stackalloc byte [byteCount]
 			: new byte [byteCount];
-		fixed (char* pChars = name)
-		fixed (byte* pBuffer = buffer) {
-			encoding.GetBytes (pChars, name.Length, pBuffer, byteCount);
-		}
+		GetBytes (name, encoding, buffer);
 		return HashBytes (buffer, is64Bit);
 	}
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -96,6 +96,73 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void PublishReadyToRunPartial ([Values] bool isComposite)
+		{
+			const string logcatMessage = "R2R_PARTIAL_TEST_ONCREATE";
+
+			var rid = MonoAndroidHelper.AbiToRid (DeviceAbi);
+			var proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (AndroidRuntime.CoreCLR, $"r2rpartial{isComposite}")) {
+				IsRelease = true, // Enables ReadyToRun by default
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("RuntimeIdentifier", rid);
+			proj.SetProperty ("AndroidEnableAssemblyCompression", "false");
+			proj.SetProperty ("PublishReadyToRunComposite", isComposite.ToString ());
+			// "--partial" restricts crossgen2 to the methods in the profile, "--map" makes it
+			// write a listing of everything it compiled.
+			proj.SetProperty ("PublishReadyToRunCrossgen2ExtraArgs", "--partial;--map");
+			proj.SetDefaultTargetDevice ();
+			proj.MainActivity = proj.DefaultMainActivity.Replace (
+				"//${AFTER_ONCREATE}",
+				$"Console.WriteLine (\"{logcatMessage}\");");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Install (proj), "Project should have installed.");
+
+			var assemblyName = proj.ProjectName;
+			var intermediate = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath);
+
+			// _AndroidGenerateMibcProfile should have written a profile for the app assembly.
+			var mibc = Directory.GetFiles (intermediate, $"{assemblyName}.mibc", SearchOption.AllDirectories);
+			Assert.IsNotEmpty (mibc, $"{assemblyName}.mibc should have been generated!");
+
+			var apk = Path.Combine (Root, builder.ProjectDirectory, proj.OutputPath, rid, $"{proj.PackageName}-Signed.apk");
+			FileAssert.Exists (apk);
+
+			var helper = new ArchiveAssemblyHelper (apk, true);
+			var apkEntry = $"assemblies/{DeviceAbi}/{assemblyName}.dll";
+			Assert.IsTrue (helper.Exists (apkEntry), $"{assemblyName}.dll should exist in apk!");
+
+			using (var stream = helper.ReadEntry (apkEntry, MonoAndroidHelper.AbiToTargetArch (DeviceAbi))) {
+				Assert.IsNotNull (stream, $"{apkEntry} should be readable from the apk!");
+				stream.Position = 0;
+				using var peReader = new System.Reflection.PortableExecutable.PEReader (stream);
+				Assert.IsTrue (peReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory.Size > 0,
+					$"ReadyToRun image not found in {assemblyName}.dll! ManagedNativeHeaderDirectory should not be empty!");
+			}
+
+			// The crossgen2 map lists every method that made it into the R2R image.  Without the
+			// generated profile, "--partial" would leave the app's own code out entirely.  The
+			// file is named after the app assembly, or after the composite image in a composite
+			// build.
+			var maps = Directory.GetFiles (intermediate, "*.map", SearchOption.AllDirectories);
+			Assert.IsNotEmpty (maps, "crossgen2 should have written a .map file!");
+			// e.g. "0x000108C0 | 0x000100 | 0 | .text | UnnamedProject_UnnamedProject_MainActivity__OnCreate  (MethodWithGCInfo)"
+			var symbol = $"{assemblyName}_{assemblyName}_MainActivity__OnCreate  (MethodWithGCInfo)";
+			Assert.IsTrue (maps.Any (m => File.ReadAllText (m).Contains (symbol)),
+				$"MainActivity.OnCreate() should be ReadyToRun compiled! Looked for '{symbol}' in: {string.Join (", ", maps)}");
+
+			// A partially ReadyToRun compiled app must still start and run its managed code.
+			RunProjectAndAssert (proj, builder, doNotCleanupOnUpdate: true);
+			Assert.IsTrue (WaitForActivityToStart (proj.PackageName, "MainActivity",
+				Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), ActivityStartTimeoutInSeconds), "Activity should have started.");
+			Assert.IsTrue (MonitorAdbLogcat ((line) => line.Contains (logcatMessage),
+				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"), 45),
+				$"Output did not contain {logcatMessage}! MainActivity.OnCreate() should have run.");
+			Assert.IsTrue (builder.Uninstall (proj), "Project should have uninstalled.");
+		}
+
+		[Test]
 		public void TrimmableTypeMapInheritedVirtualOverrideUsesCorrectUco ([Values (AndroidRuntime.CoreCLR)] AndroidRuntime runtime)
 		{
 			const string expectedLogcatOutput = "UCO_OVERRIDE_REUSE_RESULTS 107:211:1:1:405:1:0";


### PR DESCRIPTION
crossgen2's `--partial` only precompiles methods named in the profile data passed via `--mibc`. There is no profile for a new app, so today the main app assembly is effectively not ReadyToRun compiled at all.

This adds a `GenerateMibcProfile` task that writes a `.mibc` naming the compilable methods of the main app assembly and adds it to `@(PublishReadyToRunPgoFiles)`, so crossgen2 compiles that assembly while everything else stays partial. Android version of dotnet/maui#34837.

The target runs `AfterTargets="ILLink" BeforeTargets="CreateReadyToRunImages"`, so the profile only contains methods that survived trimming, and only when `$(PublishReadyToRunCrossgen2ExtraArgs)` contains `--partial`.

Two things worth knowing:

- Methods in a generic context are left to the JIT. crossgen2 compiles those as shared code over `System.__Canon`, which a profile can only name via that implementation detail. So the assembly ends up mostly, not fully, R2R compiled.
- Output is deterministic, so an unchanged app produces a byte identical `.mibc` and does not invalidate incremental builds.

## Bring your own profile

If you record a real startup profile, for example with the `maui profile startup --format mibc` skill in [dotnet/maui-labs](https://github.com/dotnet/maui-labs), you have already said exactly what you want compiled, and the whole point of `--partial` is to compile only that. Naming every method of the app assembly on top of it would swamp it.

So this turns itself off when `@(PublishReadyToRunPgoFiles)` is already non-empty. Just adding your `.mibc` to that item group is enough, no extra property needed. MAUI's own framework profiles go into the private `@(_ReadyToRunPgoFiles)`, so they do not suppress this.

`$(_AndroidReadyToRunMainAssembly)` overrides the decision: `true` forces the profile on, `false` turns it off, blank (the default) means "on when crossgen2 is partial and the app brought no profile of its own".

## Results

Measured on the two MAUI templates, Android-only TFM, CoreCLR, Release, composite, `--partial;--map`, `-p:RuntimeIdentifier=android-arm64` so the APK carries a single ABI and the size numbers are not diluted by a second copy of everything. Each pair is the same project built twice, differing only by `$(_AndroidReadyToRunMainAssembly)`, so the profile is the only variable.

Startup is from a physical arm64 device: 25 iterations per run, and the whole thing run twice in opposite order (before/after, then after/before) so any ordering or thermal drift would show up as a gap between the two passes of the same APK. It does not.

| | `dotnet new maui` | `dotnet new maui -sc` |
| --- | --- | --- |
| methods in profile | 87 | 1,291 |
| profile size | 1,829 bytes | 14,867 bytes |
| skipped as generic | 0 | 23 |
| app methods in R2R image | 0 -> 87 | 0 -> 1,289 |
| APK size | 20,013,784 -> 20,079,320 | 23,032,560 -> 23,298,800 |
| APK delta | +65,536 (+0.33%) | +266,240 (+1.16%) |
| startup before | 826.6 +/- 3.6, 825.2 +/- 2.9 ms | 1685.1 +/- 3.8, 1688.3 +/- 4.0 ms |
| startup after | 805.7 +/- 2.7, 806.6 +/- 2.7 ms | 1609.0 +/- 2.9, 1613.7 +/- 3.7 ms |
| startup delta | -19.8 ms (-2.4%) | -75.4 ms (-4.5%) |

Both passes of each APK agree to within a couple of ms, and the before/after gap is 5-15x the combined standard error, so the deltas are well clear of the noise.

Essentially every method named in the profile lands in the R2R image, and the trade scales with how much code the app actually has: the blank template gains 87 methods for 64 KB, `-sc` gains 1,289 for 260 KB.

`apkdiff` shows all the growth is the composite R2R image; dex and every other entry are byte identical in both templates.

```
$ apkdiff full-arm64-before.apk full-arm64-after.apk      # dotnet new maui
  +      66,488 lib/arm64-v8a/libassembly-store.so
Summary:
  +           0 Other entries 0.00% (of 3,930,902)
  +           0 Dalvik executables 0.00% (of 16,997,756)
  +      66,488 Shared libraries 0.39% (of 17,016,032)
  +      65,536 Package size difference 0.33% (of 20,013,784)

$ apkdiff sc-arm64-before.apk sc-arm64-after.apk          # dotnet new maui -sc
  +     267,632 lib/arm64-v8a/libassembly-store.so
Summary:
  +           0 Other entries 0.00% (of 7,041,375)
  +           0 Dalvik executables 0.00% (of 17,026,184)
  +     267,632 Shared libraries 1.34% (of 20,013,592)
  +     266,240 Package size difference 1.16% (of 23,032,560)
```

## Build time cost

This never runs in a Debug build. `$(PublishReadyToRun)` only defaults to `true` for `$(Configuration)` of `Release`, and the target additionally requires crossgen2 to be in partial mode, so the inner-loop build is untouched. It is also CoreCLR only, since `Microsoft.Android.Sdk.CoreCLR.targets` is imported only for that runtime.

For Release builds, `GenerateMibcProfile` runs once per RID. Durations pulled from the binlogs:

| build | methods | 1st RID | 2nd RID |
| --- | --- | --- | --- |
| `dotnet new maui` | 87 | 33.6 ms | 1.0 ms |
| `dotnet new maui -sc` | 1,291 | 34.5 ms | 1.9 ms |
| `-sc`, `PublishTrimmed=false` | 1,291 | 40.4 ms | 1.9 ms |

So 35-45 ms per build, against roughly 50 s of wall clock and 128-142 s of total task time. Whichever RID runs first pays about 34 ms of task assembly load and JIT; the second pays 1-2 ms, and that marginal cost is the same whether the profile names 87 methods or 1,291. Writing the profile is effectively free, you are just paying to load the task once.

For scale, `RunReadyToRunCompiler` is 4.0-5.0 s in these same builds, so this is well under 1% of crossgen2's own time.

## Tests

`GenerateMibcProfileTests` for the writer, and `InstallAndRunTests.PublishReadyToRunPartial ([Values] bool isComposite)` builds, verifies the app assembly is R2R compiled in the APK, then installs and launches it. Both variants pass on an x86_64 emulator.

All four decision paths were verified end to end on a real MAUI app: partial with no profile generates it, a user supplied `@(PublishReadyToRunPgoFiles)` suppresses it, and each explicit value of `$(_AndroidReadyToRunMainAssembly)` overrides both. Both trimming paths were checked too: the default build profiles `obj/.../linked/App.dll`, and `-p:PublishTrimmed=false` profiles `obj/.../App.dll`.