### PR TITLE
[android-tools] Align command-line tool discovery order

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/CommandLineToolsResolver.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/CommandLineToolsResolver.cs
@@ -136,6 +136,11 @@ static class CommandLineToolsResolver
 
 	static int CompareCandidates (Candidate first, Candidate second)
 	{
+		var firstIsLatest = string.Equals (first.DirectoryName, "latest", StringComparison.Ordinal);
+		var secondIsLatest = string.Equals (second.DirectoryName, "latest", StringComparison.Ordinal);
+		if (firstIsLatest != secondIsLatest)
+			return firstIsLatest ? -1 : 1;
+
 		if (first.Revision.HasValue != second.Revision.HasValue)
 			return first.Revision.HasValue ? -1 : 1;
 
@@ -147,11 +152,6 @@ static class CommandLineToolsResolver
 
 		if (first.RevisionFromSource != second.RevisionFromSource)
 			return first.RevisionFromSource ? -1 : 1;
-
-		var firstIsLatest = string.Equals (first.DirectoryName, "latest", StringComparison.Ordinal);
-		var secondIsLatest = string.Equals (second.DirectoryName, "latest", StringComparison.Ordinal);
-		if (firstIsLatest != secondIsLatest)
-			return firstIsLatest ? -1 : 1;
 
 		return string.Compare (first.DirectoryName, second.DirectoryName, StringComparison.Ordinal);
 	}

--- a/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
@@ -303,8 +303,9 @@ namespace Xamarin.Android.Tools
 
 		/// <summary>
 		/// Searches for a cmdline-tools binary in the SDK.
-		/// Selects the highest installed revision reported by source.properties,
-		/// with deterministic directory-name fallback when metadata is unavailable.
+		/// Selects cmdline-tools/latest first, then the highest installed revision reported
+		/// by source.properties, with deterministic directory-name fallback when metadata is unavailable.
+		/// Legacy tools/bin installations are not supported.
 		/// </summary>
 		/// <param name="sdkPath">Root path to the Android SDK.</param>
 		/// <param name="toolName">Tool binary name without extension (e.g., "avdmanager").</param>

--- a/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.CommandLineTools.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.CommandLineTools.cs
@@ -14,12 +14,12 @@ public partial class SdkManager
 	const string LatestCommandLineToolsPackage = "cmdline-tools;latest";
 
 	/// <summary>
-	/// Finds the installed <c>sdkmanager</c> from the highest command-line tools
-	/// revision reported by <c>source.properties</c>.
+	/// Finds <c>sdkmanager</c> in <c>cmdline-tools/latest/bin</c>, or falls back to
+	/// the highest installed command-line tools revision reported by <c>source.properties</c>.
 	/// </summary>
 	/// <returns>
 	/// The selected executable and revision, or <see langword="null"/> when no compatible
-	/// <c>sdkmanager</c> is installed.
+	/// <c>sdkmanager</c> is installed. Legacy <c>tools/bin</c> installations are not supported.
 	/// </returns>
 	public CommandLineTool? FindSdkManager ()
 	{

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/CommandLineToolsResolverTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/CommandLineToolsResolverTests.cs
@@ -61,18 +61,18 @@ public class CommandLineToolsResolverTests
 	}
 
 	[Test]
-	public void FindCommandLineTool_NumericHasHigherPackageRevision_SelectsNumeric ()
+	public void FindCommandLineTool_NumericHasHigherPackageRevision_SelectsLatest ()
 	{
-		var expectedSdkManager = CreateCommandLineTool ("22.0", "sdkmanager", "22.0");
-		var expectedAvdManager = CreateCommandLineTool ("22.0", "avdmanager", "22.0");
-		CreateCommandLineTool ("latest", "sdkmanager", "19.0");
-		CreateCommandLineTool ("latest", "avdmanager", "19.0");
+		CreateCommandLineTool ("22.0", "sdkmanager", "22.0");
+		CreateCommandLineTool ("22.0", "avdmanager", "22.0");
+		var expectedSdkManager = CreateCommandLineTool ("latest", "sdkmanager", "19.0");
+		var expectedAvdManager = CreateCommandLineTool ("latest", "avdmanager", "19.0");
 
 		using var manager = CreateSdkManager ();
 		var selected = manager.FindSdkManager ();
 
 		Assert.That (selected?.Path, Is.EqualTo (expectedSdkManager));
-		Assert.That (selected?.Revision, Is.EqualTo ("22.0"));
+		Assert.That (selected?.Revision, Is.EqualTo ("19.0"));
 		Assert.That (
 			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
 			Is.EqualTo (expectedAvdManager));
@@ -95,21 +95,52 @@ public class CommandLineToolsResolverTests
 	}
 
 	[Test]
