### PR TITLE
[java-runtime] Improve native library load diagnostics

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/JavaInteropRuntime.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/JavaInteropRuntime.java
@@ -1,11 +1,13 @@
 package net.dot.jni.nativeaot;
 
 import android.util.Log;
+import android.content.Context;
+import mono.NativeLibraryHelper;
 
 public class JavaInteropRuntime {
-    static {
+    public static void loadLibrary(Context context) {
         Log.d("JavaInteropRuntime", "Loading @MAIN_ASSEMBLY_NAME@.so...");
-        System.loadLibrary("@MAIN_ASSEMBLY_NAME@");
+        NativeLibraryHelper.loadLibrary("@MAIN_ASSEMBLY_NAME@", context);
     }
 
     private JavaInteropRuntime() {

--- a/src/Xamarin.Android.Build.Tasks/Resources/NativeAotRuntimeProvider.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/NativeAotRuntimeProvider.java
@@ -36,6 +36,7 @@ public class NativeAotRuntimeProvider
         String cacheDir = context.getCacheDir().getAbsolutePath();
 
         // Initialize .NET runtime
+        JavaInteropRuntime.loadLibrary(context);
         JavaInteropRuntime.init(loader, language, filesDir, cacheDir);
         // NOTE: only required for custom applications
         ApplicationRegistration.registerApplications();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.R8.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.R8.apkdesc
@@ -5,7 +5,7 @@
       "Size": 6652
     },
     "classes.dex": {
-      "Size": 3240220
+      "Size": 3242876
     },
     "kotlin/annotation/annotation.kotlin_builtins": {
       "Size": 928
@@ -29,31 +29,31 @@
       "Size": 2396
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 11217040
+      "Size": 11415872
     },
     "lib/arm64-v8a/libclrjit.so": {
-      "Size": 2761136
+      "Size": 2788736
     },
     "lib/arm64-v8a/libcoreclr.so": {
-      "Size": 4839560
+      "Size": 4841976
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 1184912
+      "Size": 1184800
     },
     "lib/arm64-v8a/libSystem.Globalization.Native.so": {
       "Size": 72432
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
-      "Size": 1258776
+      "Size": 1259088
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 99776
+      "Size": 99792
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 169768
+      "Size": 171584
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 119656
+      "Size": 119776
     },
     "META-INF/androidx.activity_activity.version": {
       "Size": 6

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -99,19 +99,19 @@ public class MonoPackageManager {
 				// below, leading to an error locating the Mono runtime
 				//
 				if (BuildConfig.Debug) {
-					System.loadLibrary ("xamarin-debug-app-helper");
+					NativeLibraryHelper.loadLibrary ("xamarin-debug-app-helper", runtimePackage, apks);
 					DebugRuntime.init (apks, runtimeDir, appDirs, haveSplitApks);
 				} else {
-					System.loadLibrary("monosgen-2.0");
+					NativeLibraryHelper.loadLibrary ("monosgen-2.0", runtimePackage, apks);
 				}
-				System.loadLibrary("xamarin-app");
+				NativeLibraryHelper.loadLibrary ("xamarin-app", runtimePackage, apks);
 
 				if (!BuildConfig.DotNetRuntime) {
 					// .net5+ APKs don't contain `libmono-native.so`
-					System.loadLibrary("mono-native");
+					NativeLibraryHelper.loadLibrary ("mono-native", runtimePackage, apks);
 				}
 
-				System.loadLibrary("monodroid");
+				NativeLibraryHelper.loadLibrary ("monodroid", runtimePackage, apks);
 
 				Runtime.initInternal (
 						language,

--- a/src/java-runtime/java/mono/android/NativeLibraryHelper.java
+++ b/src/java-runtime/java/mono/android/NativeLibraryHelper.java
@@ -1,0 +1,149 @@
+package mono;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.os.Build;
+import android.util.Log;
+
+public final class NativeLibraryHelper {
+	static final String TAG = "monodroid";
+
+	private NativeLibraryHelper ()
+	{
+	}
+
+	public static void loadLibrary (String libraryName, Context context)
+	{
+		ApplicationInfo applicationInfo = context.getApplicationInfo ();
+		String[] splitApks = applicationInfo.splitSourceDirs;
+		String[] apks;
+		if (splitApks != null && splitApks.length > 0) {
+			apks = new String [splitApks.length + 1];
+			apks [0] = applicationInfo.sourceDir;
+			System.arraycopy (splitApks, 0, apks, 1, splitApks.length);
+		} else {
+			apks = new String [] { applicationInfo.sourceDir };
+		}
+
+		loadLibrary (libraryName, applicationInfo, apks);
+	}
+
+	static void loadLibrary (String libraryName, ApplicationInfo applicationInfo, String[] apks)
+	{
+		try {
+			System.loadLibrary (libraryName);
+		} catch (UnsatisfiedLinkError cause) {
+			String diagnosticMessage = getDiagnosticMessage (libraryName, applicationInfo, apks, cause);
+			Log.e (TAG, diagnosticMessage, cause);
+
+			UnsatisfiedLinkError error = new UnsatisfiedLinkError (diagnosticMessage);
+			error.initCause (cause);
+			throw error;
+		} catch (SecurityException cause) {
+			String diagnosticMessage = getDiagnosticMessage (libraryName, applicationInfo, apks, cause);
+			Log.e (TAG, diagnosticMessage, cause);
+			throw new SecurityException (diagnosticMessage, cause);
+		}
+	}
+
+	static String getDiagnosticMessage (String libraryName, ApplicationInfo applicationInfo, String[] apks, Throwable cause)
+	{
+		String mappedLibraryName = System.mapLibraryName (libraryName);
+		StringBuilder message = new StringBuilder ();
+		message.append ("Failed to load native library '").append (mappedLibraryName).append ("'.");
+		message.append (" Supported ABIs: ").append (Arrays.toString (Build.SUPPORTED_ABIS)).append (".");
+
+		boolean foundLibrary = appendNativeLibraryDirectoryDiagnostics (message, applicationInfo.nativeLibraryDir, mappedLibraryName);
+		foundLibrary |= appendApkDiagnostics (message, apks, mappedLibraryName);
+
+		if (!foundLibrary) {
+			message.append (" The library was not found in the native library directory or any application APK that could be inspected.");
+			message.append (" The application installation may be corrupt; reinstalling the application may fix this error.");
+		}
+
+		String causeMessage = cause.getMessage ();
+		if (causeMessage != null && causeMessage.length () > 0) {
+			message.append (" Original error: ").append (causeMessage);
+		}
+
+		return message.toString ();
+	}
+
+	static boolean appendNativeLibraryDirectoryDiagnostics (StringBuilder message, String nativeLibraryDir, String mappedLibraryName)
+	{
+		message.append (" Native library directory: ");
+		if (nativeLibraryDir == null) {
+			message.append ("<unknown>.");
+			return false;
+		}
+
+		File directory = new File (nativeLibraryDir);
+		File library = new File (directory, mappedLibraryName);
+		boolean libraryExists = library.isFile ();
+		message.append ('\'').append (nativeLibraryDir).append ('\'');
+		message.append (" (directory exists: ").append (directory.isDirectory ());
+		message.append (", library exists: ").append (libraryExists);
+		if (libraryExists) {
+			message.append (", library size: ").append (library.length ());
+			message.append (", library readable: ").append (library.canRead ());
+		}
+		message.append (").");
+		return libraryExists;
+	}
+
+	static boolean appendApkDiagnostics (StringBuilder message, String[] apks, String mappedLibraryName)
+	{
+		boolean foundLibrary = false;
+		message.append (" APKs:");
+		if (apks == null || apks.length == 0) {
+			message.append (" <none>.");
+			return false;
+		}
+
+		for (String apk : apks) {
+			message.append (" '").append (apk).append ("'");
+			if (apk == null) {
+				message.append (" (invalid path);");
+				continue;
+			}
+
+			File apkFile = new File (apk);
+			if (!apkFile.isFile ()) {
+				message.append (" (file exists: false);");
+				continue;
+			}
+
+			ArrayList<String> entries = new ArrayList<String> ();
+			try (ZipFile zip = new ZipFile (apkFile)) {
+				for (String abi : Build.SUPPORTED_ABIS) {
+					String entryName = "lib/" + abi + "/" + mappedLibraryName;
+					ZipEntry entry = zip.getEntry (entryName);
+					if (entry == null)
+						continue;
+
+					foundLibrary = true;
+					String storage = entry.getMethod () == ZipEntry.STORED ? "stored" : "compressed";
+					entries.add (abi + ", " + storage + ", size " + entry.getSize ());
+				}
+				if (entries.size () == 0)
+					message.append (" (contains no matching native libraries);");
+				else
+					message.append (" (contains: ").append (entries).append (");");
+			} catch (IOException | SecurityException e) {
+				message.append (" (could not inspect: ").append (e.getClass ().getSimpleName ());
+				String errorMessage = e.getMessage ();
+				if (errorMessage != null && errorMessage.length () > 0)
+					message.append (": ").append (errorMessage);
+				message.append (");");
+			}
+		}
+
+		return foundLibrary;
+	}
+}

--- a/src/java-runtime/java/mono/android/clr/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/clr/MonoPackageManager.java
@@ -70,7 +70,7 @@ public class MonoPackageManager {
 				String[] appDirs = new String[] {filesDir, cacheDir, dataDir, codeCacheDir};
 				boolean haveSplitApks = runtimePackage.splitSourceDirs != null && runtimePackage.splitSourceDirs.length > 0;
 
-				System.loadLibrary("monodroid");
+				NativeLibraryHelper.loadLibrary ("monodroid", runtimePackage, apks);
 
 				Runtime.initInternal (
 					language,

--- a/tests/MSBuildDeviceIntegration/Tests/NativeLibraryLoadTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/NativeLibraryLoadTests.cs
@@ -36,9 +36,9 @@ public class NativeLibraryLoadTests : DeviceTest
 			libraryName = $"lib{proj.ProjectName}.so";
 			removeLibraryItems = $@"
 			<FrameworkNativeLibrary Remove=""@(FrameworkNativeLibrary)""
-				Condition="" '%(FrameworkNativeLibrary.ArchiveFileName)' == '{libraryName}' or '%(FrameworkNativeLibrary.FileName)%(FrameworkNativeLibrary.Extension)' == '{proj.ProjectName}.so' "" />
+				Condition="" '%(FrameworkNativeLibrary.ArchiveFileName)' == '{libraryName}' or '%(FrameworkNativeLibrary.FileName)%(FrameworkNativeLibrary.Extension)' == '{libraryName}' "" />
 			<_ApplicationSharedLibrary Remove=""@(_ApplicationSharedLibrary)""
-				Condition="" '%(_ApplicationSharedLibrary.ArchiveFileName)' == '{libraryName}' or '%(_ApplicationSharedLibrary.FileName)%(_ApplicationSharedLibrary.Extension)' == '{proj.ProjectName}.so' "" />";
+				Condition="" '%(_ApplicationSharedLibrary.ArchiveFileName)' == '{libraryName}' or '%(_ApplicationSharedLibrary.FileName)%(_ApplicationSharedLibrary.Extension)' == '{libraryName}' "" />";
 		} else {
 			libraryName = "libmonodroid.so";
 			removeLibraryItems = @"

--- a/tests/MSBuildDeviceIntegration/Tests/NativeLibraryLoadTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/NativeLibraryLoadTests.cs
@@ -6,50 +6,50 @@ using NUnit.Framework;
 using Xamarin.Android.Tasks;
 using Xamarin.ProjectTools;
 
-namespace Xamarin.Android.Build.Tests
+namespace Xamarin.Android.Build.Tests;
+
+[TestFixture]
+[Category ("UsesDevice")]
+public class NativeLibraryLoadTests : DeviceTest
 {
-	[TestFixture]
-	[Category ("UsesDevice")]
-	public class NativeLibraryLoadTests : DeviceTest
+	[Test]
+	public void MissingNativeLibraryHasUsefulErrorMessage ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 	{
-		[Test]
-		public void MissingNativeLibraryHasUsefulErrorMessage ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
-		{
-			bool isRelease = runtime == AndroidRuntime.NativeAOT;
-			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
-				return;
-			}
+		bool isRelease = runtime == AndroidRuntime.NativeAOT;
+		if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
+			return;
+		}
 
-			var proj = new XamarinAndroidApplicationProject (
-				packageName: PackageUtils.MakePackageName (runtime, "missingnativelibrary")
-			) {
-				IsRelease = isRelease,
-				ProjectName = "MissingNativeLibrary",
-			};
-			proj.SetRuntime (runtime);
-			proj.SetRuntimeIdentifiers (new [] { DeviceAbi });
-			proj.SetDefaultTargetDevice ();
+		var proj = new XamarinAndroidApplicationProject (
+			packageName: PackageUtils.MakePackageName (runtime, "missingnativelibrary")
+		) {
+			IsRelease = isRelease,
+			ProjectName = "MissingNativeLibrary",
+		};
+		proj.SetRuntime (runtime);
+		proj.SetRuntimeIdentifiers (new [] { DeviceAbi });
+		proj.SetDefaultTargetDevice ();
 
-			string libraryName;
-			string removeLibraryItems;
-			if (runtime == AndroidRuntime.NativeAOT) {
-				libraryName = $"lib{proj.ProjectName}.so";
-				removeLibraryItems = $@"
+		string libraryName;
+		string removeLibraryItems;
+		if (runtime == AndroidRuntime.NativeAOT) {
+			libraryName = $"lib{proj.ProjectName}.so";
+			removeLibraryItems = $@"
 			<FrameworkNativeLibrary Remove=""@(FrameworkNativeLibrary)""
 				Condition="" '%(FrameworkNativeLibrary.ArchiveFileName)' == '{libraryName}' or '%(FrameworkNativeLibrary.FileName)%(FrameworkNativeLibrary.Extension)' == '{proj.ProjectName}.so' "" />
 			<_ApplicationSharedLibrary Remove=""@(_ApplicationSharedLibrary)""
 				Condition="" '%(_ApplicationSharedLibrary.ArchiveFileName)' == '{libraryName}' or '%(_ApplicationSharedLibrary.FileName)%(_ApplicationSharedLibrary.Extension)' == '{proj.ProjectName}.so' "" />";
-			} else {
-				libraryName = "libmonodroid.so";
-				removeLibraryItems = @"
+		} else {
+			libraryName = "libmonodroid.so";
+			removeLibraryItems = @"
 			<FrameworkNativeLibrary Remove=""@(FrameworkNativeLibrary)""
 				Condition="" '%(FrameworkNativeLibrary.ArchiveFileName)' == 'libmonodroid.so' or '%(FrameworkNativeLibrary.FileName)%(FrameworkNativeLibrary.Extension)' == 'libmonodroid.so' "" />
 			<_ApplicationSharedLibrary Remove=""@(_ApplicationSharedLibrary)""
 				Condition="" '%(_ApplicationSharedLibrary.ArchiveFileName)' == 'libmonodroid.so' or '%(_ApplicationSharedLibrary.FileName)%(_ApplicationSharedLibrary.Extension)' == 'libmonodroid.so' "" />";
-			}
+		}
 
-			proj.Imports.Add (new Import (() => "Directory.Build.targets") {
-				TextContent = () => $"""
+		proj.Imports.Add (new Import (() => "Directory.Build.targets") {
+			TextContent = () => $"""
 <Project>
 	<Target Name="_RemoveNativeLibraryForTest" BeforeTargets="_BuildApkEmbed">
 		<ItemGroup>
@@ -58,41 +58,40 @@ namespace Xamarin.Android.Build.Tests
 	</Target>
 </Project>
 """
-			});
+		});
 
-			using var builder = CreateApkBuilder ();
-			Assert.IsTrue (builder.Install (proj), "Project should have installed.");
+		using var builder = CreateApkBuilder ();
+		Assert.IsTrue (builder.Install (proj), "Project should have installed.");
 
-			string outputDirectory = Path.Combine (Root, builder.ProjectDirectory, proj.OutputPath);
-			string[] apks = Directory.GetFiles (outputDirectory, $"{proj.PackageName}-Signed.apk", SearchOption.AllDirectories);
-			Assert.IsNotEmpty (apks, "The signed APK should exist.");
-			using (var apk = ZipHelper.OpenZip (apks [0])) {
-				Assert.IsFalse (apk.ContainsEntry ($"lib/{DeviceAbi}/{libraryName}"),
-					$"{libraryName} should have been removed from the APK.");
-			}
-
-			var expectedMessages = new HashSet<string> {
-				$"Failed to load native library '{libraryName}'.",
-				"Supported ABIs:",
-				"Native library directory:",
-				"library exists: false",
-				"APKs:",
-				"contains no matching native libraries",
-				"The application installation may be corrupt; reinstalling the application may fix this error.",
-			};
-			string logcatPath = Path.Combine (Root, builder.ProjectDirectory, "native-library-load.log");
-			bool foundDiagnostic = MonitorAdbLogcat (
-				line => {
-					expectedMessages.RemoveWhere (message => line.Contains (message, StringComparison.Ordinal));
-					return expectedMessages.Count == 0;
-				},
-				logcatPath,
-				timeout: 45,
-				onMonitoringStarted: () => AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity")
-			);
-
-			Assert.IsTrue (foundDiagnostic,
-				$"The native library diagnostic was incomplete. Missing: {string.Join (", ", expectedMessages)}");
+		string outputDirectory = Path.Combine (Root, builder.ProjectDirectory, proj.OutputPath);
+		string[] apks = Directory.GetFiles (outputDirectory, $"{proj.PackageName}-Signed.apk", SearchOption.AllDirectories);
+		Assert.IsNotEmpty (apks, "The signed APK should exist.");
+		using (var apk = ZipHelper.OpenZip (apks [0])) {
+			Assert.IsFalse (apk.ContainsEntry ($"lib/{DeviceAbi}/{libraryName}"),
+				$"{libraryName} should have been removed from the APK.");
 		}
+
+		var expectedMessages = new HashSet<string> {
+			$"Failed to load native library '{libraryName}'.",
+			"Supported ABIs:",
+			"Native library directory:",
+			"library exists: false",
+			"APKs:",
+			"contains no matching native libraries",
+			"The application installation may be corrupt; reinstalling the application may fix this error.",
+		};
+		string logcatPath = Path.Combine (Root, builder.ProjectDirectory, "native-library-load.log");
+		bool foundDiagnostic = MonitorAdbLogcat (
+			line => {
+				expectedMessages.RemoveWhere (message => line.Contains (message, StringComparison.Ordinal));
+				return expectedMessages.Count == 0;
+			},
+			logcatPath,
+			timeout: 45,
+			onMonitoringStarted: () => AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity")
+		);
+
+		Assert.IsTrue (foundDiagnostic,
+			$"The native library diagnostic was incomplete. Missing: {string.Join (", ", expectedMessages)}");
 	}
 }

--- a/tests/MSBuildDeviceIntegration/Tests/NativeLibraryLoadTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/NativeLibraryLoadTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	[Category ("UsesDevice")]
+	public class NativeLibraryLoadTests : DeviceTest
+	{
+		[Test]
+		public void MissingNativeLibraryHasUsefulErrorMessage ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
+		{
+			bool isRelease = runtime == AndroidRuntime.NativeAOT;
+			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject (
+				packageName: PackageUtils.MakePackageName (runtime, "missingnativelibrary")
+			) {
+				IsRelease = isRelease,
+				ProjectName = "MissingNativeLibrary",
+			};
+			proj.SetRuntime (runtime);
+			proj.SetRuntimeIdentifiers (new [] { DeviceAbi });
+			proj.SetDefaultTargetDevice ();
+
+			string libraryName;
+			string removeLibraryItems;
+			if (runtime == AndroidRuntime.NativeAOT) {
+				libraryName = $"lib{proj.ProjectName}.so";
+				removeLibraryItems = $@"
+			<FrameworkNativeLibrary Remove=""@(FrameworkNativeLibrary)""
+				Condition="" '%(FrameworkNativeLibrary.ArchiveFileName)' == '{libraryName}' or '%(FrameworkNativeLibrary.FileName)%(FrameworkNativeLibrary.Extension)' == '{proj.ProjectName}.so' "" />
+			<_ApplicationSharedLibrary Remove=""@(_ApplicationSharedLibrary)""
+				Condition="" '%(_ApplicationSharedLibrary.ArchiveFileName)' == '{libraryName}' or '%(_ApplicationSharedLibrary.FileName)%(_ApplicationSharedLibrary.Extension)' == '{proj.ProjectName}.so' "" />";
+			} else {
+				libraryName = "libmonodroid.so";
+				removeLibraryItems = @"
+			<FrameworkNativeLibrary Remove=""@(FrameworkNativeLibrary)""
+				Condition="" '%(FrameworkNativeLibrary.ArchiveFileName)' == 'libmonodroid.so' or '%(FrameworkNativeLibrary.FileName)%(FrameworkNativeLibrary.Extension)' == 'libmonodroid.so' "" />
+			<_ApplicationSharedLibrary Remove=""@(_ApplicationSharedLibrary)""
+				Condition="" '%(_ApplicationSharedLibrary.ArchiveFileName)' == 'libmonodroid.so' or '%(_ApplicationSharedLibrary.FileName)%(_ApplicationSharedLibrary.Extension)' == 'libmonodroid.so' "" />";
+			}
+
+			proj.Imports.Add (new Import (() => "Directory.Build.targets") {
+				TextContent = () => $"""
+<Project>
+	<Target Name="_RemoveNativeLibraryForTest" BeforeTargets="_BuildApkEmbed">
+		<ItemGroup>
+			{removeLibraryItems}
+		</ItemGroup>
+	</Target>
+</Project>
+"""
+			});
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Install (proj), "Project should have installed.");
+
+			string outputDirectory = Path.Combine (Root, builder.ProjectDirectory, proj.OutputPath);
+			string[] apks = Directory.GetFiles (outputDirectory, $"{proj.PackageName}-Signed.apk", SearchOption.AllDirectories);
+			Assert.IsNotEmpty (apks, "The signed APK should exist.");
+			using (var apk = ZipHelper.OpenZip (apks [0])) {
+				Assert.IsFalse (apk.ContainsEntry ($"lib/{DeviceAbi}/{libraryName}"),
+					$"{libraryName} should have been removed from the APK.");
+			}
+
+			var expectedMessages = new HashSet<string> {
+				$"Failed to load native library '{libraryName}'.",
+				"Supported ABIs:",
+				"Native library directory:",
+				"library exists: false",
+				"APKs:",
+				"contains no matching native libraries",
+				"The application installation may be corrupt; reinstalling the application may fix this error.",
+			};
+			string logcatPath = Path.Combine (Root, builder.ProjectDirectory, "native-library-load.log");
+			bool foundDiagnostic = MonitorAdbLogcat (
+				line => {
+					expectedMessages.RemoveWhere (message => line.Contains (message, StringComparison.Ordinal));
+					return expectedMessages.Count == 0;
+				},
+				logcatPath,
+				timeout: 45,
+				onMonitoringStarted: () => AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity")
+			);
+
+			Assert.IsTrue (foundDiagnostic,
+				$"The native library diagnostic was incomplete. Missing: {string.Join (", ", expectedMessages)}");
+		}
+	}
+}

--- a/tests/MSBuildDeviceIntegration/Tests/NativeLibraryLoadTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/NativeLibraryLoadTests.cs
@@ -80,6 +80,7 @@ public class NativeLibraryLoadTests : DeviceTest
 			"contains no matching native libraries",
 			"The application installation may be corrupt; reinstalling the application may fix this error.",
 		};
+		ClearAdbLogcat ();
 		string logcatPath = Path.Combine (Root, builder.ProjectDirectory, "native-library-load.log");
 		bool foundDiagnostic = MonitorAdbLogcat (
 			line => {


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [x] Unit tests

## Description

Native library startup failures currently provide too little information to diagnose corrupt, incomplete, or incorrectly split installations.

Route MonoVM, CoreCLR, and NativeAOT startup library loads through a shared helper. When loading fails, the resulting exception and logcat entry identify the requested library, supported ABIs, extracted native-library state, APK and split contents, and the original linker error. If the library is absent from all inspected locations, the message explains that reinstalling may repair a corrupt installation.

Add an MSBuildDeviceIntegration test which removes the real startup library from CoreCLR and NativeAOT APKs, verifies that it is absent from the package, and asserts the improved diagnostic in logcat.

## Testing

- `src/java-runtime/java-runtime.csproj` builds successfully for all runtime JAR variants.
- The generated NativeAOT Java bootstrap compiles against `java_runtime_trimmable.jar`.
- The new device test was not run locally because the local .NET for Android SDK was unavailable and the full repository build was skipped.

Fixes #5149