### PR TITLE
[Mono.Android] Investigation: restoring WaitForGCBridgeProcessing() on CoreCLR (informational, do not merge)

### DIFF
--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Java;
+using System.Threading;
 using Android.Runtime;
 using Java.Interop;
 
@@ -36,6 +37,75 @@ static class JavaMarshalRegisteredPeers
 
 	static readonly object initializeLock = new ();
 	static bool initialized;
+
+	/// <summary>
+	/// Signaled whenever GC bridge processing is *not* in progress.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This is the CoreCLR/NativeAOT equivalent of Mono's
+	/// <c>mono_gc_wait_for_bridge_processing()</c>, which blocks on the SGen GC lock held
+	/// for the duration of a bridge round. A bridge round flips every registered peer's
+	/// global reference strong-&gt;weak, asks ART to collect
+	/// (<c>java.lang.Runtime.gc()</c>), and then flips the survivors back. The wait exists
+	/// to match Mono's semantics: threads entering managed code from Java do not observe
+	/// peers mid-flip.
+	/// </para>
+	/// <para>
+	/// It is *not* a performance optimization. It was measured on a MAUI/SkiaSharp
+	/// benchmark (Pixel 5, arm64, 60 Hz, two runs per arm) with the barrier enabled and
+	/// disabled, and it made no useful difference: ART "Explicit concurrent copying GC"
+	/// wall time was 24.7/27.1 ms enabled vs 24.6/21.6 ms disabled, worst frame gap
+	/// 53.6/53.6 ms vs 54.3/57.4 ms. Both arms were far from the Mono baseline on the same
+	/// SDK (10.8-11.5 ms GC, 33.5 ms worst gap) even though the JNI global reference count
+	/// was identical (~840) on all arms. Whatever makes an ART bridge collection ~2x more
+	/// expensive under CoreCLR, it is not mutator activity during the round.
+	/// </para>
+	/// <para>
+	/// <see cref="ManualResetEventSlim"/> is constructed with <c>spinCount: 0</c> on
+	/// purpose: the goal is to park the waiting thread rather than burn CPU that ART's
+	/// collector could use.
+	/// </para>
+	/// </remarks>
+	static readonly ManualResetEventSlim bridgeProcessingFinished = new (initialState: true, spinCount: 0);
+
+	/// <summary>
+	/// <see cref="Environment.CurrentManagedThreadId"/> of the bridge processing thread
+	/// while a round is in progress, otherwise 0.
+	/// </summary>
+	static int bridgeProcessingThreadId;
+
+	/// <summary>
+	/// Blocks until any in-progress GC bridge round completes.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Like Mono's implementation, this is inherently racy: a thread that observes "no
+	/// bridge processing" can still be preempted by a round that begins immediately
+	/// afterwards. The wait narrows the window, it does not close it.
+	/// </para>
+	/// <para>
+	/// In practice exactly one thread parks per round in a typical UI app (measured:
+	/// 15-36 ms per round), so this trades one unbounded stall for one bounded one
+	/// without reducing total GC cost.
+	/// </para>
+	/// </remarks>
+	internal static void WaitForBridgeProcessing ()
+	{
+		if (!RuntimeFeature.WaitForGCBridgeProcessing)
+			return;
+
+		var finished = bridgeProcessingFinished;
+		if (finished.IsSet)
+			return;
+
+		// The bridge thread runs BridgeProcessingStarted/Finished itself, so it must
+		// never wait on its own completion signal.
+		if (Environment.CurrentManagedThreadId == Volatile.Read (ref bridgeProcessingThreadId))
+			return;
+
+		finished.Wait ();
+	}
 
 	/// <summary>
 	/// Performs the one-shot, process-global GC-bridge initialization the first time it is
@@ -404,6 +474,11 @@ static class JavaMarshalRegisteredPeers
 			throw new ArgumentNullException (nameof (mcr), "MarkCrossReferencesArgs should never be null.");
 		}
 
