### PR TITLE
[Microsoft.Android.Run] Await app shutdown on Ctrl+C

### DIFF
--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -6,6 +6,7 @@ using Xamarin.Android.Tools;
 
 const string Name = "Microsoft.Android.Run";
 const string VersionsFileName = "Microsoft.Android.versions.txt";
+const int CtrlCExitCode = 130; // Standard Unix exit code for SIGINT: 128 + signal 2.
 
 string? adbPath = null;
 string? adbTarget = null;
@@ -24,7 +25,7 @@ string? dotnetTestPipe = null;
 try {
 	return await RunAsync (args);
 } catch (OperationCanceledException) {
-	return 130; // 128 + SIGINT(2), standard Unix convention for Ctrl+C
+	return CtrlCExitCode;
 } catch (Exception ex) {
 	Console.Error.WriteLine ($"Error: {ex.Message}");
 	if (verbose)
@@ -202,7 +203,7 @@ async Task<int> RunAsync (string[] args)
 		cts.Dispose ();
 	}
 
-	return cancellationRequested ? 130 : exitCode;
+	return cancellationRequested ? CtrlCExitCode : exitCode;
 }
 
 void OnCancelKeyPress (object? sender, ConsoleCancelEventArgs e)

--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -185,18 +185,24 @@ async Task<int> RunAsync (string[] args)
 	// Set up Ctrl+C handler
 	Console.CancelKeyPress += OnCancelKeyPress;
 
+	int exitCode;
+	bool cancellationRequested;
 	try {
 		if (isDotnetTestMode)
-			return await RunDotnetTestAsync (remaining);
-
-		if (isInstrumentMode)
-			return await RunInstrumentationAsync (remaining);
-
-		return await RunAppAsync ();
+			exitCode = await RunDotnetTestAsync (remaining);
+		else if (isInstrumentMode)
+			exitCode = await RunInstrumentationAsync (remaining);
+		else
+			exitCode = await RunAppAsync ();
 	} finally {
 		Console.CancelKeyPress -= OnCancelKeyPress;
+		cancellationRequested = cts.IsCancellationRequested;
+		if (cancellationRequested)
+			await StopAppAsync ();
 		cts.Dispose ();
 	}
+
+	return cancellationRequested ? 130 : exitCode;
 }
 
 void OnCancelKeyPress (object? sender, ConsoleCancelEventArgs e)
@@ -206,19 +212,6 @@ void OnCancelKeyPress (object? sender, ConsoleCancelEventArgs e)
 	Console.WriteLine ("Stopping application...");
 
 	cts.Cancel ();
-
-	// Force-stop the app (fire-and-forget in cancel handler)
-	_ = StopAppAsync ();
-
-	// Kill logcat process if running
-	try {
-		if (logcatProcess != null && !logcatProcess.HasExited) {
-			logcatProcess.Kill ();
-		}
-	} catch (Exception ex) {
-		if (verbose)
-			Console.Error.WriteLine ($"Error killing logcat process: {ex.Message}");
-	}
 }
 
 async Task<int> RunInstrumentationAsync (List<string> instrumentationArgs)
@@ -616,7 +609,15 @@ async Task StopAppAsync ()
 		return;
 
 	var userArg = string.IsNullOrEmpty (deviceUserId) ? "" : $" --user {deviceUserId}";
-	await AdbHelper.RunAsync (adbPath, adbTarget, $"shell am force-stop{userArg} {package}", CancellationToken.None, verbose);
+	try {
+		var (exitCode, _, error) = await AdbHelper.RunAsync (adbPath, adbTarget, $"shell am force-stop{userArg} {package}", CancellationToken.None, verbose);
+		if (exitCode != 0)
+			Console.Error.WriteLine ($"Error: Failed to stop app: {error}");
+	} catch (Exception ex) {
+		Console.Error.WriteLine ($"Error: Failed to stop app: {ex.Message}");
+		if (verbose)
+			Console.Error.WriteLine (ex.ToString ());
+	}
 }
 
 string? FindAdbPath ()

