### PR TITLE
[CoreCLR] support MAUI full ReadyToRun

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1765,6 +1765,10 @@ assemblies in `obj/<Configuration>/android<ABI>/linked` directory.
 
 The default value is False.
 
+## MandroidI18n
+
+This MSBuild property is obsolete and is no longer supported.
+
 ## MauiEnableFullReadyToRun
 
 A boolean property for .NET MAUI Android applications that use CoreCLR
@@ -1776,10 +1780,6 @@ full ReadyToRun.
 Full ReadyToRun increases application and download size, but can
 potentially improve runtime performance because more methods are
 precompiled.
-
-## MandroidI18n
-
-This MSBuild property is obsolete and is no longer supported.
 
 ## MetricsSupport
 

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1890,8 +1890,11 @@ Mono runtime instead of CoreCLR. Set this property to `true` to use
 Mono or `false` to use CoreCLR. `$(PublishAot)` takes precedence and
 selects NativeAOT when set to `true`.
 
-.NET MAUI defaults can vary by target framework and build
-configuration. For more information, see
+This property defaults to `true` in .NET 10 and earlier, so Android
+applications use Mono. In .NET 11 and later, it defaults to `false`,
+so Android applications use CoreCLR.
+
+For more information, see
 [Runtimes and compilation in .NET MAUI][maui-runtimes-compilation].
 
 [maui-runtimes-compilation]: https://learn.microsoft.com/dotnet/maui/deployment/runtimes-compilation

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1765,6 +1765,18 @@ assemblies in `obj/<Configuration>/android<ABI>/linked` directory.
 
 The default value is False.
 
+## MauiEnableFullReadyToRun
+
+A boolean property for .NET MAUI Android applications that use CoreCLR
+and are built in `Release` configuration with ReadyToRun enabled.
+When this property is unset or `false`, MAUI uses partial ReadyToRun
+with its default MIBC profiles. Set this property to `true` to enable
+full ReadyToRun.
+
+Full ReadyToRun increases application and download size, but can
+potentially improve runtime performance because more methods are
+precompiled.
+
 ## MandroidI18n
 
 This MSBuild property is obsolete and is no longer supported.

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1775,11 +1775,15 @@ A boolean property for .NET MAUI Android applications that use CoreCLR
 and are built in `Release` configuration with ReadyToRun enabled.
 When this property is unset or `false`, MAUI uses partial ReadyToRun
 with its default MIBC profiles. Set this property to `true` to enable