+		// Publish the thread id before clearing the signal so that a reentrant call on
+		// this thread can never observe an unsignaled event with a stale id.
+		Volatile.Write (ref bridgeProcessingThreadId, Environment.CurrentManagedThreadId);
+		bridgeProcessingFinished.Reset ();
+
 		HandleContext.EnsureAllContextsAreOurs (mcr);
 	}
 
@@ -414,12 +489,19 @@ static class JavaMarshalRegisteredPeers
 			throw new ArgumentNullException (nameof (mcr), "MarkCrossReferencesArgs should never be null.");
 		}
 
-		ReadOnlySpan<GCHandle> handlesToFree = ProcessCollectedContexts (mcr);
+		try {
+			ReadOnlySpan<GCHandle> handlesToFree = ProcessCollectedContexts (mcr);
 
 // This call site is reachable on all platforms. 'JavaMarshal.FinishCrossReferenceProcessing(MarkCrossReferencesArgs*, ReadOnlySpan<GCHandle>)' is only supported on: 'android'.
 #pragma warning disable CA1416
-		JavaMarshal.FinishCrossReferenceProcessing (mcr, handlesToFree);
+			JavaMarshal.FinishCrossReferenceProcessing (mcr, handlesToFree);
 #pragma warning restore CA1416
+		} finally {
+			// Must run even if processing throws, otherwise every thread that entered
+			// managed code from Java would block forever.
+			Volatile.Write (ref bridgeProcessingThreadId, 0);
+			bridgeProcessingFinished.Set ();
+		}
 	}
 
 	static unsafe ReadOnlySpan<GCHandle> ProcessCollectedContexts (MarkCrossReferencesArgs* mcr)

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -23,12 +23,13 @@ sealed class JavaMarshalValueManager : JniRuntime.ReflectionJniValueManager
 
 	public override void WaitForGCBridgeProcessing ()
 	{
-		// Intentionally empty. The Mono runtime's own implementation acknowledges this
-		// pattern is fundamentally flawed (see FIXME in sgen-bridge.c): a thread that
-		// passes the check can still race with bridge processing that starts immediately
-		// after. The wait cannot prevent the race, only reduce its window. On CoreCLR,
-		// JNI wrapper threads hold their own handle copies via JniObjectReference, so
-		// they are not affected by the bridge swapping control_block handles.
+		// Note the caveat from https://github.com/dotnet/android/pull/11119, which removed
+		// this wait: it cannot actually prevent the race it appears to guard, only shrink
+		// the window, and CoreCLR's JNI wrapper threads hold their own handle copies via
+		// JniObjectReference so they do not observe the bridge swapping control_block
+		// handles. It is restored purely to match Mono's observable blocking semantics --
+		// it was measured to be performance-neutral. See JavaMarshalRegisteredPeers.
+		JavaMarshalRegisteredPeers.WaitForBridgeProcessing ();
 	}
 
 	public override void CollectPeers ()

--- a/src/Mono.Android/Microsoft.Android.Runtime/RuntimeFeature.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/RuntimeFeature.cs
@@ -13,6 +13,7 @@ static class RuntimeFeature
 	const bool TrimmableTypeMapEnabledByDefault = false;
 	const bool ObjectReferenceLoggingEnabledByDefault = false;
 	const bool ManagedToJavaUsesAssemblyFullNameEnabledByDefault = false;
+	const bool WaitForGCBridgeProcessingEnabledByDefault = true;
 
 	const string FeatureSwitchPrefix = "Microsoft.Android.Runtime.RuntimeFeature.";
 	const string StartupHookProviderSwitch = "System.StartupHookProvider.IsSupported";
@@ -50,4 +51,10 @@ static class RuntimeFeature
 	[FeatureSwitchDefinition ($"{FeatureSwitchPrefix}{nameof (ManagedToJavaUsesAssemblyFullName)}")]
 	internal static bool ManagedToJavaUsesAssemblyFullName { get; } =
 		AppContext.TryGetSwitch ($"{FeatureSwitchPrefix}{nameof (ManagedToJavaUsesAssemblyFullName)}", out bool isEnabled) ? isEnabled : ManagedToJavaUsesAssemblyFullNameEnabledByDefault;
