### PR TITLE
[native] Investigation: GC bridge gref churn is not the cause of CoreCLR ART GC regression (informational, do not merge)

### DIFF
--- a/src/native/clr/host/bridge-processing.cc
+++ b/src/native/clr/host/bridge-processing.cc
@@ -165,6 +165,17 @@ void BridgeProcessingShared::process () noexcept
 	GCBridge::trigger_java_gc (env);
 	cleanup_after_java_collection ();
 	log_gc_summary ();
+
+	// GC bridge gref churn instrumentation (dotnet/runtime#131370): one line per round.
+	// Every peer is flipped strong->weak in prepare (NewWeakGlobalRef + DeleteGlobalRef) and
+	// weak->strong in cleanup (NewGlobalRef + DeleteWeakGlobalRef): 4 JNI global-ref ops per peer.
+	size_t churn_peers = 0;
+	for (size_t i = 0; i < cross_refs->ComponentCount; i++) {
+		churn_peers = Helpers::add_with_overflow_check<size_t> (churn_peers, cross_refs->Components [i].Count);
+	}
+	log_warnf (LOG_GC, "GCBRIDGE_CHURN runtime=coreclr sccs=%zu peers=%zu xrefs=%zu jni_transitions=%zu",
+		static_cast<size_t> (cross_refs->ComponentCount), churn_peers,
+		static_cast<size_t> (cross_refs->CrossReferenceCount), churn_peers * 4);
 }
 
 void BridgeProcessingShared::prepare_for_java_collection () noexcept

--- a/src/native/mono/monodroid/osbridge.cc
+++ b/src/native/mono/monodroid/osbridge.cc
@@ -1035,6 +1035,15 @@ OSBridge::gc_cross_references (int num_sccs, MonoGCBridgeSCC **sccs, int num_xre
 
 	gc_cleanup_after_java_collection (env, num_sccs, sccs);
 	set_bridge_processing_field (domains_list, 0);
+
+	// GC bridge gref churn instrumentation (dotnet/runtime#131370): one line per round.
+	// Every peer is flipped strong->weak in prepare (NewWeakGlobalRef + DeleteGlobalRef) and
+	// weak->strong in cleanup (NewGlobalRef + DeleteWeakGlobalRef): 4 JNI global-ref ops per peer.
+	int churn_peers = 0;
+	for (int i = 0; i < num_sccs; i++)
+		churn_peers += sccs [i]->num_objs;
+	log_warn (LOG_GC, "GCBRIDGE_CHURN runtime=mono sccs={} peers={} xrefs={} jni_transitions={}",
+		num_sccs, churn_peers, num_xrefs, churn_peers * 4);
 }
 
 void


### PR DESCRIPTION
> [!NOTE]
> **Informational only — not intended for review or merge.**
>
> This branch records a measured **negative** result for https://github.com/dotnet/runtime/issues/131370, so the next person doesn't re-run this experiment. The instrumentation is correct and verified, but it does **not** fix the reported problem, and it kills one more hypothesis. Nobody needs to review it.

## Background

dotnet/runtime#131370 reports periodic frame-rate drops (60→54 FPS every ~5–8 s) in a .NET MAUI + SkiaSharp game after moving from Mono to CoreCLR (the .NET 11 default). A prior investigation (draft PR #12262) established that the entire delta lives in ART's **concurrent** copying-GC phase — with an identical managed root set (~840 grefs), identical `Runtime.gc()` trigger, identical stop-the-world pause (µs), and identical heap occupancy — and killed three hypotheses (larger gref root set, bridge thread priority, missing `WaitForGCBridgeProcessing` barrier).

This branch tests the last structural difference #12262 called out: **does CoreCLR's GC bridge issue far more JNI weak/strong global-reference transitions per bridge round than Mono?** That churn is invisible to the managed `JniEnvironment.Runtime.GlobalReferenceCount` because it is a native-side count.

## What I did

Both GC bridges use the *identical* algorithm, confirmed by reading the code:

- **prepare**: iterate every SCC × object, flip each peer strong→weak (`NewWeakGlobalRef` + `DeleteGlobalRef`)
- `java.lang.Runtime.gc()`
- **cleanup**: iterate every SCC × object, flip each peer weak→strong (`NewGlobalRef` + `DeleteWeakGlobalRef`)

