### PR TITLE
[Xamarin.Android.Build.Tasks] more LLVM IR generator build perf

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -92,6 +92,7 @@
     <GenerateTypeMappings
         AndroidRuntime="$(_AndroidRuntime)"
         Debug="$(AndroidIncludeDebugSymbols)"
+        EmitLlvmIrComments="$(_AndroidEmitLlvmIrComments)"
         EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
         IntermediateOutputDirectory="$(IntermediateOutputPath)"
         ResolvedAssemblies="@(_ResolvedAssemblies)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
@@ -31,6 +31,13 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string ProjectFullPath { get; set; } = "";
 
+		/// <summary>
+		/// When <c>true</c>, descriptive comments are written into the generated LLVM IR.  They make
+		/// the <c>.ll</c> far easier to read, but have no effect on the object code produced from it.
+		/// Set from the <c>$(_AndroidEmitLlvmIrComments)</c> MSBuild property.
+		/// </summary>
+		public bool EmitLlvmIrComments { get; set; }
+
 		public override bool RunTask ()
 		{
 			GenerateCompressedAssemblySources ();
@@ -93,7 +100,9 @@ namespace Xamarin.Android.Tasks
 
 			void Generate (Dictionary<AndroidTargetArch, Dictionary<string, CompressedAssemblyInfo>>? dict)
 			{
-				var composer = new CompressedAssembliesNativeAssemblyGenerator (Log, dict);
+				var composer = new CompressedAssembliesNativeAssemblyGenerator (Log, dict) {
+					EmitComments = EmitLlvmIrComments,
+				};
 				LLVMIR.LlvmIrModule compressedAssemblies = composer.Construct ();
 
 				foreach (string abi in SupportedAbis) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeApplicationConfigSources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeApplicationConfigSources.cs
@@ -58,6 +58,14 @@ namespace Xamarin.Android.Tasks
 		public string AndroidRuntime { get; set; } = "";
 
 		public bool EnableMarshalMethods { get; set; }
+
+		/// <summary>
+		/// When <c>true</c>, descriptive comments are written into the generated LLVM IR.  They make
+		/// the <c>.ll</c> far easier to read, but have no effect on the object code produced from it.
+		/// Set from the <c>$(_AndroidEmitLlvmIrComments)</c> MSBuild property.
+		/// </summary>
+		public bool EmitLlvmIrComments { get; set; }
+
 		public bool AndroidEnableAssemblyStoreDecompressionCache { get; set; }
 		public string? RuntimeConfigBinFilePath { get; set; }
 		public string ProjectRuntimeConfigFilePath { get; set; } = String.Empty;
@@ -318,6 +326,7 @@ namespace Xamarin.Android.Tasks
 				};
 			}
 			LLVMIR.LlvmIrModule appConfigModule = appConfigAsmGen.Construct ();
+			appConfigAsmGen.EmitComments = EmitLlvmIrComments;
 
 			foreach (string abi in SupportedAbis) {
 				string targetAbi = abi.ToLowerInvariant ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTypeMappings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTypeMappings.cs
@@ -23,6 +23,13 @@ public class GenerateTypeMappings : AndroidTask
 
 	public bool Debug { get; set; }
 
+	/// <summary>
+	/// When <c>true</c>, descriptive comments are written into the generated LLVM IR.  They make
+	/// the <c>.ll</c> far easier to read, but have no effect on the object code produced from it.
+	/// Set from the <c>$(_AndroidEmitLlvmIrComments)</c> MSBuild property.
+	/// </summary>
+	public bool EmitLlvmIrComments { get; set; }
+
 	public bool EnableMarshalMethods { get;set; }
 
 	[Output]
@@ -94,7 +101,9 @@ public class GenerateTypeMappings : AndroidTask
 			state.XmlFiles.Clear ();
 		}
 
-		var tmg = new TypeMapGenerator (Log, state, androidRuntime);
+		var tmg = new TypeMapGenerator (Log, state, androidRuntime) {
+			EmitComments = EmitLlvmIrComments,
+		};
 		tmg.Generate (Debug, SkipJniAddNativeMethodRegistrationAttributeScan, TypemapOutputDirectory);
 
 		// Set for use by <GeneratePackageManagerJava/> task later