+
+	// When disabled, the trimmer can remove the GC bridge barrier and every
+	// WaitForGCBridgeProcessing() call site becomes an empty method body.
+	[FeatureSwitchDefinition ($"{FeatureSwitchPrefix}{nameof (WaitForGCBridgeProcessing)}")]
+	internal static bool WaitForGCBridgeProcessing { get; } =
+		AppContext.TryGetSwitch ($"{FeatureSwitchPrefix}{nameof (WaitForGCBridgeProcessing)}", out bool isEnabled) ? isEnabled : WaitForGCBridgeProcessingEnabledByDefault;
 }

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapValueManager.cs
@@ -22,12 +22,13 @@ sealed partial class TrimmableTypeMapValueManager : JniRuntime.JniValueManager
 
 	public override void WaitForGCBridgeProcessing ()
 	{
-		// Intentionally empty. The Mono runtime's own implementation acknowledges this
-		// pattern is fundamentally flawed (see FIXME in sgen-bridge.c): a thread that
-		// passes the check can still race with bridge processing that starts immediately
-		// after. The wait cannot prevent the race, only reduce its window. On CoreCLR,
-		// JNI wrapper threads hold their own handle copies via JniObjectReference, so
-		// they are not affected by the bridge swapping control_block handles.
+		// Note the caveat from https://github.com/dotnet/android/pull/11119, which removed
+		// this wait: it cannot actually prevent the race it appears to guard, only shrink
+		// the window, and CoreCLR's JNI wrapper threads hold their own handle copies via
+		// JniObjectReference so they do not observe the bridge swapping control_block
+		// handles. It is restored purely to match Mono's observable blocking semantics --
+		// it was measured to be performance-neutral. See JavaMarshalRegisteredPeers.
+		JavaMarshalRegisteredPeers.WaitForBridgeProcessing ();
 	}
 
 	public override void CollectPeers ()

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
@@ -19,6 +19,11 @@ See: https://github.com/dotnet/runtime/blob/b13715b6984889a709ba29ea8a1961db469f
     <!-- Enable .NET runtime crash reporting before Android's signal chaining takes place.
          See: https://github.com/dotnet/runtime/pull/123735 -->
     <_AndroidEnableDiagnosticCrashReporting Condition=" '$(_AndroidEnableDiagnosticCrashReporting)' == '' ">true</_AndroidEnableDiagnosticCrashReporting>
+    <!-- Internal switch. Blocks Java->managed transitions for the duration of a GC bridge round,
+         matching Mono's mono_gc_wait_for_bridge_processing(). This is a semantics knob, not a
+         performance one: enabling vs disabling it measured as neutral on a MAUI/SkiaSharp
+         benchmark. Set to false to opt out; the trimmer then removes the barrier entirely. -->
+    <_AndroidWaitForGCBridgeProcessing Condition=" '$(_AndroidWaitForGCBridgeProcessing)' == '' ">true</_AndroidWaitForGCBridgeProcessing>
   </PropertyGroup>
 
   <ItemGroup>
@@ -61,6 +66,11 @@ See: https://github.com/dotnet/runtime/blob/b13715b6984889a709ba29ea8a1961db469f
     <RuntimeHostConfigurationOption Include="Microsoft.Android.Runtime.RuntimeFeature.ObjectReferenceLogging"
         Condition="'$(_AndroidEnableObjectReferenceLogging)' != ''"
         Value="$(_AndroidEnableObjectReferenceLogging)"
+        Trim="true"
+    />
+    <RuntimeHostConfigurationOption Include="Microsoft.Android.Runtime.RuntimeFeature.WaitForGCBridgeProcessing"
+        Condition="'$(_AndroidWaitForGCBridgeProcessing)' != ''"
+        Value="$(_AndroidWaitForGCBridgeProcessing)"
         Trim="true"
     />
     <!-- https://github.com/dotnet/runtime/pull/123735 -->


