### PR TITLE
[FastDeploy2] Clean orphan staging files

### DIFF
--- a/Documentation/guides/FastDeploy2.md
+++ b/Documentation/guides/FastDeploy2.md
@@ -33,7 +33,7 @@ details:
 | `$(_AndroidFastDeployMaxShellCommandLength)` | `900` | Maximum length of a single `adb shell` command line before it is split. |
 | `$(_AndroidFastDeployMaxAdbCommandLength)` | `4096` | Maximum length of a single `adb` command line before it is split. |
 | `$(_AndroidFastDeploySkipCleanup)` | blank | Set to `true` to skip orphan staging cleanup. |
-| `$(_AndroidFastDeployForceCleanup)` | blank | Set to `true` to run orphan staging cleanup on every install without the interval or age guards. |
+| `$(_AndroidFastDeployForceCleanup)` | blank | Set to `true` to bypass the orphan cleanup interval and age guards on a cold deployment. |
 
 ## On-device layout
 

--- a/Documentation/guides/FastDeploy2.md
+++ b/Documentation/guides/FastDeploy2.md
@@ -23,9 +23,8 @@ properties intended for end users are:
 | `$(_AndroidFastDeployAppFileTransferMode)` | `Symlink` (for `FastDeploy2`) | How staged files are surfaced in the override directory: `Symlink` or `Copy`. |
 | `$(AndroidFastDeploymentAdbCompressionAlgorithm)` | `any` | The `adb push -z` compression algorithm. `FastDeploy2` relies on a modern Android SDK Platform-Tools `adb` for multi-file `push -z` support. |
 
-The following internal/unsupported properties tune batching. They exist mainly so
-the batching paths can be exercised with smaller batches while testing; their
-defaults match the matching task properties:
+The following internal/unsupported properties tune or disable implementation
+details:
 
 | Property | Default | Description |
 | --- | --- | --- |
@@ -33,6 +32,7 @@ defaults match the matching task properties:
 | `$(_AndroidFastDeployCopyBatchSize)` | `25` | Number of files copied per batch when staging fast-deployment files. |
 | `$(_AndroidFastDeployMaxShellCommandLength)` | `900` | Maximum length of a single `adb shell` command line before it is split. |
 | `$(_AndroidFastDeployMaxAdbCommandLength)` | `4096` | Maximum length of a single `adb` command line before it is split. |
+| `$(_AndroidFastDeploySkipCleanup)` | blank | Set to `true` to skip orphan staging cleanup. |
 
 ## On-device layout
 
@@ -46,6 +46,16 @@ defaults match the matching task properties:
   staging and override directories. It records the hash of the last successfully
   deployed manifest so the next build can detect whether the device is already up
   to date and skip redundant work.
+
+At the start of an install, FastDeploy2 also checks for orphaned staging
+directories. The check runs at most once every 24 hours per device. In one
+`adb shell` command it enumerates staged `<package-name>/<user-id>` directories,
+compares them with `pm list packages --user <user-id>`, and removes directories
+for packages that are no longer installed. A staging directory must also be at
+least 24 hours old before it can be removed, which prevents cleanup from racing a
+concurrent first-time deployment. Cleanup runs only on the cold deployment path,
+so warm incremental installs do not perform this check or add another `adb`
+invocation.
 
 Changing `$(_AndroidFastDevStrategy)` or
 `$(_AndroidFastDeployAppFileTransferMode)` invalidates the deployment
@@ -196,3 +206,55 @@ Install failures are reported with `ADB####` codes; fast-deployment shell
 failures (`mkdir`/`rm`/`push`/`ln`) are reported with `XA0129`. `run-as`
 diagnostics map to `XA0131`–`XA0137`. See the
 [build/deploy message docs](../docs-mobile/messages/index.md) for details.