-	public void FindCommandLineTool_MissingAndMalformedPackageRevision_UsesDirectoryVersion ()
+	public void FindCommandLineTool_LatestHasMalformedPackageRevision_SelectsLatest ()
 	{
-		var expectedSdkManager = CreateCommandLineTool ("22.0", "sdkmanager");
-		var expectedAvdManager = CreateCommandLineTool ("22.0", "avdmanager");
-		CreateCommandLineTool ("latest", "sdkmanager", "not-a-version");
-		CreateCommandLineTool ("latest", "avdmanager", "not-a-version");
+		CreateCommandLineTool ("22.0", "sdkmanager");
+		CreateCommandLineTool ("22.0", "avdmanager");
+		var expectedSdkManager = CreateCommandLineTool ("latest", "sdkmanager", "not-a-version");
+		var expectedAvdManager = CreateCommandLineTool ("latest", "avdmanager", "not-a-version");
 
 		using var manager = CreateSdkManager ();
 		var selected = manager.FindSdkManager ();
 
 		Assert.That (selected?.Path, Is.EqualTo (expectedSdkManager));
-		Assert.That (selected?.Revision, Is.EqualTo ("22.0"));
+		Assert.That (selected?.Revision, Is.Null);
 		Assert.That (
 			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
 			Is.EqualTo (expectedAvdManager));
+	}
+
+	[Test]
+	public void FindCommandLineTool_LatestMissingTool_FallsBackToHighestVersioned ()
+	{
+		var expectedSdkManager = CreateCommandLineTool ("22.0", "sdkmanager", "22.0");
+		var expectedAvdManager = CreateCommandLineTool ("22.0", "avdmanager", "22.0");
+		CreateCommandLineTool ("latest", "unrelated", "23.0");
+
+		using var manager = CreateSdkManager ();
+
+		Assert.That (manager.FindSdkManagerPath (), Is.EqualTo (expectedSdkManager));
+		Assert.That (
+			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
+			Is.EqualTo (expectedAvdManager));
+	}
+
+	[Test]
+	public void FindCommandLineTool_LegacyToolsBin_IsNotSupported ()
+	{
+		var binDirectory = Path.Combine (SdkDirectory, "tools", "bin");
+		Directory.CreateDirectory (binDirectory);
+		File.WriteAllText (Path.Combine (binDirectory, "sdkmanager" + ExecutableExtension), "");
+		File.WriteAllText (Path.Combine (binDirectory, "avdmanager" + ExecutableExtension), "");
+
+		using var manager = CreateSdkManager ();
+
+		Assert.That (manager.FindSdkManagerPath (), Is.Null);
+		Assert.That (
+			ProcessUtils.FindCmdlineTool (SdkDirectory, "avdmanager", ExecutableExtension),
+			Is.Null);
 	}
 
 	[Test]


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [x] Unit tests

`FindSdkManagerPath()` and `FindCmdlineTool()` must resolve Android command-line tools consistently. Prefer the SDK-managed `cmdline-tools/latest/bin` layout before considering versioned installations, while retaining versioned fallback when `latest` does not contain the requested binary.

The shared resolver now treats `latest` as the first selection tier. Remaining candidates continue to use `Pkg.Revision`, parsed directory versions, and deterministic fallback ordering. Legacy `tools/bin` remains intentionally unsupported because those tools use incompatible command-line arguments.

Tests cover lower or malformed metadata on `latest`, versioned fallback, and exclusion of legacy `tools/bin`. The full `Xamarin.Android.Tools.AndroidSdk-Tests` project passes with 378 passed and 16 skipped.

Fixes #12072