@@ -144,7 +153,9 @@ public class GenerateTypeMappings : AndroidTask
 			state = new NativeCodeGenState (state.TargetArch, new TypeDefinitionCache (), state.Resolver, [], [], state.Classifier);
 		}
 
-		var tmg = new TypeMapGenerator (Log, new NativeCodeGenStateAdapter (state), androidRuntime);
+		var tmg = new TypeMapGenerator (Log, new NativeCodeGenStateAdapter (state), androidRuntime) {
+			EmitComments = EmitLlvmIrComments,
+		};
 		tmg.Generate (Debug, SkipJniAddNativeMethodRegistrationAttributeScan, TypemapOutputDirectory);
 
 		AddOutputTypeMaps (tmg, state.TargetArch);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
@@ -18,6 +18,12 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		protected readonly TaskLoggingHelper Log;
 
 		/// <summary>
+		/// Whether to write descriptive comments into the generated LLVM IR.  Defaults to
+		/// <c>false</c>; see <see cref="LlvmIrGenerator.EmitComments" />.
+		/// </summary>
+		public bool EmitComments { get; set; }
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="LlvmIrComposer"/> class.
 		/// </summary>
 		/// <param name="log">The task logging helper for logging messages.</param>
@@ -62,6 +68,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			}
 
 			LlvmIrGenerator generator = LlvmIrGenerator.Create (arch, fileName);