### PR DESCRIPTION
> [!NOTE]
> **Informational only — not intended for review or merge.**
>
> This branch exists to record a measured negative result for https://github.com/dotnet/runtime/issues/131370, so the next person doesn't re-run this experiment. The code change works and is verified, but it does **not** fix the reported problem. Nobody needs to review it.

## Background

dotnet/runtime#131370 reports periodic frame-rate drops (60→54 FPS every ~5 s) in a .NET MAUI + SkiaSharp game after moving from Mono to CoreCLR. CoreCLR became the default runtime in .NET 11, so this surfaces for apps that did nothing but upgrade.

`JniRuntime.JniValueManager.WaitForGCBridgeProcessing()` has been an intentional no-op on CoreCLR/NativeAOT since #11119 removed it, while Mono still blocks for the duration of a bridge round via `mono_gc_wait_for_bridge_processing()`. That difference was the leading hypothesis: a real, deliberate Mono↔CoreCLR behavioral divergence in exactly the code path under suspicion.

So I implemented it, and then measured it.

## The result: performance-neutral

Before trusting any numbers, I verified the barrier actually fires. Temporary instrumentation in `BridgeProcessingFinished` reported exactly one thread parking per round, 15–36 ms:

```
round done: enabled=True blockedThreads=1 blockedTotalMs=20.2
round done: enabled=True blockedThreads=1 blockedTotalMs=36.0
round done: enabled=True blockedThreads=1 blockedTotalMs=17.4
```

