### PR TITLE
[FastDeploy2] fix `adb push` argument quoting on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.Adb.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.Adb.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Xamarin.Android.Tasks
@@ -179,25 +178,6 @@ namespace Xamarin.Android.Tasks
 				InstallResultKind.InsufficientSpace => "ADB0060",
 				_ => "ADB0010",
 			};
-		}
-
-		/// <summary>Quotes an argument for <see cref="System.Diagnostics.ProcessStartInfo.Arguments"/>.</summary>
-		static string QuoteProcessArgument (string argument)
-		{
-			if (argument == null) {
-				return "\"\"";
-			}
-			var sb = new StringBuilder ();
-			sb.Append ('"');
-			// The .NET process class only supports quoted arguments with escaped quotes/backslashes.
-			foreach (char c in argument) {
-				if (c == '"' || c == '\\') {
-					sb.Append ('\\');
-				}
-				sb.Append (c);
-			}
-			sb.Append ('"');
-			return sb.ToString ();
 		}
 	}
 

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Framework;
 using Xamarin.Android.Build.Debugging.Tasks.Properties;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
@@ -732,70 +733,21 @@ namespace Xamarin.Android.Tasks
 			}
 			adbArguments.AddRange (arguments);
 
-			var stdout = new StringBuilder ();
-			var stderr = new StringBuilder ();
-			using var stdoutCompleted = new ManualResetEvent (false);
-			using var stderrCompleted = new ManualResetEvent (false);
-			var psi = new ProcessStartInfo {
-				FileName = adb,
-				Arguments = string.Join (" ", adbArguments.Select (QuoteProcessArgument)),
-				UseShellExecute = false,
-				RedirectStandardOutput = true,
-				RedirectStandardError = true,
-				CreateNoWindow = true,
-				WindowStyle = ProcessWindowStyle.Hidden,
+			var psi = ProcessUtils.CreateProcessStartInfo (adb, adbArguments.ToArray ());
+			psi.WindowStyle = ProcessWindowStyle.Hidden;
+
+			LogDiagnostic ($"adb command: {psi.FileName} {string.Join (" ", adbArguments)}");
+
+			using var stdout = new StringWriter ();
+			using var stderr = new StringWriter ();
+			int exitCode = await ProcessUtils.StartProcess (psi, stdout, stderr, CancellationToken, environmentVariables);
+			var result = new AdbCommandResult {
+				ExitCode = exitCode,
+				StandardOutput = stdout.ToString ().Trim (),
+				StandardError = stderr.ToString ().Trim (),
 			};
-			if (environmentVariables != null) {
-				foreach (var kvp in environmentVariables) {
-					psi.EnvironmentVariables [kvp.Key] = kvp.Value;
-				}
-			}
-
-			LogDiagnostic ($"adb command: {psi.FileName} {psi.Arguments}");
-			using (var process = new Process ()) {
-				process.StartInfo = psi;
-				process.OutputDataReceived += (sender, e) => {
-					if (e.Data != null) {
-						lock (stdout) {
-							stdout.AppendLine (e.Data);
-						}
-					} else {
-						stdoutCompleted.Set ();
-					}
-				};
-				process.ErrorDataReceived += (sender, e) => {
-					if (e.Data != null) {
-						lock (stderr) {
-							stderr.AppendLine (e.Data);
-						}
-					} else {
-						stderrCompleted.Set ();
-					}
-				};
-
-				process.Start ();
-				process.BeginOutputReadLine ();
-				process.BeginErrorReadLine ();
-				using (CancellationToken.Register (() => {
-					try {
-						if (!process.HasExited) {
-							process.Kill ();
-						}
-					} catch (InvalidOperationException) {
-					}
-				})) {
-					await Task.Run (() => process.WaitForExit (), CancellationToken);
-				}
-				stdoutCompleted.WaitOne (TimeSpan.FromSeconds (30));
-				stderrCompleted.WaitOne (TimeSpan.FromSeconds (30));
-				var result = new AdbCommandResult {
-					ExitCode = process.ExitCode,
-					StandardOutput = stdout.ToString ().Trim (),
-					StandardError = stderr.ToString ().Trim (),
-				};
-				LogAdbCommandResult (result);
-				return result;
-			}
+			LogAdbCommandResult (result);
+			return result;
 		}
 
 		void LogAdbCommandResult (AdbCommandResult result)

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
@@ -736,7 +736,12 @@ namespace Xamarin.Android.Tasks
 			var psi = ProcessUtils.CreateProcessStartInfo (adb, adbArguments.ToArray ());
 			psi.WindowStyle = ProcessWindowStyle.Hidden;
 