= exactly **4 JNI global-ref ops per peer per round** on both runtimes.

- CoreCLR: `BridgeProcessingShared::process()` — `src/native/clr/host/bridge-processing.cc`
- Mono: `OSBridge::gc_cross_references()` — `src/native/mono/monodroid/osbridge.cc`

I added one unconditional `log_warn` per round to each, so the per-round churn can be compared directly against ART's GC wall time:

```
GCBRIDGE_CHURN runtime=<coreclr|mono> sccs=<n> peers=<n> xrefs=<n> jni_transitions=<n>
```

Both instrumented native libs were byte-verified inside the packaged APKs before trusting any numbers.

## The result: performance-neutral / inverted

Same local SDK, same device (Pixel 5, Android 14, arm64, refresh rate pinned to 60 Hz), 60 s per arm, two rounds in reversed order to control for ordering. Steady state (startup + first bridge round dropped as warm-up), no contamination:

| Arm | Rnd | peers/round | JNI transitions/round | ART GC avg | ART GC max | FPS |
|---|---|---:|---:|---:|---:|---:|
| CoreCLR | 1 | 442 | 1768 | 20.9 ms | 22.0 ms | 59.77 |
| CoreCLR | 2 | 442 | 1767 | 22.9 ms | 26.4 ms | 59.76 |
| **Mono** | 1 | 503 | 2012 | **10.5 ms** | 10.9 ms | 59.87 |
| **Mono** | 2 | 502 | 2010 | **10.6 ms** | 11.1 ms | 59.82 |

ART GC columns are `Explicit concurrent copying GC` total wall time, filtered to the benchmark process.

- CoreCLR issues **~12% fewer** JNI global-ref transitions per round than Mono (≈1767 vs ≈2011).
- Yet CoreCLR's ART concurrent GC is **~2.1× slower** (≈21.9 ms vs ≈10.6 ms).
- The relationship is **inverted**: the runtime doing *more* gref churn (Mono) is the *faster* one.

So per-round native global-ref churn does **not** explain the ~13 ms concurrent-phase delta.

## Bonus: also rules out the SCC/cross-ref machinery

On **both** runtimes, every round reported `sccs == peers` and `xrefs == 0`. Every bridged object is a singleton strongly-connected component with no cross-references, so `monodroidAddReference` / `monodroidClearReferences`, the circular-reference wiring, and the temporary-peer path are **never exercised** by this benchmark. Those are not the differentiator either.

## What this rules out (cumulative with #12262)

| Hypothesis | Result |
|---|---|
| CoreCLR holds a larger JNI global-ref root set | Dead (#12262) — ~840 on all arms; CoreCLR holds ~3% *fewer* |
| Bridge thread runs at a lower priority | Dead (#12262) — both nice −10 / PRI 29 |
| Missing `WaitForGCBridgeProcessing` barrier | Dead (#12262) — restored, verified firing, no gain |
| **CoreCLR issues more native gref transitions per round** | **Dead (this branch) — CoreCLR issues *fewer*, yet is 2.1× slower** |
| **SCC circular-ref / add/clear-reference machinery** | **Dead (this branch) — never exercised; xrefs==0, sccs==peers** |

## Where I'd look next

The delta is in ART's concurrent phase under an *identical* bridge algorithm, identical trigger cadence, identical managed root set, and now near-identical (slightly *lower* for CoreCLR) native gref churn. The cause is not the *count* of bridge JNI operations. Remaining structural suspects:

- **Per-object ART work resolving each weak global** — differences in the Java-side peer wrapper objects / `GCHandle` registration between the two runtimes, rather than the number of transitions.
- **Scheduling of `Runtime.gc()` relative to ART's concurrent worker** — whether the bridge thread's timing causes ART's concurrent copy to overlap differently with app allocation on CoreCLR.

## The code, for the record

Two files, +20 lines, instrumentation only — one per-round summary `log_warn` appended to each runtime's existing bridge round entry point. Gated by nothing (always on) purely so the experiment is reproducible; it would be removed or made `#if DEBUG` before any real use.

Fixes nothing. Closes nothing. Recorded so the next person doesn't repeat it. Related: dotnet/runtime#131370, #12262.