+			generator.EmitComments = EmitComments;
 			generator.Generate (output, module);
 			output.Flush ();
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		public void Generate (LlvmIrModule module, AndroidTargetArch arch, StreamWriter output, string fileName)
 		{
 			if (!constructed) {
-				throw new InvalidOperationException ($"Internal error: module not constructed yet. Was Constrict () called?");
+				throw new InvalidOperationException ($"Internal error: module not constructed yet. Was Construct () called?");
 			}
 
 			LlvmIrGenerator generator = LlvmIrGenerator.Create (arch, fileName);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrFunctionBody.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrFunctionBody.cs
@@ -21,8 +21,19 @@ abstract class LlvmIrFunctionBodyItem
 	public bool SkipInOutput { get; protected set; }
 	public string? Comment   { get; set; }
 
+	/// <summary>
+	/// Whether the item consists of nothing but a comment.  Such items produce no output at
+	/// all when <see cref="GeneratorWriteContext.EmitComments" /> is <c>false</c>, as opposed
+	/// to items which merely carry a trailing comment alongside real content.
+	/// </summary>
+	protected virtual bool IsCommentOnly => false;
+
 	public void Write (GeneratorWriteContext context, LlvmIrGenerator generator)
 	{
+		if (IsCommentOnly && !context.EmitComments) {
+			return;
+		}
+
 		DoWrite (context, generator);
 		if (context.EmitComments && !String.IsNullOrEmpty (Comment)) {
 			context.Output.Write (' ');
@@ -126,6 +137,8 @@ class LlvmIrFunctionLabelItem : LlvmIrFunctionLocalItem
 class LlvmIrFunctionBodyComment : LlvmIrFunctionBodyItem
 {
 	public string Text     { get; }
+
+	protected override bool IsCommentOnly => true;
 
 	public LlvmIrFunctionBodyComment (string comment)
 	{

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrFunctionBody.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrFunctionBody.cs
@@ -24,7 +24,7 @@ abstract class LlvmIrFunctionBodyItem
 	public void Write (GeneratorWriteContext context, LlvmIrGenerator generator)
 	{
 		DoWrite (context, generator);
-		if (!String.IsNullOrEmpty (Comment)) {
+		if (context.EmitComments && !String.IsNullOrEmpty (Comment)) {
 			context.Output.Write (' ');
 			generator.WriteComment (context, Comment);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -914,8 +914,9 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			// A consequence of this is that we can no longer annotate individual strings with comments,
 			// because a constant string literal must fit on a single line and `;` comments extend to the
 			// end of the line.
-			const int chunkSize = 4096;
-			char[] chunk = ArrayPool<char>.Shared.Rent (chunkSize);
+			// `Rent()` may return a larger array than requested, so use its actual length as the capacity.
+			char[] chunk = ArrayPool<char>.Shared.Rent (4096);
+			int chunkCapacity = chunk.Length;
 			int chunkUsed = 0;
 
 			try {
@@ -941,14 +942,14 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			{
 				// `"` and `\` must always be escaped, as must anything outside of the printable ASCII range.
 				if (b != (byte)'"' && b != (byte)'\\' && b >= 32 && b < 127) {
-					if (chunkUsed == chunkSize) {
+					if (chunkUsed == chunkCapacity) {
 						Flush ();
 					}
 					chunk[chunkUsed++] = (char)b;
 					return;
 				}
 
-				if (chunkUsed + 3 > chunkSize) {
+				if (chunkUsed + 3 > chunkCapacity) {
 					Flush ();
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -906,17 +906,13 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		void WriteStringBlobArray (GeneratorWriteContext context, LlvmIrStringBlob blob)
 		{
-			// String blobs are emitted as a single LLVM IR constant byte string (`c"..."`) instead of one
-			// `i8 u0xNN` element per byte.  A hello world MAUI app has ~3.6 million bytes of type map
-			// strings, so the array form produces a >50MB `.ll` file which is slow both to write here and
-			// to consume in `llc`.  The `c"..."` form is roughly ten times smaller.
-			//
-			// A consequence of this is that we can no longer annotate individual strings with comments,
-			// because a constant string literal must fit on a single line and `;` comments extend to the
-			// end of the line.
+			// Emitted as a single `c"..."` literal rather than one `i8` element per byte, which shrinks
+			// the `.ll` ~10x.  No per-string comments are possible, as the literal must be on one line.
+			const int HexDigits = 2;
+			const int MaxEscapeWidth = 1 + HexDigits;
+			const int ChunkSize = 4096;
 
-			// `Rent()` may return a larger array than requested, so use its actual length as the capacity.
-			char [] chunk = ArrayPool<char>.Shared.Rent (4096);
+			char [] chunk = ArrayPool<char>.Shared.Rent (ChunkSize);
 			int chunkCapacity = chunk.Length;
 			int chunkUsed = 0;
 
@@ -941,7 +937,6 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 			void WriteByte (byte b)
 			{
-				// `"` and `\` must always be escaped, as must anything outside of the printable ASCII range.
 				if (b != (byte) '"' && b != (byte) '\\' && b >= 32 && b < 127) {
 					if (chunkUsed == chunkCapacity) {
 						Flush ();
@@ -950,13 +945,13 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					return;
 				}
 
-				if (chunkUsed + 3 > chunkCapacity) {
+				if (chunkUsed + MaxEscapeWidth > chunkCapacity) {
 					Flush ();
 				}
 
 				chunk [chunkUsed++] = '\\';
-				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed, 2), b, upperCase: true);
-				chunkUsed += 2;
+				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed, HexDigits), b, upperCase: true);
+				chunkUsed += HexDigits;
 			}
 
 			void Flush ()

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -914,6 +914,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			// A consequence of this is that we can no longer annotate individual strings with comments,
 			// because a constant string literal must fit on a single line and `;` comments extend to the
 			// end of the line.
+
 			// `Rent()` may return a larger array than requested, so use its actual length as the capacity.
 			char[] chunk = ArrayPool<char>.Shared.Rent (4096);
 			int chunkCapacity = chunk.Length;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -916,7 +916,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			// end of the line.
 
 			// `Rent()` may return a larger array than requested, so use its actual length as the capacity.
-			char[] chunk = ArrayPool<char>.Shared.Rent (4096);
+			char [] chunk = ArrayPool<char>.Shared.Rent (4096);
 			int chunkCapacity = chunk.Length;
 			int chunkUsed = 0;
 
@@ -942,11 +942,11 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			void WriteByte (byte b)
 			{
 				// `"` and `\` must always be escaped, as must anything outside of the printable ASCII range.
-				if (b != (byte)'"' && b != (byte)'\\' && b >= 32 && b < 127) {
+				if (b != (byte) '"' && b != (byte) '\\' && b >= 32 && b < 127) {
 					if (chunkUsed == chunkCapacity) {
 						Flush ();
 					}
-					chunk[chunkUsed++] = (char)b;
+					chunk [chunkUsed++] = (char) b;
 					return;
 				}
 
@@ -954,7 +954,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					Flush ();
 				}
 
-				chunk[chunkUsed++] = '\\';
+				chunk [chunkUsed++] = '\\';
 				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed), b, upperCase: true);
 				chunkUsed += 2;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -255,7 +255,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				context.NumberFormat = gv.NumberFormat;
 
 				if (gv is LlvmIrGroupDelimiterVariable groupDelimiter) {
-					if (!context.InVariableGroup && !String.IsNullOrEmpty (groupDelimiter.Comment)) {
+					if (context.EmitComments && !context.InVariableGroup && !String.IsNullOrEmpty (groupDelimiter.Comment)) {
 						context.Output.WriteLine ();
 						context.Output.Write (context.CurrentIndent);
 						WriteComment (context, groupDelimiter.Comment);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -442,7 +442,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				return;
 			}
 
-			if (memberInfo.IsIRStruct (context.TypeCache)) {
+			if (memberInfo.IsIRStruct) {
 				var sim = new GeneratorStructureInstance (context.Module.GetStructureInfo (memberInfo.MemberType), memberInfo.GetValue (si.Obj));
 				WriteStructureType (context, sim, out typeInfo);
 				return;
@@ -718,7 +718,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				throw new NotSupportedException ($"Internal error: inline arrays of type {smi.MemberType} aren't supported at this point. Field {smi.Info.Name} in structure {structInstance.Info.Name}");
 			}
 
-			if (smi.IsIRStruct (context.TypeCache)) {
+			if (smi.IsIRStruct) {
 				StructureInfo si = context.Module.GetStructureInfo (smi.MemberType);
 				WriteValue (context, typeof(GeneratorStructureInstance), new GeneratorStructureInstance (si, value));
 				return;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -906,71 +906,65 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		void WriteStringBlobArray (GeneratorWriteContext context, LlvmIrStringBlob blob)
 		{
-			// The stride determines how many elements are written on a single line before a newline is added.
-			const uint stride = 16;
-			Type elementType = typeof(byte);
+			// String blobs are emitted as a single LLVM IR constant byte string (`c"..."`) instead of one
+			// `i8 u0xNN` element per byte.  A hello world MAUI app has ~3.6 million bytes of type map
+			// strings, so the array form produces a >50MB `.ll` file which is slow both to write here and
+			// to consume in `llc`.  The `c"..."` form is roughly ten times smaller.
+			//
+			// A consequence of this is that we can no longer annotate individual strings with comments,
+			// because a constant string literal must fit on a single line and `;` comments extend to the
+			// end of the line.
+			const int chunkSize = 4096;
+			char[] chunk = ArrayPool<char>.Shared.Rent (chunkSize);
+			int chunkUsed = 0;
 
-			LlvmIrVariableNumberFormat oldNumberFormat = context.NumberFormat;
-			context.NumberFormat = LlvmIrVariableNumberFormat.Hexadecimal;
-			WriteArrayValueStart (context);
-			foreach (LlvmIrStringBlob.StringInfo si in blob.GetSegments ()) {
-				if (si.Offset > 0) {
-					context.Output.Write (',');
-					context.Output.WriteLine ();
-					context.Output.WriteLine ();
-				}
+			try {
+				context.Output.Write ('c');
+				context.Output.Write ('"');
 
-				context.Output.Write (context.CurrentIndent);
-				WriteCommentLine (context, $" '{si.Value}' @ {si.Offset}");
-				WriteBytes (si.Bytes);
-			}
-			context.Output.WriteLine ();
-			WriteArrayValueEnd (context);
-			context.NumberFormat = oldNumberFormat;
-
-			void WriteBytes (byte[] bytes)
-			{
-				ulong counter = 0;
-				bool first = true;
-				foreach (byte b in bytes) {
-					if (!first) {
-						WriteCommaWithStride (counter);
-					} else {
-						context.Output.Write (context.CurrentIndent);
-						first = false;
+				foreach (LlvmIrStringBlob.StringInfo si in blob.GetSegments ()) {
+					foreach (byte b in si.Bytes) {
+						WriteByte (b);
 					}
 
-					counter++;
-					WriteByteTypeAndValue (b);
+					// Terminating NUL is counted for each string, but not included in its bytes
+					WriteByte (0);
 				}
 
-				if (bytes.Length > 0) {
-					WriteCommaWithStride (counter);
-				} else {
-					context.Output.Write (context.CurrentIndent);
-				}
-				WriteByteTypeAndValue (0); // Terminating NUL is counted for each string, but not included in its bytes
+				Flush ();
+				context.Output.Write ('"');
+			} finally {
+				ArrayPool<char>.Shared.Return (chunk);
 			}
 
-			void WriteCommaWithStride (ulong counter)
+			void WriteByte (byte b)
 			{
-				context.Output.Write (',');
-				if (stride == 1 || counter % stride == 0) {
-					context.Output.WriteLine ();
-					context.Output.Write (context.CurrentIndent);
-				} else {
-					context.Output.Write (' ');
+				// `"` and `\` must always be escaped, as must anything outside of the printable ASCII range.
+				if (b != (byte)'"' && b != (byte)'\\' && b >= 32 && b < 127) {
+					if (chunkUsed == chunkSize) {
+						Flush ();
+					}
+					chunk[chunkUsed++] = (char)b;
+					return;
 				}
+
+				if (chunkUsed + 3 > chunkSize) {
+					Flush ();
+				}
+
+				chunk[chunkUsed++] = '\\';
+				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed), b, upperCase: true);
+				chunkUsed += 2;
 			}
 
-			void WriteByteTypeAndValue (byte v)
+			void Flush ()
 			{
-				// This is by far the hottest path in the generator: a hello world MAUI app writes
-				// ~3.6 million bytes here.  WriteType()/WriteValue() would box the byte and allocate a
-				// handful of strings per element, so write the (always identical) type and the two hex
-				// digits directly.
-				context.Output.Write ("i8 u0x");
-				HexUtilities.WriteHex (context.Output, v, upperCase: false);
+				if (chunkUsed == 0) {
+					return;
+				}
+
+				context.Output.Write (chunk, 0, chunkUsed);
+				chunkUsed = 0;
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -955,7 +955,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				}
 
 				chunk [chunkUsed++] = '\\';
-				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed), b, upperCase: true);
+				HexUtilities.WriteHex (chunk.AsSpan (chunkUsed, 2), b, upperCase: true);
 				chunkUsed += 2;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -33,6 +33,14 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		public readonly LlvmIrMetadataManager MetadataManager;
 		public readonly LlvmIrTypeCache TypeCache;
 		public readonly LlvmIrGenerator Generator;
+
+		/// <summary>
+		/// Whether descriptive comments are written to the generated LLVM IR.  Comments make the
+		/// output easier to read, but they can account for the majority of the file's size and
+		/// have no effect on the code <c>llc</c> produces.
+		/// </summary>
+		public readonly bool EmitComments;
+
 		public string CurrentIndent { get; private set; } = String.Empty;
 		public bool InVariableGroup { get; set; }
 		public LlvmIrVariableNumberFormat NumberFormat { get; set; } = LlvmIrVariableNumberFormat.Default;
@@ -40,6 +48,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		public GeneratorWriteContext (LlvmIrGenerator generator, TextWriter writer, LlvmIrModule module, LlvmIrModuleTarget target, LlvmIrMetadataManager metadataManager, LlvmIrTypeCache cache)
 		{
 			Generator = generator;
+			EmitComments = generator.EmitComments;
 			Output = writer;
 			Module = module;
 			Target = target;
@@ -144,6 +153,14 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		public string FilePath           { get; }
 		public string FileName           { get; }
 
+		/// <summary>
+		/// Whether to write descriptive comments into the generated LLVM IR.  Defaults to
+		/// <c>false</c>, since comments can easily account for more than half of the generated
+		/// file's size while having no effect whatsoever on the object code <c>llc</c> emits.
+		/// Set from the <c>$(_AndroidEmitLlvmIrComments)</c> MSBuild property.
+		/// </summary>
+		public bool EmitComments         { get; set; }
+
 		LlvmIrModuleTarget target;
 
 		protected LlvmIrGenerator (string filePath, LlvmIrModuleTarget target)
@@ -207,7 +224,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				foreach (LlvmIrStringVariable info in group.Strings) {
 					string s = QuoteString (info, out ulong size);
 
-					if (!info.IsConstantStringLiteral) {
+					if (context.EmitComments && !info.IsConstantStringLiteral) {
 						WriteCommentLine (context, $" '{info.Value}'");
 					}
 
@@ -1007,15 +1024,19 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					context.Output.Write (", ");
 				}
 
-				string? comment = info.GetCommentFromProvider (smi, instance);
-				if (String.IsNullOrEmpty (comment)) {
-					var sb = new StringBuilder (" ");
-					sb.Append (MapManagedTypeToNative (context, smi));
-					sb.Append (' ');
-					sb.Append (smi.MappedName);
-					comment = sb.ToString ();
+				if (context.EmitComments) {
+					string? comment = info.GetCommentFromProvider (smi, instance);
+					if (String.IsNullOrEmpty (comment)) {
+						var sb = new StringBuilder (" ");
+						sb.Append (MapManagedTypeToNative (context, smi));
+						sb.Append (' ');
+						sb.Append (smi.MappedName);
+						comment = sb.ToString ();
+					}
+					WriteCommentLine (context, comment);
+				} else {
+					context.Output.WriteLine ();
 				}
-				WriteCommentLine (context, comment);
 			}
 
 			context.DecreaseIndent ();
@@ -1047,7 +1068,8 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		void WriteArrayEntries (GeneratorWriteContext context, LlvmIrVariable? variable, ICollection? entries, Type elementType, uint stride, bool writeIndices, bool terminateWithComma = false)
 		{
 			bool first = true;
-			bool ignoreComments = stride > 1;
+			// Comments are skipped when the array is written in rows, as they would break the layout
+			bool ignoreComments = stride > 1 || !context.EmitComments;
 			string? prevItemComment = null;
 			ulong counter = 0;
 			bool writeStringInComment = !ignoreComments && (elementType == typeof(string) || elementType == typeof(StringHolder));
@@ -1349,7 +1371,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					context.Output.Write (' ');
 				}
 
-				if (!String.IsNullOrEmpty (comment)) {
+				if (context.EmitComments && !String.IsNullOrEmpty (comment)) {
 					WriteCommentLine (context, comment);
 				} else {
 					context.Output.WriteLine ();
@@ -1684,12 +1706,20 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		public void WriteComment (GeneratorWriteContext context, string comment)
 		{
+			if (!context.EmitComments) {
+				return;
+			}
+
 			context.Output.Write (';');
 			context.Output.Write (comment);
 		}
 
 		public void WriteCommentLine (GeneratorWriteContext context, string comment)
 		{
+			if (!context.EmitComments) {
+				return;
+			}
+
 			WriteComment (context, comment);
 			context.Output.WriteLine ();
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrInstructions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrInstructions.cs
@@ -730,7 +730,7 @@ sealed class LlvmIrInstructions
 				context.Generator.WriteValue (context, value.Type, constant);
 				context.Output.Write (", label %");
 				context.Output.Write (label.Name);
-				if (!String.IsNullOrEmpty (comment)) {
+				if (context.EmitComments && !String.IsNullOrEmpty (comment)) {
 					context.Output.Write (' ');
 					context.Generator.WriteCommentLine (context, comment);
 				} else {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrModule.cs
@@ -351,7 +351,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		void PrepareStructure (StructureInstance structure)
 		{
 			foreach (StructureMemberInfo smi in structure.Info.Members) {
-				if (smi.IsIRStruct (TypeCache)) {
+				if (smi.IsIRStruct) {
 					object? instance = structure.Obj == null ? null : smi.GetValue (structure.Obj);
 					if (instance == null) {
 						continue;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/StructureInfo.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/StructureInfo.cs
@@ -92,7 +92,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				// do NOT want to store any members while doing that, as the struct should have been mapped by the composer previously.
 				// The presence of strings/buffers is important at the generation time as it is used to decide whether we need separate stream writers for them and
 				// if the owning structure does **not** have any of those, the generated code would be invalid
-				if (info.IsIRStruct (cache)) {
+				if (info.IsIRStruct) {
 					GatherMembers (info.MemberType, module, storeMembers: false);
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/StructureMemberInfo.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/StructureMemberInfo.cs
@@ -30,6 +30,14 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		public bool NeedsPadding    { get; }
 
 		/// <summary>
+		/// Whether this member is written out as an LLVM IR structure, as opposed to a simple
+		/// value, a string or a pointer.  Computed once during construction: it depends only on
+		/// the member's type and attributes, both of which are fixed, while the value is queried
+		/// once per member for *every* structure instance being generated.
+		/// </summary>
+		public bool IsIRStruct      { get; }
+
+		/// <summary>
 		/// Some fields/properties may override their name for presentation purposes, <see cref="NativeAssemblerAttribute.MemberName" />.
 		/// In such instances, this property will return the overridden/mapped name, otherwise it returns <see cref="Info.Name"/>.
 		/// This property should be used only for "presentation" purposes - for instance when generating comments which refer to
@@ -54,6 +62,13 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				PropertyInfo pi => pi.PropertyType,
 				_ => throw new InvalidOperationException ($"Unsupported member type {mi}")
 			};
+
+			// MemberType.IsStructure () handles checks for primitive types, enums etc
+			IsIRStruct =
+				MemberType != typeof(string) &&
+				!mi.IsInlineArray (cache) &&
+				!mi.IsNativePointer (cache) &&
+				(MemberType.IsStructure () || MemberType.IsClass);
 
 			ulong size = 0;
 			bool isPointer = false;
@@ -99,7 +114,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 				IRType = $"[{arrayElements} x {IRType}]";
 				ArrayElements = (ulong)arrayElements;
-			} else if (this.IsIRStruct (cache)) {
+			} else if (IsIRStruct) {
 				StructureInfo si = module.GetStructureInfo (MemberType);
 				size = si.Size;
 				Alignment = (ulong)si.MaxFieldAlignment;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/TypeUtilities.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/TypeUtilities.cs
@@ -61,24 +61,6 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		}
 
 		/// <summary>
-		/// Determines whether a structure member represents an LLVM IR structure.
-		/// </summary>
-		/// <param name="smi">The structure member info to check.</param>
-		/// <param name="cache">The LLVM IR type cache.</param>
-		/// <returns>true if the member represents an IR structure; otherwise, false.</returns>
-		public static bool IsIRStruct (this StructureMemberInfo smi, LlvmIrTypeCache cache)
-		{
-			Type type = smi.MemberType;
-
-			// type.IsStructure() handles checks for primitive types, enums etc
-			return
-				type != typeof(string) &&
-				!smi.Info.IsInlineArray (cache) &&
-				!smi.Info.IsNativePointer (cache) &&
-				(type.IsStructure () || type.IsClass);
-		}
-
-		/// <summary>
 		/// Gets the data provider for a type if it has a NativeAssemblerStructContextDataProviderAttribute.
 		/// </summary>
 		/// <param name="t">The type to get the data provider for.</param>

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
@@ -128,6 +128,12 @@ namespace Xamarin.Android.Tasks
 
 		public IList<string> GeneratedBinaryTypeMaps { get; } = new List<string> ();
 
+		/// <summary>
+		/// Whether to write descriptive comments into the generated LLVM IR type maps.
+		/// See <see cref="LLVMIR.LlvmIrGenerator.EmitComments" />.
+		/// </summary>
+		public bool EmitComments { get; set; }
+
 		public TypeMapGenerator (TaskLoggingHelper log, ITypeMapGeneratorAdapter state, AndroidRuntime runtime)
 		{
 			this.log = log ?? throw new ArgumentNullException (nameof (log));
@@ -204,6 +210,8 @@ namespace Xamarin.Android.Tasks
 		void GenerateNativeAssembly (LLVMIR.LlvmIrComposer composer, LLVMIR.LlvmIrModule typeMapModule, string baseFileName)
 		{
 			string outputFile = $"{baseFileName}.{MonoAndroidHelper.ArchToAbi (state.TargetArch)}.ll";
+
+			composer.EmitComments = EmitComments;
 
 			// TODO: each .ll file should have a comment which lists paths to all the DLLs that were used to generate
 			// the native code

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1807,6 +1807,7 @@ because xbuild doesn't support framework reference assemblies.
       EnableLLVM="$(EnableLLVM)"
       TlsProvider="$(AndroidTlsProvider)"
       Debug="$(AndroidIncludeDebugSymbols)"
+      EmitLlvmIrComments="$(_AndroidEmitLlvmIrComments)"
       AndroidSequencePointsMode="$(_SequencePointsMode)"
       EnableSGenConcurrent="$(AndroidEnableSGenConcurrent)"
       SupportedAbis="@(_BuildTargetAbis)"
@@ -2083,6 +2084,7 @@ because xbuild doesn't support framework reference assemblies.
       EnvironmentOutputDirectory="$(IntermediateOutputPath)android"
       SupportedAbis="@(_BuildTargetAbis)"
       Debug="$(AndroidIncludeDebugSymbols)"
+      EmitLlvmIrComments="$(_AndroidEmitLlvmIrComments)"
       EnableCompression="$(AndroidEnableAssemblyCompression)"
       ProjectFullPath="$(MSBuildProjectFullPath)"
   />


### PR DESCRIPTION
Stacked on #12280. Squash on merge.

Two more LLVM IR generator wins found by profiling a `dotnet new maui -sc` app (Debug, CoreCLR, `arm64-v8a`) with `dotnet-trace` against the MSBuild *worker* node.

## 1. Cache `StructureMemberInfo.IsIRStruct`

`IsIRStruct()` was an extension method that walked the member's type on every call, and it is called once per member per array element. In the trace it was **345 ms of the 550 ms** spent in `TypeMapGenerator.GenerateNativeAssembly`:

```
TypeMapGenerator.GenerateNativeAssembly                       549.9
└─ LlvmIrGenerator.Generate                                   517.8
   └─ WriteGlobalVariables → WriteArrayEntries                438.6
      ├─ TypeUtilities.IsIRStruct                             345.1   <-- 63%
      │  └─ TypeUtilities.IsStructure                         282.0
      └─ WriteType                                            298.2
```

The answer depends only on the member, which is immutable, so it's now computed once in the `StructureMemberInfo` constructor.

`TypeUtilities.IsIRStruct` and `TypeUtilities.IsStructure` are **entirely absent** from the frame table of a trace captured after the change. `.ll` and `.o` are byte-identical.

## 2. `$(_AndroidEmitLlvmIrComments)`, off by default

Comments in the generated IR are purely descriptive — `llc` ignores them — but they are more than half the file:

| File | comments on | comments off (new default) |
| --- | --- | --- |
| `typemaps.arm64-v8a.ll` | 15,181,829 | **7,631,959** (−49.7%) |
| `typemaps.arm64-v8a.o` | 4,161,824 | 4,161,824 |

New private property `$(_AndroidEmitLlvmIrComments)`, blank (off) by default, flows into `<GenerateTypeMappings/>`, `<GenerateNativeApplicationConfigSources/>` and `<GenerateCompressedAssembliesNativeSourceFiles/>`. Set it to `true` to get the old output back when debugging the generators.

Where a comment used to terminate a line of real content, an explicit newline is written instead, and the hot paths skip *building* the comment string rather than just skipping the write.

`GenerateTypeMappings`, 12 interleaved on/off runs on the same app, raw ms:

```
on   733, 793, 807, 839, 841, 848
off  679, 689, 689, 696, 721, 746
```

Roughly 100 ms, same direction in every pair. It is **not** visible in wall clock (~6.1 s either way) — this machine can't resolve 100 ms end to end, so please don't read more into it than the paired ordering.

## Correctness

Matched pair, same SDK binary, only the property flipped:

* `typemaps.arm64-v8a.o` byte-identical — SHA256 `230894AF63A583A8D2FCAC18C9AA962131A815EFCC307704B6D1E96887A837A0`
* all three string blobs byte-identical
* 132,537 `i32` values in an identical sequence
* every non-sentinel offset still resolves to the start of a nul-terminated string in its blob; the 4,909 that don't are all the `0xFFFFFFFF` sentinel

Worth calling out: the `; from:` / `; to:` annotations that go away by default are exactly what that offset check reads. It was run *before* flipping the default, and `$(_AndroidEmitLlvmIrComments)=true` exists so it can be run again.

## Tests

* `LlvmIrGeneratorTests` 9/9
* `GenerateNativeApplicationConfigSourcesTests` 4/4 (runs real `llc` and parses the `.s`)
* `Microsoft.Android.Build.BaseTasks-Tests` 129/129
