### PR TITLE
[Xamarin.Android.Build.Tasks] merge `targetSdkVersion` into existing `<uses-sdk>`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestDocumentTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestDocumentTest.cs
@@ -9,105 +9,104 @@ using Mono.Cecil;
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
 
-namespace Xamarin.Android.Build.Tests
+namespace Xamarin.Android.Build.Tests;
+
+/// <summary>
+/// In-process tests for how <see cref="ManifestDocument"/> merges the computed
+/// minSdkVersion/targetSdkVersion into a user-authored &lt;uses-sdk/&gt; element.
+/// </summary>
+[TestFixture]
+[Parallelizable (ParallelScope.Self)]
+public class ManifestDocumentTest : BaseTest
 {
-	/// <summary>
-	/// In-process tests for how <see cref="ManifestDocument"/> merges the computed
-	/// minSdkVersion/targetSdkVersion into a user-authored &lt;uses-sdk/&gt; element.
-	/// </summary>
-	[TestFixture]
-	[Parallelizable (ParallelScope.Self)]
-	public class ManifestDocumentTest : BaseTest
-	{
-		const string DefaultMinSdkVersion = "21";
-		const string DefaultTargetSdkVersion = "37";
+	const string DefaultMinSdkVersion = "21";
+	const string DefaultTargetSdkVersion = "37";
 
-		static readonly XNamespace AndroidNs = "http://schemas.android.com/apk/res/android";
+	static readonly XNamespace AndroidNs = "http://schemas.android.com/apk/res/android";
 
-		static string CreateManifest (string usesSdk) => $@"<?xml version=""1.0"" encoding=""utf-8""?>
+	static string CreateManifest (string usesSdk) => $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.xamarin.usessdk"">
 	{usesSdk}
 	<application android:label=""UsesSdk"">
 	</application>
 </manifest>";
 
-		static XElement MergeAndGetUsesSdk (string usesSdk, out XDocument document)
-		{
-			var templateFile = Path.GetTempFileName ();
-			try {
-				File.WriteAllText (templateFile, CreateManifest (usesSdk));
-
-				var manifest = new ManifestDocument (templateFile) {
-					PackageName = "com.xamarin.usessdk",
-					TargetSdkVersion = DefaultTargetSdkVersion,
-					MinSdkVersion = DefaultMinSdkVersion,
-					VersionResolver = new MockVersionResolver {
-						GetApiLevelFromIdFunc = id => int.TryParse (id, out var apiLevel) ? (int?) apiLevel : null,
-						GetIdFromApiLevelFunc = apiLevel => apiLevel,
-					},
-				};
-
-				var engine = new MockBuildEngine (TestContext.Out);
-				var log = new TaskLoggingHelper (engine, nameof (ManifestDocumentTest));
-				manifest.Merge (log, new TypeDefinitionCache (), new List<TypeDefinition> (), applicationClass: null, embed: false, bundledWearApplicationName: null, mergedManifestDocuments: null);
-
-				var writer = new StringWriter ();
-				manifest.Save ((code, message) => { }, writer);
-
-				document = XDocument.Parse (writer.ToString ());
-				var element = document.Root.Element ("uses-sdk");
-				Assert.IsNotNull (element, "uses-sdk element should exist");
-				return element;
-			} finally {
-				File.Delete (templateFile);
-			}
-		}
-
-		static void AssertUsesSdk (string usesSdk, string expectedMinSdkVersion, string expectedTargetSdkVersion)
-		{
-			var element = MergeAndGetUsesSdk (usesSdk, out var document);
-
-			Assert.AreEqual (expectedMinSdkVersion, element.Attribute (AndroidNs + "minSdkVersion")?.Value, "unexpected android:minSdkVersion");
-			Assert.AreEqual (expectedTargetSdkVersion, element.Attribute (AndroidNs + "targetSdkVersion")?.Value, "unexpected android:targetSdkVersion");
-
-			foreach (var comment in document.DescendantNodes ().OfType<XComment> ()) {
-				StringAssert.DoesNotContain ("UsesMinSdkAttributes", comment.Value, "the lint suppression comment should no longer be emitted");
-			}
-		}
-
-		[Test]
-		public void NoUsesSdkElement ()
-		{
-			AssertUsesSdk ("", DefaultMinSdkVersion, DefaultTargetSdkVersion);
-		}
-
-		[Test]
-		public void MinSdkVersionOnly ()
-		{
-			// Regression test: targetSdkVersion was never written, so `aapt2` defaulted it to minSdkVersion.
-			AssertUsesSdk (@"<uses-sdk android:minSdkVersion=""24"" />", "24", DefaultTargetSdkVersion);
-		}
-
-		[Test]
-		public void TargetSdkVersionOnly ()
-		{
-			AssertUsesSdk (@"<uses-sdk android:targetSdkVersion=""30"" />", DefaultMinSdkVersion, "30");
-		}
-
-		[Test]
-		public void MinAndTargetSdkVersion ()
-		{
-			AssertUsesSdk (@"<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""30"" />", "24", "30");
-		}
-	}
-
-	class MockVersionResolver : IVersionResolver
+	static XElement MergeAndGetUsesSdk (string usesSdk, out XDocument document)
 	{
-		public Func<string, int?> GetApiLevelFromIdFunc { get; set; } = _ => 99;
-		public Func<string, string> GetIdFromApiLevelFunc { get; set; } = _ => "API-99";
+		var templateFile = Path.GetTempFileName ();
+		try {
+			File.WriteAllText (templateFile, CreateManifest (usesSdk));
 
-		public int? GetApiLevelFromId (string id) => GetApiLevelFromIdFunc (id);
+			var manifest = new ManifestDocument (templateFile) {
+				PackageName = "com.xamarin.usessdk",
+				TargetSdkVersion = DefaultTargetSdkVersion,
+				MinSdkVersion = DefaultMinSdkVersion,
+				VersionResolver = new MockVersionResolver {
+					GetApiLevelFromIdFunc = id => int.TryParse (id, out var apiLevel) ? (int?) apiLevel : null,
+					GetIdFromApiLevelFunc = apiLevel => apiLevel,
+				},
+			};
 
-		public string GetIdFromApiLevel (string apiLevel) => GetIdFromApiLevelFunc (apiLevel);
+			var engine = new MockBuildEngine (TestContext.Out);
+			var log = new TaskLoggingHelper (engine, nameof (ManifestDocumentTest));
+			manifest.Merge (log, new TypeDefinitionCache (), new List<TypeDefinition> (), applicationClass: null, embed: false, bundledWearApplicationName: null, mergedManifestDocuments: null);
+
+			var writer = new StringWriter ();
+			manifest.Save ((code, message) => { }, writer);
+
+			document = XDocument.Parse (writer.ToString ());
+			var element = document.Root.Element ("uses-sdk");
+			Assert.IsNotNull (element, "uses-sdk element should exist");
+			return element;
+		} finally {
+			File.Delete (templateFile);
+		}
 	}
+
+	static void AssertUsesSdk (string usesSdk, string expectedMinSdkVersion, string expectedTargetSdkVersion)
+	{
+		var element = MergeAndGetUsesSdk (usesSdk, out var document);
+
+		Assert.AreEqual (expectedMinSdkVersion, element.Attribute (AndroidNs + "minSdkVersion")?.Value, "unexpected android:minSdkVersion");
+		Assert.AreEqual (expectedTargetSdkVersion, element.Attribute (AndroidNs + "targetSdkVersion")?.Value, "unexpected android:targetSdkVersion");
+
+		foreach (var comment in document.DescendantNodes ().OfType<XComment> ()) {
+			StringAssert.DoesNotContain ("UsesMinSdkAttributes", comment.Value, "the lint suppression comment should no longer be emitted");
+		}
+	}
+
+	[Test]
+	public void NoUsesSdkElement ()
+	{
+		AssertUsesSdk ("", DefaultMinSdkVersion, DefaultTargetSdkVersion);
+	}
+
+	[Test]
+	public void MinSdkVersionOnly ()
+	{
+		// Regression test: targetSdkVersion was never written, so `aapt2` defaulted it to minSdkVersion.
+		AssertUsesSdk (@"<uses-sdk android:minSdkVersion=""24"" />", "24", DefaultTargetSdkVersion);
+	}
+
+	[Test]
+	public void TargetSdkVersionOnly ()
+	{
+		AssertUsesSdk (@"<uses-sdk android:targetSdkVersion=""30"" />", DefaultMinSdkVersion, "30");
+	}
+
+	[Test]
+	public void MinAndTargetSdkVersion ()
+	{
+		AssertUsesSdk (@"<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""30"" />", "24", "30");
+	}
+}
+
+class MockVersionResolver : IVersionResolver
+{
+	public Func<string, int?> GetApiLevelFromIdFunc { get; set; } = _ => 99;
+	public Func<string, string> GetIdFromApiLevelFunc { get; set; } = _ => "API-99";
+
+	public int? GetApiLevelFromId (string id) => GetApiLevelFromIdFunc (id);
+
+	public string GetIdFromApiLevel (string apiLevel) => GetIdFromApiLevelFunc (apiLevel);
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestDocumentTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestDocumentTest.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Java.Interop.Tools.Cecil;
+using Microsoft.Build.Utilities;
+using Mono.Cecil;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests
+{
+	/// <summary>
+	/// In-process tests for how <see cref="ManifestDocument"/> merges the computed
+	/// minSdkVersion/targetSdkVersion into a user-authored &lt;uses-sdk/&gt; element.
+	/// </summary>
+	[TestFixture]
+	[Parallelizable (ParallelScope.Self)]
+	public class ManifestDocumentTest : BaseTest
+	{
+		const string DefaultMinSdkVersion = "21";
+		const string DefaultTargetSdkVersion = "37";
+
+		static readonly XNamespace AndroidNs = "http://schemas.android.com/apk/res/android";
+
+		static string CreateManifest (string usesSdk) => $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""com.xamarin.usessdk"">
+	{usesSdk}
+	<application android:label=""UsesSdk"">
+	</application>
+</manifest>";
+
+		static XElement MergeAndGetUsesSdk (string usesSdk, out XDocument document)
+		{
+			var templateFile = Path.GetTempFileName ();
+			try {
+				File.WriteAllText (templateFile, CreateManifest (usesSdk));
+
+				var manifest = new ManifestDocument (templateFile) {
+					PackageName = "com.xamarin.usessdk",
+					TargetSdkVersion = DefaultTargetSdkVersion,
+					MinSdkVersion = DefaultMinSdkVersion,
+					VersionResolver = new MockVersionResolver {
+						GetApiLevelFromIdFunc = id => int.TryParse (id, out var apiLevel) ? (int?) apiLevel : null,
+						GetIdFromApiLevelFunc = apiLevel => apiLevel,
+					},
+				};
+
+				var engine = new MockBuildEngine (TestContext.Out);
+				var log = new TaskLoggingHelper (engine, nameof (ManifestDocumentTest));
+				manifest.Merge (log, new TypeDefinitionCache (), new List<TypeDefinition> (), applicationClass: null, embed: false, bundledWearApplicationName: null, mergedManifestDocuments: null);
+
+				var writer = new StringWriter ();
+				manifest.Save ((code, message) => { }, writer);
+
+				document = XDocument.Parse (writer.ToString ());
+				var element = document.Root.Element ("uses-sdk");
+				Assert.IsNotNull (element, "uses-sdk element should exist");
+				return element;
+			} finally {
+				File.Delete (templateFile);
+			}
+		}
+
+		static void AssertUsesSdk (string usesSdk, string expectedMinSdkVersion, string expectedTargetSdkVersion)
+		{
+			var element = MergeAndGetUsesSdk (usesSdk, out var document);
+
+			Assert.AreEqual (expectedMinSdkVersion, element.Attribute (AndroidNs + "minSdkVersion")?.Value, "unexpected android:minSdkVersion");
+			Assert.AreEqual (expectedTargetSdkVersion, element.Attribute (AndroidNs + "targetSdkVersion")?.Value, "unexpected android:targetSdkVersion");
+
+			foreach (var comment in document.DescendantNodes ().OfType<XComment> ()) {
+				StringAssert.DoesNotContain ("UsesMinSdkAttributes", comment.Value, "the lint suppression comment should no longer be emitted");
+			}
+		}
+
+		[Test]
+		public void NoUsesSdkElement ()
+		{
+			AssertUsesSdk ("", DefaultMinSdkVersion, DefaultTargetSdkVersion);
+		}
+
+		[Test]
+		public void MinSdkVersionOnly ()
+		{
+			// Regression test: targetSdkVersion was never written, so `aapt2` defaulted it to minSdkVersion.
+			AssertUsesSdk (@"<uses-sdk android:minSdkVersion=""24"" />", "24", DefaultTargetSdkVersion);
+		}
+
+		[Test]
+		public void TargetSdkVersionOnly ()
+		{
+			AssertUsesSdk (@"<uses-sdk android:targetSdkVersion=""30"" />", DefaultMinSdkVersion, "30");
+		}
+
+		[Test]
+		public void MinAndTargetSdkVersion ()
+		{
+			AssertUsesSdk (@"<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""30"" />", "24", "30");
+		}
+	}
+
+	class MockVersionResolver : IVersionResolver
+	{
+		public Func<string, int?> GetApiLevelFromIdFunc { get; set; } = _ => 99;
+		public Func<string, string> GetIdFromApiLevelFunc { get; set; } = _ => "API-99";
+
+		public int? GetApiLevelFromId (string id) => GetApiLevelFromIdFunc (id);
+
+		public string GetIdFromApiLevel (string apiLevel) => GetIdFromApiLevelFunc (apiLevel);
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -1728,16 +1728,6 @@ class TestActivity : Activity { }"
 				File.Delete (templateFile);
 			}
 		}
-
-		class MockVersionResolver : IVersionResolver
-		{
-			public Func<string, int?> GetApiLevelFromIdFunc { get; set; } = _ => 99;
-			public Func<string, string> GetIdFromApiLevelFunc { get; set; } = _ => "API-99";
-
-			public int? GetApiLevelFromId (string id) => GetApiLevelFromIdFunc (id);
-
-			public string GetIdFromApiLevel (string apiLevel) => GetIdFromApiLevelFunc (apiLevel);
-		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -324,13 +324,14 @@ namespace Xamarin.Android.Tasks {
 				uses.SetAttributeValue (androidNs + "minSdkVersion", minSdkVersionString);
 			}
 
+			// If no targetSdkVersion is specified, set it. Otherwise `aapt2` defaults it to minSdkVersion.
 			string targetSdkVersion;
 			var tsv = uses.Attribute (androidNs + "targetSdkVersion");
 			if (tsv != null)
 				targetSdkVersion = tsv.Value;
 			else {
 				targetSdkVersion = TargetSdkVersionName;
-				uses.AddBeforeSelf (new XComment ("suppress UsesMinSdkAttributes"));
+				uses.SetAttributeValue (androidNs + "targetSdkVersion", targetSdkVersion);
 			}
 
 			int? tryTargetSdkVersion  = VersionResolver.GetApiLevelFromId (targetSdkVersion);


### PR DESCRIPTION
### Context

When a project's `AndroidManifest.xml` already declares a `<uses-sdk />` element, `ManifestDocument` merges `android:minSdkVersion` into it if absent — but it never merged `android:targetSdkVersion`. Instead it computed the value purely for internal bookkeeping (`targetSdkVersionValue`, which drives `<instrumentation>`, permission, and `screenOrientation` codegen) and emitted a `<!-- suppress UsesMinSdkAttributes -->` lint comment:

```csharp
string targetSdkVersion;
var tsv = uses.Attribute (androidNs + "targetSdkVersion");
if (tsv != null)
    targetSdkVersion = tsv.Value;
else {
    targetSdkVersion = TargetSdkVersionName;
    uses.AddBeforeSelf (new XComment ("suppress UsesMinSdkAttributes"));
}
```

`aapt2` **silently defaults `targetSdkVersion` to `minSdkVersion`** when the attribute is missing. So any app with a partial hand-written `<uses-sdk />` shipped with an unintentionally ancient `targetSdk`, with no warning anywhere in the build.

### The motivating example

`tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Properties/AndroidManifest.xml` declared:

```xml
<uses-sdk android:minSdkVersion="24" />
```

`$(TargetSdkVersion)` was 37. Installing the resulting `.apk` on a physical Pixel 10 (API 36):

```
$ adb shell dumpsys package Xamarin.Android.JcwGen_Tests
# before
    minSdk=24 targetSdk=24
# after this change
    minSdk=24 targetSdk=37
```

Android 15+ shows the end user an "app built for an older version of Android" warning dialog on install when `targetSdk` is low enough — which is how this was noticed.

### Why was it like this?

I looked for a deliberate "respect the user's `<uses-sdk />` verbatim" policy and could not find one:

- `git log -S 'suppress UsesMinSdkAttributes' -- .../ManifestDocument.cs` returns exactly **one** commit: `59ec488b4 [Xamarin.Android.Build.Tasks] Import from monodroid/301e7238`. The behavior predates this repo entirely.
- Every subsequent touch of this region (`a66013b5c`, `941e04c22`, `3ab04df75`) only re-pointed *where the value comes from*. None revisited the "don't write it" decision.
- `UsesMinSdkAttributes` is an Android lint check id ("Minimum SDK and target SDK attributes not defined"). The comment is a *symptom* of the omission, not an independent feature — and `<!-- suppress ... -->` is IntelliJ inspection syntax, whereas Android `lint` honours `tools:ignore`, so it was likely never effective for our `Lint` task anyway. The string appears exactly once in the whole repo: the line that writes it. Nothing reads it.
- Decisively, the immediately preceding branch **already** merges `minSdkVersion` into a user-authored element. The `targetSdkVersion` omission is an inconsistency, not a design.

### The change

Write `android:targetSdkVersion` when the user did not specify one, and drop the now-dead suppression comment. User-specified values still win — both merges only fire when the attribute is `null`.

### ⚠️ Back-compat consideration for reviewers

This changes the produced manifest for any customer who hand-wrote a partial `<uses-sdk />` (min only, or neither attribute). Those apps will now get an explicit `targetSdkVersion` equal to `$(TargetSdkVersion)` where `aapt2` previously defaulted it to `minSdkVersion`.

That is the point of the fix — apps stop silently shipping with an ancient `targetSdk` — but it is a real behavioral change at runtime: platform behavior changes gated on `targetSdk` now apply to those apps. Customers who genuinely want a lower `targetSdk` can still set `android:targetSdkVersion` explicitly (or `$(TargetSdkVersion)`); those values continue to win.

### Tests

New `ManifestDocumentTest` with fast in-process coverage of all four `<uses-sdk />` shapes, plus an assertion that the suppression comment is gone:

| case | input | expected `minSdkVersion` | expected `targetSdkVersion` |
| --- | --- | --- | --- |
| `NoUsesSdkElement` | *element absent* | computed | computed |
| `MinSdkVersionOnly` | `android:minSdkVersion="24"` | `24` | computed |
| `TargetSdkVersionOnly` | `android:targetSdkVersion="30"` | computed | `30` |
| `MinAndTargetSdkVersion` | both | `24` | `30` |

Verified the tests actually catch the bug: with the `ManifestDocument.cs` change reverted, `MinSdkVersionOnly` fails with `Expected: "37" But was: null`. With the fix, all 4 pass, as does the existing `ManifestTest.TargetSdkVersion_361In_36Out`.

`MockVersionResolver` moved from a `private` nested class in `ManifestTest` to namespace scope so both fixtures can share it; the `ManifestTest.cs` diff is removal-only.