(An earlier round of this experiment was invalid — `-t:PackDotNet` silently didn't refresh `bin/Release/dotnet/packs/**`, so both arms linked a byte-identical unmodified `Mono.Android.dll`. Worth knowing if you reproduce this locally: mirror the whole pack directory, not individual files.)

All three APKs below were built from the **same** local SDK, run on the same device (Pixel 5, Android 14, arm64, refresh rate pinned to 60 Hz), 60 s each, two rounds in reversed order to control for ordering:

| Arm | Rnd | GCs | GC avg | GC max | FPS | max frame gap | frames >20 ms | gref avg |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| CoreCLR, barrier **ON** | 1 | 9 | 24.7 | 57.9 | 59.79 | 53.6 | 25 | 839 |
| CoreCLR, barrier **ON** | 2 | 9 | 27.1 | 74.7 | 59.78 | 53.6 | 28 | 840 |
| CoreCLR, barrier **OFF** | 1 | 9 | 24.6 | 61.3 | 59.75 | 54.3 | 25 | 840 |
| CoreCLR, barrier **OFF** | 2 | 9 | 21.6 | 25.7 | 59.77 | 57.4 | 24 | 840 |
| **Mono** | 1 | 8 | **11.5** | 21.3 | **59.91** | **33.6** | 75 | 836 |
| **Mono** | 2 | 8 | **10.8** | 14.3 | **59.90** | **33.5** | 70 | 830 |

GC columns are ART `Explicit concurrent copying GC` wall time in ms; `gref` is `JniEnvironment.Runtime.GlobalReferenceCount`.

- ON vs OFF is inside run-to-run noise, and ON is if anything marginally worse.
- The Mono↔CoreCLR gap is untouched: ~2.3× ART GC wall time and ~1.6× worst frame gap.
- Mono has *more* mildly-late frames (70–75) but a bounded ~34 ms worst case; CoreCLR has *fewer* late frames (24–28) but 54–75 ms spikes. Mono holds a small consistent FPS edge.

## What this rules out

Four hypotheses have now been measured and killed on this benchmark:

| # | Hypothesis | Result |
|---|---|---|
| a | CoreCLR holds a larger JNI global-ref root set | **Dead** — ~840 grefs on all arms; CoreCLR holds ~3% *fewer* and reclaims *fewer* peers |
| b | Bridge thread runs at a lower priority | **Dead** — `ps -T` shows both at nice −10 / PRI 29 |
| c | Missing `WaitForGCBridgeProcessing` barrier | **Dead** — this branch; restored, verified firing, no gain |
| d | CoreCLR issues more native JNI global-ref transitions per round | **Dead** — see below |

### (d) Native per-round global-ref churn

Measured separately by instrumenting both bridges with one `log_warn` per round emitting `GCBRIDGE_CHURN runtime=… sccs=… peers=… xrefs=… jni_transitions=…`, two reversed-order rounds on the same device.

**The algorithm is identical on both runtimes.** CoreCLR `BridgeProcessingShared::process()` and Mono `OSBridge::gc_cross_references()` both iterate all sccs × objects, flipping every peer strong→weak before `Runtime.gc()` (`NewWeakGlobalRef` + `DeleteGlobalRef`) and weak→strong after (`NewGlobalRef` + `DeleteWeakGlobalRef`) — exactly 4 JNI global-ref ops per peer.

| Arm | peers/round | JNI transitions/round | ART GC avg | ART GC max | FPS |
|---|---:|---:|---:|---:|---:|
| CoreCLR | ~442 | ~1767 | 21.9 ms | 26 ms | 59.77 |
| Mono | ~502 | ~2011 | **10.6 ms** | 11 ms | 59.85 |

CoreCLR issues ~12% **fewer** transitions per round yet pays ~2.1× the ART concurrent GC cost. The relationship is *inverted* — the runtime doing more churn is the faster one.

That run also showed `sccs == peers` and `xrefs == 0` every round on both runtimes: every bridged peer is a singleton SCC with no cross-references, so `monodroidAddReference` / `monodroidClearReferences` and the circular-reference / temporary-peer machinery are never exercised by this benchmark either.

## What's left

Both runtimes call `java.lang.Runtime.gc()` identically, the ART stop-the-world pause is microseconds on both (24–57 µs), heap occupancy is identical (~86% free, 3.7/27 MB), the trigger cadence matches, the managed root set matches, and the native transition count matches (slightly favoring CoreCLR). **The entire delta is in ART's concurrent phase.**

dotnet/runtime has no ART knowledge — `GCBridge::mark_cross_references` just publishes to a semaphore — so whatever this is, it lives in dotnet/android.

The cause is not the *count* of anything the bridge does. Remaining suspects concern per-object work and scheduling:

- Differences in the Java-side peer wrapper objects / `GCHandle` registration between the two runtimes, which would change how much work ART does resolving each weak global.
- Scheduling of `Runtime.gc()` relative to ART's concurrent worker threads.

Unrelated but noted while debugging: the CoreCLR bridge thread is created as an anonymous `pthread` in `gc-bridge.cc`, so it shows up as `Thread-N` in `ps -T` while Mono's equivalent is the named `Finalizer` thread. A `pthread_setname_np` call there would be diagnosability-only, but it cost real time in this investigation.

## The code, for the record

If anyone does want to revive this, what's here is complete and correct:

- `JavaMarshalRegisteredPeers.WaitForBridgeProcessing()` parks on a `ManualResetEventSlim` (`spinCount: 0`) reset for the duration of a round, driven by the existing `BridgeProcessingStarted`/`BridgeProcessingFinished` callbacks that already bracket exactly the right window.
- `BridgeProcessingFinished` signals from a `finally`, so an exception during processing can't deadlock every Java→managed transition in the app.
- The bridge thread early-outs on its own thread id, so it can never wait on its own completion signal.
- Gated by a trimmer feature switch, `Microsoft.Android.Runtime.RuntimeFeature.WaitForGCBridgeProcessing`, settable via the private `$(_AndroidWaitForGCBridgeProcessing)` MSBuild property (verified reaching `runtimeconfig.json` in both directions). When disabled, the trimmer removes the barrier entirely.

The rationale from #11119 for removing it in the first place still holds, and is preserved in the code comments: the wait cannot prevent the race it appears to guard (only shrink the window), and CoreCLR's JNI wrapper threads hold their own handle copies via `JniObjectReference`, so they don't observe the bridge swapping `control_block` handles.