--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -576,34 +576,36 @@ void StartLogcat ()
 
 async Task WaitForAppExitAsync ()
 {
-	while (!cts.Token.IsCancellationRequested) {
-		// Check if app is still running
-		var pid = await GetAppPidAsync ();
-		if (pid == null || pid != logcatPid) {
-			if (verbose)
-				Console.WriteLine ("App has exited.");
-			break;
-		}
-
-		// Also check if logcat process exited unexpectedly
-		if (logcatProcess != null && logcatProcess.HasExited) {
-			if (verbose)
-				Console.WriteLine ("Logcat process exited.");
-			break;
-		}
-
-		await Task.Delay (1000, cts.Token).ConfigureAwait (ConfigureAwaitOptions.SuppressThrowing);
-	}
-
-	// Clean up logcat process
 	try {
-		if (logcatProcess != null && !logcatProcess.HasExited) {
-			logcatProcess.Kill ();
-			logcatProcess.WaitForExit (1000);
+		while (!cts.Token.IsCancellationRequested) {
+			// Check if app is still running
+			var pid = await GetAppPidAsync ();
+			if (pid == null || pid != logcatPid) {
+				if (verbose)
+					Console.WriteLine ("App has exited.");
+				break;
+			}
+
+			// Also check if logcat process exited unexpectedly
+			if (logcatProcess != null && logcatProcess.HasExited) {
+				if (verbose)
+					Console.WriteLine ("Logcat process exited.");
+				break;
+			}
+
+			await Task.Delay (1000, cts.Token).ConfigureAwait (ConfigureAwaitOptions.SuppressThrowing);
 		}
-	} catch (Exception ex) {
-		if (verbose)
-			Console.Error.WriteLine ($"Error cleaning up logcat process: {ex.Message}");
+	} finally {
+		// Clean up logcat process
+		try {
+			if (logcatProcess != null && !logcatProcess.HasExited) {
+				logcatProcess.Kill ();
+				logcatProcess.WaitForExit (1000);
+			}
+		} catch (Exception ex) {
+			if (verbose)
+				Console.Error.WriteLine ($"Error cleaning up logcat process: {ex.Message}");
+		}
 	}
 }
 

--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -7,6 +7,7 @@ using Xamarin.Android.Tools;
 const string Name = "Microsoft.Android.Run";
 const string VersionsFileName = "Microsoft.Android.versions.txt";
 const int CtrlCExitCode = 130; // Standard Unix exit code for SIGINT: 128 + signal 2.
+const int StopAppTimeoutSeconds = 10;
 
 string? adbPath = null;
 string? adbTarget = null;
@@ -612,10 +613,13 @@ async Task StopAppAsync ()
 		return;
 
 	var userArg = string.IsNullOrEmpty (deviceUserId) ? "" : $" --user {deviceUserId}";
+	using var timeoutCts = new CancellationTokenSource (TimeSpan.FromSeconds (StopAppTimeoutSeconds));
 	try {
-		var (exitCode, _, error) = await AdbHelper.RunAsync (adbPath, adbTarget, $"shell am force-stop{userArg} {package}", CancellationToken.None, verbose);
+		var (exitCode, _, error) = await AdbHelper.RunAsync (adbPath, adbTarget, $"shell am force-stop{userArg} {package}", timeoutCts.Token, verbose);
 		if (exitCode != 0)
 			Console.Error.WriteLine ($"Error: Failed to stop app: {error}");
+	} catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested) {
+		Console.Error.WriteLine ($"Error: Timed out stopping app after {StopAppTimeoutSeconds} seconds.");
 	} catch (Exception ex) {
 		Console.Error.WriteLine ($"Error: Failed to stop app: {ex.Message}");
 		if (verbose)

--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -18,6 +18,7 @@ bool verbose = false;
 int? logcatPid = null;
 Process? logcatProcess = null;
 CancellationTokenSource cts = new ();
+int ctrlCRequested = 0;
 string? logcatArgs = null;
 bool isDotnetTestMode = false;
 string? dotnetTestPipe = null;
@@ -197,7 +198,7 @@ async Task<int> RunAsync (string[] args)
 			exitCode = await RunAppAsync ();
 	} finally {
 		Console.CancelKeyPress -= OnCancelKeyPress;
-		cancellationRequested = cts.IsCancellationRequested;
+		cancellationRequested = Volatile.Read (ref ctrlCRequested) != 0;
 		if (cancellationRequested)
 			await StopAppAsync ();
 		cts.Dispose ();
@@ -212,6 +213,7 @@ void OnCancelKeyPress (object? sender, ConsoleCancelEventArgs e)
 	Console.WriteLine ();
 	Console.WriteLine ("Stopping application...");
 
+	Interlocked.Exchange (ref ctrlCRequested, 1);
 	cts.Cancel ();
 }
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -479,19 +479,12 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 				string outputText = output.ToString ();
 				Assert.IsTrue (outputText.Contains ("Stopping application..."),
 					$"Output should contain 'Stopping application...' from Microsoft.Android.Run's Ctrl+C handler");
+				Assert.IsFalse (outputText.Contains ("Error: The operation was canceled."),
+					"Cancellation should not be reported as an error");
 
-				// Verify the app is no longer running on the device.
-				// Poll with retries since StopAppAsync is fire-and-forget in the Ctrl+C handler.
-				bool appStopped = false;
-				for (int i = 0; i < 10; i++) {
-					pidOutput = RunAdbCommand ($"shell pidof {proj.PackageName}").Trim ();
-					if (string.IsNullOrEmpty (pidOutput)) {
-						appStopped = true;
-						break;
-					}
-					Thread.Sleep (1000);
-				}
-				Assert.IsTrue (appStopped,
+				// Microsoft.Android.Run must not exit until force-stop has completed.
+				pidOutput = RunAdbCommand ($"shell pidof {proj.PackageName}").Trim ();
+				Assert.IsTrue (string.IsNullOrEmpty (pidOutput),
 					$"App should not be running on the device after Ctrl+C. pidof output: '{pidOutput}'");
 			} finally {
 				// Ensure the process is killed if it's still running

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -474,6 +474,7 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 				// Wait for the process to exit gracefully
 				bool exited = process.WaitForExit (30_000);
 				Assert.IsTrue (exited, "dotnet run process should have exited after SIGINT");
+				Assert.AreEqual (130, process.ExitCode, "dotnet run process should report user cancellation after SIGINT");
 
 				// Verify the output contains the "Stopping application..." message from Microsoft.Android.Run
 				string outputText = output.ToString ();


### PR DESCRIPTION
----

Pressing Ctrl+C during `dotnet run` could let `Microsoft.Android.Run` exit before its fire-and-forget `adb shell am force-stop` completed, leaving the application running on the device.

Move shutdown into the awaited run lifecycle. The Ctrl+C handler now only signals cancellation, while final cleanup waits for `force-stop` before returning the standard SIGINT exit code. The device integration test now requires the app to be stopped immediately when `dotnet run` exits instead of polling around the race.

Fixes #11264

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [x] Unit tests: strengthened `DotNetRunCtrlC`; `Microsoft.Android.Run` builds with 0 warnings and errors.