### PR TITLE
Wake device before launching Android apps

### DIFF
--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -14,6 +14,7 @@ string? activity = null;
 string? deviceUserId = null;
 string? instrumentation = null;
 bool verbose = false;
+bool wakeDevice = true;
 int? logcatPid = null;
 Process? logcatProcess = null;
 CancellationTokenSource cts = new ();
@@ -72,6 +73,9 @@ async Task<int> RunAsync (string[] args)
 		{ "v|verbose",
 			"Enable verbose output for debugging.",
 			v => verbose = v != null },
+		{ "no-wake-device",
+			"Do not wake the device or dismiss its keyguard before launching the application.",
+			v => wakeDevice = v == null },
 		{ "logcat-args=",
 			"Extra {ARGUMENTS} to pass to 'adb logcat' (e.g., 'monodroid-assembly:S' to silence a tag).",
 			v => logcatArgs = v },
@@ -515,7 +519,8 @@ async Task<int> RunAppAsync ()
 async Task<bool> StartAppAsync ()
 {
 	var userArg = string.IsNullOrEmpty (deviceUserId) ? "" : $" --user {deviceUserId}";
-	var cmdArgs = $"shell am start -S -W{userArg} -n \"{package}/{activity}\"";
+	var wakeDeviceCommand = wakeDevice ? "input keyevent KEYCODE_WAKEUP && wm dismiss-keyguard && " : "";
+	var cmdArgs = $"shell {wakeDeviceCommand}am start -S -W{userArg} -n \"{package}/{activity}\"";
 	var (exitCode, output, error) = await AdbHelper.RunAsync (adbPath, adbTarget, cmdArgs, cts.Token, verbose);
 	if (exitCode != 0) {
 		Console.Error.WriteLine ($"Error: Failed to start app: {error}");

--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -519,7 +519,8 @@ async Task<int> RunAppAsync ()
 async Task<bool> StartAppAsync ()
 {
 	var userArg = string.IsNullOrEmpty (deviceUserId) ? "" : $" --user {deviceUserId}";
-	var wakeDeviceCommand = wakeDevice ? "input keyevent KEYCODE_WAKEUP && wm dismiss-keyguard && " : "";
+	// Device preparation is best effort; am start must run and determine the shell exit code.
+	var wakeDeviceCommand = wakeDevice ? "input keyevent KEYCODE_WAKEUP; wm dismiss-keyguard; " : "";
 	var cmdArgs = $"shell {wakeDeviceCommand}am start -S -W{userArg} -n \"{package}/{activity}\"";
 	var (exitCode, output, error) = await AdbHelper.RunAsync (adbPath, adbTarget, cmdArgs, cts.Token, verbose);
 	if (exitCode != 0) {

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -407,7 +407,7 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 			TestContext.AddTestAttachment (logPath);
 
 			if (shouldWakeDevice) {
-				StringAssert.Contains ("shell input keyevent KEYCODE_WAKEUP && wm dismiss-keyguard && am start", output.ToString (),
+				StringAssert.Contains ("shell input keyevent KEYCODE_WAKEUP; wm dismiss-keyguard; am start", output.ToString (),
 					$"`dotnet run` should wake the device and dismiss its keyguard in the same adb shell command used to start the app. See {logPath} for details.");
 			} else {
 				StringAssert.Contains ("shell am start", output.ToString (),

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -402,19 +402,20 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 			}
 
 			// Write the output to a log file for debugging
+			string outputText = output.ToString ();
 			string logPath = Path.Combine (Root, builder.ProjectDirectory, $"dotnet-run-output-wake-{shouldWakeDevice}.log");
-			File.WriteAllText (logPath, output.ToString ());
+			File.WriteAllText (logPath, outputText);
 			TestContext.AddTestAttachment (logPath);
 
 			if (shouldWakeDevice) {
-				StringAssert.Contains ("shell input keyevent KEYCODE_WAKEUP; wm dismiss-keyguard; am start", output.ToString (),
+				StringAssert.Contains ("shell input keyevent KEYCODE_WAKEUP; wm dismiss-keyguard; am start", outputText,
 					$"`dotnet run` should wake the device and dismiss its keyguard in the same adb shell command used to start the app. See {logPath} for details.");
 			} else {
-				StringAssert.Contains ("shell am start", output.ToString (),
+				StringAssert.Contains ("shell am start", outputText,
 					$"`dotnet run` should start the app without waking the device or dismissing its keyguard when --no-wake-device is specified. See {logPath} for details.");
-				StringAssert.DoesNotContain ("KEYCODE_WAKEUP", output.ToString (),
+				StringAssert.DoesNotContain ("KEYCODE_WAKEUP", outputText,
 					$"`dotnet run` should not wake the device when --no-wake-device is specified. See {logPath} for details.");
-				StringAssert.DoesNotContain ("dismiss-keyguard", output.ToString (),
+				StringAssert.DoesNotContain ("dismiss-keyguard", outputText,
 					$"`dotnet run` should not dismiss the keyguard when --no-wake-device is specified. See {logPath} for details.");
 			}
 			Assert.IsTrue (foundMessage, $"Expected message '{logcatMessage}' was not found in output. See {logPath} for details.");

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -341,14 +341,15 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 			Assert.True (builder.Uninstall (proj), "Project should have uninstalled.");
 		}
 
-		[Test]
-		public void DotNetRunWaitForExit ()
+		[TestCase ("", true)]
+		[TestCase ("--no-wake-device", false)]
+		public void DotNetRunWaitForExit (string extraArgs, bool shouldWakeDevice)
 		{
 			const string logcatMessage = "DOTNET_RUN_TEST_MESSAGE_12345";
 			var proj = new XamarinAndroidApplicationProject ();
 
 			// Enable verbose output from Microsoft.Android.Run for debugging
-			proj.SetProperty ("_AndroidRunExtraArgs", "--verbose");
+			proj.SetProperty ("_AndroidRunExtraArgs", $"--verbose {extraArgs}");
 
 			// Add a Console.WriteLine that will appear in logcat
 			proj.MainActivity = proj.DefaultMainActivity.Replace (
@@ -401,10 +402,21 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 			}
 
 			// Write the output to a log file for debugging
-			string logPath = Path.Combine (Root, builder.ProjectDirectory, "dotnet-run-output.log");
+			string logPath = Path.Combine (Root, builder.ProjectDirectory, $"dotnet-run-output-wake-{shouldWakeDevice}.log");
 			File.WriteAllText (logPath, output.ToString ());
 			TestContext.AddTestAttachment (logPath);
 
+			if (shouldWakeDevice) {
+				StringAssert.Contains ("shell input keyevent KEYCODE_WAKEUP && wm dismiss-keyguard && am start", output.ToString (),
+					$"`dotnet run` should wake the device and dismiss its keyguard in the same adb shell command used to start the app. See {logPath} for details.");
+			} else {
+				StringAssert.Contains ("shell am start", output.ToString (),
+					$"`dotnet run` should start the app without waking the device or dismissing its keyguard when --no-wake-device is specified. See {logPath} for details.");
+				StringAssert.DoesNotContain ("KEYCODE_WAKEUP", output.ToString (),
+					$"`dotnet run` should not wake the device when --no-wake-device is specified. See {logPath} for details.");
+				StringAssert.DoesNotContain ("dismiss-keyguard", output.ToString (),
+					$"`dotnet run` should not dismiss the keyguard when --no-wake-device is specified. See {logPath} for details.");
+			}
 			Assert.IsTrue (foundMessage, $"Expected message '{logcatMessage}' was not found in output. See {logPath} for details.");
 		}
 


### PR DESCRIPTION
## Summary

- wake sleeping devices before `Microsoft.Android.Run` starts an activity
- dismiss non-secure keyguards so the deployed app becomes visible
- keep wakeup, keyguard dismissal, and activity launch in one `adb shell` invocation
- add `--no-wake-device`, available to MSBuild callers through `$(_AndroidRunExtraArgs)`, as an escape hatch

Fixes #11064.

## Testing

- built `Xamarin.Android.sln` and configured the local Android workload
- created an app with the in-tree `dotnet new android` template
- deployed and launched it with `dotnet-local.cmd run` on a sleeping, locked physical device
- confirmed the device woke, dismissed the keyguard, and displayed the app
- verified `--no-wake-device` omits both device-preparation commands