### PR TITLE
[Mono.Android] Prevent premature JNI handle collection

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -105,6 +105,7 @@ namespace Android.Runtime {
 			if (throwable == null)
 				throw new ArgumentNullException ("throwable");
 			JNIEnv.Throw (throwable.Handle);
+			GC.KeepAlive (throwable);
 		}
 
 		internal static void UnhandledException (Exception e)

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -506,9 +506,9 @@ namespace Android.Runtime {
 			if (value == null)
 				return IntPtr.Zero;
 			var ex = value as IJavaObjectEx;
-			if (ex != null)
-				return ex.ToLocalJniHandle ();
-			return NewLocalRef (value.Handle);
+			IntPtr result = ex != null ? ex.ToLocalJniHandle () : NewLocalRef (value.Handle);
+			GC.KeepAlive (value);
+			return result;
 		}
 
 		public static string? GetCharSequence (IntPtr jobject, JniHandleOwnership transfer)
@@ -895,6 +895,7 @@ namespace Android.Runtime {
 			for (int i = 0; i < src.Length; i++) {
 				IJavaObject o = src [i];
 				JniEnvironment.Arrays.SetObjectArrayElement (new JniObjectReference (dest), i, new JniObjectReference (o == null ? IntPtr.Zero : o.Handle));
+				GC.KeepAlive (o);
 			}
 		}
 
@@ -1545,6 +1546,7 @@ namespace Android.Runtime {
 				} },
 				{ typeof (IJavaObject), (dest, index, value) => {
 					SetObjectArrayElement (dest, index, value == null ? IntPtr.Zero : ((IJavaObject) value).Handle);
+					GC.KeepAlive (value);
 				} },
 				{ typeof (Array), (dest, index, value) => {
 					IntPtr _v = NewArray ((Array) value!);

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -506,7 +506,17 @@ namespace Android.Runtime {
 			if (value == null)
 				return IntPtr.Zero;
 			var ex = value as IJavaObjectEx;
-			IntPtr result = ex != null ? ex.ToLocalJniHandle () : NewLocalRef (value.Handle);
+			if (ex != null) {
+				IntPtr result = ex.ToLocalJniHandle ();
+				GC.KeepAlive (value);
+				return result;
+			}
+			return ToLocalJniHandleFallback (value);
+		}
+
+		internal static IntPtr ToLocalJniHandleFallback (IJavaObject value)
+		{
+			IntPtr result = NewLocalRef (value.Handle);
 			GC.KeepAlive (value);
 			return result;
 		}

--- a/src/Mono.Android/Android.Runtime/JavaObject.cs
+++ b/src/Mono.Android/Android.Runtime/JavaObject.cs
@@ -11,29 +11,7 @@ namespace Android.Runtime {
 			if (obj == null)
 				return IntPtr.Zero;
 
-			Type type = obj.GetType ();
-			if (type == typeof (bool))
-				return new Java.Lang.Boolean ((bool)obj).Handle;
-			else if (type == typeof (sbyte))
-				return new Java.Lang.Byte ((sbyte)obj).Handle;
-			else if (type == typeof (char))
-				return new Java.Lang.Character ((char)obj).Handle;
-			else if (type == typeof (short))
-				return new Java.Lang.Short ((short)obj).Handle;
-			else if (type == typeof (int))
-				return new Java.Lang.Integer ((int)obj).Handle;
-			else if (type == typeof (long))
-				return new Java.Lang.Long ((long)obj).Handle;
-			else if (type == typeof (float))
-				return new Java.Lang.Float ((float)obj).Handle;
-			else if (type == typeof (double))
-				return new Java.Lang.Double ((double)obj).Handle;
-			else if (type == typeof (string))
-				return JNIEnv.NewString ((string)obj);
-			else if (typeof (IJavaObject).IsAssignableFrom (type))
-				return ((IJavaObject)obj).Handle;
-			else
-				return new JavaObject (obj).Handle;
+			return Java.Interop.JavaConvert.ToLocalJniHandle (obj);
 		}
 
 		public static object? GetObject (IntPtr handle, JniHandleOwnership transfer)
@@ -112,4 +90,3 @@ namespace Android.Runtime {
 		}
 	}
 }
