### PR TITLE
[CoreCLR] Set the RUNTIME_IDENTIFIER runtime property

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
@@ -20,6 +20,9 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 	const string HOST_PROPERTY_BUNDLE_PROBE     = "BUNDLE_PROBE";
 	const string HOST_PROPERTY_PINVOKE_OVERRIDE = "PINVOKE_OVERRIDE";
 
+	// Set by `hostfxr` on other platforms, by our native runtime here
+	const string HOST_PROPERTY_RUNTIME_IDENTIFIER = "RUNTIME_IDENTIFIER";
+
 	sealed class DSOCacheEntryContextDataProvider : NativeAssemblerStructContextDataProvider
 	{
 		public override string GetComment (object data, string fieldName)
@@ -217,8 +220,9 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 			this.runtimeProperties = new SortedDictionary<string, string> (StringComparer.Ordinal);
 		}
 
-		// This will be filled in by the native host.
+		// These will be filled in by the native host.
 		this.runtimeProperties[HOST_PROPERTY_RUNTIME_CONTRACT] = String.Empty;
+		this.runtimeProperties[HOST_PROPERTY_RUNTIME_IDENTIFIER] = String.Empty;
 
 		// these mustn't be there, they would break our host contract
 		this.runtimeProperties.Remove (HOST_PROPERTY_PINVOKE_OVERRIDE);
@@ -317,19 +321,23 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 		};
 		module.Add (bundled_assemblies);
 