-full ReadyToRun.
+full ReadyToRun. This property has no effect when
+[`$(PublishReadyToRun)`](#publishreadytorun) is `false`.
 
 Full ReadyToRun increases application and download size, but can
 potentially improve runtime performance because more methods are
 precompiled.
+
+For more information about CoreCLR and ReadyToRun in .NET MAUI, see
+[Runtimes and compilation in .NET MAUI][maui-runtimes-compilation].
 
 ## MetricsSupport
 
@@ -1831,18 +1835,66 @@ debugging symbols enabled:
 [`$(Optimize)`](/visualstudio/msbuild/common-msbuild-project-properties)
 is True.
 
+## PublishReadyToRun
+
+A boolean property that controls whether assemblies are compiled to
+[ReadyToRun][ready-to-run] format when using CoreCLR. ReadyToRun
+assemblies contain both MSIL and native code. This can improve
+application startup time while retaining JIT compatibility, but
+increases application and download size.
+
+For Android applications that use CoreCLR, this property defaults to
+`true` in `Release` configuration and is not enabled by default in
+`Debug` configuration. ReadyToRun does not apply when using Mono or
+NativeAOT.
+
+ReadyToRun compilation is composite by default. See
+[`$(PublishReadyToRunComposite)`](#publishreadytoruncomposite).
+.NET MAUI also uses partial ReadyToRun with default MIBC profiles. See
+[`$(MauiEnableFullReadyToRun)`](#mauienablefullreadytorun) to opt in to
+full ReadyToRun.
+
+For more information, see
+[Runtimes and compilation in .NET MAUI][maui-runtimes-compilation].
+
+[ready-to-run]: https://learn.microsoft.com/dotnet/core/deploying/ready-to-run
+
+## PublishReadyToRunComposite
+
+A boolean property that controls whether ReadyToRun compilation
+combines application assemblies into a composite image. Composite
+ReadyToRun enables cross-assembly optimizations, but can increase build
+time.
+
+For Android applications that use CoreCLR, this property defaults to
+`true` when [`$(PublishReadyToRun)`](#publishreadytorun) is `true`.
+
 ## RunAOTCompilation
 
 A boolean property that determines whether or not assemblies will be
-Ahead-of-Time compiled into native code and included in applications.
-This property is `False` by default for `Debug` builds and `True` by
-default for `Release` builds.
+Ahead-of-Time compiled with the Mono AOT compiler and included in
+applications that use the Mono runtime. This property is `False` by
+default for `Debug` builds and `True` by default for `Release` builds
+that use Mono. It does not enable ReadyToRun or NativeAOT.
 
 This MSBuild property replaces the
 [`$(AotAssemblies)`](#aotassemblies) MSBuild property from
 Xamarin.Android. This is the same property used for [Blazor WASM][blazor].
 
 [blazor]: /aspnet/core/blazor/host-and-deploy/webassembly/#ahead-of-time-aot-compilation
+
+## UseMonoRuntime
+
+A boolean property that controls whether Android applications use the
+Mono runtime instead of CoreCLR. Set this property to `true` to use
+Mono or `false` to use CoreCLR. `$(PublishAot)` takes precedence and
+selects NativeAOT when set to `true`.
+
+.NET MAUI defaults can vary by target framework and build
+configuration. For more information, see
+[Runtimes and compilation in .NET MAUI][maui-runtimes-compilation].
+
+[maui-runtimes-compilation]: https://learn.microsoft.com/dotnet/maui/deployment/runtimes-compilation
 
 ## WaitForExit
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
@@ -69,11 +69,12 @@ This file contains the CoreCLR-specific MSBuild logic for .NET for Android.
     has not run yet, and `@(PublishReadyToRunPgoFiles)` is the supported way to hand a profile to
     crossgen2; `_PrepareForReadyToRunCompilation` copies it into its own private item group.
 
-    `$(_AndroidReadyToRunMainAssembly)` decides whether the profile is generated, in order:
+    The generated profile decision is made in this order:
 
-      1. An explicit `true` or `false` always wins.
-      2. Otherwise off when the app supplies its own `@(PublishReadyToRunPgoFiles)`.
-      3. Otherwise on when crossgen2 is running in partial mode.
+      1. Off when MAUI enables full ReadyToRun.
+      2. An explicit `true` or `false` otherwise wins.
+      3. Otherwise off when the app supplies its own `@(PublishReadyToRunPgoFiles)`.
+      4. Otherwise on when crossgen2 is running in partial mode.
 
     An app that supplies its own profile, e.g. one recorded from a real startup trace with
     `dotnet-pgo`, has already said exactly what it wants compiled, and the whole point of partial
@@ -107,7 +108,7 @@ This file contains the CoreCLR-specific MSBuild logic for .NET for Android.
       AfterTargets="ILLink"
       BeforeTargets="CreateReadyToRunImages"
       DependsOnTargets="_AndroidGenerateMibcProfileInputs"
-      Condition=" '$(PublishReadyToRun)' == 'true' and '$(_AndroidReadyToRunMainAssembly)' != 'false' and ('$(_AndroidReadyToRunMainAssembly)' == 'true' or ($(PublishReadyToRunCrossgen2ExtraArgs.Contains('--partial')) and '@(PublishReadyToRunPgoFiles->Count())' == '0')) "
+      Condition=" '$(PublishReadyToRun)' == 'true' and '$(MauiEnableFullReadyToRun)' != 'true' and '$(_AndroidReadyToRunMainAssembly)' != 'false' and ('$(_AndroidReadyToRunMainAssembly)' == 'true' or ($(PublishReadyToRunCrossgen2ExtraArgs.Contains('--partial')) and '@(PublishReadyToRunPgoFiles->Count())' == '0')) "
       Inputs="$(_AndroidMibcMainAssembly)"
       Outputs="$(_AndroidMibcProfile)">
     <GenerateMibcProfile


### PR DESCRIPTION
.NET MAUI uses partial ReadyToRun with default MIBC profiles for Android
CoreCLR Release builds.  The companion MAUI change adds
`$(MauiEnableFullReadyToRun)` and, when enabled, omits the partial
compilation switch and those profiles.

Honor that opt-in in .NET for Android by preventing the generated
main-assembly MIBC profile from being added to the ReadyToRun inputs.
The property is checked directly in the target condition so its value
from MAUI's `buildTransitive` targets is observed at execution time.

Expand the build-property reference to document:

- `$(PublishReadyToRun)`, including its Android CoreCLR `Release`
  default and size/startup tradeoffs.
- `$(PublishReadyToRunComposite)`, which defaults to `true` when
  ReadyToRun is enabled.
- `$(UseMonoRuntime)`, which selects Mono instead of CoreCLR.
- `$(RunAOTCompilation)` as Mono-specific AOT compilation.
- `$(MauiEnableFullReadyToRun)`, including its partial/full behavior
  and size/performance tradeoffs.

The documentation links to the .NET MAUI runtimes and compilation
guide for broader runtime and compilation context.

Issue: https://github.com/dotnet/maui/issues/36587

Companion MAUI PR: https://github.com/dotnet/maui/pull/37094

----

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [ ] Unit tests