-

--- a/src/Mono.Android/Android.Runtime/XmlReaderPullParser.cs
+++ b/src/Mono.Android/Android.Runtime/XmlReaderPullParser.cs
@@ -15,8 +15,11 @@ namespace Android.Runtime
 				return IntPtr.Zero;
 
 			var xpr = value as XmlResourceParserReader;
-			if (xpr != null)
-				return JNIEnv.NewLocalRef (xpr.Handle);
+			if (xpr != null) {
+				IntPtr result = JNIEnv.NewLocalRef (xpr.Handle);
+				GC.KeepAlive (xpr);
+				return result;
+			}
 			return JNIEnv.ToLocalJniHandle (new Android.Runtime.XmlReaderResourceParser (value));
 		}
 
@@ -130,8 +133,11 @@ namespace Android.Runtime
 				return IntPtr.Zero;
 
 			var xppr = value as XmlPullParserReader;
-			if (xppr != null)
-				return JNIEnv.NewLocalRef (xppr.Handle);
+			if (xppr != null) {
+				IntPtr result = JNIEnv.NewLocalRef (xppr.Handle);
+				GC.KeepAlive (xppr);
+				return result;
+			}
 			return JNIEnv.ToLocalJniHandle (new Android.Runtime.XmlReaderPullParser (value));
 		}
 		

--- a/src/Mono.Android/Android.Widget/AbsListView.cs
+++ b/src/Mono.Android/Android.Widget/AbsListView.cs
@@ -79,6 +79,8 @@ namespace Android.Widget {
 				JNIEnv.CallVoidMethod  (Handle, id_setAdapter_Landroid_widget_ListAdapter_, new JValue (adapter));
 			else
 				JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, id_setAdapter_Landroid_widget_ListAdapter_, new JValue (adapter));
+			GC.KeepAlive (adapter);
+			GC.KeepAlive (this);
 		}
 #endif
 	}

--- a/src/Mono.Android/Android.Widget/AdapterView.cs
+++ b/src/Mono.Android/Android.Widget/AdapterView.cs
@@ -81,6 +81,7 @@ namespace Android.Widget {
 						JniHandleOwnership.TransferLocalRef);
 				JNIEnv.FinishCreateInstance (Handle, "(Landroid/content/Context;)V", new JValue (context));
 			}
+			GC.KeepAlive (context);
 		}
 
 		static IntPtr id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_;
@@ -104,6 +105,8 @@ namespace Android.Widget {
 						JniHandleOwnership.TransferLocalRef);
 				JNIEnv.FinishCreateInstance (Handle, "(Landroid/content/Context;Landroid/util/AttributeSet;)V", new JValue (context), new JValue (attrs));
 			}
+			GC.KeepAlive (context);
+			GC.KeepAlive (attrs);
 		}
 
 		static IntPtr id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I;
@@ -127,6 +130,8 @@ namespace Android.Widget {
 						JniHandleOwnership.TransferLocalRef);
 				JNIEnv.FinishCreateInstance (Handle, "(Landroid/content/Context;Landroid/util/AttributeSet;I)V", new JValue (context), new JValue (attrs), new JValue (defStyle));
 			}
+			GC.KeepAlive (context);
+			GC.KeepAlive (attrs);
 		}
 
 		protected override Java.Lang.Object? RawAdapter {
@@ -140,4 +145,3 @@ namespace Android.Widget {
 		}
 	}
 }
-