-			LogDiagnostic ($"adb command: {psi.FileName} {string.Join (" ", adbArguments)}");
+			// psi.Arguments holds the exact, correctly quoted command line whenever ProcessUtils
+			// joined the arguments itself; it is empty when it used ProcessStartInfo.ArgumentList.
+			string commandLine = !string.IsNullOrEmpty (psi.Arguments)
+				? psi.Arguments
+				: string.Join (" ", adbArguments.Select (a => $"[{a}]"));
+			LogDiagnostic ($"adb command: {psi.FileName} {commandLine}");
 
 			using var stdout = new StringWriter ();
 			using var stderr = new StringWriter ();

--- a/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
@@ -186,7 +186,8 @@ namespace Xamarin.Android.Tools
 		/// <summary>
 		/// Creates a <see cref="ProcessStartInfo"/> with the given filename and arguments.
 		/// On .NET 5+ uses <see cref="ProcessStartInfo.ArgumentList"/> to avoid shell-escaping issues;
-		/// on older frameworks falls back to a single <see cref="ProcessStartInfo.Arguments"/> string.
+		/// on older frameworks falls back to a single <see cref="ProcessStartInfo.Arguments"/> string
+		/// built by <see cref="JoinArguments"/>.
 		/// </summary>
 		public static ProcessStartInfo CreateProcessStartInfo (string fileName, params string[] args)
 		{
@@ -204,18 +205,66 @@ namespace Xamarin.Android.Tools
 			return psi;
 		}
 
-#if !NET5_0_OR_GREATER
-		static string JoinArguments (string[] args)
+		static readonly char [] CharsRequiringQuotes = { ' ', '\t', '"', '\n', '\v' };
+
+		/// <summary>
+		/// Joins <paramref name="args"/> into a single command line suitable for
+		/// <see cref="ProcessStartInfo.Arguments"/>.
+		/// </summary>
+		/// <remarks>
+		/// Implements the quoting rules understood by <c>CommandLineToArgvW</c>, which are also
+		/// the rules .NET uses when it parses <see cref="ProcessStartInfo.Arguments"/> on Unix.
+		/// A run of backslashes is only an escape sequence when it is immediately followed by a
+		/// quote, so backslashes must *not* be doubled unconditionally: doing so turns
+		/// <c>C:\dir\file.dll</c> into <c>C:\\dir\\file.dll</c>, which some tools (notably
+		/// <c>adb push</c>) reject.
+		/// </remarks>
+		internal static string JoinArguments (params string?[] args)
 		{
 			var sb = new StringBuilder ();
 			for (int i = 0; i < args.Length; i++) {
 				if (i > 0)
 					sb.Append (' ');
-				sb.Append ('"').Append (args [i]).Append ('"');
+				AppendArgument (sb, args [i]);
 			}
 			return sb.ToString ();
 		}
-#endif
+
+		static void AppendArgument (StringBuilder sb, string? argument)
+		{
+			if (argument is null || argument.Length == 0) {
+				sb.Append ("\"\"");
+				return;
+			}
+
+			if (argument.IndexOfAny (CharsRequiringQuotes) < 0) {
+				sb.Append (argument);
+				return;
+			}
+
+			sb.Append ('"');
+			for (int i = 0; i < argument.Length; i++) {
+				int backslashes = 0;
+				while (i < argument.Length && argument [i] == '\\') {
+					backslashes++;
+					i++;
+				}
+
+				if (i == argument.Length) {
+					// Trailing backslashes precede the closing quote, so they must be doubled
+					// to avoid escaping it.
+					sb.Append ('\\', backslashes * 2);
+					break;
+				}
+
+				if (argument [i] == '"') {
+					sb.Append ('\\', backslashes * 2 + 1).Append ('"');
+				} else {
+					sb.Append ('\\', backslashes).Append (argument [i]);
+				}
+			}
+			sb.Append ('"');
+		}
 
 		/// <summary>
 		/// Throws <see cref="InvalidOperationException"/> when <paramref name="exitCode"/> is non-zero.