-		// HOST_PROPERTY_RUNTIME_CONTRACT will come first, our native runtime requires that since it needs
-		// to set its value in the values array and we don't want to spend time searching for the index, nor
-		// we want to add yet another variable storing the index to the entry. KISS.
+		// HOST_PROPERTY_RUNTIME_CONTRACT and HOST_PROPERTY_RUNTIME_IDENTIFIER will come first, in that
+		// order, our native runtime requires that since it needs to set their values in the values array
+		// and we don't want to spend time searching for the indices, nor we want to add yet another
+		// variable storing the index to the entry. KISS.
 		var runtime_property_names = new List<string> {
 			HOST_PROPERTY_RUNTIME_CONTRACT,
+			HOST_PROPERTY_RUNTIME_IDENTIFIER,
 		};
 		var runtime_property_values = new List<string?> {
+			null,
 			null,
 		};
 
 		if (runtimeProperties != null) {
 			foreach (var kvp in runtimeProperties) {
-				if (MonoAndroidHelper.StringEquals (kvp.Key, HOST_PROPERTY_RUNTIME_CONTRACT)) {
+				if (MonoAndroidHelper.StringEquals (kvp.Key, HOST_PROPERTY_RUNTIME_CONTRACT) ||
+						MonoAndroidHelper.StringEquals (kvp.Key, HOST_PROPERTY_RUNTIME_IDENTIFIER)) {
 					continue;
 				}
 				runtime_property_names.Add (kvp.Key);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
@@ -20,6 +20,9 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 	const string HOST_PROPERTY_BUNDLE_PROBE     = "BUNDLE_PROBE";
 	const string HOST_PROPERTY_PINVOKE_OVERRIDE = "PINVOKE_OVERRIDE";
 
+	// Set by our native runtime, which is the only place that knows the ABI it was built for
+	const string HOST_PROPERTY_RUNTIME_IDENTIFIER = "RUNTIME_IDENTIFIER";
+
 	sealed class DSOCacheEntryContextDataProvider : NativeAssemblerStructContextDataProvider
 	{
 		public override string GetComment (object data, string fieldName)
@@ -223,6 +226,10 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 		// these mustn't be there, they would break our host contract
 		this.runtimeProperties.Remove (HOST_PROPERTY_PINVOKE_OVERRIDE);
 		this.runtimeProperties.Remove (HOST_PROPERTY_BUNDLE_PROBE);
+
+		// The native runtime appends this one, with the value matching the ABI it was built for,
+		// so we must not pass a second (potentially wrong) copy to `coreclr_initialize`.
+		this.runtimeProperties.Remove (HOST_PROPERTY_RUNTIME_IDENTIFIER);
 	}
 
 	protected override void Construct (LlvmIrModule module)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
@@ -16,11 +16,9 @@ namespace Xamarin.Android.Tasks;
 class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 {
 	// From host_runtime_contract.h in dotnet/runtime
-	const string HOST_PROPERTY_RUNTIME_CONTRACT = "HOST_RUNTIME_CONTRACT";
-	const string HOST_PROPERTY_BUNDLE_PROBE     = "BUNDLE_PROBE";
-	const string HOST_PROPERTY_PINVOKE_OVERRIDE = "PINVOKE_OVERRIDE";
-
-	// Set by `hostfxr` on other platforms, by our native runtime here
+	const string HOST_PROPERTY_RUNTIME_CONTRACT   = "HOST_RUNTIME_CONTRACT";
+	const string HOST_PROPERTY_BUNDLE_PROBE       = "BUNDLE_PROBE";
+	const string HOST_PROPERTY_PINVOKE_OVERRIDE   = "PINVOKE_OVERRIDE";
 	const string HOST_PROPERTY_RUNTIME_IDENTIFIER = "RUNTIME_IDENTIFIER";
 
 	sealed class DSOCacheEntryContextDataProvider : NativeAssemblerStructContextDataProvider

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
@@ -20,9 +20,6 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 	const string HOST_PROPERTY_BUNDLE_PROBE     = "BUNDLE_PROBE";
 	const string HOST_PROPERTY_PINVOKE_OVERRIDE = "PINVOKE_OVERRIDE";
 
-	// Set by our native runtime, which is the only place that knows the ABI it was built for
-	const string HOST_PROPERTY_RUNTIME_IDENTIFIER = "RUNTIME_IDENTIFIER";
-
 	sealed class DSOCacheEntryContextDataProvider : NativeAssemblerStructContextDataProvider
 	{
 		public override string GetComment (object data, string fieldName)
@@ -226,10 +223,6 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 		// these mustn't be there, they would break our host contract
 		this.runtimeProperties.Remove (HOST_PROPERTY_PINVOKE_OVERRIDE);
 		this.runtimeProperties.Remove (HOST_PROPERTY_BUNDLE_PROBE);
-
-		// The native runtime appends this one, with the value matching the ABI it was built for,
-		// so we must not pass a second (potentially wrong) copy to `coreclr_initialize`.
-		this.runtimeProperties.Remove (HOST_PROPERTY_RUNTIME_IDENTIFIER);
 	}
 
 	protected override void Construct (LlvmIrModule module)

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -34,6 +34,11 @@
 
 using namespace xamarin::android;
 
+// Not part of `host_runtime_contract.h`: `hostfxr` sets this property when it starts the runtime,
+// and `System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier` reads it back through
+// `AppContext.GetData`.
+constexpr char HOST_PROPERTY_RUNTIME_IDENTIFIER[] = "RUNTIME_IDENTIFIER";
+
 void Host::clr_error_writer (const char *message) noexcept
 {
 	log_error (LOG_DEFAULT, "CLR error: {}", optional_string (message));
@@ -356,36 +361,41 @@ void Host::Java_mono_android_Runtime_initInternal (
 	const char **prop_values = const_cast<const char**>(init_runtime_property_values);
 	int prop_count = static_cast<int>(application_config.number_of_runtime_properties);
 
+	// Storage must outlive `coreclr_initialize`; function-local statics
+	// give us process lifetime without polluting global namespace.
+	static std::vector<const char*> host_prop_names;
+	static std::vector<const char*> host_prop_values;
+
+	host_prop_names.assign (prop_names, prop_names + prop_count);
+	host_prop_values.assign (prop_values, prop_values + prop_count);
+
+	// `hostfxr` normally hands `RUNTIME_IDENTIFIER` to the runtime, but we don't use `hostfxr`.
+	// Without it, `RuntimeInformation.RuntimeIdentifier` returns "unknown". MonoVM does the same
+	// thing in `MonoVMProperties`. The value is per-ABI, so it can't come from the (shared)
+	// `*.runtimeconfig.json` properties baked in at build time.
+	host_prop_names.push_back (HOST_PROPERTY_RUNTIME_IDENTIFIER);
+	host_prop_values.push_back (Constants::runtime_identifier.data ());
+
 	// In Debug builds with FastDev, append `TRUSTED_PLATFORM_ASSEMBLIES` with full
 	// paths to the assemblies pushed into `.__override__/<arch>/`. CoreCLR then
 	// opens those files from disk so `Assembly.Location` is populated and
 	// `StackTraceSymbols` can find sibling `.pdb` files for runtime-rendered
 	// managed stack traces (file/line).
 	if constexpr (Constants::is_debug_build) {
-		// Storage must outlive `coreclr_initialize`; function-local statics
-		// give us process lifetime without polluting global namespace.
 		static std::string fastdev_tpa_list;
-		static std::vector<const char*> fastdev_prop_names;
-		static std::vector<const char*> fastdev_prop_values;
 
 		if (FastDevAssemblies::build_tpa_list (fastdev_tpa_list)) {
-			fastdev_prop_names.assign (prop_names, prop_names + prop_count);
-			fastdev_prop_values.assign (prop_values, prop_values + prop_count);
-			fastdev_prop_names.push_back (HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES);
-			fastdev_prop_values.push_back (fastdev_tpa_list.c_str ());
-
-			prop_names = fastdev_prop_names.data ();
-			prop_values = fastdev_prop_values.data ();
-			prop_count = static_cast<int>(fastdev_prop_names.size ());
+			host_prop_names.push_back (HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES);
+			host_prop_values.push_back (fastdev_tpa_list.c_str ());
 		}
 	}
 
 	int hr = FastTiming::time_call ("coreclr_initialize"sv, coreclr_initialize,
 		application_config.android_package_name,
 		"Xamarin.Android",
-		prop_count,
-		prop_names,
-		prop_values,
+		static_cast<int>(host_prop_names.size ()),
+		host_prop_names.data (),
+		host_prop_values.data (),
 		&clr_host,
 		&domain_id
 	);

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -34,11 +34,6 @@
 
 using namespace xamarin::android;
 
-// Not part of `host_runtime_contract.h`: `hostfxr` sets this property when it starts the runtime,
-// and `System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier` reads it back through
-// `AppContext.GetData`.
-constexpr char HOST_PROPERTY_RUNTIME_IDENTIFIER[] = "RUNTIME_IDENTIFIER";
-
 void Host::clr_error_writer (const char *message) noexcept
 {
 	log_error (LOG_DEFAULT, "CLR error: {}", optional_string (message));
@@ -353,28 +348,19 @@ void Host::Java_mono_android_Runtime_initInternal (
 	// We REALLY shouldn't be doing this
 	snprintf (host_contract_ptr_buffer.data (), host_contract_ptr_buffer.size (), "%p", &runtime_contract);
 
-	// The first entry in the property arrays is for the host contract pointer. Application build makes sure
-	// of that.
+	// The first two entries in the property arrays are for the host contract pointer and the
+	// runtime identifier. Application build makes sure of that.
 	init_runtime_property_values[0] = host_contract_ptr_buffer.data ();
+
+	// `hostfxr` normally hands `RUNTIME_IDENTIFIER` to the runtime, but we don't use `hostfxr`.
+	// Without it, `RuntimeInformation.RuntimeIdentifier` returns "unknown". The value can only
+	// come from here: `libxamarin-app.so` is per-ABI, but it is generated from the (shared)
+	// `*.runtimeconfig.json`, which knows nothing about the ABI it is being built for.
+	init_runtime_property_values[1] = const_cast<char*>(Constants::runtime_identifier.data ());
 
 	const char **prop_names = init_runtime_property_names;
 	const char **prop_values = const_cast<const char**>(init_runtime_property_values);
 	int prop_count = static_cast<int>(application_config.number_of_runtime_properties);
-
-	// Storage must outlive `coreclr_initialize`; function-local statics
-	// give us process lifetime without polluting global namespace.
-	static std::vector<const char*> host_prop_names;
-	static std::vector<const char*> host_prop_values;
-
-	host_prop_names.assign (prop_names, prop_names + prop_count);
-	host_prop_values.assign (prop_values, prop_values + prop_count);
-
-	// `hostfxr` normally hands `RUNTIME_IDENTIFIER` to the runtime, but we don't use `hostfxr`.
-	// Without it, `RuntimeInformation.RuntimeIdentifier` returns "unknown". MonoVM does the same
-	// thing in `MonoVMProperties`. The value is per-ABI, so it can't come from the (shared)
-	// `*.runtimeconfig.json` properties baked in at build time.
-	host_prop_names.push_back (HOST_PROPERTY_RUNTIME_IDENTIFIER);
-	host_prop_values.push_back (Constants::runtime_identifier.data ());
 
 	// In Debug builds with FastDev, append `TRUSTED_PLATFORM_ASSEMBLIES` with full
 	// paths to the assemblies pushed into `.__override__/<arch>/`. CoreCLR then
@@ -382,20 +368,30 @@ void Host::Java_mono_android_Runtime_initInternal (
 	// `StackTraceSymbols` can find sibling `.pdb` files for runtime-rendered
 	// managed stack traces (file/line).
 	if constexpr (Constants::is_debug_build) {
+		// Storage must outlive `coreclr_initialize`; function-local statics
+		// give us process lifetime without polluting global namespace.
 		static std::string fastdev_tpa_list;
+		static std::vector<const char*> fastdev_prop_names;
+		static std::vector<const char*> fastdev_prop_values;
 
 		if (FastDevAssemblies::build_tpa_list (fastdev_tpa_list)) {
-			host_prop_names.push_back (HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES);
-			host_prop_values.push_back (fastdev_tpa_list.c_str ());
+			fastdev_prop_names.assign (prop_names, prop_names + prop_count);
+			fastdev_prop_values.assign (prop_values, prop_values + prop_count);
+			fastdev_prop_names.push_back (HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES);
+			fastdev_prop_values.push_back (fastdev_tpa_list.c_str ());
+
+			prop_names = fastdev_prop_names.data ();
+			prop_values = fastdev_prop_values.data ();
+			prop_count = static_cast<int>(fastdev_prop_names.size ());
 		}
 	}
 
 	int hr = FastTiming::time_call ("coreclr_initialize"sv, coreclr_initialize,
 		application_config.android_package_name,
 		"Xamarin.Android",
-		static_cast<int>(host_prop_names.size ()),
-		host_prop_names.data (),
-		host_prop_values.data (),
+		prop_count,
+		prop_names,
+		prop_values,
 		&clr_host,
 		&domain_id
 	);

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -348,15 +348,19 @@ void Host::Java_mono_android_Runtime_initInternal (
 	// We REALLY shouldn't be doing this
 	snprintf (host_contract_ptr_buffer.data (), host_contract_ptr_buffer.size (), "%p", &runtime_contract);
 
-	// The first two entries in the property arrays are for the host contract pointer and the
-	// runtime identifier. Application build makes sure of that.
-	init_runtime_property_values[0] = host_contract_ptr_buffer.data ();
+	// These indices are load-bearing: the application build emits the property names in this
+	// exact order (see `ApplicationConfigNativeAssemblyGeneratorCLR`) so that we can fill in
+	// the values here without searching the names array.
+	constexpr size_t RUNTIME_PROPERTY_INDEX_HOST_CONTRACT = 0;
+	constexpr size_t RUNTIME_PROPERTY_INDEX_RUNTIME_IDENTIFIER = 1;
+
+	init_runtime_property_values[RUNTIME_PROPERTY_INDEX_HOST_CONTRACT] = host_contract_ptr_buffer.data ();
 
 	// `hostfxr` normally hands `RUNTIME_IDENTIFIER` to the runtime, but we don't use `hostfxr`.
 	// Without it, `RuntimeInformation.RuntimeIdentifier` returns "unknown". The value can only
 	// come from here: `libxamarin-app.so` is per-ABI, but it is generated from the (shared)
 	// `*.runtimeconfig.json`, which knows nothing about the ABI it is being built for.
-	init_runtime_property_values[1] = const_cast<char*>(Constants::runtime_identifier.data ());
+	init_runtime_property_values[RUNTIME_PROPERTY_INDEX_RUNTIME_IDENTIFIER] = const_cast<char*>(Constants::runtime_identifier.data ());
 
 	const char **prop_names = init_runtime_property_names;
 	const char **prop_values = const_cast<const char**>(init_runtime_property_values);

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -51,7 +51,7 @@ const ApplicationConfig application_config = {
 	.jni_add_native_method_registration_attribute_present = false,
 	.marshal_methods_enabled = false,
 	.ignore_split_configs = false,
-	.number_of_runtime_properties = 1,
+	.number_of_runtime_properties = 2,
 	.package_naming_policy = 0,
 	.environment_variable_count = 0,
 	.system_property_count = 0,
@@ -218,8 +218,10 @@ const JniRemappingTypeReplacementEntry jni_remapping_type_replacements[] = {
 
 const char *init_runtime_property_names[] = {
 	"HOST_RUNTIME_CONTRACT",
+	"RUNTIME_IDENTIFIER",
 };
 
 char *init_runtime_property_values[] {
+	nullptr,
 	nullptr,
 };

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -167,6 +167,7 @@
     <Compile Include="System.Net.NetworkInformation\NetworkChangeTest.cs" />
     <Compile Include="System.Net.NetworkInformation\PingTest.cs" />
     <Compile Include="System.Runtime.InteropServices\DllImportTest.cs" />
+    <Compile Include="System.Runtime.InteropServices\RuntimeInformationTest.cs" />
     <Compile Include="System.Text\EncodingTests.cs" />
     <Compile Include="System.Text.Json\JsonSerializerTest.cs" />
     <Compile Include="System.Threading\InterlockedTest.cs" />

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System.Runtime.InteropServices/RuntimeInformationTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System.Runtime.InteropServices/RuntimeInformationTest.cs
@@ -27,11 +27,14 @@ namespace Xamarin.Android.RuntimeTests {
 			// `android.os.Process.is64Bit()` tells us the bitness this process actually runs as,
 			// and `android.os.Build.SUPPORTED_{32,64}_BIT_ABIS` are ordered most-preferred-first,
 			// so the first entry is the ABI Android picked for us.
-			var abis = Android.OS.Process.Is64Bit ()
-				? Android.OS.Build.Supported64BitAbis
-				: Android.OS.Build.Supported32BitAbis;
-			Assert.IsNotNull (abis, "`android.os.Build` did not report any supported ABIs.");
-			Assert.IsNotEmpty (abis, "`android.os.Build` did not report any supported ABIs.");
+			var abis = global::Android.OS.Process.Is64Bit ()
+				? global::Android.OS.Build.Supported64BitAbis
+				: global::Android.OS.Build.Supported32BitAbis;
+			// `Assert.IsNotEmpty()` reads `.Count` through reflection, which NativeAOT trims away.
+			if (abis == null || abis.Count == 0) {
+				Assert.Fail ("`android.os.Build` did not report any supported ABIs.");
+				return;
+			}
 			Assert.AreEqual (abis [0], RidToAbi (rid), $"`RuntimeInformation.RuntimeIdentifier` was '{rid}'.");
 		}
 	}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System.Runtime.InteropServices/RuntimeInformationTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System.Runtime.InteropServices/RuntimeInformationTest.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.InteropServices;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.RuntimeTests {
+
+	[TestFixture]
+	public class RuntimeInformationTest {
+
+		// Maps a .NET RID to the ABI name Android reports in `android.os.Build.SUPPORTED_ABIS`
+		static string RidToAbi (string rid) => rid switch {
+			"android-arm64" => "arm64-v8a",
+			"android-arm"   => "armeabi-v7a",
+			"android-x64"   => "x86_64",
+			"android-x86"   => "x86",
+			_ => throw new NotSupportedException ($"Unexpected runtime identifier '{rid}'."),
+		};
+
+		// https://github.com/dotnet/android/issues/12273
+		[Test]
+		public void RuntimeIdentifierMatchesAbi ()
+		{
+			string rid = RuntimeInformation.RuntimeIdentifier;
+			Assert.AreNotEqual ("unknown", rid, "The native runtime did not set the `RUNTIME_IDENTIFIER` property.");
+
+			// `android.os.Process.is64Bit()` tells us the bitness this process actually runs as,
+			// and `android.os.Build.SUPPORTED_{32,64}_BIT_ABIS` are ordered most-preferred-first,
+			// so the first entry is the ABI Android picked for us.
+			var abis = Android.OS.Process.Is64Bit ()
+				? Android.OS.Build.Supported64BitAbis
+				: Android.OS.Build.Supported32BitAbis;
+			Assert.IsNotNull (abis, "`android.os.Build` did not report any supported ABIs.");
+			Assert.IsNotEmpty (abis, "`android.os.Build` did not report any supported ABIs.");
+			Assert.AreEqual (abis [0], RidToAbi (rid), $"`RuntimeInformation.RuntimeIdentifier` was '{rid}'.");
+		}
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/12273

`System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier` returned `"unknown"` on CoreCLR. That property is just `AppContext.GetData("RUNTIME_IDENTIFIER")`, and on other platforms `hostfxr` supplies the value when it starts the runtime. We do not use `hostfxr`, so nothing ever set it.

MonoVM already handles this in `MonoVMProperties` (`monovm-properties.cc`), and NativeAOT already works because ILC emits `--runtimeknob:RUNTIME_IDENTIFIER=$(RuntimeIdentifier)` from `Microsoft.NETCore.Native.targets`. Only the CoreCLR host was missing it.

### Approach

The value has to come from native code. `libxamarin-app.so` is generated per-ABI, but from a single shared `*.runtimeconfig.json` that knows nothing about the ABI it is being built for. `Constants::runtime_identifier` in `constants.hh` is already defined per-ABI and was previously unused.

Rather than allocating and copying the generated property arrays at startup, this follows the existing `HOST_RUNTIME_CONTRACT`-at-index-0 contract:

- `ApplicationConfigNativeAssemblyGeneratorCLR` emits `RUNTIME_IDENTIFIER` as the second entry in `init_runtime_property_names` with a `null` value.
- `Host::Java_mono_android_Runtime_initInternal` fills in `init_runtime_property_values[1]`, the same way it already does for `[0]`.
- `application_dso_stub.cc` is updated to match the new layout.

No extra allocation in Release. The existing `std::vector` copy stays FastDev-only.

Verified in dotnet/runtime that this reaches managed code even though we have no `static void Main()`: `coreclr_initialize` -> `CorHost2::CreateAppDomainWithManager` -> `AppContext.Setup`, all during domain creation, before any entry point. We call `coreclr_initialize` then `coreclr_create_delegate`, never `coreclr_execute_assembly`, so this is the path that already makes existing `runtimeconfig.json` `configProperties` work today. `RUNTIME_IDENTIFIER` is also not in `AppContext.IsKnownHostProperty`, so it lands directly in the data store rather than requiring a host callback.

### Tests

New `RuntimeInformationTest.RuntimeIdentifierMatchesAbi` in `Mono.Android-Tests` asserts the RID against the ABI Android actually reports, via `android.os.Process.is64Bit()` plus `android.os.Build.SUPPORTED_{32,64}_BIT_ABIS` (ordered most-preferred-first, so `[0]` is the ABI Android picked for the process). It runs under all three runtimes.

Ran on a physical arm64-v8a device:

| Config | Runtime | Result |
| --- | --- | --- |
| Debug, `UseMonoRuntime=false` | CoreCLR | Passed (940 passed / 0 failed / 62 skipped) |
| Release, `PublishAot=true` | NativeAOT | Passed (622 passed / 0 failed / 8 skipped) |

### Notes for reviewers

Two things in the test are load-bearing and worth a look:

- The fixture lives in `Xamarin.Android.RuntimeTests`, so an unqualified `Android.OS` binds to `Xamarin.Android.OS` and fails to compile. Hence `global::Android.OS`.
- `Assert.IsNotEmpty()` reads `.Count` reflectively, which NativeAOT trims away (`System.NotSupportedException : Object_NotInvokable`). Replaced with a plain null/count guard. Notably this failure happened *after* the `!= "unknown"` assertion passed, which is independent confirmation the RID is correct on NativeAOT.

Unrelated pre-existing issue hit while testing, not fixed here: `tests/Mono.Android-Tests/Java.Interop-Tests/Jars/` is not configuration-scoped, so building Debug and then Release in the same tree leaves both `Mono.Android-Test-classes.jar` and `-trimmable.jar` behind and R8 fails with `Type net.dot.jni.test.AndroidInterface is defined multiple times`.

Also out of scope but worth noting: `APP_CONTEXT_BASE_DIRECTORY` is set for MonoVM but not for CoreCLR, so `AppContext.BaseDirectory` is likely wrong there too.