+
+## Command Compatibility
+
+.NET for Android supports Android 7.0 (API level 24) and later. FastDeploy2's
+device-side commands are available by Android 6.0 (API level 23), before the
+supported device floor. The API levels below are approximate because shell
+utilities are not Android SDK APIs.
+
+Host-side `adb` commands depend on the installed Android SDK Platform-Tools
+version rather than the device API level:
+
+| Command | FastDeploy2 use | Compatibility |
+| --- | --- | --- |
+| `adb devices`, `adb -s <device> shell ...` | Device selection and all device-side operations | Standard Platform-Tools commands |
+| `adb install -r -d [-t] [--user <id>]` | APK installation and replacement | Standard Platform-Tools command; `--user` corresponds to Android multi-user support introduced in API 17 |
+| `adb push -z <algorithm>` | Batched compressed staging-file upload | Modern Platform-Tools capability; not controlled by the device application API level |
+
+FastDeploy2 uses these device-side commands and shell features:
+
+| Command or shell feature | FastDeploy2 use | Approximate availability |
+| --- | --- | --- |
+| `sh`/mksh syntax, `[ ... ]`, `test`, `command -v`, `cd`, `pwd`, `echo`, `trap`, globbing, command/parameter/arithmetic expansion, and redirection | Combined checks, override updates, and cleanup control flow | API 14; Android has used mksh since Android 4.0 |
+| `getprop` | Validate `run-as` compatibility properties | API 1 |
+| `run-as <package>` | Access the private data directory of a debuggable app | Early Android; availability alone is insufficient because the package must be debuggable and the device must permit `run-as` |
+| `su <user>` | Access files for a system application when adbd is not root | Not guaranteed on production devices; used only for the system-app fallback |
+| `cat`, `true`, `rm -f`, `rm -rf`, `mkdir -p`, `rmdir`, `touch`, `cp -p`, and `ln -sf` | Read markers and manage staging/override files, locks, copies, and symlinks | API 21 or earlier; supplied by toolbox/BSD utilities before toybox |
+| `readlink -f`, `whoami` | Resolve system-app paths and determine whether adbd is root | Reliably available by API 23 |
+| `pidof` | Find the running application process | Reliably available by API 23 |
+| `find -type f -exec stat ... {} +` and `stat -c` | Enumerate and compare staged and override files | API 23; supplied by toybox starting in Android 6.0 |
+| `printf %s` | Write manifest hash markers without a trailing newline | API 23; supplied by toybox starting in Android 6.0 |
+| `date +%s` | Cleanup rate limiting and staging-directory age checks | API 21 or earlier |
+| `grep -Fqx` | Exact installed-package lookup during orphan cleanup | API 21 or earlier |
+| `pm list packages --user <id>` | Find installed packages during orphan cleanup | API 17 |
+| `pm uninstall [-k] [--user <id>]` | Remove an incompatible package before retrying installation | Base command predates the supported floor; `--user` requires API 17 multi-user support |
+| `am force-stop <package>` | Stop the app before replacing fast-deployment files | API 8 or earlier |
+| `am start-user -w <id>` | Ensure a secondary Android user is running before `run-as` | API 17 multi-user support |
+
+The orphan cleanup command additionally checks that each external utility is
+present before cleanup. Missing utilities, failed or empty `pm` output, `stat`
+failures, and `grep` errors all skip deletion. Only `grep` exit status `1`,
+meaning a definite non-match, permits an old staging directory to be removed.
+
+These estimates are based on the
+[AOSP shell and utility inventories][aosp-shell-utilities], the
+[Android 6.0 toybox build][aosp-marshmallow-toybox], the
+[Android 4.2 `pm --user` implementation][aosp-pm-user], and the
+[Android Debug Bridge documentation][adb-docs].
+
+[aosp-shell-utilities]: https://android.googlesource.com/platform/system/core/+/refs/heads/main/shell_and_utilities/README.md
+[aosp-marshmallow-toybox]: https://android.googlesource.com/platform/external/toybox/+/android-6.0.1_r81/Android.mk
+[aosp-pm-user]: https://android.googlesource.com/platform/frameworks/base/+/android-4.2_r1/cmds/pm/src/com/android/commands/pm/Pm.java
+[adb-docs]: https://developer.android.com/tools/adb

--- a/Documentation/guides/FastDeploy2.md
+++ b/Documentation/guides/FastDeploy2.md
@@ -23,9 +23,8 @@ properties intended for end users are:
 | `$(_AndroidFastDeployAppFileTransferMode)` | `Symlink` (for `FastDeploy2`) | How staged files are surfaced in the override directory: `Symlink` or `Copy`. |
 | `$(AndroidFastDeploymentAdbCompressionAlgorithm)` | `any` | The `adb push -z` compression algorithm. `FastDeploy2` relies on a modern Android SDK Platform-Tools `adb` for multi-file `push -z` support. |
 
-The following internal/unsupported properties tune batching. They exist mainly so
-the batching paths can be exercised with smaller batches while testing; their
-defaults match the matching task properties:
+The following internal/unsupported properties tune or disable implementation
+details:
 
 | Property | Default | Description |
 | --- | --- | --- |
@@ -33,6 +32,7 @@ defaults match the matching task properties:
 | `$(_AndroidFastDeployCopyBatchSize)` | `25` | Number of files copied per batch when staging fast-deployment files. |
 | `$(_AndroidFastDeployMaxShellCommandLength)` | `900` | Maximum length of a single `adb shell` command line before it is split. |
 | `$(_AndroidFastDeployMaxAdbCommandLength)` | `4096` | Maximum length of a single `adb` command line before it is split. |
+| `$(_AndroidFastDeploySkipCleanup)` | blank | Set to `true` to skip orphan staging cleanup. |
 
 ## On-device layout
 
@@ -46,6 +46,13 @@ defaults match the matching task properties:
   staging and override directories. It records the hash of the last successfully
   deployed manifest so the next build can detect whether the device is already up
   to date and skip redundant work.
+
+After installing or reinstalling an APK, FastDeploy2 checks for orphaned staging
+directories. In one `adb shell` command it enumerates staged
+`<package-name>/<user-id>` directories, compares them with
+`pm list packages --user <user-id>`, and removes directories for packages that
+are no longer installed. Incremental deployments that do not install the APK
+skip cleanup entirely.
 
 Changing `$(_AndroidFastDevStrategy)` or
 `$(_AndroidFastDeployAppFileTransferMode)` invalidates the deployment
@@ -196,3 +203,55 @@ Install failures are reported with `ADB####` codes; fast-deployment shell
 failures (`mkdir`/`rm`/`push`/`ln`) are reported with `XA0129`. `run-as`
 diagnostics map to `XA0131`–`XA0137`. See the
 [build/deploy message docs](../docs-mobile/messages/index.md) for details.
