### PR TITLE
[Mono.Android] Deprecate removed constructors

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1133,6 +1133,14 @@
     The problem with this is that our tooling doesn't have any real support for stating that
     a method was removed; api-merge assumes that once an API is added, it's present for ALL TIME.
     -->
+  <!-- These constructors were removed before the minimum supported Android API level. -->
+  <attr path="/api/package[@name='android.util']/class[@name='Config' or @name='DebugUtils' or @name='EventLog' or @name='StateSet' or @name='TimeUtils' or @name='Xml']/constructor[(@visibility='public' or @visibility='protected') and count(parameter)=0]" name="deprecated">This constructor was removed in Android API level 15.</attr>
+  <attr path="/api/package[@name='android.webkit']/class[@name='Plugin' or @name='PluginList' or @name='UrlInterceptRegistry']/constructor[@visibility='public' or @visibility='protected']" name="deprecated">This constructor was removed in Android API level 15.</attr>
+  <attr path="/api/package[@name='android.webkit']/class[@name='GeolocationPermissions' or @name='WebStorage']/constructor[(@visibility='public' or @visibility='protected') and count(parameter)=0]" name="deprecated">This constructor was removed in Android API level 16.</attr>
+  <attr path="/api/package[@name='android.webkit']/class[@name='CacheManager']/constructor[(@visibility='public' or @visibility='protected') and count(parameter)=0]" name="deprecated">This constructor was removed in Android API level 17.</attr>
+  <attr path="/api/package[@name='android.media']/class[@name='AudioFormat']/constructor[(@visibility='public' or @visibility='protected') and count(parameter)=0]" name="deprecated">This constructor was removed in Android API level 21.</attr>
+  <attr path="/api/package[@name='android.os']/class[@name='BatteryManager' or @name='RecoverySystem']/constructor[(@visibility='public' or @visibility='protected') and count(parameter)=0]" name="deprecated">This constructor was removed in Android API level 23.</attr>
+
   <!-- View.fitsSystemWindows() was removed from docs/android.jar, but still appears to exist on-device. -->
   <attr api-since="14" path="/api/package[@name='android.view']/class[@name='View']/method[@name='fitsSystemWindows' and count(parameters)=0]"
       name="managedName"


### PR DESCRIPTION
Mark the 11 bound constructors that Android removed before the current minimum supported API level as obsolete.

The current API profile was rescanned through API level 24; no additional public or protected constructors require this treatment.

Closes #5172