### PR TITLE
[Xamarin.Android.Build.Tasks] instrumentation-only apps + `dotnet run`

### DIFF
--- a/Documentation/docs-mobile/TOC.yml
+++ b/Documentation/docs-mobile/TOC.yml
@@ -266,6 +266,10 @@
         href: messages/xa1037.md
       - name: XA1038
         href: messages/xa1038.md
+      - name: XA1042
+        href: messages/xa1042.md
+      - name: XA1043
+        href: messages/xa1043.md
     - name: "XA2xxx: Linker"
       items:
       - name: "XA2xxx: Linker"

--- a/Documentation/docs-mobile/TOC.yml
+++ b/Documentation/docs-mobile/TOC.yml
@@ -270,6 +270,8 @@
         href: messages/xa1042.md
       - name: XA1043
         href: messages/xa1043.md
+      - name: XA1048
+        href: messages/xa1048.md
     - name: "XA2xxx: Linker"
       items:
       - name: "XA2xxx: Linker"

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -688,9 +688,35 @@ A string property that specifies the Android
 [instrumentation](https://developer.android.com/reference/android/app/Instrumentation)
 runner class name to use when launching the application via `dotnet run`.
 
-When [`$(EnableMSTestRunner)`](#enablemstestrunner) is `true` and this property
-is not set, the instrumentation runner class name is automatically resolved from
-the generated `AndroidManifest.xml` in the intermediate output.
+When this property is not set, `dotnet run` resolves what to launch from the
+generated `AndroidManifest.xml` in the intermediate output:
+
+* If [`$(AndroidUseInstrumentation)`](#androiduseinstrumentation) is `true`, the
+  first `<instrumentation/>` element is used.
+* Otherwise the launchable `<activity/>` is preferred, and the first
+  `<instrumentation/>` element is used when the app declares no launchable
+  activity. This makes it possible to `dotnet run` an app whose only entry point
+  is an `Android.App.Instrumentation` subclass, such as a
+  [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) host.
+
+If the app declares neither, the build fails with
+[XA1043](../messages/xa1043.md).
+
+When an instrumentation is launched, `dotnet run` runs
+`adb shell am instrument -w -r` and exits with a non-zero exit code if the
+instrumentation crashes or calls `Instrumentation.Finish()` with
+`Result.Canceled`.
+
+Any arguments after `--` are forwarded to the instrumentation as `am instrument`
+extras. Arguments of the form `KEY=VALUE` become `-e KEY VALUE`, and all
+remaining arguments are joined into a single `-e args "..."` extra:
+
+```dotnetcli
+dotnet run -- --filter *MyBenchmark*
+```
+
+is delivered to `Instrumentation.OnCreate(Bundle?)` as
+`arguments.GetString("args")`.
 
 Introduced in .NET 11.
 
@@ -1252,6 +1278,24 @@ which does have this feature enabled in a project that does not, you will
 get a `XA1034` build error.
 
 Added in .NET 8.
+
+## AndroidUseInstrumentation
+
+A boolean property that indicates the application is launched through its
+`<instrumentation/>` element rather than an `<activity/>`, such as a test or
+[BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) host.
+
+When `true`, `dotnet run` resolves
+[`$(AndroidInstrumentation)`](#androidinstrumentation) from the generated
+`AndroidManifest.xml` and launches it with `adb shell am instrument`, even if
+the app also declares a launchable activity.
+
+The default value is `true` when
+[`$(EnableMSTestRunner)`](#enablemstestrunner) is `true`, and `false` otherwise.
+Note that an app with no launchable `<activity/>` launches through its
+`<instrumentation/>` regardless of this property.
+
+Introduced in .NET 11.
 
 ## AndroidUseInterpreter
 

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -705,7 +705,9 @@ If the app declares neither, the build fails with
 When an instrumentation is launched, `dotnet run` runs
 `adb shell am instrument -w -r` and exits with a non-zero exit code if the
 instrumentation crashes or calls `Instrumentation.Finish()` with
-`Result.Canceled`.
+`Result.Canceled`. Setting [`$(WaitForExit)`](#waitforexit) to `false` drops the
+`-w`, so `dotnet run` returns as soon as the instrumentation is started and no
+results are reported.
 
 Any arguments after `--` are forwarded to the instrumentation as `am instrument`
 extras. Arguments of the form `KEY=VALUE` become `-e KEY VALUE`, and all
@@ -1841,7 +1843,22 @@ When `$(WaitForExit)` not `false` (the default), `dotnet run` will:
 * Force-stop the application when Ctrl+C is pressed
 
 When `$(WaitForExit)` is `false`, `dotnet run` will simply launch the
-application using `adb shell am start` and return immediately without
-waiting for the application to exit or streaming any output.
+application and return immediately without waiting for the application to exit
+or streaming any output.
+
+This property also controls whether `adb shell am instrument` is passed `-w`
+when the application is launched through its
+[`$(AndroidInstrumentation)`](#androidinstrumentation):
+
+| `$(WaitForExit)` | Launching an `<activity/>`   | Launching an `<instrumentation/>`   |
+| ---------------- | ---------------------------- | ----------------------------------- |
+| `true` (default) | `adb shell am start -S -W`   | `adb shell am instrument -w -r`     |
+| `false`          | `adb shell am start -S`      | `adb shell am instrument -r`        |
+
+Because `adb shell am instrument` only reports results once the instrumentation
+completes, `$(WaitForExit)` must not be `false` if you need the instrumentation's
+output or a meaningful exit code. This matters for scenarios such as running
+tests or a [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) host,
+which is why `dotnet test` always uses the default.
 
 Introduced in .NET 11.

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -700,7 +700,9 @@ generated `AndroidManifest.xml` in the intermediate output:
   [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) host.
 
 If the app declares neither, the build fails with
-[XA1043](../messages/xa1043.md).
+[XA1043](../messages/xa1043.md). If `$(AndroidUseInstrumentation)` is `true` but
+the app declares no `<instrumentation/>`, the build fails with
+[XA1048](../messages/xa1048.md).
 
 When an instrumentation is launched, `dotnet run` runs
 `adb shell am instrument -w -r` and exits with a non-zero exit code if the

--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -158,6 +158,7 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 + [XA1045](xa1045.md): Input file `{0}` does not start with `<replacements/>`.
 + [XA1046](xa1046.md): Attribute '{0}' in element '{1}' has value '{2}' that cannot be parsed as boolean; {3} line {4}.
 + [XA1047](xa1047.md): Required attribute '{0}' missing from element '{1}'; {2} line {3}.
++ [XA1048](xa1048.md): '{0}' does not contain an &lt;instrumentation&gt; element.
 
 ## XA2xxx: Linker
 

--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -152,6 +152,8 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 + [XA1039](xa1039.md): The Android Support libraries are not supported in .NET 9 and later, please migrate to AndroidX. See https://aka.ms/xamarin/androidx for more details.
 + [XA1040](xa1040.md): The NativeAOT runtime on Android is an experimental feature and not yet suitable for production use. File issues at: https://github.com/dotnet/android/issues
 + [XA1041](xa1041.md): The MSBuild property 'MonoAndroidAssetPrefix' has an invalid value of 'c:\Foo\Assets'. The value is expected to be a directory path representing the relative location of your Assets or Resources
++ [XA1042](xa1042.md): The &lt;instrumentation&gt; element in '{0}' is missing the android:name attribute.
++ [XA1043](xa1043.md): Could not determine what to launch: '{0}' does not contain a launchable &lt;activity&gt; or an &lt;instrumentation&gt; element.
 + [XA1044](xa1044.md): The MSBuild property '{0}' is not compatible with the {1} runtime. The build cannot continue while this property is enabled.
 + [XA1045](xa1045.md): Input file `{0}` does not start with `<replacements/>`.
 + [XA1046](xa1046.md): Attribute '{0}' in element '{1}' has value '{2}' that cannot be parsed as boolean; {3} line {4}.

--- a/Documentation/docs-mobile/messages/xa1042.md
+++ b/Documentation/docs-mobile/messages/xa1042.md
@@ -1,0 +1,45 @@
+---
+title: .NET for Android error XA1042
+description: XA1042 error code
+ms.date: 07/29/2026
+f1_keywords:
+  - "XA1042"
+---
+
+# .NET for Android error XA1042
+
+## Example messages
+
+```dotnetcli
+error XA1042: The <instrumentation> element in 'obj/Debug/net11.0-android/android/AndroidManifest.xml' is missing the android:name attribute.
+```
+
+## Issue
+
+`dotnet run` launches an app without a launchable `<activity>` through its
+`<instrumentation>` element, but the `<instrumentation>` element found in
+`AndroidManifest.xml` has no `android:name` attribute, so there is no class to
+launch.
+
+## Solution
+
+Give the `<instrumentation>` element a name. If it is declared in your hand
+written `AndroidManifest.xml`, add the attribute:
+
+```xml
+<instrumentation android:name="com.companyname.myapp.MyInstrumentation" />
+```
+
+If the element is generated from an `Android.App.Instrumentation` subclass, set
+the `Name` property on the `[Instrumentation]` attribute:
+
+```csharp
+[Instrumentation (Name = "com.companyname.myapp.MyInstrumentation")]
+public class MyInstrumentation : Instrumentation
+{
+}
+```
+
+Alternatively, set the
+[`$(AndroidInstrumentation)`](../building-apps/build-properties.md#androidinstrumentation)
+MSBuild property to the class name to launch.

--- a/Documentation/docs-mobile/messages/xa1043.md
+++ b/Documentation/docs-mobile/messages/xa1043.md
@@ -1,0 +1,50 @@
+---
+title: .NET for Android error XA1043
+description: XA1043 error code
+ms.date: 07/29/2026
+f1_keywords:
+  - "XA1043"
+---
+
+# .NET for Android error XA1043
+
+## Example messages
+
+```dotnetcli
+error XA1043: Could not determine what to launch: 'obj/Debug/net11.0-android/android/AndroidManifest.xml' does not contain a launchable <activity> or an <instrumentation> element. Set the $(AndroidLaunchActivity) or $(AndroidInstrumentation) MSBuild property to specify one.
+```
+
+## Issue
+
+`dotnet run` needs something to launch on the device. It looks for a launchable
+`<activity>` in `AndroidManifest.xml`, and falls back to an `<instrumentation>`
+element for apps that have no user interface, such as a benchmark host. Neither
+was found.
+
+## Solution
+
+Declare an activity with a `MAIN`/`LAUNCHER` intent filter:
+
+```csharp
+[Activity (MainLauncher = true)]
+public class MainActivity : Activity
+{
+}
+```
+
+Or, for an app that has no activity, declare an instrumentation:
+
+```csharp
+[Instrumentation (Name = "com.companyname.myapp.MyInstrumentation")]
+public class MyInstrumentation : Instrumentation
+{
+    protected MyInstrumentation (IntPtr handle, JniHandleOwnership ownership)
+        : base (handle, ownership) { }
+}
+```
+
+You can also name the class to launch explicitly with the
+[`$(AndroidLaunchActivity)`](../building-apps/build-properties.md#androidlaunchactivity)
+or
+[`$(AndroidInstrumentation)`](../building-apps/build-properties.md#androidinstrumentation)
+MSBuild properties.

--- a/Documentation/docs-mobile/messages/xa1048.md
+++ b/Documentation/docs-mobile/messages/xa1048.md
@@ -1,0 +1,46 @@
+---
+title: .NET for Android error XA1048
+description: XA1048 error code
+ms.date: 07/29/2026
+f1_keywords:
+  - "XA1048"
+---
+
+# .NET for Android error XA1048
+
+## Example messages
+
+```dotnetcli
+error XA1048: 'obj/Debug/net11.0-android/android/AndroidManifest.xml' does not contain an <instrumentation> element. Add an Android.App.Instrumentation subclass to the application, or set the $(AndroidInstrumentation) MSBuild property to the name of one.
+```
+
+## Issue
+
+The application opted into launching through an
+[`Android.App.Instrumentation`](https://developer.android.com/reference/android/app/Instrumentation),
+either by setting
+[`$(AndroidUseInstrumentation)`](../building-apps/build-properties.md#androiduseinstrumentation)
+or
+[`$(EnableMSTestRunner)`](../building-apps/build-properties.md#enablemstestrunner)
+to `true`, but no `<instrumentation>` element was found in `AndroidManifest.xml`.
+
+This differs from [XA1043](xa1043.md), which is reported when the application has
+neither a launchable `<activity>` nor an `<instrumentation>`.
+
+## Solution
+
+Declare an instrumentation in the application:
+
+```csharp
+[Instrumentation (Name = "com.companyname.myapp.MyInstrumentation")]
+public class MyInstrumentation : Instrumentation
+{
+    protected MyInstrumentation (IntPtr handle, JniHandleOwnership ownership)
+        : base (handle, ownership) { }
+}
+```
+
+You can also name the class to launch explicitly with the
+[`$(AndroidInstrumentation)`](../building-apps/build-properties.md#androidinstrumentation)
+MSBuild property, or set `$(AndroidUseInstrumentation)` to `false` to launch the
+application's activity instead.

--- a/src/Microsoft.Android.Run/AdbHelper.cs
+++ b/src/Microsoft.Android.Run/AdbHelper.cs
@@ -16,6 +16,31 @@ static class AdbHelper
 		};
 	}
 
+	/// <summary>
+	/// Builds a <see cref="ProcessStartInfo"/> from a pre-split argument list.
+	/// <see cref="ProcessStartInfo.ArgumentList"/> quotes each element for us, so
+	/// values containing spaces or double quotes survive the trip through the
+	/// operating system's command line parser untouched.
+	/// </summary>
+	public static ProcessStartInfo CreateStartInfo (string adbPath, string? adbTarget, IEnumerable<string> arguments)
+	{
+		var psi = new ProcessStartInfo {
+			FileName = adbPath,
+			UseShellExecute = false,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			CreateNoWindow = true,
+		};
+		if (!string.IsNullOrEmpty (adbTarget)) {
+			// `adbTarget` is an already formatted switch such as `-s emulator-5554`.
+			foreach (var part in adbTarget.Split (' ', StringSplitOptions.RemoveEmptyEntries))
+				psi.ArgumentList.Add (part);
+		}
+		foreach (var argument in arguments)
+			psi.ArgumentList.Add (argument);
+		return psi;
+	}
+
 	public static async Task<(int ExitCode, string Output, string Error)> RunAsync (string adbPath, string? adbTarget, string arguments, CancellationToken cancellationToken, bool verbose = false)
 	{
 		var psi = CreateStartInfo (adbPath, adbTarget, arguments);

--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Text;
 using Microsoft.Testing.Extensions;
 using Mono.Options;
 using Xamarin.Android.Tools;
@@ -91,7 +92,7 @@ async Task<int> RunAsync (string[] args)
 		return 1;
 	}
 
-	if (remaining.Count > 0 && !isDotnetTestMode) {
+	if (remaining.Count > 0 && !isDotnetTestMode && string.IsNullOrEmpty (instrumentation)) {
 		Console.Error.WriteLine ($"Error: Unexpected argument(s): {string.Join (" ", remaining)}");
 		Console.Error.WriteLine ($"Try '{Name} --help' for more information.");
 		return 1;
@@ -115,7 +116,12 @@ async Task<int> RunAsync (string[] args)
 		Console.WriteLine ("Examples:");
 		Console.WriteLine ($"  {Name} -p com.example.myapp -c com.example.myapp.MainActivity");
 		Console.WriteLine ($"  {Name} -p com.example.myapp -i com.example.myapp.TestInstrumentation");
+		Console.WriteLine ($"  {Name} -p com.example.myapp -i com.example.myapp.Benchmarks --filter *MyBench*");
 		Console.WriteLine ($"  {Name} --adb /path/to/adb -p com.example.myapp -c com.example.myapp.MainActivity");
+		Console.WriteLine ();
+		Console.WriteLine ("When --instrument is used, any unrecognized arguments are forwarded to");
+		Console.WriteLine ("'am instrument' as extras: KEY=VALUE becomes '-e KEY VALUE', and everything");
+		Console.WriteLine ("else is joined into a single '-e args \"...\"' extra.");
 		Console.WriteLine ();
 		Console.WriteLine ("Press Ctrl+C while running to stop the Android application and exit.");
 		return 0;
@@ -184,7 +190,7 @@ async Task<int> RunAsync (string[] args)
 			return await RunDotnetTestAsync (remaining);
 
 		if (isInstrumentMode)
-			return await RunInstrumentationAsync ();
+			return await RunInstrumentationAsync (remaining);
 
 		return await RunAppAsync ();
 	} finally {
@@ -215,11 +221,13 @@ void OnCancelKeyPress (object? sender, ConsoleCancelEventArgs e)
 	}
 }
 
-async Task<int> RunInstrumentationAsync ()
+async Task<int> RunInstrumentationAsync (List<string> instrumentationArgs)
 {
-	// Build the am instrument command
+	// '-w' waits for the run to complete; '-r' prints raw INSTRUMENTATION_STATUS
+	// blocks as they arrive instead of buffering everything until the end.
 	var userArg = string.IsNullOrEmpty (deviceUserId) ? "" : $" --user {deviceUserId}";
-	var cmdArgs = $"shell am instrument -w{userArg} {package}/{instrumentation}";
+	var extraArgs = BuildInstrumentationExtras (instrumentationArgs);
+	var cmdArgs = $"shell am instrument -w -r{userArg}{extraArgs} {package}/{instrumentation}";
 
 	if (verbose)
 		Console.WriteLine ($"Running instrumentation: adb {cmdArgs}");
@@ -229,27 +237,32 @@ async Task<int> RunInstrumentationAsync ()
 	using var instrumentProcess = new Process { StartInfo = psi };
 
 	var locker = new Lock ();
+	var output = new StringBuilder ();
 
 	instrumentProcess.OutputDataReceived += (s, e) => {
 		if (e.Data != null)
-			lock (locker)
+			lock (locker) {
+				output.AppendLine (e.Data);
 				Console.WriteLine (e.Data);
+			}
 	};
 
 	instrumentProcess.ErrorDataReceived += (s, e) => {
 		if (e.Data != null)
-			lock (locker)
+			lock (locker) {
+				output.AppendLine (e.Data);
 				Console.Error.WriteLine (e.Data);
+			}
 	};
 
 	instrumentProcess.Start ();
 	instrumentProcess.BeginOutputReadLine ();
 	instrumentProcess.BeginErrorReadLine ();
 
-	// Also start logcat in the background for additional debug output
-	logcatPid = await GetAppPidAsync ();
-	if (logcatPid != null)
-		StartLogcat ();
+	// Also stream logcat in the background, which is where Console output from the
+	// app ends up. The app process does not exist yet when `am instrument` starts,
+	// so poll for it rather than giving up after a single `pidof`.
+	var logcatTask = StartLogcatWhenAppStartsAsync ();
 
 	// Wait for instrumentation to complete or Ctrl+C
 	try {
@@ -263,6 +276,8 @@ async Task<int> RunInstrumentationAsync ()
 			return 1;
 		}
 	} finally {
+		cts.Cancel ();
+		await logcatTask;
 		// Clean up logcat
 		try {
 			if (logcatProcess != null && !logcatProcess.HasExited) {
@@ -281,7 +296,119 @@ async Task<int> RunInstrumentationAsync ()
 		return 1;
 	}
 
+	// `am instrument` exits 0 even when the instrumentation crashes or reports
+	// failure, so inspect what it printed to decide the exit code.
+	var failure = GetInstrumentationFailure (output.ToString ());
+	if (failure != null) {
+		Console.Error.WriteLine ($"Error: {failure}");
+		return 1;
+	}
+
 	return 0;
+}
+
+/// <summary>
+/// Translates trailing `dotnet run -- ARGS` into `am instrument` extras.
+/// `KEY=VALUE` arguments become `-e KEY VALUE`; everything else is joined and
+/// passed as a single `-e args "..."` extra.
+/// </summary>
+string BuildInstrumentationExtras (List<string> instrumentationArgs)
+{
+	if (instrumentationArgs.Count == 0)
+		return "";
+
+	var builder = new StringBuilder ();
+	var positional = new List<string> ();
+
+	foreach (var arg in instrumentationArgs) {
+		var eqIndex = arg.IndexOf ('=');
+		if (eqIndex > 0 && !arg.StartsWith ("-", StringComparison.Ordinal) && IsBundleKey (arg.AsSpan (0, eqIndex))) {
+			builder.Append (" -e ").Append (arg.Substring (0, eqIndex)).Append (' ')
+				.Append (QuoteForDeviceShell (arg.Substring (eqIndex + 1)));
+		} else {
+			positional.Add (arg);
+		}
+	}
+
+	if (positional.Count > 0)
+		builder.Append (" -e args ").Append (QuoteForDeviceShell (string.Join (" ", positional)));
+
+	return builder.ToString ();
+
+	static bool IsBundleKey (ReadOnlySpan<char> key)
+	{
+		foreach (var c in key) {
+			if (!char.IsLetterOrDigit (c) && c != '_' && c != '.')
+				return false;
+		}
+		return key.Length > 0;
+	}
+}
+
+/// <summary>
+/// Wraps a value in single quotes so the shell on the device treats it as a
+/// single token, no matter what `adb shell` does to the surrounding arguments.
+/// </summary>
+static string QuoteForDeviceShell (string value) =>
+	"'" + value.Replace ("'", "'\\''") + "'";
+
+/// <summary>
+/// Inspects `am instrument` output for signs that the instrumentation crashed or
+/// reported failure. Returns a human readable reason, or <c>null</c> on success.
+/// </summary>
+static string? GetInstrumentationFailure (string output)
+{
+	if (output.Contains ("INSTRUMENTATION_FAILED", StringComparison.Ordinal))
+		return "The instrumentation failed to start. See the output above for details.";
+
+	string? shortMsg = null, longMsg = null;
+	int? code = null;
+	foreach (var rawLine in output.Split ('\n')) {
+		var line = rawLine.TrimEnd ('\r');
+		if (line.StartsWith ("INSTRUMENTATION_RESULT: shortMsg=", StringComparison.Ordinal))
+			shortMsg = line.Substring ("INSTRUMENTATION_RESULT: shortMsg=".Length).Trim ();
+		else if (line.StartsWith ("INSTRUMENTATION_RESULT: longMsg=", StringComparison.Ordinal))
+			longMsg = line.Substring ("INSTRUMENTATION_RESULT: longMsg=".Length).Trim ();
+		else if (line.StartsWith ("INSTRUMENTATION_CODE: ", StringComparison.Ordinal)) {
+			if (int.TryParse (line.Substring ("INSTRUMENTATION_CODE: ".Length).Trim (), out int parsed))
+				code = parsed;
+		}
+	}
+
+	if (longMsg != null || shortMsg != null)
+		return $"The application crashed: {longMsg ?? shortMsg}";
+
+	// Activity.RESULT_CANCELED (0) is what Instrumentation.Finish() reports on failure.
+	if (code == 0)
+		return "The instrumentation reported failure (INSTRUMENTATION_CODE: 0).";
+
+	if (code == null)
+		return "The instrumentation did not complete. It may have crashed before calling Finish().";
+
+	return null;
+}
+
+/// <summary>
+/// Polls for the application process and starts streaming logcat once it appears.
+/// </summary>
+async Task StartLogcatWhenAppStartsAsync ()
+{
+	try {
+		while (!cts.Token.IsCancellationRequested) {
+			var pid = await GetAppPidAsync ();
+			if (pid != null) {
+				logcatPid = pid;
+				StartLogcat ();
+				return;
+			}
+			await Task.Delay (250, cts.Token).ConfigureAwait (ConfigureAwaitOptions.SuppressThrowing);
+		}
+	} catch (OperationCanceledException) {
+		// The instrumentation finished (or was cancelled) before the app process was seen
+	} catch (Exception ex) {
+		if (verbose)
+			Console.Error.WriteLine ($"Error starting logcat: {ex.Message}");
+	}
 }
 
 async Task<int> RunDotnetTestAsync (List<string> mtpArgs)

--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -225,12 +225,16 @@ async Task<int> RunInstrumentationAsync (List<string> instrumentationArgs)
 {
 	// '-w' waits for the run to complete; '-r' prints raw INSTRUMENTATION_STATUS
 	// blocks as they arrive instead of buffering everything until the end.
-	var userArg = string.IsNullOrEmpty (deviceUserId) ? "" : $" --user {deviceUserId}";
-	var extraArgs = BuildInstrumentationExtras (instrumentationArgs);
-	var cmdArgs = $"shell am instrument -w -r{userArg}{extraArgs} {package}/{instrumentation}";
+	var cmdArgs = new List<string> { "shell", "am", "instrument", "-w", "-r" };
+	if (!string.IsNullOrEmpty (deviceUserId)) {
+		cmdArgs.Add ("--user");
+		cmdArgs.Add (deviceUserId);
+	}
+	cmdArgs.AddRange (BuildInstrumentationExtras (instrumentationArgs));
+	cmdArgs.Add ($"{package}/{instrumentation}");
 
 	if (verbose)
-		Console.WriteLine ($"Running instrumentation: adb {cmdArgs}");
+		Console.WriteLine ($"Running instrumentation: adb {string.Join (" ", cmdArgs)}");
 
 	// Run instrumentation with streaming output
 	var psi = AdbHelper.CreateStartInfo (adbPath, adbTarget, cmdArgs);
@@ -317,28 +321,32 @@ async Task<int> RunInstrumentationAsync (List<string> instrumentationArgs)
 /// `KEY=VALUE` arguments become `-e KEY VALUE`; everything else is joined and
 /// passed as a single `-e args "..."` extra.
 /// </summary>
-string BuildInstrumentationExtras (List<string> instrumentationArgs)
+List<string> BuildInstrumentationExtras (List<string> instrumentationArgs)
 {
+	var result = new List<string> ();
 	if (instrumentationArgs.Count == 0)
-		return "";
+		return result;
 
-	var builder = new StringBuilder ();
 	var positional = new List<string> ();
 
 	foreach (var arg in instrumentationArgs) {
 		var eqIndex = arg.IndexOf ('=');
 		if (eqIndex > 0 && !arg.StartsWith ("-", StringComparison.Ordinal) && IsBundleKey (arg.AsSpan (0, eqIndex))) {
-			builder.Append (" -e ").Append (arg.Substring (0, eqIndex)).Append (' ')
-				.Append (QuoteForDeviceShell (arg.Substring (eqIndex + 1)));
+			result.Add ("-e");
+			result.Add (arg.Substring (0, eqIndex));
+			result.Add (QuoteForDeviceShell (arg.Substring (eqIndex + 1)));
 		} else {
 			positional.Add (arg);
 		}
 	}
 
-	if (positional.Count > 0)
-		builder.Append (" -e args ").Append (QuoteForDeviceShell (string.Join (" ", positional)));
+	if (positional.Count > 0) {
+		result.Add ("-e");
+		result.Add ("args");
+		result.Add (QuoteForDeviceShell (string.Join (" ", positional)));
+	}
 
-	return builder.ToString ();
+	return result;
 
 	static bool IsBundleKey (ReadOnlySpan<char> key)
 	{
@@ -352,7 +360,10 @@ string BuildInstrumentationExtras (List<string> instrumentationArgs)
 
 /// <summary>
 /// Wraps a value in single quotes so the shell on the device treats it as a
-/// single token, no matter what `adb shell` does to the surrounding arguments.
+/// single token. `adb shell` deliberately does not escape the arguments it
+/// forwards, it just joins them with spaces (like `ssh`), so quoting for the
+/// device shell is up to the caller. The surrounding quoting needed to survive
+/// the *local* command line is handled by <see cref="ProcessStartInfo.ArgumentList"/>.
 /// </summary>
 static string QuoteForDeviceShell (string value) =>
 	"'" + value.Replace ("'", "'\\''") + "'";

--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -297,8 +297,13 @@ async Task<int> RunInstrumentationAsync (List<string> instrumentationArgs)
 	}
 
 	// `am instrument` exits 0 even when the instrumentation crashes or reports
-	// failure, so inspect what it printed to decide the exit code.
-	var failure = GetInstrumentationFailure (output.ToString ());
+	// failure, so inspect what it printed to decide the exit code. `WaitForExitAsync`
+	// has already drained both readers, but read under the same lock for clarity.
+	string capturedOutput;
+	lock (locker)
+		capturedOutput = output.ToString ();
+
+	var failure = GetInstrumentationFailure (capturedOutput);
 	if (failure != null) {
 		Console.Error.WriteLine ($"Error: {failure}");
 		return 1;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -121,6 +121,7 @@ This file contains targets specific for Android application projects.
     -->
     <GetAndroidInstrumentationName
         Condition=" '$(AndroidLaunchActivity)' == '' and '$(AndroidInstrumentation)' == '' "
+        NoLaunchableActivity="true"
         ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml">
       <Output TaskParameter="InstrumentationName" PropertyName="AndroidInstrumentation" />
     </GetAndroidInstrumentationName>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -101,13 +101,26 @@ This file contains targets specific for Android application projects.
   <Target Name="_AndroidComputeRunArguments"
       BeforeTargets="ComputeRunArguments"
       DependsOnTargets="$(_AndroidComputeRunArgumentsDependsOn)">
+    <!--
+      $(AndroidUseInstrumentation) apps launch through their <instrumentation>, even if they
+      also declare a launchable <activity>. $(EnableMSTestRunner) sets this by default.
+    -->
+    <GetAndroidInstrumentationName
+        Condition=" '$(AndroidLaunchActivity)' == '' and '$(AndroidInstrumentation)' == '' and '$(AndroidUseInstrumentation)' == 'true' "
+        ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml">
+      <Output TaskParameter="InstrumentationName" PropertyName="AndroidInstrumentation" />
+    </GetAndroidInstrumentationName>
     <GetAndroidActivityName
-        Condition=" '$(AndroidLaunchActivity)' == '' and '$(AndroidInstrumentation)' == '' and '$(EnableMSTestRunner)' != 'true' "
+        Condition=" '$(AndroidLaunchActivity)' == '' and '$(AndroidInstrumentation)' == '' "
         ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml">
       <Output TaskParameter="ActivityName" PropertyName="AndroidLaunchActivity" />
     </GetAndroidActivityName>
+    <!--
+      Apps without a launchable <activity>, such as a BenchmarkDotNet host, launch through
+      their <instrumentation> instead. This errors if the app has neither.
+    -->
     <GetAndroidInstrumentationName
-        Condition=" '$(AndroidLaunchActivity)' == '' and '$(AndroidInstrumentation)' == '' and '$(EnableMSTestRunner)' == 'true' "
+        Condition=" '$(AndroidLaunchActivity)' == '' and '$(AndroidInstrumentation)' == '' "
         ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml">
       <Output TaskParameter="InstrumentationName" PropertyName="AndroidInstrumentation" />
     </GetAndroidInstrumentationName>
@@ -129,7 +142,9 @@ This file contains targets specific for Android application projects.
     <PropertyGroup Condition=" '$(WaitForExit)' == 'false' ">
       <_AmStartUserArg Condition=" '$(AndroidDeviceUserId)' != '' "> --user $(AndroidDeviceUserId)</_AmStartUserArg>
       <RunCommand>$(_AdbToolPath)</RunCommand>
-      <RunArguments>$(AdbTarget) shell am start -S$(_AmStartUserArg) -n &quot;$(_AndroidPackage)/$(AndroidLaunchActivity)&quot;</RunArguments>
+      <RunArguments Condition=" '$(AndroidInstrumentation)' == '' ">$(AdbTarget) shell am start -S$(_AmStartUserArg) -n &quot;$(_AndroidPackage)/$(AndroidLaunchActivity)&quot;</RunArguments>
+      <!-- No `-w`, the caller asked not to wait for the instrumentation to finish -->
+      <RunArguments Condition=" '$(AndroidInstrumentation)' != '' ">$(AdbTarget) shell am instrument -r$(_AmStartUserArg) &quot;$(_AndroidPackage)/$(AndroidInstrumentation)&quot;</RunArguments>
     </PropertyGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -6,6 +6,12 @@
     <MonoAndroidResourcePrefix Condition=" '$(MonoAndroidResourcePrefix)' == '' ">Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix Condition=" '$(MonoAndroidAssetsPrefix)' == '' ">Assets</MonoAndroidAssetsPrefix>
     <AndroidResgenClass Condition=" '$(AndroidResgenClass)' == '' ">Resource</AndroidResgenClass>
+    <!--
+      Apps that launch through an <instrumentation> instead of an <activity>, such as test
+      or benchmark hosts. $(EnableMSTestRunner) opts in automatically.
+    -->
+    <AndroidUseInstrumentation Condition=" '$(AndroidUseInstrumentation)' == '' and '$(EnableMSTestRunner)' == 'true' ">true</AndroidUseInstrumentation>
+    <AndroidUseInstrumentation Condition=" '$(AndroidUseInstrumentation)' == '' ">false</AndroidUseInstrumentation>
     <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
     <AndroidGenerateResourceDesigner Condition=" '$(AndroidGenerateResourceDesigner)' == '' ">true</AndroidGenerateResourceDesigner>
     <AndroidUseDesignerAssembly Condition=" '$(AndroidUseDesignerAssembly)' == '' ">true</AndroidUseDesignerAssembly>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -964,7 +964,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &lt;instrumentation&gt; element in AndroidManifest.xml is missing the android:name attribute..
+        ///   Looks up a localized string similar to The &lt;instrumentation&gt; element in &apos;{0}&apos; is missing the android:name attribute..
         /// </summary>
         public static string XA1042 {
             get {
@@ -973,7 +973,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No &lt;instrumentation&gt; element found in AndroidManifest.xml..
+        ///   Looks up a localized string similar to Could not determine what to launch: &apos;{0}&apos; does not contain a launchable &lt;activity&gt; or an &lt;instrumentation&gt; element. Set the $(AndroidLaunchActivity) or $(AndroidInstrumentation) MSBuild property to specify one..
         /// </summary>
         public static string XA1043 {
             get {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1018,6 +1018,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not contain an &lt;instrumentation&gt; element. Add an Android.App.Instrumentation subclass to the application, or set the $(AndroidInstrumentation) MSBuild property to the name of one..
+        /// </summary>
+        public static string XA1048 {
+            get {
+                return ResourceManager.GetString("XA1048", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 and higher will only support a single AppDomain, so this API will no longer be available in .NET for Android once .NET 6 is released..
         /// </summary>
         public static string XA2000 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1074,6 +1074,18 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - The current value of the property
 </comment>
   </data>
+  <data name="XA1042" xml:space="preserve">
+    <value>The &lt;instrumentation&gt; element in '{0}' is missing the android:name attribute.</value>
+    <comment>The following are literal names and should not be translated: instrumentation, android:name.
+{0} - The path to the AndroidManifest.xml file.
+</comment>
+  </data>
+  <data name="XA1043" xml:space="preserve">
+    <value>Could not determine what to launch: '{0}' does not contain a launchable &lt;activity&gt; or an &lt;instrumentation&gt; element. Set the $(AndroidLaunchActivity) or $(AndroidInstrumentation) MSBuild property to specify one.</value>
+    <comment>The following are literal names and should not be translated: activity, instrumentation, MSBuild, AndroidLaunchActivity, AndroidInstrumentation.
+{0} - The path to the AndroidManifest.xml file.
+</comment>
+  </data>
   <data name="XA1044" xml:space="preserve">
     <value>The MSBuild property '{0}' is not compatible with the {1} runtime. The build cannot continue while this property is enabled. Either remove the property or guard it with a condition: Condition="'$(UseMonoRuntime)' == 'true'"</value>
     <comment>The following are literal names and should not be translated: MSBuild, UseMonoRuntime.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1105,6 +1105,12 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
     <value>Required attribute '{0}' missing from element '{1}'; {2} line {3}.</value>
     <comment>{0} - attribute name; {1} - element name; {2} - file path; {3} - line number</comment>
   </data>
+  <data name="XA1048" xml:space="preserve">
+    <value>'{0}' does not contain an &lt;instrumentation&gt; element. Add an Android.App.Instrumentation subclass to the application, or set the $(AndroidInstrumentation) MSBuild property to the name of one.</value>
+    <comment>The following are literal names and should not be translated: instrumentation, Android.App.Instrumentation, MSBuild, AndroidInstrumentation.
+{0} - The path to the AndroidManifest.xml file.
+</comment>
+  </data>
   <data name="XA4241" xml:space="preserve">
     <value>Java dependency '{0}' is not satisfied.</value>
     <comment>The following are literal names and should not be translated: Java.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidInstrumentationName.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidInstrumentationName.cs
@@ -16,6 +16,14 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string ManifestFile { get; set; } = "";
 
+		/// <summary>
+		/// Set when the application was already found to have no launchable
+		/// &lt;activity&gt;, in which case a missing &lt;instrumentation&gt; element
+		/// means there is nothing at all to launch and XA1043 is reported.
+		/// Otherwise a missing &lt;instrumentation&gt; is reported as XA1048.
+		/// </summary>
+		public bool NoLaunchableActivity { get; set; }
+
 		[Output]
 		public string? InstrumentationName { get; set; }
 
@@ -26,7 +34,11 @@ namespace Xamarin.Android.Tasks
 
 			var instrumentation = manifest.Document?.Root?.Element ("instrumentation");
 			if (instrumentation == null) {
-				Log.LogCodedError ("XA1043", Properties.Resources.XA1043, ManifestFile);
+				if (NoLaunchableActivity) {
+					Log.LogCodedError ("XA1043", Properties.Resources.XA1043, ManifestFile);
+				} else {
+					Log.LogCodedError ("XA1048", Properties.Resources.XA1048, ManifestFile);
+				}
 				return !Log.HasLoggedErrors;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidInstrumentationName.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidInstrumentationName.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using Microsoft.Build.Framework;
 using Xamarin.Android.Tools;
 using Microsoft.Android.Build.Tasks;
@@ -24,13 +23,16 @@ namespace Xamarin.Android.Tasks
 		{
 			var manifest = AndroidAppManifest.Load (ManifestFile, MonoAndroidHelper.SupportedVersions);
 			var androidNs = AndroidAppManifest.AndroidXNamespace;
-			var doc = manifest.Document;
 
-			var instrumentation = doc?.Root?.Element ("instrumentation")
-				?? throw new InvalidOperationException ("No <instrumentation> element found in AndroidManifest.xml.");
+			var instrumentation = manifest.Document?.Root?.Element ("instrumentation");
+			if (instrumentation == null) {
+				Log.LogCodedError ("XA1043", Properties.Resources.XA1043, ManifestFile);
+				return !Log.HasLoggedErrors;
+			}
+
 			InstrumentationName = instrumentation.Attribute (androidNs + "name")?.Value;
-			if (string.IsNullOrEmpty (InstrumentationName))
-				throw new InvalidOperationException ("The <instrumentation> element in AndroidManifest.xml is missing the android:name attribute.");
+			if (InstrumentationName.IsNullOrEmpty ())
+				Log.LogCodedError ("XA1042", Properties.Resources.XA1042, ManifestFile);
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetAndroidInstrumentationNameTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetAndroidInstrumentationNameTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class GetAndroidInstrumentationNameTests : BaseTest
+	{
+		string temp;
+		string manifest;
+
+		[SetUp]
+		public void Setup ()
+		{
+			string tempDirectoryName = Path.Combine ("temp", TestName);
+			temp = Path.Combine (Root, tempDirectoryName);
+			Directory.CreateDirectory (temp);
+			manifest = Path.Combine (temp, "AndroidManifest.xml");
+
+			var references = CreateFauxReferencesDirectory (Path.Combine (tempDirectoryName, "references"), new [] {
+				new ApiInfo { Id = "28", Level = 28, Name = "Pie", FrameworkVersion = "v9.0", Stable = true },
+			});
+			MonoAndroidHelper.RefreshSupportedVersions (new [] {
+				Path.Combine (references, "MonoAndroid"),
+			});
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			Directory.Delete (temp, recursive: true);
+		}
+
+		void WriteManifest (string body)
+		{
+			File.WriteAllText (manifest,
+				$"""
+				<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.mycompanyname.foo">
+					<application />
+				{body}
+				</manifest>
+				""");
+		}
+
+		GetAndroidInstrumentationName CreateTask (List<BuildErrorEventArgs> errors, bool noLaunchableActivity = false) =>
+			new GetAndroidInstrumentationName {
+				BuildEngine = new MockBuildEngine (TestContext.Out, errors),
+				ManifestFile = manifest,
+				NoLaunchableActivity = noLaunchableActivity,
+			};
+
+		[Test]
+		public void InstrumentationFound ()
+		{
+			WriteManifest ("""	<instrumentation android:name="com.mycompanyname.foo.MyInstrumentation" android:targetPackage="com.mycompanyname.foo" />""");
+
+			var errors = new List<BuildErrorEventArgs> ();
+			var task = CreateTask (errors);
+			Assert.IsTrue (task.Execute (), "Execute() should have succeeded.");
+			Assert.AreEqual (0, errors.Count, "There should be no errors.");
+			Assert.AreEqual ("com.mycompanyname.foo.MyInstrumentation", task.InstrumentationName);
+		}
+
+		[Test]
+		public void MissingInstrumentationIsXA1048 ()
+		{
+			// `$(AndroidUseInstrumentation)` opted in, but there is nothing to run.
+			WriteManifest ("");
+
+			var errors = new List<BuildErrorEventArgs> ();
+			var task = CreateTask (errors);
+			Assert.IsFalse (task.Execute (), "Execute() should have failed.");
+			Assert.AreEqual (1, errors.Count, "There should be one error.");
+			Assert.AreEqual ("XA1048", errors [0].Code);
+			Assert.IsNull (task.InstrumentationName);
+		}
+
+		[Test]
+		public void MissingInstrumentationAndActivityIsXA1043 ()
+		{
+			// The fallback call site: no launchable `<activity/>` was found either.
+			WriteManifest ("");
+
+			var errors = new List<BuildErrorEventArgs> ();
+			var task = CreateTask (errors, noLaunchableActivity: true);
+			Assert.IsFalse (task.Execute (), "Execute() should have failed.");
+			Assert.AreEqual (1, errors.Count, "There should be one error.");
+			Assert.AreEqual ("XA1043", errors [0].Code);
+			Assert.IsNull (task.InstrumentationName);
+		}
+
+		[Test]
+		public void MissingAndroidNameIsXA1042 ()
+		{
+			WriteManifest ("""	<instrumentation android:targetPackage="com.mycompanyname.foo" />""");
+
+			var errors = new List<BuildErrorEventArgs> ();
+			var task = CreateTask (errors);
+			Assert.IsFalse (task.Execute (), "Execute() should have failed.");
+			Assert.AreEqual (1, errors.Count, "There should be one error.");
+			Assert.AreEqual ("XA1042", errors [0].Code);
+		}
+	}
+}

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2826,6 +2826,149 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 			}
 		}
 
+		/// <summary>
+		/// An app whose only entry point is an `Android.App.Instrumentation` subclass that
+		/// runs BenchmarkDotNet in-process. There is no `<activity/>`, so `dotnet run` has to
+		/// resolve `$(AndroidInstrumentation)` from the generated `AndroidManifest.xml`.
+		/// </summary>
+		const string BenchmarkDotNetInstrumentationSource = """
+			using System;
+			using System.IO;
+			using BenchmarkDotNet.Attributes;
+			using BenchmarkDotNet.Columns;
+			using BenchmarkDotNet.Configs;
+			using BenchmarkDotNet.Jobs;
+			using BenchmarkDotNet.Loggers;
+			using BenchmarkDotNet.Running;
+			using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+
+			namespace ${ROOT_NAMESPACE}
+			{
+				public class SampleBenchmarks
+				{
+					[Benchmark]
+					public int Sum ()
+					{
+						int total = 0;
+						for (int i = 0; i < 1000; i++)
+							total += i;
+						return total;
+					}
+				}
+
+				[Instrumentation (Name = "${JAVA_PACKAGENAME}.BenchmarkInstrumentation")]
+				public class BenchmarkInstrumentation : Instrumentation
+				{
+					protected BenchmarkInstrumentation (IntPtr handle, Android.Runtime.JniHandleOwnership ownership)
+						: base (handle, ownership) { }
+
+					public override void OnCreate (Bundle? arguments)
+					{
+						base.OnCreate (arguments);
+						Console.WriteLine ($"BENCHMARK_ARGS args={arguments?.GetString ("args")} greeting={arguments?.GetString ("greeting")}");
+						Start ();
+					}
+
+					public override void OnStart ()
+					{
+						base.OnStart ();
+						var results = new Bundle ();
+						try {
+							var artifacts = Path.Combine (
+								Application.Context.GetExternalFilesDir (null)?.AbsolutePath ?? Path.GetTempPath (),
+								"BenchmarkDotNet.Artifacts");
+							// BenchmarkDotNet cannot spawn child processes on Android, so run in-process.
+							// Job.Dry keeps the run to a single iteration.
+							var config = ManualConfig.CreateEmpty ()
+								.AddJob (Job.Dry.WithToolchain (InProcessNoEmitToolchain.Instance))
+								.AddLogger (ConsoleLogger.Default)
+								.AddColumnProvider (DefaultColumnProviders.Instance)
+								.WithArtifactsPath (artifacts)
+								.WithOptions (ConfigOptions.DisableOptimizationsValidator);
+							var summary = BenchmarkRunner.Run<SampleBenchmarks> (config);
+							Console.WriteLine ($"BENCHMARKS_COMPLETE reports={summary.Reports.Length}");
+							results.PutInt ("reports", summary.Reports.Length);
+							Finish (Result.Ok, results);
+						} catch (Exception ex) {
+							Console.WriteLine ($"BENCHMARKS_FAILED {ex}");
+							results.PutString ("error", ex.ToString ());
+							Finish (Result.Canceled, results);
+						}
+					}
+				}
+			}
+			""";
+
+		[Test]
+		public void DotNetRunBenchmarkDotNet ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				ProjectName = nameof (DotNetRunBenchmarkDotNet),
+				RootNamespace = nameof (DotNetRunBenchmarkDotNet),
+				IsRelease = false,
+			};
+			proj.PackageReferences.Add (new Package { Id = "BenchmarkDotNet", Version = "0.15.8" });
+
+			// Enable verbose output from Microsoft.Android.Run for debugging
+			proj.SetProperty ("_AndroidRunExtraArgs", "--verbose");
+
+			// Replace MainActivity.cs, so the app declares an <instrumentation> and no <activity>
+			proj.MainActivity = BenchmarkDotNetInstrumentationSource;
+
+			using var builder = CreateApkBuilder ();
+			builder.Save (proj);
+
+			var dotnet = new DotNetCLI (Path.Combine (Root, builder.ProjectDirectory, proj.ProjectFilePath));
+			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
+
+			// Arguments after `--` are forwarded to `am instrument` as extras:
+			// `greeting=hello` becomes `-e greeting hello`, and `--custom-flag` is
+			// collected into a single `-e args "..."` extra.
+			using var process = dotnet.StartRun (waitForExit: true, parameters: new [] { "--", "greeting=hello", "--custom-flag" });
+
+			var locker = new Lock ();
+			var output = new StringBuilder ();
+
+			process.OutputDataReceived += (sender, e) => {
+				if (e.Data != null)
+					lock (locker)
+						output.AppendLine (e.Data);
+			};
+			process.ErrorDataReceived += (sender, e) => {
+				if (e.Data != null)
+					lock (locker)
+						output.AppendLine ($"STDERR: {e.Data}");
+			};
+
+			process.BeginOutputReadLine ();
+			process.BeginErrorReadLine ();
+
+			bool completed = process.WaitForExit ((int) TimeSpan.FromMinutes (10).TotalMilliseconds);
+			if (!completed) {
+				try { process.Kill (entireProcessTree: true); } catch { }
+			} else {
+				// Ensure async output events are fully drained
+				process.WaitForExit ();
+			}
+
+			string logPath = Path.Combine (Root, builder.ProjectDirectory, "dotnet-run-benchmarkdotnet.log");
+			File.WriteAllText (logPath, output.ToString ());
+			TestContext.AddTestAttachment (logPath);
+
+			Assert.IsTrue (completed, $"`dotnet run` did not complete in time. See {logPath} for details.");
+
+			var outputText = output.ToString ();
+
+			// `Console.WriteLine` from the app lands in logcat, which `dotnet run` streams
+			StringAssert.Contains ("BENCHMARK_ARGS args=--custom-flag greeting=hello", outputText,
+				$"The instrumentation should receive the arguments passed after `--`. See {logPath} for details.");
+			StringAssert.Contains ("BENCHMARKS_COMPLETE reports=1", outputText,
+				$"BenchmarkDotNet should have produced 1 report. See {logPath} for details.");
+			StringAssert.Contains ("INSTRUMENTATION_CODE: -1", outputText,
+				$"The instrumentation should have finished with Result.Ok. See {logPath} for details.");
+			Assert.AreEqual (0, process.ExitCode, $"`dotnet run` should succeed. See {logPath} for details.");
+		}
+
 		static int ParseInstrumentationResult (string output, string key)
 		{
 			// Parses lines like: INSTRUMENTATION_RESULT: passed=1


### PR DESCRIPTION
## Why

You can already write an Android "app" whose only entry point is an `Android.App.Instrumentation` subclass, with no `Activity` at all. This is exactly the shape you want for a BenchmarkDotNet host, or any headless on-device harness.

`dotnet test` handles this today, but `dotnet run` did not. Instrumentation auto-detection was gated behind `$(EnableMSTestRunner)`, and several code paths in `Microsoft.Android.Run` assumed a launchable `<activity/>` existed.

## What changed

**Resolving what to launch.** New `$(AndroidUseInstrumentation)` property, defaulting to `true` when `$(EnableMSTestRunner)` is `true`. When set, the app launches through its `<instrumentation/>` even if it also declares a launchable activity. Separately, `$(AndroidInstrumentation)` is now resolved as a *fallback* when the app has no launchable `<activity/>`, so an instrumentation-only app needs no opt-in at all. If the app has neither, the build fails with a coded error instead of an unhandled exception.

**`Microsoft.Android.Run` fixes.** Four bugs made the instrumentation path unusable for anything but MSTest:

- No `-r` on `am instrument -w`, so status blocks were buffered instead of streamed.
- A single `pidof` call raced the app process start and usually lost, which silently dropped *all* `Console.WriteLine` output. Now polls until the process appears.
- `am instrument` exits 0 even when the instrumentation crashes. Output is now parsed for `INSTRUMENTATION_FAILED`, `shortMsg`/`longMsg`, and `INSTRUMENTATION_CODE` to produce a real exit code.
- No way to pass arguments. Trailing `dotnet run -- <args>` are now forwarded as `am instrument` extras: `KEY=VALUE` becomes `-e KEY VALUE`, and anything else is collected into a single `-e args "..."`.

**`$(WaitForExit)`.** The `false` path hard-coded `am start`; it now uses `am instrument` (without `-w`) when instrumentation is set.

**Error codes.** `XA1042` and `XA1043` existed in `Resources.Designer.cs` but were missing from `Resources.resx`. Added, along with `xa1042.md` / `xa1043.md` docs.

## Notes for reviewers

**Does this break `dotnet test`?** No. `$(EnableMSTestRunner)` opts into `$(AndroidUseInstrumentation)`, so instrumentation resolution is byte-for-byte identical to before. `dotnet test` routes through `RunDotnetTestAsync`, which is untouched; all the new behavior is confined to `RunInstrumentationAsync`.

One deliberate design constraint worth flagging: I did *not* add a `--` end-of-options separator to `RunArguments`. Mono.Options treats `--` as a terminator, which would push `--server dotnettestcli` into the unparsed list and silently break MTP. Trailing user args are picked up from the `remaining` list instead. The known trade-off is that user args colliding with `Microsoft.Android.Run`'s own option names (`--verbose`, `--package`, `--adb`) get consumed by the tool.

The failure heuristic treats `INSTRUMENTATION_CODE: 0` (`Activity.RESULT_CANCELED`) as a failure and `-1` (`RESULT_OK`) as success, matching what the `androidtest` template does. A third-party runner that uses `0` for success would be misreported.

Still not covered: pulling `BenchmarkDotNet.Artifacts/` back off the device.

## Testing

New `DotNetRunBenchmarkDotNet` device test in `MSBuildDeviceIntegration`. It builds an app whose `MainActivity.cs` is replaced with a BenchmarkDotNet host and an `Instrumentation` subclass, runs `dotnet run -- greeting=hello --custom-flag`, and asserts on arg forwarding, benchmark results, and the instrumentation exit code.

Verified on a physical Pixel 5:

```
Instrumentation runner: com.xamarin.dotnetrunbenchmarkdotnet.BenchmarkInstrumentation
Running instrumentation: adb shell am instrument -w -r -e greeting 'hello' -e args '--custom-flag' ...
I DOTNET  : BENCHMARK_ARGS args=--custom-flag greeting=hello
I DOTNET  : // ***** BenchmarkRunner: Start   *****
I DOTNET  : SampleBenchmarks.Sum: Dry(Toolchain=InProcessNoEmitToolchain, ...)
I DOTNET  : Mean = 444.948 us, StdErr = 0.000 us (0.00%), N = 1
I DOTNET  : Run time: 00:00:00 (0.22 sec), executed benchmarks: 1
I DOTNET  : BENCHMARKS_COMPLETE reports=1
INSTRUMENTATION_RESULT: reports=1
INSTRUMENTATION_CODE: -1
```

So BenchmarkDotNet does genuinely run in-process on Android via `InProcessNoEmitToolchain`.

`DotNetRunWaitForExit` also passes. Three `DotNetNewAndroidTest` cases fail locally, but I confirmed they are pre-existing by reverting `src/` and `tests/` to the parent commit and reproducing the identical failures. They are `XA0101 @(Content) build action is not supported` warnings coming from `microsoft.testplatform.testhost` 18.4.0, unrelated to this change.

## Documentation

`Documentation/docs-mobile/building-apps/build-properties.md` updates:

- `$(AndroidInstrumentation)` rewritten to describe the resolution order, exit code semantics, and argument forwarding.
- New `$(AndroidUseInstrumentation)` section.
- `$(WaitForExit)` now documents that it controls whether `-w` is passed to `am instrument`, with a table of the four activity/instrumentation combinations, and a note that `false` means no output and no meaningful exit code.