+
+## Command Compatibility
+
+.NET for Android supports Android 7.0 (API level 24) and later. FastDeploy2's
+device-side commands are available by Android 6.0 (API level 23), before the
+supported device floor. The API levels below are approximate because shell
+utilities are not Android SDK APIs.
+
+Host-side `adb` commands depend on the installed Android SDK Platform-Tools
+version rather than the device API level:
+
+| Command | FastDeploy2 use | Compatibility |
+| --- | --- | --- |
+| `adb devices`, `adb -s <device> shell ...` | Device selection and all device-side operations | Standard Platform-Tools commands |
+| `adb install -r -d [-t] [--user <id>]` | APK installation and replacement | Standard Platform-Tools command; `--user` corresponds to Android multi-user support introduced in API 17 |
+| `adb push -z <algorithm>` | Batched compressed staging-file upload | Modern Platform-Tools capability; not controlled by the device application API level |
+
+FastDeploy2 uses these device-side commands and shell features:
+
+| Command or shell feature | FastDeploy2 use | Approximate availability |
+| --- | --- | --- |
+| `sh`/mksh syntax, `[ ... ]`, `test`, `command -v`, `cd`, `pwd`, `echo`, globbing, command/parameter/arithmetic expansion, and redirection | Combined checks, override updates, and cleanup control flow | API 14; Android has used mksh since Android 4.0 |
+| `getprop` | Validate `run-as` compatibility properties | API 1 |
+| `run-as <package>` | Access the private data directory of a debuggable app | Early Android; availability alone is insufficient because the package must be debuggable and the device must permit `run-as` |
+| `su <user>` | Access files for a system application when adbd is not root | Not guaranteed on production devices; used only for the system-app fallback |
+| `cat`, `true`, `rm -f`, `rm -rf`, `mkdir -p`, `rmdir`, `cp -p`, and `ln -sf` | Read markers and manage staging/override files, copies, and symlinks | API 21 or earlier; supplied by toolbox/BSD utilities before toybox |
+| `readlink -f`, `whoami` | Resolve system-app paths and determine whether adbd is root | Reliably available by API 23 |
+| `pidof` | Find the running application process | Reliably available by API 23 |
+| `find -type f -exec stat ... {} +` and `stat -c` | Enumerate and compare staged and override files | API 23; supplied by toybox starting in Android 6.0 |
+| `printf %s` | Write manifest hash markers without a trailing newline | API 23; supplied by toybox starting in Android 6.0 |
+| `grep -Fqx` | Exact installed-package lookup during orphan cleanup | API 21 or earlier |
+| `pm list packages --user <id>` | Find installed packages during orphan cleanup | API 17 |
+| `pm uninstall [-k] [--user <id>]` | Remove an incompatible package before retrying installation | Base command predates the supported floor; `--user` requires API 17 multi-user support |
+| `am force-stop <package>` | Stop the app before replacing fast-deployment files | API 8 or earlier |
+| `am start-user -w <id>` | Ensure a secondary Android user is running before `run-as` | API 17 multi-user support |
+
+The orphan cleanup command additionally checks that each external utility is
+present before cleanup. Missing utilities, failed, empty, or malformed `pm`
+output, symlinked staging paths, and `grep` errors all skip deletion. Only
+`grep` exit status `1`, meaning a definite non-match, permits a staging
+directory to be removed.
+
+These estimates are based on the
+[AOSP shell and utility inventories][aosp-shell-utilities], the
+[Android 6.0 toybox build][aosp-marshmallow-toybox], the
+[Android 4.2 `pm --user` implementation][aosp-pm-user], and the
+[Android Debug Bridge documentation][adb-docs].
+
+[aosp-shell-utilities]: https://android.googlesource.com/platform/system/core/+/refs/heads/main/shell_and_utilities/README.md
+[aosp-marshmallow-toybox]: https://android.googlesource.com/platform/external/toybox/+/android-6.0.1_r81/Android.mk
+[aosp-pm-user]: https://android.googlesource.com/platform/frameworks/base/+/android-4.2_r1/cmds/pm/src/com/android/commands/pm/Pm.java
+[adb-docs]: https://developer.android.com/tools/adb

--- a/Documentation/guides/FastDeploy2.md
+++ b/Documentation/guides/FastDeploy2.md
@@ -33,6 +33,7 @@ details:
 | `$(_AndroidFastDeployMaxShellCommandLength)` | `900` | Maximum length of a single `adb shell` command line before it is split. |
 | `$(_AndroidFastDeployMaxAdbCommandLength)` | `4096` | Maximum length of a single `adb` command line before it is split. |
 | `$(_AndroidFastDeploySkipCleanup)` | blank | Set to `true` to skip orphan staging cleanup. |
