### PR TITLE
More thorough check of framework description for .NET 6+

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildArchive.cs
@@ -221,7 +221,7 @@ public class BuildArchive : AndroidTask
 		var frameworkDescription = RuntimeInformation.FrameworkDescription;
 		Log.LogDebugMessage ($"RuntimeInformation.FrameworkDescription: {frameworkDescription}");
 		if (Environment.Version.Major < 6) {
-			Log.LogDebugMessage ("Falling back to LibZipSharp because we are *not* running on .NET 6+.");
+			Log.LogDebugMessage ($"Falling back to LibZipSharp because we are *not* running on .NET 6+, Environment.Version.Major: {Environment.Version.Major}");
 			return true;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildArchive.cs
@@ -220,7 +220,7 @@ public class BuildArchive : AndroidTask
 		// Always fallback on .NET Framework
 		var frameworkDescription = RuntimeInformation.FrameworkDescription;
 		Log.LogDebugMessage ($"RuntimeInformation.FrameworkDescription: {frameworkDescription}");
-		if (IsDotNet(frameworkDescription)) {
+		if (Environment.Version.Major < 6) {
 			Log.LogDebugMessage ("Falling back to LibZipSharp because we are *not* running on .NET 6+.");
 			return true;
 		}
@@ -228,12 +228,6 @@ public class BuildArchive : AndroidTask
 		// .NET 6+ handles uncompressed files correctly, so we don't need to fallback.
 		Log.LogDebugMessage ("Using System.IO.Compression because we're running on .NET 6+.");
 		return false;
-	}
-
-	internal static bool IsDotNet (string frameworkDescription)
-	{
-		return !(frameworkDescription.StartsWith (".NET Framework", StringComparison.Ordinal) ||
-			frameworkDescription.StartsWith ("Mono", StringComparison.Ordinal));
 	}
 
 	bool AddFileToArchiveIfNewer (IZipArchive apk, string file, string inArchivePath, ITaskItem item, List<string> existingEntries)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildArchive.cs
@@ -220,7 +220,7 @@ public class BuildArchive : AndroidTask
 		// Always fallback on .NET Framework
 		var frameworkDescription = RuntimeInformation.FrameworkDescription;
 		Log.LogDebugMessage ($"RuntimeInformation.FrameworkDescription: {frameworkDescription}");
-		if (frameworkDescription != ".NET") {
+		if (IsDotNet(frameworkDescription)) {
 			Log.LogDebugMessage ("Falling back to LibZipSharp because we are *not* running on .NET 6+.");
 			return true;
 		}
@@ -228,6 +228,12 @@ public class BuildArchive : AndroidTask
 		// .NET 6+ handles uncompressed files correctly, so we don't need to fallback.
 		Log.LogDebugMessage ("Using System.IO.Compression because we're running on .NET 6+.");
 		return false;
+	}
+
+	internal static bool IsDotNet (string frameworkDescription)
+	{
+		return !(frameworkDescription.StartsWith (".NET Framework", StringComparison.Ordinal) ||
+			frameworkDescription.StartsWith ("Mono", StringComparison.Ordinal));
 	}
 
 	bool AddFileToArchiveIfNewer (IZipArchive apk, string file, string inArchivePath, ITaskItem item, List<string> existingEntries)


### PR DESCRIPTION
[Xamarin.Android.Build.Tasks] Issue where `frameworkDescription` wasn't simply ".NET" but instead was ".NET" with additional version information. This requires we check beyond just a simple compare.

----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [ ] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [ ] Unit tests