--- a/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
@@ -205,8 +205,6 @@ namespace Xamarin.Android.Tools
 			return psi;
 		}
 
-		static readonly char [] CharsRequiringQuotes = { ' ', '\t', '"', '\n', '\v' };
-
 		/// <summary>
 		/// Joins <paramref name="args"/> into a single command line suitable for
 		/// <see cref="ProcessStartInfo.Arguments"/>.
@@ -237,7 +235,7 @@ namespace Xamarin.Android.Tools
 				return;
 			}
 
-			if (argument.IndexOfAny (CharsRequiringQuotes) < 0) {
+			if (ContainsNoWhitespaceOrQuotes (argument)) {
 				sb.Append (argument);
 				return;
 			}
@@ -264,6 +262,16 @@ namespace Xamarin.Android.Tools
 				}
 			}
 			sb.Append ('"');
+		}
+
+		static bool ContainsNoWhitespaceOrQuotes (string s)
+		{
+			for (int i = 0; i < s.Length; i++) {
+				char c = s [i];
+				if (char.IsWhiteSpace (c) || c == '"')
+					return false;
+			}
+			return true;
 		}
 
 		/// <summary>

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/ProcessUtilsTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/ProcessUtilsTests.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 
 using NUnit.Framework;
 
@@ -65,6 +67,170 @@ namespace Xamarin.Android.Tools.Tests
 			// Smoke test: just verify it returns without crashing
 			bool result = ProcessUtils.IsElevated ();
 			Assert.That (result, Is.TypeOf<bool> ());