+| `$(_AndroidFastDeployForceCleanup)` | blank | Set to `true` to run orphan staging cleanup on every install without the interval or age guards. |
 
 ## On-device layout
 

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.Manifest.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.Manifest.cs
@@ -14,8 +14,52 @@ namespace Xamarin.Android.Tasks
 	{
 		const string RemoteStagingRootPath = "/data/local/tmp/fastdeploy2";
 		const string ManifestHashMarker = ".fastdeploy2-manifest-hash";
+		const string CleanupMarker = ".last-orphan-cleanup";
+		const string CleanupLockDirectory = ".orphan-cleanup-lock";
+		const int CleanupIntervalSeconds = 24 * 60 * 60;
+		const int CleanupSafetyWindowSeconds = 24 * 60 * 60;
 
 		string RemoteStagingRoot => RemoteStagingRootPath;
+
+		async Task CleanupRemoteStagingDirectories ()
+		{
+			string command = CreateRemoteStagingCleanupCommand (
+				RemoteStagingRoot,
+				CleanupIntervalSeconds,
+				CleanupSafetyWindowSeconds);
+			AdbCommandResult result = await RunAdbShellCommand (command);
+			if (result.ExitCode != 0) {
+				LogDiagnostic ($"FastDeploy2 orphan staging cleanup failed and will be skipped. Output: {result.Output}");
+			} else if (!string.IsNullOrEmpty (result.StandardOutput)) {
+				LogDiagnostic (result.StandardOutput);
+			}
+		}
+
+		internal static string CreateRemoteStagingCleanupCommand (string remoteStagingRoot, int cleanupIntervalSeconds, int safetyWindowSeconds)
+		{
+			return string.Join ("; ", new [] {
+				$"root={QuoteShellArgument (remoteStagingRoot)}",
+				$"marker=\"$root/{CleanupMarker}\"",
+				$"lock=\"$root/{CleanupLockDirectory}\"",
+				"if [ ! -d \"$root\" ]; then echo 'FastDeploy2 orphan staging cleanup: no staging root'; exit 0; fi",
+				"for tool in date stat rm mkdir rmdir touch pm grep; do if ! command -v \"$tool\" >/dev/null 2>&1; then echo \"FastDeploy2 orphan staging cleanup: $tool unavailable\"; exit 0; fi; done",
+				"now=$(date +%s) || exit 1",
+				"last=$(stat -c %Y \"$marker\" 2>/dev/null || echo 0)",
+				$"if [ \"$((now - last))\" -lt {cleanupIntervalSeconds} ]; then echo 'FastDeploy2 orphan staging cleanup: already checked'; exit 0; fi",
+				"lock_time=$(stat -c %Y \"$lock\" 2>/dev/null || echo \"$now\")",
+				$"if [ -d \"$lock\" ] && [ \"$((now - lock_time))\" -ge {cleanupIntervalSeconds} ]; then rm -rf \"$lock\"; fi",
+				"if ! mkdir \"$lock\" 2>/dev/null; then echo 'FastDeploy2 orphan staging cleanup: already running'; exit 0; fi",
+				"trap 'rm -rf \"$lock\"' 0",
+				"last=$(stat -c %Y \"$marker\" 2>/dev/null || echo 0)",
+				$"if [ \"$((now - last))\" -lt {cleanupIntervalSeconds} ]; then echo 'FastDeploy2 orphan staging cleanup: already checked'; exit 0; fi",
+				"touch \"$marker\" || exit 1",
+				"removed=0",
+				"status=0",
+				$"for user_dir in \"$root\"/*/*; do [ -d \"$user_dir\" ] || continue; modified=$(stat -c %Y \"$user_dir\" 2>/dev/null) || {{ status=1; continue; }}; [ \"$((now - modified))\" -ge {safetyWindowSeconds} ] || continue; package_dir=${{user_dir%/*}}; package=${{package_dir##*/}}; user=${{user_dir##*/}}; case \"$user\" in ''|*[!0-9]*) continue ;; esac; packages_file=\"$lock/packages-$user\"; packages_failed=\"$packages_file.failed\"; if [ ! -f \"$packages_file\" ] && [ ! -f \"$packages_failed\" ]; then if ! pm list packages --user \"$user\" > \"$packages_file\" || [ ! -s \"$packages_file\" ]; then rm -f \"$packages_file\"; touch \"$packages_failed\"; status=1; fi; fi; [ -f \"$packages_failed\" ] && continue; grep -Fqx \"package:$package\" \"$packages_file\"; grep_status=$?; if [ \"$grep_status\" -eq 0 ]; then continue; fi; if [ \"$grep_status\" -ne 1 ]; then status=1; continue; fi; if rm -rf \"$user_dir\"; then rmdir \"$package_dir\" 2>/dev/null || true; removed=$((removed + 1)); else status=1; fi; done",
+				"echo \"FastDeploy2 orphan staging cleanup: removed $removed directories\"",
+				"exit \"$status\"",
+			});
+		}
 
 		async Task<bool> DeployFastDevFilesWithAdbPush (string overridePath, bool forceFreshDeployment = false)
 		{

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.Manifest.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.Manifest.cs
@@ -21,12 +21,12 @@ namespace Xamarin.Android.Tasks
 
 		string RemoteStagingRoot => RemoteStagingRootPath;
 
-		async Task CleanupRemoteStagingDirectories ()
+		async Task CleanupRemoteStagingDirectories (bool force)
 		{
 			string command = CreateRemoteStagingCleanupCommand (
 				RemoteStagingRoot,
-				CleanupIntervalSeconds,
-				CleanupSafetyWindowSeconds);
+				force ? 0 : CleanupIntervalSeconds,
+				force ? 0 : CleanupSafetyWindowSeconds);
 			AdbCommandResult result = await RunAdbShellCommand (command);
 			if (result.ExitCode != 0) {
 				LogDiagnostic ($"FastDeploy2 orphan staging cleanup failed and will be skipped. Output: {result.Output}");
@@ -35,7 +35,7 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		internal static string CreateRemoteStagingCleanupCommand (string remoteStagingRoot, int cleanupIntervalSeconds, int safetyWindowSeconds)
+		static string CreateRemoteStagingCleanupCommand (string remoteStagingRoot, int cleanupIntervalSeconds, int safetyWindowSeconds)
 		{
 			return string.Join ("; ", new [] {
 				$"root={QuoteShellArgument (remoteStagingRoot)}",
@@ -47,7 +47,7 @@ namespace Xamarin.Android.Tasks
 				"last=$(stat -c %Y \"$marker\" 2>/dev/null || echo 0)",
 				$"if [ \"$((now - last))\" -lt {cleanupIntervalSeconds} ]; then echo 'FastDeploy2 orphan staging cleanup: already checked'; exit 0; fi",
 				"lock_time=$(stat -c %Y \"$lock\" 2>/dev/null || echo \"$now\")",
-				$"if [ -d \"$lock\" ] && [ \"$((now - lock_time))\" -ge {cleanupIntervalSeconds} ]; then rm -rf \"$lock\"; fi",
+				$"if [ -d \"$lock\" ] && [ \"$((now - lock_time))\" -ge {CleanupIntervalSeconds} ]; then rm -rf \"$lock\"; fi",
 				"if ! mkdir \"$lock\" 2>/dev/null; then echo 'FastDeploy2 orphan staging cleanup: already running'; exit 0; fi",
 				"trap 'rm -rf \"$lock\"' 0",
 				"last=$(stat -c %Y \"$marker\" 2>/dev/null || echo 0)",

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.Manifest.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.Manifest.cs
@@ -17,6 +17,34 @@ namespace Xamarin.Android.Tasks
 
 		string RemoteStagingRoot => RemoteStagingRootPath;
 
+		async Task CleanupRemoteStagingDirectories ()
+		{
+			string command = CreateRemoteStagingCleanupCommand (RemoteStagingRoot);
+			if (command.Length >= MaxShellCommandLength) {
+				LogDiagnostic ($"FastDeploy2 orphan staging cleanup command length {command.Length} exceeds the configured maximum of {MaxShellCommandLength}; cleanup will be skipped.");
+				return;
+			}
+			AdbCommandResult result = await RunAdbShellCommand (command);
+			if (result.ExitCode != 0) {
+				LogDiagnostic ($"FastDeploy2 orphan staging cleanup failed and will be skipped. Output: {result.Output}");
+			} else if (!string.IsNullOrEmpty (result.StandardOutput)) {
+				LogDiagnostic (result.StandardOutput);
+			}
+		}
+
+		static string CreateRemoteStagingCleanupCommand (string remoteStagingRoot)
+		{
+			return string.Join ("; ", new [] {
+				$"r={QuoteShellArgument (remoteStagingRoot)}",
+				"[ -d \"$r\" ]&&[ ! -L \"$r\" ]||exit 0",
+				"for t in rm rmdir pm grep;do command -v \"$t\">/dev/null 2>&1||exit 0;done",
+				"n=0;s=0;u=''",
+				"for c in \"$r\"/*/*;do [ -d \"$c\" ]||continue;i=${c##*/};case \"$i\" in ''|*[!0-9]*)continue;;esac;case \" $u \" in *\" $i \"*)continue;;esac;u=\"$u $i\";p=$(pm list packages --user \"$i\");x=$?;if [ $x -ne 0 ]||[ -z \"$p\" ];then s=1;continue;fi;echo \"$p\"|grep -qv '^package:';[ $? -eq 1 ]||{ s=1;continue;};for d in \"$r\"/*/\"$i\";do [ -d \"$d\" ]||continue;q=${d%/*};a=${q##*/};echo \"$p\"|grep -Fqx \"package:$a\";x=$?;[ $x -eq 0 ]&&continue;if [ $x -ne 1 ];then s=1;continue;fi;if [ -L \"$r\" ]||[ -L \"$q\" ]||[ -L \"$d\" ];then s=1;continue;fi;if rm -rf \"$d\";then rmdir \"$q\" 2>/dev/null||true;n=$((n+1));else s=1;fi;done;done",
+				"echo \"FastDeploy2 orphan staging cleanup: removed $n directories\"",
+				"exit \"$s\"",
+			});
+		}
+
 		async Task<bool> DeployFastDevFilesWithAdbPush (string overridePath, bool forceFreshDeployment = false)
 		{
 			var files = PrepareDirectPushFiles ();

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
@@ -190,20 +190,16 @@ namespace Xamarin.Android.Tasks
 		async Task RunInstall ()
 		{
 			ManifestData previousManifest = LoadPreviousManifest ();
-			if (!FastDeploySkipCleanup && FastDeployForceCleanup) {
-				await CleanupRemoteStagingDirectories (force: true);
-			}
-
 			WarmStateProbeOutcome warmState = await TryRunWarmStateProbe (previousManifest);
 			if (warmState == WarmStateProbeOutcome.Failed) {
 				return;
 			}
 
-			if (!FastDeploySkipCleanup && !FastDeployForceCleanup && warmState != WarmStateProbeOutcome.Ready) {
-				await CleanupRemoteStagingDirectories (force: false);
-			}
-
 			if (warmState != WarmStateProbeOutcome.Ready) {
+				if (!FastDeploySkipCleanup) {
+					await CleanupRemoteStagingDirectories (force: FastDeployForceCleanup);
+				}
+
 				string redirectStdio = await GetDeviceProperty ("log.redirect-stdio");
 				if (string.Equals ("true", redirectStdio, StringComparison.OrdinalIgnoreCase)) {
 					LogFastDeploy2Error ("XA0128", Resources.XA0128_RedirectStdioIsEnabled);

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
@@ -62,6 +62,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool DiagnosticLogging { get; set; } = false;
 
+		public bool FastDeploySkipCleanup { get; set; } = false;
+
 		public string UserID { get; set; }
 
 		public bool IsTestOnly { get; set; }
@@ -210,12 +212,11 @@ namespace Xamarin.Android.Tasks
 				await RemoveOverrideDirectory ();
 			}
 
+			bool packageFileOutOfDate = !string.IsNullOrEmpty (PackageFile) &&
+				(packageInfo.InternalPath.IndexOf ("unknown", StringComparison.OrdinalIgnoreCase) >= 0 || ReInstall || IsPackageFileOutOfDate ());
 			if (ReInstall && !string.IsNullOrEmpty (PackageFile)) {
 				await UninstallPackage (PackageName, preserveData: PreserveUserData, user: UserID);
 			}
-
-			bool packageFileOutOfDate = !string.IsNullOrEmpty (PackageFile) &&
-				(packageInfo.InternalPath.IndexOf ("unknown", StringComparison.OrdinalIgnoreCase) >= 0 || ReInstall || IsPackageFileOutOfDate ());
 
 			if (packageFileOutOfDate) {
 				try {
@@ -223,6 +224,9 @@ namespace Xamarin.Android.Tasks
 				} catch (Exception ex) {
 					LogFastDeploy2Error (GetErrorCode (ex), ex.ToString ());
 					return;
+				}
+				if (!FastDeploySkipCleanup) {
+					await CleanupRemoteStagingDirectories ();
 				}
 				if (!EmbedAssembliesIntoApk && packageInfo.InternalPath.IndexOf ("unknown", StringComparison.OrdinalIgnoreCase) >= 0) {
 					packageInfo.InternalPath = null;

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
@@ -64,6 +64,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool FastDeploySkipCleanup { get; set; } = false;
 
+		public bool FastDeployForceCleanup { get; set; } = false;
+
 		public string UserID { get; set; }
 
 		public bool IsTestOnly { get; set; }
@@ -188,16 +190,20 @@ namespace Xamarin.Android.Tasks
 		async Task RunInstall ()
 		{
 			ManifestData previousManifest = LoadPreviousManifest ();
+			if (!FastDeploySkipCleanup && FastDeployForceCleanup) {
+				await CleanupRemoteStagingDirectories (force: true);
+			}
+
 			WarmStateProbeOutcome warmState = await TryRunWarmStateProbe (previousManifest);
 			if (warmState == WarmStateProbeOutcome.Failed) {
 				return;
 			}
 
-			if (warmState != WarmStateProbeOutcome.Ready) {
-				if (!FastDeploySkipCleanup) {
-					await CleanupRemoteStagingDirectories ();
-				}
+			if (!FastDeploySkipCleanup && !FastDeployForceCleanup && warmState != WarmStateProbeOutcome.Ready) {
+				await CleanupRemoteStagingDirectories (force: false);
+			}
 
+			if (warmState != WarmStateProbeOutcome.Ready) {
 				string redirectStdio = await GetDeviceProperty ("log.redirect-stdio");
 				if (string.Equals ("true", redirectStdio, StringComparison.OrdinalIgnoreCase)) {
 					LogFastDeploy2Error ("XA0128", Resources.XA0128_RedirectStdioIsEnabled);

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
@@ -62,6 +62,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool DiagnosticLogging { get; set; } = false;
 
+		public bool FastDeploySkipCleanup { get; set; } = false;
+
 		public string UserID { get; set; }
 
 		public bool IsTestOnly { get; set; }
@@ -185,12 +187,17 @@ namespace Xamarin.Android.Tasks
 
 		async Task RunInstall ()
 		{
-			WarmStateProbeOutcome warmState = await TryRunWarmStateProbe (LoadPreviousManifest ());
+			ManifestData previousManifest = LoadPreviousManifest ();
+			WarmStateProbeOutcome warmState = await TryRunWarmStateProbe (previousManifest);
 			if (warmState == WarmStateProbeOutcome.Failed) {
 				return;
 			}
 
 			if (warmState != WarmStateProbeOutcome.Ready) {
+				if (!FastDeploySkipCleanup) {
+					await CleanupRemoteStagingDirectories ();
+				}
+
 				string redirectStdio = await GetDeviceProperty ("log.redirect-stdio");
 				if (string.Equals ("true", redirectStdio, StringComparison.OrdinalIgnoreCase)) {
 					LogFastDeploy2Error ("XA0128", Resources.XA0128_RedirectStdioIsEnabled);

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Xamarin.Android.Common.Debugging.targets
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Xamarin.Android.Common.Debugging.targets
@@ -400,6 +400,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       MaxShellCommandLength="$(_AndroidFastDeployMaxShellCommandLength)"
       MaxAdbCommandLength="$(_AndroidFastDeployMaxAdbCommandLength)"
       FastDeploySkipCleanup="$(_AndroidFastDeploySkipCleanup)"
+      FastDeployForceCleanup="$(_AndroidFastDeployForceCleanup)"
     />
     <Touch Files="$(_UploadFlag)" AlwaysCreate="True" />
     <MakeDir Directories="$(_ConfigurationCacheDirectory)" Condition="!Exists('$(_ConfigurationCacheDirectory)')" />

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Xamarin.Android.Common.Debugging.targets
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Xamarin.Android.Common.Debugging.targets
@@ -399,6 +399,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       CopyBatchSize="$(_AndroidFastDeployCopyBatchSize)"
       MaxShellCommandLength="$(_AndroidFastDeployMaxShellCommandLength)"
       MaxAdbCommandLength="$(_AndroidFastDeployMaxAdbCommandLength)"
+      FastDeploySkipCleanup="$(_AndroidFastDeploySkipCleanup)"
     />
     <Touch Files="$(_UploadFlag)" AlwaysCreate="True" />
     <MakeDir Directories="$(_ConfigurationCacheDirectory)" Condition="!Exists('$(_ConfigurationCacheDirectory)')" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
@@ -161,6 +161,26 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsFalse (FastDeploy2.IsUnexpectedRemoteFilesystemError ("adb: error: device offline"));
 		}
 
+		[Test]
+		public void FastDeploy2CreatesOrphanStagingCleanupCommand ()
+		{
+			string command = FastDeploy2.CreateRemoteStagingCleanupCommand ("/data/local/tmp/fastdeploy2", 86400, 86400);
+
+			StringAssert.Contains ("command -v \"$tool\"", command);
+			StringAssert.Contains ("last=$(stat -c %Y \"$marker\"", command);
+			StringAssert.Contains ("mkdir \"$lock\"", command);
+			StringAssert.Contains ("modified=$(stat -c %Y \"$user_dir\"", command);
+			StringAssert.Contains ("pm list packages --user \"$user\"", command);
+			StringAssert.Contains ("packages_file=\"$lock/packages-$user\"", command);
+			StringAssert.Contains ("[ ! -s \"$packages_file\" ]", command);
+			StringAssert.Contains ("grep -Fqx \"package:$package\"", command);
+			StringAssert.Contains ("if [ \"$grep_status\" -ne 1 ]", command);
+			StringAssert.Contains ("rm -rf \"$user_dir\"", command);
+			StringAssert.Contains ("[ \"$((now - modified))\" -ge 86400 ]", command);
+			StringAssert.DoesNotContain ("printf", command);
+			Assert.Less (command.IndexOf ("touch \"$marker\"", StringComparison.Ordinal), command.IndexOf ("for user_dir", StringComparison.Ordinal));
+		}
+
 	}
 
 	/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
@@ -161,26 +161,6 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsFalse (FastDeploy2.IsUnexpectedRemoteFilesystemError ("adb: error: device offline"));
 		}
 
-		[Test]
-		public void FastDeploy2CreatesOrphanStagingCleanupCommand ()
-		{
-			string command = FastDeploy2.CreateRemoteStagingCleanupCommand ("/data/local/tmp/fastdeploy2", 86400, 86400);
-
-			StringAssert.Contains ("command -v \"$tool\"", command);
-			StringAssert.Contains ("last=$(stat -c %Y \"$marker\"", command);
-			StringAssert.Contains ("mkdir \"$lock\"", command);
-			StringAssert.Contains ("modified=$(stat -c %Y \"$user_dir\"", command);
-			StringAssert.Contains ("pm list packages --user \"$user\"", command);
-			StringAssert.Contains ("packages_file=\"$lock/packages-$user\"", command);
-			StringAssert.Contains ("[ ! -s \"$packages_file\" ]", command);
-			StringAssert.Contains ("grep -Fqx \"package:$package\"", command);
-			StringAssert.Contains ("if [ \"$grep_status\" -ne 1 ]", command);
-			StringAssert.Contains ("rm -rf \"$user_dir\"", command);
-			StringAssert.Contains ("[ \"$((now - modified))\" -ge 86400 ]", command);
-			StringAssert.DoesNotContain ("printf", command);
-			Assert.Less (command.IndexOf ("touch \"$marker\"", StringComparison.Ordinal), command.IndexOf ("for user_dir", StringComparison.Ordinal));
-		}
-
 	}
 
 	/// <summary>

--- a/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
@@ -321,6 +321,77 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		[Test]
+		public void FastDeploy2CleansOrphanStagingDirectoriesAfterApkInstall ()
+		{
+			string [] orphanDirectories = {
+				"/data/local/tmp/fastdeploy2/com.xamarin.fastdeploy2_cleanup_one/0",
+				"/data/local/tmp/fastdeploy2/com.xamarin.fastdeploy2_cleanup_two/0",
+			};
+			string incrementalOrphanDirectory = "/data/local/tmp/fastdeploy2/com.xamarin.fastdeploy2_cleanup_incremental/0";
+			string symlinkDirectory = "/data/local/tmp/fastdeploy2/com.xamarin.fastdeploy2_cleanup_symlink";
+			string symlinkTargetDirectory = "/data/local/tmp/fastdeploy2_cleanup_symlink_target/0";
+			var proj = new XamarinAndroidApplicationProject {
+				PackageName = "com.xamarin.fastdeploy2_cleanup",
+			};
+			proj.MainActivity = proj.DefaultMainActivity;
+			proj.SetDefaultTargetDevice ();
+			proj.SetProperty ("_AndroidFastDevStrategy", "FastDeploy2");
+			var installedProj = new XamarinAndroidApplicationProject {
+				PackageName = "com.xamarin.fastdeploy2_cleanup_installed",
+				ProjectName = "FastDeploy2CleanupInstalled",
+			};
+			installedProj.SetDefaultTargetDevice ();
+			string installedDirectory = $"/data/local/tmp/fastdeploy2/{installedProj.PackageName}/0";
+
+			using (var installedBuilder = CreateApkBuilder (Path.Combine ("temp", TestName, installedProj.ProjectName)))
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName, proj.ProjectName))) {
+				builder.Verbosity = LoggerVerbosity.Detailed;
+				try {
+					Assert.IsTrue (installedBuilder.Install (installedProj), "Installed-package fixture should have installed successfully.");
+					foreach (string directory in orphanDirectories) {
+						RunAdbCommand ($"shell mkdir -p {directory}");
+						RunAdbCommand ($"shell touch {directory}/orphan.txt");
+					}
+					RunAdbCommand ($"shell mkdir -p {installedDirectory}");
+					RunAdbCommand ($"shell touch {installedDirectory}/installed.txt");
+					RunAdbCommand ($"shell mkdir -p {symlinkTargetDirectory}");
+					RunAdbCommand ($"shell touch {symlinkTargetDirectory}/outside.txt");
+					RunAdbCommand ($"shell ln -s {Path.GetDirectoryName (symlinkTargetDirectory).Replace ('\\', '/')} {symlinkDirectory}");
+
+					Assert.IsTrue (builder.Install (proj), "FastDeploy2 install should have succeeded.");
+
+					foreach (string directory in orphanDirectories) {
+						Assert.AreEqual ("missing", RunAdbCommand ($"shell if test -e {directory}; then echo exists; else echo missing; fi").Trim (),
+							$"Orphan staging directory '{directory}' should have been deleted.");
+					}
+					Assert.AreEqual ("exists", RunAdbCommand ($"shell if test -f {installedDirectory}/installed.txt; then echo exists; else echo missing; fi").Trim (),
+						"Staging for an installed package should not be deleted.");
+					Assert.AreEqual ("exists", RunAdbCommand ($"shell if test -f {symlinkTargetDirectory}/outside.txt; then echo exists; else echo missing; fi").Trim (),
+						"Cleanup should not follow a symlinked package directory outside the staging root.");
+
+					RunAdbCommand ($"shell mkdir -p {incrementalOrphanDirectory}");
+					RunAdbCommand ($"shell touch {incrementalOrphanDirectory}/orphan.txt");
+					proj.MainActivity = proj.MainActivity.Replace ("clicks", "CLICKS");
+					proj.Touch ("MainActivity.cs");
+					Assert.IsTrue (builder.Install (proj, doNotCleanupOnUpdate: true, saveProject: false), "Incremental FastDeploy2 install should have succeeded.");
+					Assert.IsFalse (builder.Output.IsApkInstalled, "The APK should not have been reinstalled.");
+					Assert.AreEqual ("exists", RunAdbCommand ($"shell if test -f {incrementalOrphanDirectory}/orphan.txt; then echo exists; else echo missing; fi").Trim (),
+						"Cleanup should not run during an incremental deployment that skips APK installation.");
+				} finally {
+					foreach (string directory in orphanDirectories) {
+						RunAdbCommand ($"shell rm -rf {directory}");
+					}
+					RunAdbCommand ($"shell rm -rf {installedDirectory}");
+					RunAdbCommand ($"shell rm -rf {incrementalOrphanDirectory}");
+					RunAdbCommand ($"shell rm -rf {symlinkDirectory}");
+					RunAdbCommand ($"shell rm -rf {Path.GetDirectoryName (symlinkTargetDirectory).Replace ('\\', '/')}");
+					builder.Uninstall (proj);
+					installedBuilder.Uninstall (installedProj);
+				}
+			}
+		}
+
 		string GetOverrideFileKind (string packageName, string path)
 		{
 			return RunAdbCommand ($"shell run-as {packageName} sh -c 'if test -L {path}; then echo symlink; elif test -f {path}; then echo regular; else echo missing; fi'").Trim ();

--- a/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
@@ -321,6 +321,35 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		[Test]
+		public void FastDeploy2CleansOrphanStagingDirectory ()
+		{
+			const string orphanPackageName = "com.xamarin.fastdeploy2_cleanup_orphan";
+			string orphanDirectory = $"/data/local/tmp/fastdeploy2/{orphanPackageName}/0";
+			string orphanFile = $"{orphanDirectory}/orphan.txt";
+			var proj = new XamarinAndroidApplicationProject {
+				PackageName = "com.xamarin.fastdeploy2_cleanup",
+			};
+			proj.SetDefaultTargetDevice ();
+			proj.SetProperty ("_AndroidFastDevStrategy", "FastDeploy2");
+			proj.SetProperty ("_AndroidFastDeployForceCleanup", "true");
+
+			using (var builder = CreateApkBuilder ()) {
+				try {
+					RunAdbCommand ($"shell mkdir -p {orphanDirectory}");
+					RunAdbCommand ($"shell touch {orphanFile}");
+					Assert.AreEqual ("exists", RunAdbCommand ($"shell if test -f {orphanFile}; then echo exists; else echo missing; fi").Trim ());
+
+					Assert.IsTrue (builder.Install (proj), "FastDeploy2 install should have succeeded.");
+
+					Assert.AreEqual ("missing", RunAdbCommand ($"shell if test -e {orphanDirectory}; then echo exists; else echo missing; fi").Trim ());
+				} finally {
+					RunAdbCommand ($"shell rm -rf {orphanDirectory}");
+					builder.Uninstall (proj);
+				}
+			}
+		}
+
 		string GetOverrideFileKind (string packageName, string path)
 		{
 			return RunAdbCommand ($"shell run-as {packageName} sh -c 'if test -L {path}; then echo symlink; elif test -f {path}; then echo regular; else echo missing; fi'").Trim ();


### PR DESCRIPTION
## Summary

- remove `/data/local/tmp/fastdeploy2/<package>/<user>` staging directories when the package is definitely no longer installed for that Android user
- run cleanup after every successful APK install/reinstall, while skipping managed-only incremental deployments
- query installed packages once per user and fail closed on missing tools, failed, empty, or malformed `pm` output, and ambiguous `grep` results
- reject symlinked staging roots, package directories, and user directories before deletion
- keep the cleanup command below and explicitly enforce `$(_AndroidFastDeployMaxShellCommandLength)`
- retain private `$(_AndroidFastDeploySkipCleanup)` as an escape hatch
- add an `MSBuildDeviceIntegration` test covering orphan deletion, installed-package retention, symlink confinement, and cleanup skipping on a managed-only incremental deployment
- document FastDeploy2 commands and approximate Android API support

## Validation

- built `Xamarin.Android.Build.Debugging.Tasks.csproj`
- validated the generated 837-character cleanup command with shell syntax checking
- validated `Xamarin.Android.Common.Debugging.targets` as XML
- reproduced the previous root/package symlink traversal on an attached API 37 device and verified the guarded command retains the outside sentinel while deleting a real orphan
- verified malformed status-0 package output retains staging and fails closed on the attached device

The full device integration test requires the repository's .NET 11 local SDK, which is not available in this worktree.