### PR TITLE
[build] Brand main builds with release suffix

### DIFF
--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -63,7 +63,7 @@
       <!-- See Azure Pipelines predefined variables. -->
       <_AndroidPackLabel Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">ci.pr.gh$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackBranch>$([System.Text.RegularExpressions.Regex]::Replace('$(XAVersionBranch)', '[^a-zA-Z0-9-]', '-'))</_AndroidPackBranch>
-      <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' and $(XAVersionBranch.StartsWith('release/'))">$(AndroidPackVersionSuffix).$(PackVersionCommitCount)</_AndroidPackLabel>
+      <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' and ('$(XAVersionBranch)' == 'main' or $(XAVersionBranch.StartsWith('release/')))">$(AndroidPackVersionSuffix).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(_AndroidPackBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
       <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)</AndroidPackVersionLong>
       <AndroidMSIVersion>$(AndroidPackVersion).$(PackVersionCommitCount)</AndroidMSIVersion>


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.

  Main currently ignores `AndroidPackVersionSuffix` and produces `ci.main` workload pack branding. Treating `main` like `release/*` makes it use the configured release branding, currently `rc.1`, while preserving PR and feature branch `ci.*` branding.

- [ ] Links to issues fixed

  N/A

- [x] Unit tests

  Evaluated the MSBuild target for main, release, feature, and PR branches. Main and release produce `37.0.0-rc.1.42`; feature and PR builds retain their existing `ci.*` labels.