+		}
+
+		[Test]
+		public void JoinArguments_WindowsPathIsNotDoubleEscaped ()
+		{
+			// Regression test: escaping every backslash produced `C:\\dir\\file.dll`, which
+			// made `adb push` fail with "failed to read all of ...: Invalid argument".
+			Assert.AreEqual (@"C:\Users\me\obj\a.dll", ProcessUtils.JoinArguments (@"C:\Users\me\obj\a.dll"));
+		}
+
+		[Test]
+		public void JoinArguments_PathWithSpacesIsQuotedButNotDoubleEscaped ()
+		{
+			Assert.AreEqual ("\"C:\\path with spaces\\a.dll\"", ProcessUtils.JoinArguments (@"C:\path with spaces\a.dll"));
+		}
+
+		[Test]
+		public void JoinArguments_EmbeddedQuoteIsEscaped ()
+		{
+			Assert.AreEqual ("\"he said \\\"hi\\\"\"", ProcessUtils.JoinArguments ("he said \"hi\""));
+		}
+
+		[Test]
+		public void JoinArguments_BackslashBeforeQuoteIsDoubled ()
+		{
+			Assert.AreEqual ("\"a\\\\\\\"b\"", ProcessUtils.JoinArguments ("a\\\"b"));
+		}
+
+		[Test]
+		public void JoinArguments_TrailingBackslashWithSpacesIsDoubled ()
+		{
+			// The trailing backslash precedes the closing quote, so it must be doubled.
+			Assert.AreEqual ("\"C:\\a b\\\\\"", ProcessUtils.JoinArguments (@"C:\a b\"));
+		}
+
+		[Test]
+		public void JoinArguments_TrailingBackslashWithoutSpacesNeedsNoQuoting ()
+		{
+			Assert.AreEqual (@"C:\dir\", ProcessUtils.JoinArguments (@"C:\dir\"));
+		}
+
+		[Test]
+		public void JoinArguments_EmptyArgument ()
+		{
+			Assert.AreEqual ("\"\"", ProcessUtils.JoinArguments (""));
+		}
+
+		[Test]
+		public void JoinArguments_NullArgument ()
+		{
+			Assert.AreEqual ("\"\"", ProcessUtils.JoinArguments (default (string)));
+		}
+
+		[Test]
+		public void JoinArguments_NoArguments ()
+		{
+			Assert.AreEqual ("", ProcessUtils.JoinArguments ());
+		}
+
+		[Test]
+		public void JoinArguments_MultipleArgumentsAreSpaceSeparated ()
+		{
+			Assert.AreEqual (
+				"push -z any \"C:\\a b\\x.dll\" C:\\y.dll /data/local/tmp",
+				ProcessUtils.JoinArguments ("push", "-z", "any", @"C:\a b\x.dll", @"C:\y.dll", "/data/local/tmp"));
+		}
+
+		[Test]
+		public void JoinArguments_RoundTripsThroughArgumentParsing ()
+		{
+			var args = new [] {
+				@"C:\Users\me\obj\Debug\net11.0-android\a.dll",
+				@"C:\path with spaces\b.dll",
+				"he said \"hi\"",
+				@"C:\dir\",
+				@"C:\a b\",
+				"plain",
+			};
+			var parsed = SplitCommandLine (ProcessUtils.JoinArguments (args));
+			CollectionAssert.AreEqual (args, parsed);
+		}
+
+		/// <summary>
+		/// Arguments that contain no whitespace or quotes are now emitted bare rather than
+		/// wrapped in quotes. That is transparent to the child process (the quotes were always
+		/// stripped by argument parsing), but <see cref="AdbRunner"/> passes many such arguments,
+		/// so assert the shapes it uses still arrive unchanged.
+		/// </summary>
+		[TestCase ("devices")]
+		[TestCase ("-l")]
+		[TestCase ("-s")]
+		[TestCase ("58230DLCR0013R")]
+		[TestCase ("emulator-5554")]
+		[TestCase ("tcp:5555")]
+		[TestCase ("localabstract:org.example_debug")]
+		[TestCase ("--remove-all")]
+		[TestCase ("ro.product.cpu.abilist")]
+		[TestCase ("getprop")]
+		public void JoinArguments_AdbArgumentShapesRoundTrip (string argument)
+		{
+			CollectionAssert.AreEqual (new [] { argument }, SplitCommandLine (ProcessUtils.JoinArguments (argument)));
+		}
+
+		[Test]
+		public void JoinArguments_AdbShellCommandRoundTrips ()
+		{
+			// `AdbRunner.RunShellCommandAsync` passes an entire shell command as one argument.
+			var args = new [] { "-s", "58230DLCR0013R", "shell", "echo \"remote=$(cat /data/local/tmp/x)\"" };
+			CollectionAssert.AreEqual (args, SplitCommandLine (ProcessUtils.JoinArguments (args)));
+		}
+
+		/// <summary>
+		/// Minimal implementation of the <c>CommandLineToArgvW</c> parsing rules, used to verify
+		/// that <see cref="ProcessUtils.JoinArguments"/> round-trips.
+		/// </summary>
+		static List<string> SplitCommandLine (string commandLine)
+		{
+			var results = new List<string> ();
+			var current = new StringBuilder ();
+			bool inQuotes = false, hasArgument = false;
+
+			for (int i = 0; i < commandLine.Length; i++) {
+				char c = commandLine [i];
+				if (c == '\\') {
+					int backslashes = 0;
+					while (i < commandLine.Length && commandLine [i] == '\\') {
+						backslashes++;
+						i++;
+					}
+					if (i < commandLine.Length && commandLine [i] == '"') {
+						current.Append ('\\', backslashes / 2);
+						if (backslashes % 2 == 0) {
+							inQuotes = !inQuotes;
+						} else {
+							current.Append ('"');
+						}
+						hasArgument = true;
+					} else {
+						current.Append ('\\', backslashes);
+						i--;
+					}
+					continue;
+				}
+				if (c == '"') {
+					inQuotes = !inQuotes;
+					hasArgument = true;
+					continue;
+				}
+				if (!inQuotes && (c == ' ' || c == '\t')) {
+					if (hasArgument || current.Length > 0) {
+						results.Add (current.ToString ());
+						current.Clear ();
+						hasArgument = false;
+					}
+					continue;
+				}
+				current.Append (c);
+				hasArgument = true;
+			}
+
+			if (hasArgument || current.Length > 0) {
+				results.Add (current.ToString ());
+			}
+			return results;
 		}
 	}
 }

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/ProcessUtilsTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/ProcessUtilsTests.cs
@@ -179,6 +179,23 @@ namespace Xamarin.Android.Tools.Tests
 		}
 
 		/// <summary>
