### PR TITLE
Improve Maven POM resolution errors

### DIFF
--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -210,7 +210,7 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 + [XA4234](xa4234.md): '<{item}>' item '{itemspec}' is missing required attribute '{name}'.
 + [XA4235](xa4235.md): Maven artifact specification '{artifact}' is invalid. The correct format is 'group_id:artifact_id'.
 + [XA4236](xa4236.md): Cannot download Maven artifact '{group}:{artifact}'. - {jar}: {exception} - {aar}: {exception}
-+ [XA4237](xa4237.md): Cannot download POM file for Maven artifact '{artifact}'. - {exception}
++ [XA4237](xa4237.md): Cannot download POM file for Maven artifact '{artifact}'. - Failed to resolve POM for Maven artifact '{dependency}' from '{url}'. - {exception}
 + [XA4239](xa4239.md): Unknown Maven repository: '{repository}'.
 + [XA4241](xa4241.md): Java dependency '{artifact}' is not satisfied.
 + [XA4242](xa4242.md): Java dependency '{artifact}' is not satisfied. Microsoft maintains the NuGet package '{nugetId}' that could fulfill this dependency.

--- a/Documentation/docs-mobile/messages/xa4237.md
+++ b/Documentation/docs-mobile/messages/xa4237.md
@@ -1,7 +1,7 @@
 ---
 title: .NET for Android error XA4237
 description: XA4237 error code
-ms.date: 04/11/2024
+ms.date: 08/07/2026
 f1_keywords:
   - "XA4237"
 ---
@@ -11,17 +11,15 @@ f1_keywords:
 ## Example message
 
 ```
-error XA4237: Cannot download POM file for Maven artifact 'com.example:mylib':1.0.0.
-error XA4237: - mylib-1.0.0.pom: Response status code does not indicate success: 404 (Not Found).
+error XA4237: Cannot download POM file for Maven artifact 'com.example:mylib:1.0.0'.
+error XA4237: - Failed to resolve POM for Maven artifact 'com.example:dependency:2.0.0' from 'https://repo1.maven.org/maven2/com/example/dependency/2.0.0/dependency-2.0.0.pom'.
+error XA4237: - Response status code does not indicate success: 404 (Not Found).
 ```
 
 ## Issue
 
-An error was encountered while trying to download the requested POM file from Maven.
+An error was encountered while trying to download the requested POM file or one of its parent or imported POM files from Maven. The message identifies both the originally requested artifact and the POM URL that could not be resolved.
 
 ## Solution
 
