### PR TITLE
[Xamarin.Android.Build.Tasks] Use resolved NDK for AOT

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -964,6 +964,19 @@ If you are getting this error you can add the following to the
 
 which will allow the `dx` step to succeed.
 
+## AndroidNdkDirectory
+
+The `$(AndroidNdkDirectory)` property specifies a custom Android NDK
+installation directory. The path can be set in the project file or on the
+command line:
+
+```dotnetcli
+dotnet build -p:AndroidNdkDirectory=/path/to/android-ndk
+```
+
+If this property is not set, .NET for Android locates the NDK from the
+configured Android development environment.
+
 ## AndroidPackageFormat
 
 An enum-style property with valid

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -90,7 +90,7 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
 
     <GetAotAssemblies
         AndroidAotMode="$(AndroidAotMode)"
-        AndroidNdkDirectory="$(AndroidNdkDirectory)"
+        AndroidNdkDirectory="$(_AndroidNdkDirectory)"
         AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
         AndroidApiLevel="$(_AndroidApiLevel)"
         MinimumSupportedApiLevel="$(AndroidMinimumSupportedApiLevel)"


### PR DESCRIPTION
AOT currently passes the public `$(AndroidNdkDirectory)` property directly to `<GetAotAssemblies/>`. When that property is unset but `ResolveSdks` discovers an NDK from the configured environment, AOT incorrectly behaves as though no NDK was found.

Use the resolved `$(_AndroidNdkDirectory)` value consistently for AOT while retaining `$(AndroidNdkDirectory)` as the supported discovery override. Document the public property and its command-line usage.

Fixes #7599

----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [ ] Unit tests (not applicable; this is an MSBuild property wiring correction and documentation update)