--- a/src/Mono.Android/Android.Widget/AdapterViewAnimator.cs
+++ b/src/Mono.Android/Android.Widget/AdapterViewAnimator.cs
@@ -86,15 +86,18 @@ namespace Android.Widget {
                         get {
                                 if (id_getAdapter == IntPtr.Zero)
                                         id_getAdapter = JNIEnv.GetMethodID (class_ref, "getAdapter", "()Landroid/widget/Adapter;");
+                                Android.Widget.IAdapter? result;
                                 if (GetType () == ThresholdType)
-                                        return Java.Lang.Object.GetObject<Android.Widget.IAdapter> (JNIEnv.CallObjectMethod  (Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
+                                        result = Java.Lang.Object.GetObject<Android.Widget.IAdapter> (JNIEnv.CallObjectMethod  (Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
                                 else
-                                        return Java.Lang.Object.GetObject<Android.Widget.IAdapter> (
+                                        result = Java.Lang.Object.GetObject<Android.Widget.IAdapter> (
                                                 JNIEnv.CallNonvirtualObjectMethod  (
                                                     Handle,
                                                     ThresholdClass,
                                                     JNIEnv.GetMethodID (ThresholdClass, "getAdapter", "()Landroid/widget/Adapter;")),
                                                 JniHandleOwnership.TransferLocalRef);
+                                GC.KeepAlive (this);
+                                return result;
                         }
                         set {
                                 if (id_setAdapter_Landroid_widget_Adapter_ == IntPtr.Zero)
@@ -108,6 +111,8 @@ namespace Android.Widget {
                                                 ThresholdClass,
                                                 JNIEnv.GetMethodID (ThresholdClass, "setAdapter", "(Landroid/widget/Adapter;)V"),
                                                 new JValue (JNIEnv.ToJniHandle ((IJavaObject?) value)));
+                               GC.KeepAlive (value);
+                               GC.KeepAlive (this);
                         }
 
                 }

--- a/src/Mono.Android/Android.Widget/ArrayAdapter.cs
+++ b/src/Mono.Android/Android.Widget/ArrayAdapter.cs
@@ -39,6 +39,7 @@ namespace Android.Widget {
 						JniHandleOwnership.TransferLocalRef);
 				JNIEnv.FinishCreateInstance (Handle, "(Landroid/content/Context;I)V", new JValue (context), new JValue (textViewResourceId));
 			}
+			GC.KeepAlive (context);
 		}
 
 		static IntPtr id_ctor_Landroid_content_Context_II;
@@ -62,6 +63,7 @@ namespace Android.Widget {
 						JniHandleOwnership.TransferLocalRef);
 				JNIEnv.FinishCreateInstance (Handle, "(Landroid/content/Context;II)V", new JValue (context), new JValue (resource), new JValue (textViewResourceId));
 			}
+			GC.KeepAlive (context);
 		}
 
 		static IntPtr id_ctor_Landroid_content_Context_IarrayLjava_lang_Object_;
@@ -87,6 +89,7 @@ namespace Android.Widget {
 				JNIEnv.FinishCreateInstance (Handle, "(Landroid/content/Context;I[Ljava/lang/Object;)V", new JValue (context), new JValue (textViewResourceId), new JValue (native_objects));
 			}
 			JNIEnv.DeleteLocalRef (native_objects);
+			GC.KeepAlive (context);
 		}
 
 		static IntPtr id_ctor_Landroid_content_Context_IIarrayLjava_lang_Object_;
@@ -112,6 +115,7 @@ namespace Android.Widget {
 				JNIEnv.FinishCreateInstance (Handle, "(Landroid/content/Context;II[Ljava/lang/Object;)V", new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (native_objects));
 			}
 			JNIEnv.DeleteLocalRef (native_objects);
+			GC.KeepAlive (context);
 		}
 
 		static IntPtr id_ctor_Landroid_content_Context_ILjava_util_List_;
@@ -137,6 +141,7 @@ namespace Android.Widget {
 				JNIEnv.FinishCreateInstance (Handle, "(Landroid/content/Context;ILjava/util/List;)V", new JValue (context), new JValue (textViewResourceId), new JValue (lrefObjects));
 			}
 			JNIEnv.DeleteLocalRef (lrefObjects);
+			GC.KeepAlive (context);
 		}
 
 		static IntPtr id_ctor_Landroid_content_Context_IILjava_util_List_;
@@ -162,6 +167,7 @@ namespace Android.Widget {
 				JNIEnv.FinishCreateInstance (Handle, "(Landroid/content/Context;IILjava/util/List;)V", new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (lrefObjects));
 			}
 			JNIEnv.DeleteLocalRef (lrefObjects);
+			GC.KeepAlive (context);
 		}
 
 		static IntPtr id_add_Ljava_lang_Object_;