-Resolving this error depends on the error message specified.
-
-It could be things like:
-- Check your internet connection.
+Check your internet connection and verify that the unresolved artifact is available in the repository specified by the POM URL. The selected repository must contain the requested artifact and all parent or imported POM files needed to resolve it.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1477,6 +1477,16 @@ namespace Xamarin.Android.Tasks.Properties {
                 return ResourceManager.GetString("XA4237", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to resolve POM for Maven artifact &apos;{0}&apos; from &apos;{1}&apos;.
+        ///- {2}.
+        /// </summary>
+        public static string XA4237_Details {
+            get {
+                return ResourceManager.GetString("XA4237_Details", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Unknown Maven repository: &apos;{0}&apos;..

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1037,7 +1037,7 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 - {1}</value>
     <comment>The following are literal names and should not be translated: POM, Maven
 {0} - Maven artifact id
-{1} - The HttpClient reported download exception message
+{1} - Details about the unresolved Maven artifact, POM URL, and download exception
 </comment>
   </data>
   <data name="XA4237_Details" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1040,6 +1040,15 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - The HttpClient reported download exception message
 </comment>
   </data>
+  <data name="XA4237_Details" xml:space="preserve">
+    <value>Failed to resolve POM for Maven artifact '{0}' from '{1}'.
+- {2}</value>
+    <comment>The following are literal names and should not be translated: POM, Maven
+{0} - Unresolved Maven artifact id
+{1} - Unresolved POM URL
+{2} - The HttpClient reported download exception message
+</comment>
+  </data>
   <data name="XA4239" xml:space="preserve">
     <value>Unknown Maven repository: '{0}'.</value>
     <comment>The following are literal names and should not be translated: Maven

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
@@ -129,14 +129,21 @@ public class MavenDownload : AsyncTask
 				LogMessage ("Found POM file '{0}' for Java artifact '{1}'.", kv.Value, pom_artifact);
 			}
 		} catch (Exception ex) {
-			var unresolved_artifact = resolver.UnresolvedArtifact ?? artifact;
-			var unresolved_pom = resolver.UnresolvedPomUrl ?? resolver.GetPomUrl (unresolved_artifact);
-			var details = string.Format (Properties.Resources.XA4237_Details, unresolved_artifact, unresolved_pom, ex.Unwrap ().Message);
+			var details = GetPomResolutionErrorDetails (resolver, ex);
 			LogCodedError ("XA4237", Properties.Resources.XA4237, artifact, details);
 			return null;
 		}
 
 		return result;
+	}
+
+	internal static string GetPomResolutionErrorDetails (LoggingPomResolver resolver, Exception exception)
+	{
+		var message = exception.Unwrap ().Message;
+		if (resolver.UnresolvedArtifact is not Artifact unresolved_artifact || resolver.UnresolvedPomUrl is not string unresolved_pom)
+			return message;
+
+		return string.Format (Properties.Resources.XA4237_Details, unresolved_artifact, unresolved_pom, message);
 	}
 
 	/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
@@ -131,7 +131,7 @@ public class MavenDownload : AsyncTask
 		} catch (Exception ex) {
 			var unresolved_artifact = resolver.UnresolvedArtifact ?? artifact;
 			var unresolved_pom = resolver.UnresolvedPomUrl ?? resolver.GetPomUrl (unresolved_artifact);
-			var details = $"Failed to resolve POM for Maven artifact '{unresolved_artifact}' from '{unresolved_pom}'.{Environment.NewLine}- {ex.Unwrap ().Message}";
+			var details = string.Format (Properties.Resources.XA4237_Details, unresolved_artifact, unresolved_pom, ex.Unwrap ().Message);
 			LogCodedError ("XA4237", Properties.Resources.XA4237, artifact, details);
 			return null;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
@@ -81,7 +81,7 @@ public class MavenDownload : AsyncTask
 		// Note if Repository is not specifed, it is defaulted to "Central"
 
 		// Initialize repo
-		var repository = GetRepository (item);
+		var repository = GetRepository (item, out var repository_url);
 
 		if (repository is null)
 			return null;
@@ -106,8 +106,8 @@ public class MavenDownload : AsyncTask
 			return result;
 
 		// Resolve and download POM, and any parent or imported POMs
+		var resolver = new LoggingPomResolver (repository, repository_url);
 		try {
-			var resolver = new LoggingPomResolver (repository);
 			var project = ResolvedProject.FromArtifact (artifact, resolver);
 
 			// Set the POM file path for _this_ artifact
@@ -129,7 +129,10 @@ public class MavenDownload : AsyncTask
 				LogMessage ("Found POM file '{0}' for Java artifact '{1}'.", kv.Value, pom_artifact);
 			}
 		} catch (Exception ex) {
-			LogCodedError ("XA4237", Properties.Resources.XA4237, artifact, ex.Unwrap ().Message);
+			var unresolved_artifact = resolver.UnresolvedArtifact ?? artifact;
+			var unresolved_pom = resolver.UnresolvedPomUrl ?? resolver.GetPomUrl (unresolved_artifact);
+			var details = $"Failed to resolve POM for Maven artifact '{unresolved_artifact}' from '{unresolved_pom}'.{Environment.NewLine}- {ex.Unwrap ().Message}";
+			LogCodedError ("XA4237", Properties.Resources.XA4237, artifact, details);
 			return null;
 		}
 
@@ -148,11 +151,16 @@ public class MavenDownload : AsyncTask
 			_ => null
 		};
 
