### PR TITLE
Set APP_CONTEXT_BASE_DIRECTORY on CoreCLR and NativeAOT

### DIFF
--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/JavaInteropRuntime.cs
@@ -74,6 +74,8 @@ static partial class JavaInteropRuntime
 			// Entry point into Mono.Android.dll for NativeAOT-specific JNI runtime initialization.
 			JNIEnvInit.InitializeNativeAotRuntime (runtime, initArgs);
 
+			SetAppContextBaseDirectory (filesDir);
+
 			transition  = new JniTransition (jnienv);
 
 			var handler = Java.Lang.Thread.DefaultUncaughtExceptionHandler;
@@ -84,5 +86,22 @@ static partial class JavaInteropRuntime
 			transition.SetPendingException (e);
 		}
 		transition.Dispose ();
+	}
+
+	// MonoVM and CoreCLR hand `APP_CONTEXT_BASE_DIRECTORY` to the runtime as a host property, but
+	// NativeAOT has no such property bag: without this, `AppContext.BaseDirectory` falls back to the
+	// directory of `Environment.ProcessPath`, which is `/system/bin/` (where `app_process64` lives).
+	static void SetAppContextBaseDirectory (IntPtr filesDir)
+	{
+		string? baseDirectory = JniEnvironment.Strings.ToString (filesDir);
+		if (string.IsNullOrEmpty (baseDirectory)) {
+			return;
+		}
+
+		// .NET always terminates `AppContext.BaseDirectory` with a directory separator.
+		if (!baseDirectory.EndsWith ('/')) {
+			baseDirectory += "/";
+		}
+		AppContext.SetData ("APP_CONTEXT_BASE_DIRECTORY", baseDirectory);
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
@@ -20,6 +20,7 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 	const string HOST_PROPERTY_BUNDLE_PROBE       = "BUNDLE_PROBE";
 	const string HOST_PROPERTY_PINVOKE_OVERRIDE   = "PINVOKE_OVERRIDE";
 	const string HOST_PROPERTY_RUNTIME_IDENTIFIER = "RUNTIME_IDENTIFIER";
+	const string HOST_PROPERTY_APP_CONTEXT_BASE_DIRECTORY = "APP_CONTEXT_BASE_DIRECTORY";
 
 	sealed class DSOCacheEntryContextDataProvider : NativeAssemblerStructContextDataProvider
 	{
@@ -221,6 +222,7 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 		// These will be filled in by the native host.
 		this.runtimeProperties[HOST_PROPERTY_RUNTIME_CONTRACT] = String.Empty;
 		this.runtimeProperties[HOST_PROPERTY_RUNTIME_IDENTIFIER] = String.Empty;
+		this.runtimeProperties[HOST_PROPERTY_APP_CONTEXT_BASE_DIRECTORY] = String.Empty;
 
 		// these mustn't be there, they would break our host contract
 		this.runtimeProperties.Remove (HOST_PROPERTY_PINVOKE_OVERRIDE);
@@ -319,15 +321,18 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 		};
 		module.Add (bundled_assemblies);
 
-		// HOST_PROPERTY_RUNTIME_CONTRACT and HOST_PROPERTY_RUNTIME_IDENTIFIER will come first, in that
-		// order, our native runtime requires that since it needs to set their values in the values array
-		// and we don't want to spend time searching for the indices, nor we want to add yet another
-		// variable storing the index to the entry. KISS.
+		// HOST_PROPERTY_RUNTIME_CONTRACT, HOST_PROPERTY_RUNTIME_IDENTIFIER and
+		// HOST_PROPERTY_APP_CONTEXT_BASE_DIRECTORY will come first, in that order, our native runtime
+		// requires that since it needs to set their values in the values array and we don't want to
+		// spend time searching for the indices, nor we want to add yet another variable storing the
+		// index to the entry. KISS.
 		var runtime_property_names = new List<string> {
 			HOST_PROPERTY_RUNTIME_CONTRACT,
 			HOST_PROPERTY_RUNTIME_IDENTIFIER,
+			HOST_PROPERTY_APP_CONTEXT_BASE_DIRECTORY,
 		};
 		var runtime_property_values = new List<string?> {
+			null,
 			null,
 			null,
 		};
@@ -335,7 +340,8 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 		if (runtimeProperties != null) {
 			foreach (var kvp in runtimeProperties) {
 				if (MonoAndroidHelper.StringEquals (kvp.Key, HOST_PROPERTY_RUNTIME_CONTRACT) ||
-						MonoAndroidHelper.StringEquals (kvp.Key, HOST_PROPERTY_RUNTIME_IDENTIFIER)) {
+						MonoAndroidHelper.StringEquals (kvp.Key, HOST_PROPERTY_RUNTIME_IDENTIFIER) ||
+						MonoAndroidHelper.StringEquals (kvp.Key, HOST_PROPERTY_APP_CONTEXT_BASE_DIRECTORY)) {
 					continue;
 				}
 				runtime_property_names.Add (kvp.Key);

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -353,6 +353,7 @@ void Host::Java_mono_android_Runtime_initInternal (
 	// the values here without searching the names array.
 	constexpr size_t RUNTIME_PROPERTY_INDEX_HOST_CONTRACT = 0;
 	constexpr size_t RUNTIME_PROPERTY_INDEX_RUNTIME_IDENTIFIER = 1;
+	constexpr size_t RUNTIME_PROPERTY_INDEX_APP_CONTEXT_BASE_DIRECTORY = 2;
 
 	init_runtime_property_values[RUNTIME_PROPERTY_INDEX_HOST_CONTRACT] = host_contract_ptr_buffer.data ();
 
@@ -361,6 +362,18 @@ void Host::Java_mono_android_Runtime_initInternal (
 	// come from here: `libxamarin-app.so` is per-ABI, but it is generated from the (shared)
 	// `*.runtimeconfig.json`, which knows nothing about the ABI it is being built for.
 	init_runtime_property_values[RUNTIME_PROPERTY_INDEX_RUNTIME_IDENTIFIER] = const_cast<char*>(Constants::runtime_identifier.data ());
+
+	// Likewise for `APP_CONTEXT_BASE_DIRECTORY`, which backs `AppContext.BaseDirectory`. Without it
+	// the runtime falls back to the directory of `Assembly.GetEntryAssembly ()`, which is the empty
+	// string for us since assemblies are read straight out of the APK. Point it at the application's
+	// files directory, the same value MonoVM has always used. `.NET` terminates the base directory
+	// with a directory separator, so we do too.
+	// Storage must outlive `coreclr_initialize`, hence the function-local static.
+	static std::string app_context_base_directory { files_dir.get_cstr () };
+	if (!app_context_base_directory.ends_with ('/')) {
+		app_context_base_directory.push_back ('/');
+	}
+	init_runtime_property_values[RUNTIME_PROPERTY_INDEX_APP_CONTEXT_BASE_DIRECTORY] = const_cast<char*>(app_context_base_directory.c_str ());
 
 	const char **prop_names = init_runtime_property_names;
 	const char **prop_values = const_cast<const char**>(init_runtime_property_values);

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -368,8 +368,10 @@ void Host::Java_mono_android_Runtime_initInternal (
 	// string for us since assemblies are read straight out of the APK. Point it at the application's
 	// files directory, the same value MonoVM has always used. `.NET` terminates the base directory
 	// with a directory separator, so we do too.
-	// Storage must outlive `coreclr_initialize`, hence the function-local static.
-	static std::string app_context_base_directory { files_dir.get_cstr () };
+	// Storage must outlive `coreclr_initialize`, hence the function-local static. Assign on every
+	// call rather than relying on the initializer, which would only ever see the first `files_dir`.
+	static std::string app_context_base_directory;
+	app_context_base_directory.assign (files_dir.get_cstr ());
 	if (!app_context_base_directory.ends_with ('/')) {
 		app_context_base_directory.push_back ('/');
 	}

--- a/src/native/clr/xamarin-app-stub/application_dso_stub.cc
+++ b/src/native/clr/xamarin-app-stub/application_dso_stub.cc
@@ -51,7 +51,7 @@ const ApplicationConfig application_config = {
 	.jni_add_native_method_registration_attribute_present = false,
 	.marshal_methods_enabled = false,
 	.ignore_split_configs = false,
-	.number_of_runtime_properties = 2,
+	.number_of_runtime_properties = 3,
 	.package_naming_policy = 0,
 	.environment_variable_count = 0,
 	.system_property_count = 0,
@@ -219,9 +219,11 @@ const JniRemappingTypeReplacementEntry jni_remapping_type_replacements[] = {
 const char *init_runtime_property_names[] = {
 	"HOST_RUNTIME_CONTRACT",
 	"RUNTIME_IDENTIFIER",
+	"APP_CONTEXT_BASE_DIRECTORY",
 };
 
 char *init_runtime_property_values[] {
+	nullptr,
 	nullptr,
 	nullptr,
 };

--- a/src/native/mono/monodroid/monovm-properties.hh
+++ b/src/native/mono/monodroid/monovm-properties.hh
@@ -2,6 +2,7 @@
 #define __MONOVM_PROPERTIES_HH
 
 #include <cstring>
+#include <string>
 #include <string_view>
 
 #include "monodroid-glue-internal.hh"
@@ -30,7 +31,12 @@ namespace xamarin::android::internal
 			static_assert (PROPERTY_COUNT == N_PROPERTY_KEYS);
 			static_assert (PROPERTY_COUNT == N_PROPERTY_VALUES);
 
-			_property_values[APP_CONTEXT_BASE_DIRECTORY_INDEX] = strdup (filesDir.get_cstr ());
+			// `.NET` terminates `AppContext.BaseDirectory` with a directory separator, so we do too.
+			std::string baseDirectory { filesDir.get_cstr () };
+			if (!baseDirectory.ends_with ('/')) {
+				baseDirectory.push_back ('/');
+			}
+			_property_values[APP_CONTEXT_BASE_DIRECTORY_INDEX] = strdup (baseDirectory.c_str ());
 
 			static_local_string<32uz> localDateTimeOffsetBuffer;
 			localDateTimeOffsetBuffer.append (localDateTimeOffset);

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System/AppContextTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System/AppContextTests.cs
@@ -70,5 +70,24 @@ namespace SystemTests
 				Assert.Fail($"Unknown member type: {members [0]}");
 			}
 		}
+
+		// `AppContext.BaseDirectory` is backed by the `APP_CONTEXT_BASE_DIRECTORY` host property,
+		// which every runtime must set to `Context.getFilesDir()`. When it is left unset, the
+		// `AppContext.GetBaseDirectoryCore()` fallback returns something useless on Android:
+		// the empty string on CoreCLR (assemblies are embedded, so `Assembly.Location` is empty)
+		// and `/system/bin/` on NativeAOT (that is where `app_process64` lives).
+		[Test]
+		public void BaseDirectoryIsFilesDir ()
+		{
+			var filesDir = Android.App.Application.Context.FilesDir;
+			if (filesDir == null) {
+				Assert.Fail ("`Context.FilesDir` was null.");
+				return;
+			}
+
+			// .NET always terminates `AppContext.BaseDirectory` with a directory separator.
+			string expected = filesDir.AbsolutePath + "/";
+			Assert.AreEqual (expected, AppContext.BaseDirectory);
+		}
 	}
 }

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System/AppContextTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System/AppContextTests.cs
@@ -85,8 +85,9 @@ namespace SystemTests
 				return;
 			}
 
-			// .NET always terminates `AppContext.BaseDirectory` with a directory separator.
-			string expected = filesDir.AbsolutePath + "/";
+			// .NET always terminates `AppContext.BaseDirectory` with a directory separator. Android
+			// does not return one today, but normalize instead of assuming it never will.
+			string expected = filesDir.AbsolutePath.TrimEnd ('/') + "/";
 			Assert.AreEqual (expected, AppContext.BaseDirectory);
 		}
 	}


### PR DESCRIPTION
> [!NOTE]
> This was a stacked PR on top of #12278 ("[CoreCLR] Set the RUNTIME_IDENTIFIER runtime property"), which has since merged. Rebased onto `main`; the base is now `main` and the diff contains only the `APP_CONTEXT_BASE_DIRECTORY` work.

## Why this change is necessary

`AppContext.BaseDirectory` is backed by the `APP_CONTEXT_BASE_DIRECTORY` host property:

```csharp
public static string BaseDirectory =>
    GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
    (s_defaultBaseDirectory ??= GetBaseDirectoryCore());
```

On other platforms `hostfxr` supplies that property. .NET for Android does not use `hostfxr`, so our native host has to supply it itself. MonoVM has always done this (`src/native/mono/monodroid/monovm-properties.{cc,hh}`), but **CoreCLR and NativeAOT never did**, so both silently fell through to `GetBaseDirectoryCore ()`, which returns something useless on Android:

| Runtime | Fallback used | Value before this change |
| --- | --- | --- |
| CoreCLR | `Path.GetDirectoryName (Assembly.GetEntryAssembly ()?.Location)` | **`string.Empty`** — *measured on device* with `EmbedAssembliesIntoApk=true`; assemblies are read straight out of the APK, so `Location` is empty |
| NativeAOT | `Path.GetDirectoryName (Environment.ProcessPath)` | **`/system/bin/`** — *measured on device* by reverting the fix and re-running the test; that is where `app_process64` lives |
| MonoVM | n/a, property was set | `/data/user/0/<pkg>/files` (no trailing separator) |

The CoreCLR value is also *unstable across deployment modes*: with Fast Deployment the entry assembly lives on disk under `files/.__override__/<arch>/`, so the fallback resolves somewhere different than it does for an APK-embedded build. I did **not** measure the pre-change Fast Deployment value, so treat that as documented `GetBaseDirectoryCore ()` behavior rather than an observed one — either way it is not `filesDir`. Once the host property is set from `filesDir`, `AppContext.BaseDirectory` no longer depends on where assemblies physically live.

## What changed

- **CoreCLR** — `APP_CONTEXT_BASE_DIRECTORY` is now a reserved runtime property at index 2, exactly like `RUNTIME_IDENTIFIER` in #12278. `ApplicationConfigNativeAssemblyGeneratorCLR` emits the name in the fixed prologue, and `Host::Java_mono_android_Runtime_initInternal` fills the value in from the `filesDir` it is already handed by `mono.android.Runtime.initInternal`. `application_dso_stub.cc` is kept in sync.
- **NativeAOT** — there is no property bag to write into (and no ILC knob for this, unlike `RUNTIME_IDENTIFIER`), so `JavaInteropRuntime.init ()` calls `AppContext.SetData ()` immediately after the runtime is created, using the `filesDir` jstring it already receives.
- **MonoVM** — appends the trailing directory separator so all three runtimes agree.

All three runtimes now return `<Context.getFilesDir ()>/`. Everywhere else in .NET, `AppContext.BaseDirectory` ends with a directory separator, so it does here too; that is a small behavior change for MonoVM apps that string-concatenate instead of using `Path.Combine`.

## Unit tests

`SystemTests.AppContextTests.BaseDirectoryIsFilesDir` in `Mono.Android-Tests` asserts the managed value against the independently-obtained Java value, `Android.App.Application.Context.FilesDir.AbsolutePath`, rather than a hardcoded path.

Verified on a physical arm64-v8a device:

- **CoreCLR, `Debug`** — fails before the fix with ``Expected: "/data/user/0/Mono.Android.NET_Tests/files/" But was: <string.Empty>``, passes after.
- **NativeAOT, `Release`** — fails before the fix with `Expected: "/data/user/0/Mono.Android.NET_Tests/files/" But was: "/system/bin/"`, passes after (631 tests, 0 failures).
- **CoreCLR, `Debug`, Fast Deployment** (assemblies deployed to `files/.__override__/arm64-v8a/`, confirmed present on device) — passing after the fix, confirming the value no longer depends on assembly location.

MonoVM could not be exercised: `NETSDK1242` ("Building Android projects with the Mono runtime is not supported in .NET 11.0 and later") makes the test app unbuildable on `main`. Its one-line change is by inspection only.