@@ -182,9 +188,11 @@ namespace Android.Widget {
 		{
 			if (id_createFromResource_Landroid_content_Context_II == IntPtr.Zero)
 				id_createFromResource_Landroid_content_Context_II = JNIEnv.GetStaticMethodID (class_ref, "createFromResource", "(Landroid/content/Context;II)Landroid/widget/ArrayAdapter;");
-			return JavaConvert.FromJniHandle<ArrayAdapter<Java.Lang.ICharSequence>> (
+			var result = JavaConvert.FromJniHandle<ArrayAdapter<Java.Lang.ICharSequence>> (
 					JNIEnv.CallStaticObjectMethod (class_ref, id_createFromResource_Landroid_content_Context_II, new JValue (context), new JValue (textArrayResId), new JValue (textViewResId)),
 						JniHandleOwnership.TransferLocalRef)!;
+			GC.KeepAlive (context);
+			return result;
 		}
 
 		static IntPtr id_getItem_I;
@@ -239,6 +247,8 @@ namespace Android.Widget {
 			if (id_sort_Ljava_util_Comparator_ == IntPtr.Zero)
 				id_sort_Ljava_util_Comparator_ = JNIEnv.GetMethodID (class_ref, "sort", "(Ljava/util/Comparator;)V");
 			JNIEnv.CallNonvirtualVoidMethod (Handle, class_ref, id_sort_Ljava_util_Comparator_, new JValue (comparator));
+			GC.KeepAlive (comparator);
+			GC.KeepAlive (this);
 		}
 	}
 }

--- a/src/Mono.Android/Android.Widget/ArrayAdapter.cs
+++ b/src/Mono.Android/Android.Widget/ArrayAdapter.cs
@@ -190,9 +190,9 @@ namespace Android.Widget {
 				id_createFromResource_Landroid_content_Context_II = JNIEnv.GetStaticMethodID (class_ref, "createFromResource", "(Landroid/content/Context;II)Landroid/widget/ArrayAdapter;");
 			var result = JavaConvert.FromJniHandle<ArrayAdapter<Java.Lang.ICharSequence>> (
 					JNIEnv.CallStaticObjectMethod (class_ref, id_createFromResource_Landroid_content_Context_II, new JValue (context), new JValue (textArrayResId), new JValue (textViewResId)),
-						JniHandleOwnership.TransferLocalRef)!;
+						JniHandleOwnership.TransferLocalRef);
 			GC.KeepAlive (context);
-			return result;
+			return result ?? throw new InvalidOperationException ("Unable to marshal the return value to an Android.Widget.ArrayAdapter instance.");
 		}
 
 		static IntPtr id_getItem_I;

--- a/src/Mono.Android/Android.Widget/TextView.cs
+++ b/src/Mono.Android/Android.Widget/TextView.cs
@@ -13,6 +13,8 @@ namespace Android.Widget {
 			if (id_addTextChangedListener == IntPtr.Zero)
 				id_addTextChangedListener = JNIEnv.GetMethodID (class_ref, "addTextChangedListener", "(Landroid/text/TextWatcher;)V");
 			JNIEnv.CallVoidMethod (Handle, id_addTextChangedListener, new JValue (watcher));
+			GC.KeepAlive (watcher);
+			GC.KeepAlive (this);
 		}
 
 		WeakReference? implementor_TextWatcher;
@@ -69,4 +71,3 @@ namespace Android.Widget {
 		}
 	}
 }
-

--- a/src/Mono.Android/Java.Interop/JavaConvert.cs
+++ b/src/Mono.Android/Java.Interop/JavaConvert.cs
@@ -527,7 +527,10 @@ namespace Java.Interop {
 				return JNIEnv.NewArray ((Array) value);
 			} },
 			{ typeof (Android.Runtime.JavaObject), value => {
-				return value == null ? IntPtr.Zero : JNIEnv.ToLocalJniHandle (new Android.Runtime.JavaObject (value));
+				if (value == null)
+					return IntPtr.Zero;
+				using (var v = new Android.Runtime.JavaObject (value))
+					return JNIEnv.ToLocalJniHandle (v);
 			} },
 		};
 

