### PR TITLE
[LlvmIrGenerator] emit c"..." literals for string blobs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -914,8 +914,9 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			// A consequence of this is that we can no longer annotate individual strings with comments,
 			// because a constant string literal must fit on a single line and `;` comments extend to the
 			// end of the line.
-			const int chunkSize = 4096;
-			char[] chunk = ArrayPool<char>.Shared.Rent (chunkSize);
+			// `Rent()` may return a larger array than requested, so use its actual length as the capacity.
+			char[] chunk = ArrayPool<char>.Shared.Rent (4096);
+			int chunkCapacity = chunk.Length;
 			int chunkUsed = 0;
 
 			try {
@@ -941,14 +942,14 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			{
 				// `"` and `\` must always be escaped, as must anything outside of the printable ASCII range.
 				if (b != (byte)'"' && b != (byte)'\\' && b >= 32 && b < 127) {
-					if (chunkUsed == chunkSize) {
+					if (chunkUsed == chunkCapacity) {
 						Flush ();
 					}
 					chunk[chunkUsed++] = (char)b;
 					return;
 				}
 
-				if (chunkUsed + 3 > chunkSize) {
+				if (chunkUsed + 3 > chunkCapacity) {
 					Flush ();
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -906,17 +906,13 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		void WriteStringBlobArray (GeneratorWriteContext context, LlvmIrStringBlob blob)
 		{
-			// String blobs are emitted as a single LLVM IR constant byte string (`c"..."`) instead of one
-			// `i8 u0xNN` element per byte.  A hello world MAUI app has ~3.6 million bytes of type map
-			// strings, so the array form produces a >50MB `.ll` file which is slow both to write here and
-			// to consume in `llc`.  The `c"..."` form is roughly ten times smaller.
-			//
-			// A consequence of this is that we can no longer annotate individual strings with comments,
-			// because a constant string literal must fit on a single line and `;` comments extend to the
-			// end of the line.
+			// Emitted as a single `c"..."` literal rather than one `i8` element per byte, which shrinks
+			// the `.ll` ~10x.  No per-string comments are possible, as the literal must be on one line.
+			const int HexDigits = 2;
+			const int MaxEscapeWidth = 1 + HexDigits;
+			const int ChunkSize = 4096;
 
-			// `Rent()` may return a larger array than requested, so use its actual length as the capacity.
-			char [] chunk = ArrayPool<char>.Shared.Rent (4096);
+			char [] chunk = ArrayPool<char>.Shared.Rent (ChunkSize);
 			int chunkCapacity = chunk.Length;
 			int chunkUsed = 0;
 
@@ -941,7 +937,6 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 			void WriteByte (byte b)
 			{
-				// `"` and `\` must always be escaped, as must anything outside of the printable ASCII range.
 				if (b != (byte) '"' && b != (byte) '\\' && b >= 32 && b < 127) {
 					if (chunkUsed == chunkCapacity) {
 						Flush ();
@@ -950,13 +945,13 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					return;
 				}
 
-				if (chunkUsed + 3 > chunkCapacity) {
+				if (chunkUsed + MaxEscapeWidth > chunkCapacity) {
 					Flush ();
 				}
 
 				chunk [chunkUsed++] = '\\';
-				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed, 2), b, upperCase: true);
-				chunkUsed += 2;
+				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed, HexDigits), b, upperCase: true);
+				chunkUsed += HexDigits;
 			}
 
 			void Flush ()

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -914,6 +914,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			// A consequence of this is that we can no longer annotate individual strings with comments,
 			// because a constant string literal must fit on a single line and `;` comments extend to the
 			// end of the line.
+
 			// `Rent()` may return a larger array than requested, so use its actual length as the capacity.
 			char[] chunk = ArrayPool<char>.Shared.Rent (4096);
 			int chunkCapacity = chunk.Length;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -916,7 +916,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			// end of the line.
 
 			// `Rent()` may return a larger array than requested, so use its actual length as the capacity.
-			char[] chunk = ArrayPool<char>.Shared.Rent (4096);
+			char [] chunk = ArrayPool<char>.Shared.Rent (4096);
 			int chunkCapacity = chunk.Length;
 			int chunkUsed = 0;
 
@@ -942,11 +942,11 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			void WriteByte (byte b)
 			{
 				// `"` and `\` must always be escaped, as must anything outside of the printable ASCII range.
-				if (b != (byte)'"' && b != (byte)'\\' && b >= 32 && b < 127) {
+				if (b != (byte) '"' && b != (byte) '\\' && b >= 32 && b < 127) {
 					if (chunkUsed == chunkCapacity) {
 						Flush ();
 					}
-					chunk[chunkUsed++] = (char)b;
+					chunk [chunkUsed++] = (char) b;
 					return;
 				}
 
@@ -954,7 +954,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					Flush ();
 				}
 
-				chunk[chunkUsed++] = '\\';
+				chunk [chunkUsed++] = '\\';
 				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed), b, upperCase: true);
 				chunkUsed += 2;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -906,71 +906,65 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		void WriteStringBlobArray (GeneratorWriteContext context, LlvmIrStringBlob blob)
 		{
-			// The stride determines how many elements are written on a single line before a newline is added.
-			const uint stride = 16;
-			Type elementType = typeof(byte);
+			// String blobs are emitted as a single LLVM IR constant byte string (`c"..."`) instead of one
+			// `i8 u0xNN` element per byte.  A hello world MAUI app has ~3.6 million bytes of type map
+			// strings, so the array form produces a >50MB `.ll` file which is slow both to write here and
+			// to consume in `llc`.  The `c"..."` form is roughly ten times smaller.
+			//
+			// A consequence of this is that we can no longer annotate individual strings with comments,
+			// because a constant string literal must fit on a single line and `;` comments extend to the
+			// end of the line.
+			const int chunkSize = 4096;
+			char[] chunk = ArrayPool<char>.Shared.Rent (chunkSize);
+			int chunkUsed = 0;
 
-			LlvmIrVariableNumberFormat oldNumberFormat = context.NumberFormat;
-			context.NumberFormat = LlvmIrVariableNumberFormat.Hexadecimal;
-			WriteArrayValueStart (context);
-			foreach (LlvmIrStringBlob.StringInfo si in blob.GetSegments ()) {
-				if (si.Offset > 0) {
-					context.Output.Write (',');
-					context.Output.WriteLine ();
-					context.Output.WriteLine ();
-				}
+			try {
+				context.Output.Write ('c');
+				context.Output.Write ('"');
 
-				context.Output.Write (context.CurrentIndent);
-				WriteCommentLine (context, $" '{si.Value}' @ {si.Offset}");
-				WriteBytes (si.Bytes);
-			}
-			context.Output.WriteLine ();
-			WriteArrayValueEnd (context);
-			context.NumberFormat = oldNumberFormat;
-
-			void WriteBytes (byte[] bytes)
-			{
-				ulong counter = 0;
-				bool first = true;
-				foreach (byte b in bytes) {
-					if (!first) {
-						WriteCommaWithStride (counter);
-					} else {
-						context.Output.Write (context.CurrentIndent);
-						first = false;
+				foreach (LlvmIrStringBlob.StringInfo si in blob.GetSegments ()) {
+					foreach (byte b in si.Bytes) {
+						WriteByte (b);
 					}
 
-					counter++;
-					WriteByteTypeAndValue (b);
+					// Terminating NUL is counted for each string, but not included in its bytes
+					WriteByte (0);
 				}
 
-				if (bytes.Length > 0) {
-					WriteCommaWithStride (counter);
-				} else {
-					context.Output.Write (context.CurrentIndent);
-				}
-				WriteByteTypeAndValue (0); // Terminating NUL is counted for each string, but not included in its bytes
+				Flush ();
+				context.Output.Write ('"');
+			} finally {
+				ArrayPool<char>.Shared.Return (chunk);
 			}
 
-			void WriteCommaWithStride (ulong counter)
+			void WriteByte (byte b)
 			{
-				context.Output.Write (',');
-				if (stride == 1 || counter % stride == 0) {
-					context.Output.WriteLine ();
-					context.Output.Write (context.CurrentIndent);
-				} else {
-					context.Output.Write (' ');
+				// `"` and `\` must always be escaped, as must anything outside of the printable ASCII range.
+				if (b != (byte)'"' && b != (byte)'\\' && b >= 32 && b < 127) {
+					if (chunkUsed == chunkSize) {
+						Flush ();
+					}
+					chunk[chunkUsed++] = (char)b;
+					return;
 				}
+
+				if (chunkUsed + 3 > chunkSize) {
+					Flush ();
+				}
+
+				chunk[chunkUsed++] = '\\';
+				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed), b, upperCase: true);
+				chunkUsed += 2;
 			}
 
-			void WriteByteTypeAndValue (byte v)
+			void Flush ()
 			{
-				// This is by far the hottest path in the generator: a hello world MAUI app writes
-				// ~3.6 million bytes here.  WriteType()/WriteValue() would box the byte and allocate a
-				// handful of strings per element, so write the (always identical) type and the two hex
-				// digits directly.
-				context.Output.Write ("i8 u0x");
-				HexUtilities.WriteHex (context.Output, v, upperCase: false);
+				if (chunkUsed == 0) {
+					return;
+				}
+
+				context.Output.Write (chunk, 0, chunkUsed);
+				chunkUsed = 0;
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -955,7 +955,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				}
 
 				chunk [chunkUsed++] = '\\';
-				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed), b, upperCase: true);
+				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed, 2), b, upperCase: true);
 				chunkUsed += 2;
 			}
 


### PR DESCRIPTION
Stacked on #12279 — review that first; this PR's diff is one file, `LlvmIrGenerator.cs`.

`WriteStringBlobArray()` emitted one LLVM IR element per byte of the type map string blobs:

```llvm
@type_map_managed_type_names = ... constant [3035518 x i8] [
	; 'Android.OS.AsyncTask' @ 0
	i8 u0x41, i8 u0x6e, ...
]
```

For a hello world MAUI app that's ~3.6 million elements and a 52.6MB `typemaps.arm64-v8a.ll`, which is slow to write and much slower for `llc` to consume.

Emit a single constant byte string instead — the same form the generator already uses for constant string literals:

```llvm
@type_map_managed_type_names = ... constant [3035518 x i8] c"Android.OS.AsyncTask\00..."
```

Bytes stream through a pooled `char []` rather than millions of single-character `TextWriter` writes.

## Results

`dotnet new maui -sc`, Debug, clean build, `-nodeReuse:false`. The machine is shared and noisy, so raw per-run values are shown rather than a single median:

| Metric | Before | After |
| --- | --- | --- |
| `typemaps.arm64-v8a.ll` | 52.6MB | **15.2MB** |
| `CompileNativeAssembly` (`llc`) | 2239, 2287, 2177ms | **224, 168, 203, 201, 221, 203ms** |
| `GenerateTypeMappings` | 1489, 1649, 1414ms | 645, 1187, 1206, 543, 576, 643ms |

`CompileNativeAssembly` is the headline: ~10x faster, with no overlap between the before and after ranges. That directly addresses the `CompileNativeAssembly` regression seen in the CoreCLR-vs-Mono binlog comparison that motivated this work.

`GenerateTypeMappings` is genuinely faster — every "after" run beats every "before" run — but it's noisy enough (543-1206ms across identical binaries) that I won't quote a percentage.

`LinkApplicationSharedLibraries` and total build time are **unchanged**. The linker consumes a byte-identical `.o`, so there is nothing there to win.

## Correctness

`typemaps.arm64-v8a.o` is **byte-for-byte identical** before and after (SHA256 `73E4A982E8C8098FB7909EA550CDEE392E19AAB6938E145A4C362BE0F0417DCF`, 4161824 bytes).

One caveat for anyone reproducing this: the `-ci.<branch>.<n>` SDK version string is embedded in the assembly names blob and changes on every SDK rebuild, so `.o` hashes only compare within a matched before/after pair.

Additional checks:

* All three globals decode from the `.ll` to exactly their declared `[N x i8]` length — `type_map_assembly_names` 2707, `type_map_managed_type_names` 3035518, `type_map_java_type_names` 592060 — and the decoded bytes appear verbatim in the `.o`.
* All 28,225 `i32` offsets in the file (16,567 java + 11,658 managed) resolve correctly against the decoded blobs, zero unresolved. This matters because those offsets index into the blobs.
* `Microsoft.Android.Build.BaseTasks-Tests` 129/129, `LlvmIrGeneratorTests` 9/9, `GenerateNativeApplicationConfigSourcesTests` 4/4. The last of those runs `llc` on a generated `.ll` and parses the resulting `.s`, so it round-trips a string blob end to end.

Nothing parses blob contents out of the `.ll`, so no test changes were needed. `TrimmableTypeMapBuildTests` only matches the array *type* (`[N x`), which is unchanged.

## Tradeoffs

* **Per-string `; 'Foo' @ 123` comments are gone.** A constant string literal has to fit on a single line and `;` comments extend to the end of the line, so they can't be interleaved. They were also a large fraction of the file size.
* **The managed type names line is ~3MB wide.** `llc` handles it fine; text editors and diff tools will not enjoy it.
* **15.2MB, not ~5MB.** The remaining bulk is the `i32` offset/index arrays, which this change doesn't touch — the obvious next target.
* This removes the last caller of `HexUtilities.WriteHex (TextWriter, ...)` that #12279 added for the old hot path. The overload is public and unit-tested, so it's left in place.

Squash on merge — the 4 commits are kept separate for readability.