+		/// Whitespace detection matches the BCL's <c>PasteArguments</c>, which uses
+		/// <see cref="char.IsWhiteSpace(char)"/> rather than just space and tab. Quoting an
+		/// argument is always safe, so erring towards quoting keeps the two implementations
+		/// in agreement.
+		/// </summary>
+		[TestCase ("a\rb")]
+		[TestCase ("a\fb")]
+		[TestCase ("a\nb")]
+		[TestCase ("a\vb")]
+		[TestCase ("a\u00a0b")]
+		public void JoinArguments_AllWhitespaceIsQuoted (string argument)
+		{
+			var joined = ProcessUtils.JoinArguments (argument);
+			Assert.AreEqual ($"\"{argument}\"", joined);
+		}
+
+		/// <summary>
 		/// Minimal implementation of the <c>CommandLineToArgvW</c> parsing rules, used to verify
 		/// that <see cref="ProcessUtils.JoinArguments"/> round-trips.
 		/// </summary>


### PR DESCRIPTION
## Problem

`FastDeploy2.QuoteProcessArgument()` escaped **every** backslash:

```csharp
foreach (char c in argument) {
	if (c == '"' || c == '\\') {
		sb.Append ('\\');
	}
	sb.Append (c);
}
```

Windows (`CommandLineToArgvW`/MSVCRT — and .NET's own argument parsing on Unix) only treats a run of backslashes as an escape sequence when it is **immediately followed by a quote**. A `\\` not followed by `"` is two *literal* backslashes. So `C:\dir\file.dll` was delivered to `adb` as `C:\\dir\\file.dll`.

Win32 usually collapses the duplicate separators, so most pushes work by luck. But the inflated path breaks `adb` in **two distinct ways**, and it is important not to conflate them:

**Mode 1 — `adb: error: cannot stat '...'`**
The *doubled* path exceeds `MAX_PATH` (260). Independent of file size. Measured: doubled=257 OK, doubled=261 fails.

**Mode 2 — `adb: error: failed to read all of '...': Invalid argument`**
The doubled path is comfortably *under* 260, but the **file is smaller than 64 KB**. This is the mode that actually broke real builds. `adb`'s sync protocol splits at `SYNC_DATA_MAX` (64 KB): the small-file path packs the filename and the data into a single buffer, so an inflated path corrupts it there, while the large-file path is unaffected.

Controlled sweep with the path length held **fixed** at doubled=249 (under `MAX_PATH`), varying only file size:

```
size=   8 KB  doubled=249  -> FAIL-read (Invalid argument)
size=  16 KB  doubled=249  -> FAIL-read (Invalid argument)
size=  32 KB  doubled=249  -> FAIL-read (Invalid argument)
size=  48 KB  doubled=249  -> FAIL-read (Invalid argument)
size=  63 KB  doubled=249  -> FAIL-read (Invalid argument)
size=  64 KB  doubled=249  -> OK
size=  65 KB  doubled=249  -> OK
size= 128 KB  doubled=249  -> OK
size= 873 KB  doubled=249  -> OK
```

The boundary is exactly 64 KB. That is why the production casualties were `Microsoft.Extensions.Configuration.Abstractions.dll` (28 KB) and `Microsoft.Extensions.FileProviders.Abstractions.dll` (15 KB) — both tiny, both well under `MAX_PATH`.

**This is not a `MAX_PATH` bug, and a path-length guard would not have caught it.** Correct quoting removes the inflation and eliminates both modes; no `\\?\` prefixing is warranted.

Both modes are properly detected: `adb` exits **1**, and `FastDeploy2` correctly surfaced that as XA0129. The deploy failed loudly, as it should have.

## This is wider than FastDeploy2

`Xamarin.Android.Tools.AndroidSdk` ships as **netstandard2.0 only** (`AndroidToolsDisableMultiTargeting` defaults to `true` in its `.csproj`), so `ProcessUtils.CreateProcessStartInfo` **always** takes the `JoinArguments` path in shipping builds — the `ProcessStartInfo.ArgumentList` branch is effectively test-only.

And `JoinArguments` previously did **no escaping at all**:

```csharp
sb.Append ('"').Append (args [i]).Append ('"');
```

So **every `AdbRunner` call site is latently affected today**, not just FastDeploy2 — any argument containing a `"` would be mis-parsed. FastDeploy2 is simply where it first produced a visible failure, because its own hand-rolled quoting had the *opposite* bug (over-escaping) and it pushes many small assemblies at long absolute paths.

## Fix

Rather than fix hand-rolled quoting a second time, fix the one shared helper and route FastDeploy2 through it.

- **`ProcessUtils.JoinArguments`** now implements the real Windows rules (same algorithm as the BCL's `PasteArguments`): a run of backslashes is doubled *only* when it precedes a `"` or the closing quote, `"` is escaped as `\"`, empty/null becomes `""`, and arguments with no whitespace/quote are emitted bare. It moved out of `#if !NET5_0_OR_GREATER` so it compiles and is unit-testable on all TFMs. It stays `internal`, so **no public API change** and no `PublicAPI.Unshipped.txt` churn.
- **`FastDeploy2.QuoteProcessArgument` is deleted**, and `RunAdbCommand` now uses `ProcessUtils.CreateProcessStartInfo` + `ProcessUtils.StartProcess` following the `AdbRunner` pattern — replacing the hand-rolled `ProcessStartInfo`, `ManualResetEvent` stdout/stderr pumping, and cancellation registration (~55 lines).
  - `ThrowIfFailed` is deliberately **not** used: FastDeploy2 inspects the exit code and `adb` stderr to classify install failures and must not throw.
  - The diagnostic log line is now built from the argument list instead of `psi.Arguments`, which is empty on the `ArgumentList` path.

Multi-targeting `Xamarin.Android.Build.Debugging.Tasks` was considered and rejected — since the SDK itself is netstandard2.0-only in product builds, it would buy nothing.

## Tests

`ProcessUtilsTests` gains the regression test that would have caught this (a plain Windows path must **not** be double-escaped), plus spaces, embedded quotes, trailing backslashes, empty/null arguments, and a round-trip through a `CommandLineToArgvW` parser.

Emitting arguments bare is a behavior change for existing `AdbRunner` call sites (previously everything was quoted). It's transparent to the child process — quotes are stripped by argument parsing either way — but the shapes `AdbRunner` passes are locked down explicitly: device serials, `tcp:`/`localabstract:` socket specs, `getprop` property names, bare verbs and flags, and a full `adb shell` command containing spaces and quotes.

## Verification

**Primary: full end-to-end deploy on a physical arm64-v8a device.** Bootstrap + full solution build + `-t:ConfigureLocalWorkload` (skipping this leaves a stale `Xamarin.Android.Build.Debugging.Tasks.dll` in the pack and yields a false green) + `-t:Install -c Debug` of `Mono.Android.NET-Tests` with `-p:UseMonoRuntime=false`:

- 0 errors, **no XA0129**
- 205 assemblies in `files/.__override__/arm64-v8a`, 401 files staged
- instrumentation runs with tests passing
- a second incremental install completed in 12s with matching hash markers, confirming the first deploy was complete rather than partial

This covers **mode 2** directly: the small `Microsoft.Extensions.*.Abstractions.dll` assemblies that previously failed are among the assemblies that deployed successfully.

Supporting:

1. **Unit tests** — 371 passed, 0 failed (`-p:AndroidToolsDisableMultiTargeting=false -p:DotNetTargetFrameworkVersion=10.0`).
2. **Direct A/B on device** at doubled=249 with an 8 KB file: old quoting → `failed to read all of ...: Invalid argument`, `0 files pushed`, `Process.ExitCode = 1`; new quoting → `1 file pushed`, exit 0. Plus the mode-1 case at doubled=268 → `cannot stat`, fixed likewise.
3. **`AdbRunner` on device through the netstandard2.0 shipping path** (asserting `psi.Arguments` is populated and `ArgumentList` empty first, so it cannot silently test the wrong branch): `ListDevicesAsync`, `GetShellPropertyAsync`, `RunShellCommandAsync` (including `echo "remote=$(...)"`, the FastDeploy2 marker pattern), forward/reverse port add-list-remove — all pass.

## Note on partial deploys

For the record, since it came up while diagnosing this: `adb push` does **not** abandon a batch after a failure. Measured with a 4-file batch shaped `[small-FAIL, big-OK, big-OK, small-FAIL]`, `adb` pushed both good files, reported **both** failures (not just the first), and exited 1.

The half-deployed device state came from one level up — `FastDeploy2` issues several batches, one returned non-zero, and the task raised XA0129 and stopped issuing the remaining batches. The missing files were in later batches that were never attempted. Aborting remaining work after a hard error is reasonable behavior; the only residual observation is that a failed deploy leaves the device in a mixed state that the next build has to reconcile. Not a silent failure, and not something this PR changes.