--- a/src/Mono.Android/Java.Interop/JavaConvert.cs
+++ b/src/Mono.Android/Java.Interop/JavaConvert.cs
@@ -527,10 +527,7 @@ namespace Java.Interop {
 				return JNIEnv.NewArray ((Array) value);
 			} },
 			{ typeof (Android.Runtime.JavaObject), value => {
-				if (value == null)
-					return IntPtr.Zero;
-				using (var v = new Android.Runtime.JavaObject (value))
-					return JNIEnv.ToLocalJniHandle (v);
+				return value == null ? IntPtr.Zero : JNIEnv.ToLocalJniHandle (new Android.Runtime.JavaObject (value));
 			} },
 		};
 

--- a/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
+++ b/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
@@ -81,7 +81,9 @@ namespace Java.Interop {
 			if (instance.Handle == IntPtr.Zero)
 				throw new ObjectDisposedException (instance.GetType ().FullName);
 
-			return (TResult?) Java.Lang.Object.GetObject (instance.Handle, JniHandleOwnership.DoNotTransfer, typeof (TResult)) ??
+			var result = (TResult?) Java.Lang.Object.GetObject (instance.Handle, JniHandleOwnership.DoNotTransfer, typeof (TResult));
+			GC.KeepAlive (instance);
+			return result ??
 				throw new InvalidCastException (
 					FormattableString.Invariant ($"Unable to convert instance of type '{instance.GetType ().FullName}' to type '{typeof (TResult).FullName}'."));
 		}
@@ -100,7 +102,9 @@ namespace Java.Interop {
 			if (resultType.IsAssignableFrom (instance.GetType ()))
 				return instance;
 
-			return (IJavaObject?) Java.Lang.Object.GetObject (instance.Handle, JniHandleOwnership.DoNotTransfer, resultType) ??
+			var result = (IJavaObject?) Java.Lang.Object.GetObject (instance.Handle, JniHandleOwnership.DoNotTransfer, resultType);
+			GC.KeepAlive (instance);
+			return result ??
 				throw new InvalidCastException (
 					FormattableString.Invariant ($"Unable to convert instance of type '{instance.GetType ().FullName}' to type '{resultType.FullName}'."));
 		}

--- a/src/Mono.Android/Java.Interop/Runtime.cs
+++ b/src/Mono.Android/Java.Interop/Runtime.cs
@@ -40,7 +40,9 @@ namespace Java.Interop {
 		{
 			if (value == null)
 				return false;
-			return IsGCUserPeer (value.Handle);
+			bool result = IsGCUserPeer (value.Handle);
+			GC.KeepAlive (value);
+			return result;
 		}
 
 		public static bool IsGCUserPeer (IntPtr value)

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -1746,6 +1746,7 @@ namespace Xamarin.Android.Net
 			var keyFactory = KeyFactory.GetInstance (algorithmName) ?? throw new InvalidOperationException ($"Failed to get the KeyFactory instance for algorithm {algorithmName}");
 			var privateKey = keyFactory.GeneratePrivate (new Java.Security.Spec.PKCS8EncodedKeySpec (key.ExportPkcs8PrivateKey ()));
 			var certificate = Java.Lang.Object.GetObject<Certificate> (clientCertificate.Handle, JniHandleOwnership.DoNotTransfer);
+			GC.KeepAlive (clientCertificate);
 
 			if (privateKey is null || certificate is null) {
 				return null;

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -540,7 +540,7 @@ namespace Java.InteropTests
 
 		sealed class FinalizableHandleOwner : IJavaObject
 		{
-			readonly Java.Lang.Object peer = new Java.Lang.Object ();
+			readonly Java.Lang.Object peer = new FinalizableHandlePeer ();
 
 			public IntPtr Handle => peer.Handle;
 
@@ -553,6 +553,10 @@ namespace Java.InteropTests
 			{
 				peer.Dispose ();
 			}
+		}
+
+		sealed class FinalizableHandlePeer : Java.Lang.Object
+		{
 		}
 
 		[Test, Category ("GCBridge")]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -538,24 +538,7 @@ namespace Java.InteropTests
 			}
 		}
 