-	CachedMavenRepository? GetRepository (ITaskItem item)
+	CachedMavenRepository? GetRepository (ITaskItem item, out string repositoryUrl)
 	{
 		var type = item.GetMetadataOrDefault ("Repository", "Central");
+		repositoryUrl = type.TrimEnd ('/');
 
 		var repo = GetKnownRepository (type);
+		if (repo == MavenRepository.Central)
+			repositoryUrl = "https://repo1.maven.org/maven2";
+		else if (repo == MavenRepository.Google)
+			repositoryUrl = "https://dl.google.com/android/maven2";
 
 		if (repo is null && Uri.TryCreate (type, UriKind.Absolute, out var uri) &&
 			(uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)) {
@@ -181,27 +189,46 @@ public class MavenDownload : AsyncTask
 class LoggingPomResolver : IProjectResolver
 {
 	readonly CachedMavenRepository repository;
+	readonly string repositoryUrl;
 
 	public Dictionary<string, string> ResolvedPoms { get; } = new Dictionary<string, string> ();
+	public Artifact? UnresolvedArtifact { get; private set; }
+	public string? UnresolvedPomUrl { get; private set; }
 
-	public LoggingPomResolver (CachedMavenRepository repository)
+	public LoggingPomResolver (CachedMavenRepository repository, string repositoryUrl)
 	{
 		this.repository = repository;
+		this.repositoryUrl = repositoryUrl.TrimEnd ('/');
 	}
 
 	public Project Resolve (Artifact artifact)
 	{
-		if (repository.TryGetFilePath (artifact, $"{artifact.Id}-{artifact.Version}.pom", out var path)) {
-			using (var stream = File.OpenRead (path)) {
-				var pom = Project.Load (stream) ?? throw new InvalidOperationException ($"Could not deserialize POM for {artifact}");
+		try {
+			if (repository.TryGetFilePath (artifact, $"{artifact.Id}-{artifact.Version}.pom", out var path)) {
+				using (var stream = File.OpenRead (path)) {
+					var pom = Project.Load (stream) ?? throw new InvalidOperationException ($"Could not deserialize POM for {artifact}");
 
-				// Use index instead of Add to handle duplicates
-				ResolvedPoms [artifact.VersionedArtifactString] = path;
+					// Use index instead of Add to handle duplicates
+					ResolvedPoms [artifact.VersionedArtifactString] = path;
 
-				return pom;
+					return pom;
+				}
 			}
+		} catch {
+			RecordUnresolvedPom (artifact);
+			throw;
 		}
 
+		RecordUnresolvedPom (artifact);
 		throw new InvalidOperationException ($"No POM found for {artifact}");
+	}
+
+	public string GetPomUrl (Artifact artifact)
+		=> $"{repositoryUrl}/{artifact.GroupId.Replace ('.', '/')}/{artifact.Id}/{artifact.Version}/{artifact.Id}-{artifact.Version}.pom";
+
+	void RecordUnresolvedPom (Artifact artifact)
+	{
+		UnresolvedArtifact = artifact;
+		UnresolvedPomUrl = GetPomUrl (artifact);
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MavenDownloadTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MavenDownloadTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Java.Interop.Tools.Maven;
 using Java.Interop.Tools.Maven.Models;
@@ -189,7 +190,7 @@ public class MavenDownloadTests
 			  </dependencyManagement>
 			</project>
 			""";
-		var repository = new TestMavenRepository (root, root_pom);
+		var repository = new TestMavenRepository ((root, root_pom));
 		var cache = new CachedMavenRepository (Path.Combine (Path.GetTempPath (), Guid.NewGuid ().ToString ()), repository);
 		var resolver = new LoggingPomResolver (cache, "https://repo.example.com/maven2/");
 
@@ -199,6 +200,31 @@ public class MavenDownloadTests
 			Assert.AreEqual ($"No POM found for {imported}", exception?.Message);
 			Assert.AreEqual (imported.VersionedArtifactString, resolver.UnresolvedArtifact?.VersionedArtifactString);
 			Assert.AreEqual ("https://repo.example.com/maven2/androidx/compose/compose-bom/2024.09.00/compose-bom-2024.09.00.pom", resolver.UnresolvedPomUrl);
+		} finally {
+			DeleteTempDirectory (cache.CacheDirectory);
+		}
+	}
+
+	[Test]
+	public void ImportedPomModelFailureDoesNotBlameRootArtifact ()
+	{
+		var root = new Artifact ("com.example", "library", "1.0.0");
+		var imported = new Artifact ("com.example", "bom", "1.0.0");
+		var root_pom = CreatePomWithImport (root, imported.GroupId, imported.Id, imported.Version);
+		var imported_pom = CreatePomWithImport (imported, "${invalid.group}", "nested-bom", "1.0.0");
+		var repository = new TestMavenRepository ((root, root_pom), (imported, imported_pom));
+		var cache = new CachedMavenRepository (Path.Combine (Path.GetTempPath (), Guid.NewGuid ().ToString ()), repository);
+		var resolver = new LoggingPomResolver (cache, "https://repo.example.com/maven2/");
+
+		try {
+			var exception = Assert.Throws<ArgumentException> (() => ResolvedProject.FromArtifact (root, resolver));
+			if (exception is null)
+				throw new InvalidOperationException ("Expected imported POM model resolution to fail.");
+
+			Assert.IsNull (resolver.UnresolvedArtifact);
+			Assert.IsNull (resolver.UnresolvedPomUrl);
+			Assert.IsTrue (resolver.ResolvedPoms.ContainsKey (imported.VersionedArtifactString));
+			Assert.AreEqual (exception.Message, MavenDownload.GetPomResolutionErrorDetails (resolver, exception));
 		} finally {
 			DeleteTempDirectory (cache.CacheDirectory);
 		}
@@ -345,22 +371,41 @@ public class MavenDownloadTests
 		}
 	}
 
+	static string CreatePomWithImport (Artifact artifact, string importedGroupId, string importedArtifactId, string importedVersion)
+		=> $"""
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <modelVersion>4.0.0</modelVersion>
+			  <groupId>{artifact.GroupId}</groupId>
+			  <artifactId>{artifact.Id}</artifactId>
+			  <version>{artifact.Version}</version>
+			  <dependencyManagement>
+			    <dependencies>
+			      <dependency>
+			        <groupId>{importedGroupId}</groupId>
+			        <artifactId>{importedArtifactId}</artifactId>
+			        <version>{importedVersion}</version>
+			        <type>pom</type>
+			        <scope>import</scope>
+			      </dependency>
+			    </dependencies>
+			  </dependencyManagement>
+			</project>
+			""";
+
 	sealed class TestMavenRepository : IMavenRepository
 	{
-		readonly Artifact artifact;
-		readonly byte [] pom;
+		readonly Dictionary<string, byte []> poms;
 
 		public string Name => "test";
 
-		public TestMavenRepository (Artifact artifact, string pom)
+		public TestMavenRepository (params (Artifact Artifact, string Pom) [] poms)
 		{
-			this.artifact = artifact;
-			this.pom = Encoding.UTF8.GetBytes (pom);
+			this.poms = poms.ToDictionary (p => p.Artifact.VersionedArtifactString, p => Encoding.UTF8.GetBytes (p.Pom));
 		}
 
 		public bool TryGetFile (Artifact artifact, string filename, out Stream stream)
 		{
-			if (artifact.VersionedArtifactString == this.artifact.VersionedArtifactString) {
+			if (poms.TryGetValue (artifact.VersionedArtifactString, out var pom)) {
 				stream = new MemoryStream (pom);
 				return true;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MavenDownloadTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MavenDownloadTests.cs
@@ -3,6 +3,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
+using Java.Interop.Tools.Maven;
+using Java.Interop.Tools.Maven.Models;
+using Java.Interop.Tools.Maven.Repositories;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
@@ -155,9 +159,48 @@ public class MavenDownloadTests
 			await task.RunTaskAsync ();
 
 			Assert.AreEqual (1, engine.Errors.Count);
-			Assert.AreEqual ($"Cannot download POM file for Maven artifact 'com.example:dummy:1.0.0'.{Environment.NewLine}- Response status code does not indicate success: 404 (Not Found).", engine.Errors [0].Message?.ReplaceLineEndings ());
+			Assert.AreEqual ($"Cannot download POM file for Maven artifact 'com.example:dummy:1.0.0'.{Environment.NewLine}- Failed to resolve POM for Maven artifact 'com.example:dummy:1.0.0' from 'https://repo1.maven.org/maven2/com/example/dummy/1.0.0/dummy-1.0.0.pom'.{Environment.NewLine}- Response status code does not indicate success: 404 (Not Found).", engine.Errors [0].Message?.ReplaceLineEndings ());
 		} finally {
 			DeleteTempDirectory (temp_cache_dir);
+		}
+	}
+
+	[Test]
+	public void ImportedPomFailureIdentifiesTransitiveArtifactAndRepository ()
+	{
+		var root = new Artifact ("com.example", "library", "1.0.0");
+		var imported = new Artifact ("androidx.compose", "compose-bom", "2024.09.00");
+		var root_pom = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <modelVersion>4.0.0</modelVersion>
+			  <groupId>com.example</groupId>
+			  <artifactId>library</artifactId>
+			  <version>1.0.0</version>
+			  <dependencyManagement>
+			    <dependencies>
+			      <dependency>
+			        <groupId>androidx.compose</groupId>
+			        <artifactId>compose-bom</artifactId>
+			        <version>2024.09.00</version>
+			        <type>pom</type>
+			        <scope>import</scope>
+			      </dependency>
+			    </dependencies>
+			  </dependencyManagement>
+			</project>
+			""";
+		var repository = new TestMavenRepository (root, root_pom);
+		var cache = new CachedMavenRepository (Path.Combine (Path.GetTempPath (), Guid.NewGuid ().ToString ()), repository);
+		var resolver = new LoggingPomResolver (cache, "https://repo.example.com/maven2/");
+
+		try {
+			var exception = Assert.Throws<InvalidOperationException> (() => ResolvedProject.FromArtifact (root, resolver));
+
+			Assert.AreEqual ($"No POM found for {imported}", exception?.Message);
+			Assert.AreEqual (imported.VersionedArtifactString, resolver.UnresolvedArtifact?.VersionedArtifactString);
+			Assert.AreEqual ("https://repo.example.com/maven2/androidx/compose/compose-bom/2024.09.00/compose-bom-2024.09.00.pom", resolver.UnresolvedPomUrl);
+		} finally {
+			DeleteTempDirectory (cache.CacheDirectory);
 		}
 	}
 
@@ -299,6 +342,31 @@ public class MavenDownloadTests
 			Directory.Delete (dir, true);
 		} catch {
 			// Ignore any cleanup failure
+		}
+	}
+
+	sealed class TestMavenRepository : IMavenRepository
+	{
+		readonly Artifact artifact;
+		readonly byte [] pom;
+
+		public string Name => "test";
+
+		public TestMavenRepository (Artifact artifact, string pom)
+		{
+			this.artifact = artifact;
+			this.pom = Encoding.UTF8.GetBytes (pom);
+		}
+
+		public bool TryGetFile (Artifact artifact, string filename, out Stream stream)
+		{
+			if (artifact.VersionedArtifactString == this.artifact.VersionedArtifactString) {
+				stream = new MemoryStream (pom);
+				return true;
+			}
+
+			stream = Stream.Null;
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
`AndroidMavenLibrary` resolution failures currently report the originally requested artifact even when a transitive parent or imported POM is missing. This makes repository mismatches difficult to diagnose.

Track the artifact at the failing `LoggingPomResolver` call and include its exact POM URL in XA4237. The existing localized XA4237 format remains compatible, while the new resolution detail uses a separate localizable resource. Documentation and deterministic imported-BOM coverage are included.

Fixes #9706

- [x] Useful description of why the change is necessary.
- [x] Links to issues fixed.
- [x] Unit tests (`MavenDownloadTests`: 18 passed).