-		sealed class FinalizableHandleOwner : IJavaObject
-		{
-			readonly Java.Lang.Object peer = new FinalizableHandlePeer ();
-
-			public IntPtr Handle => peer.Handle;
-
-			public void Dispose ()
-			{
-				peer.Dispose ();
-				GC.SuppressFinalize (this);
-			}
-			~FinalizableHandleOwner ()
-			{
-				peer.Dispose ();
-			}
-		}
-
-		sealed class FinalizableHandlePeer : Java.Lang.Object
+		sealed class FinalizableHandleOwner : Java.Lang.Object
 		{
 		}
 

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -527,7 +527,7 @@ namespace Java.InteropTests
 					IntPtr handle = JNIEnv.ToLocalJniHandle (new FinalizableHandleOwner ());
 					try {
 						Assert.AreNotEqual (IntPtr.Zero, handle, $"No local reference was returned during iteration {i}.");
-						Assert.AreEqual ("java/lang/Object", JNIEnv.GetClassNameFromInstance (handle), $"The local reference was invalid during iteration {i}.");
+						Assert.IsNotEmpty (JNIEnv.GetClassNameFromInstance (handle), $"The local reference was invalid during iteration {i}.");
 					} finally {
 						JNIEnv.DeleteLocalRef (handle);
 					}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -524,7 +524,7 @@ namespace Java.InteropTests
 
 			try {
 				for (int i = 0; i < iterations; i++) {
-					IntPtr handle = JNIEnv.ToLocalJniHandle (new FinalizableHandleOwner ());
+					IntPtr handle = JNIEnv.ToLocalJniHandleFallback (new FinalizableHandleOwner ());
 					try {
 						Assert.AreNotEqual (IntPtr.Zero, handle, $"No local reference was returned during iteration {i}.");
 						Assert.IsNotEmpty (JNIEnv.GetClassNameFromInstance (handle), $"The local reference was invalid during iteration {i}.");

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -506,6 +506,55 @@ namespace Java.InteropTests
 			Assert.AreEqual (null, m, "`JnienvTest` does *not* subclass Java.Lang.Object, it should *not* be in the typemap!");
 		}
 
+		[Test]
+		[Category ("GCBridge")]
+		[Category ("NativeAOTIgnore")]
+		public void ToLocalJniHandleSurvivesConcurrentCollection ()
+		{
+			const int iterations = 1000;
+			using var done = new CancellationTokenSource ();
+			var collector = new Thread (() => {
+				while (!done.IsCancellationRequested) {
+					GC.Collect ();
+					GC.WaitForPendingFinalizers ();
+					Thread.Yield ();
+				}
+			});
+			collector.Start ();
+
+			try {
+				for (int i = 0; i < iterations; i++) {
+					IntPtr handle = JNIEnv.ToLocalJniHandle (new FinalizableHandleOwner ());
+					try {
+						Assert.AreNotEqual (IntPtr.Zero, handle, $"No local reference was returned during iteration {i}.");
+						Assert.AreEqual ("java/lang/Object", JNIEnv.GetClassNameFromInstance (handle), $"The local reference was invalid during iteration {i}.");
+					} finally {
+						JNIEnv.DeleteLocalRef (handle);
+					}
+				}
+			} finally {
+				done.Cancel ();
+				collector.Join ();
+			}
+		}
+
+		sealed class FinalizableHandleOwner : IJavaObject
+		{
+			readonly Java.Lang.Object peer = new Java.Lang.Object ();
+
+			public IntPtr Handle => peer.Handle;
+
+			public void Dispose ()
+			{
+				peer.Dispose ();
+				GC.SuppressFinalize (this);
+			}
+			~FinalizableHandleOwner ()
+			{
+				peer.Dispose ();
+			}
+		}
+
 		[Test, Category ("GCBridge")]
 		[Ignore ("Failing in NativeAOT: https://github.com/dotnet/android/issues/11690")]
 		public void DoNotLeakWeakReferences ()


### PR DESCRIPTION
## Summary

- keep managed JNI handle owners alive until native calls consume borrowed handles
- return stable local references for temporary managed-to-Java wrappers
- cover `JNIEnv.ToLocalJniHandle()` with concurrent GC pressure
- consolidate legacy `JavaObject.GetHandle()` conversion through `JavaConvert`

Fixes #5405

## Testing

- Static diff validation completed
- Device runtime test not run because this worktree does not have a local .NET for Android SDK