### PR TITLE
[CoreCLR] Validate Java package and type names

### DIFF
--- a/Documentation/docs-mobile/TOC.yml
+++ b/Documentation/docs-mobile/TOC.yml
@@ -328,6 +328,8 @@
         href: messages/xa4248.md
       - name: XA4249
         href: messages/xa4249.md
+      - name: XA4258
+        href: messages/xa4258.md
       - name: XA4301
         href: messages/xa4301.md
       - name: XA4302

--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -227,6 +227,7 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 + [XA4254](xa4254.md): Trimmable type map Java source input directory '{input}' and output directory '{output}' must be different.
 + [XA4255](xa4255.md): Generated trimmable type map Java source '{path}' was not found.
 + [XA4256](xa4256.md): Skipping Java peer type '{type}' from assembly '{assembly}' because referenced type '{referencedType}' from assembly '{referencedAssembly}' could not be resolved in '{path}'. This type will not be included in the trimmable type map.
++ [XA4258](xa4258.md): Java name '{name}' contains reserved Java identifier '{identifier}'. Change the package or type name.
 + XA4300: Native library '{library}' will not be bundled because it has an unsupported ABI.
 + [XA4301](xa4301.md): Apk already contains the item `xxx`.
 + [XA4302](xa4302.md): Unhandled exception merging \`AndroidManifest.xml\`: {ex}

--- a/Documentation/docs-mobile/messages/xa4258.md
+++ b/Documentation/docs-mobile/messages/xa4258.md
@@ -16,7 +16,7 @@ error XA4258: Java name 'com.example.for' contains reserved Java identifier 'for
 
 ## Issue
 
-A Java package or type name contains a Java keyword or restricted type identifier. Java does not provide a way to escape these identifiers, so the generated Java source cannot be compiled.
+A Java package or type name contains a Java keyword or restricted type identifier. Java does not provide a way to escape keywords. Restricted type identifiers are also rejected to keep generated Java source compatible when .NET for Android moves to a newer Java source level.
 
 This can originate from the `$(ApplicationId)` MSBuild property, the `package` attribute in `AndroidManifest.xml`, a managed type name, or an explicit Java name supplied by an attribute such as `[Register]` or `[JniTypeSignature]`.
 

--- a/Documentation/docs-mobile/messages/xa4258.md
+++ b/Documentation/docs-mobile/messages/xa4258.md
@@ -1,0 +1,25 @@
+---
+title: .NET for Android error XA4258
+description: XA4258 error code
+ms.date: 08/07/2026
+f1_keywords:
+  - "XA4258"
+---
+
+# .NET for Android error XA4258
+
+## Example message
+
+```text
+error XA4258: Java name 'com.example.for' contains reserved Java identifier 'for'. Change the package or type name.
+```
+
+## Issue
+
+A Java package or type name contains a Java keyword or restricted type identifier. Java does not provide a way to escape these identifiers, so the generated Java source cannot be compiled.
+
+This can originate from the `$(ApplicationId)` MSBuild property, the `package` attribute in `AndroidManifest.xml`, a managed type name, or an explicit Java name supplied by an attribute such as `[Register]` or `[JniTypeSignature]`.
+
+## Solution
+
+Change the package or type name so no segment is a Java keyword. For a type name, also avoid restricted type identifiers such as `record`.

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
@@ -241,6 +241,12 @@ static class JniSignatureHelper
 					}
 				}
 
+				string segment = jniName.Substring (segmentStart, i - segmentStart);
+				bool isTypeName = i == jniName.Length;
+				if (JavaNameValidator.IsInvalidIdentifier (segment, isTypeName)) {
+					throw new ArgumentException ($"JNI name '{jniName}' contains reserved Java identifier '{segment}'.", nameof (jniName));
+				}
+
 				segmentStart = i + 1;
 			}
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
@@ -241,14 +241,12 @@ static class JniSignatureHelper
 					}
 				}
 
-				string segment = jniName.Substring (segmentStart, i - segmentStart);
-				bool isTypeName = i == jniName.Length;
-				if (JavaNameValidator.IsInvalidIdentifier (segment, isTypeName)) {
-					throw new ArgumentException ($"JNI name '{jniName}' contains reserved Java identifier '{segment}'.", nameof (jniName));
-				}
-
 				segmentStart = i + 1;
 			}
+		}
+
+		if (JavaNameValidator.TryGetInvalidJniNameSegment (jniName, out var invalidIdentifier)) {
+			throw new ArgumentException ($"JNI name '{jniName}' contains reserved Java identifier '{invalidIdentifier}'.", nameof (jniName));
 		}
 	}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/ITrimmableTypeMapLogger.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/ITrimmableTypeMapLogger.cs
@@ -21,6 +21,7 @@ public interface ITrimmableTypeMapLogger
 		string unresolvedAssemblyName,
 		string unresolvedAssemblyPath);
 	void LogJniAddNativeMethodRegistrationAttributeError (string managedTypeName);
+	void LogInvalidJavaNameError (string javaName, string invalidIdentifier);
 	void LogCustomJavaObjectError (string managedTypeName);
 	void LogCustomJavaObjectWarning (string managedTypeName);
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+internal static class JavaNameValidator
+{
+	// Java SE 21 reserved keywords and literals:
+	// https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-3.9
+	static readonly HashSet<string> JavaKeywords = new (StringComparer.Ordinal) {
+		"_",
+		"abstract", "assert", "boolean", "break", "byte",
+		"case", "catch", "char", "class", "const", "continue",
+		"default", "do", "double",
+		"else", "enum", "extends",
+		"false", "final", "finally", "float", "for",
+		"goto",
+		"if", "implements", "import", "instanceof", "int", "interface",
+		"long",
+		"native", "new", "null",
+		"package", "private", "protected", "public",
+		"return",
+		"short", "static", "strictfp", "super", "switch", "synchronized",
+		"this", "throw", "throws", "transient", "true", "try",
+		"void", "volatile",
+		"while",
+	};
+
+	// TypeIdentifier additionally excludes these contextual keywords:
+	// https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-TypeIdentifier
+	static readonly HashSet<string> RestrictedTypeIdentifiers = new (StringComparer.Ordinal) {
+		"permits", "record", "sealed", "var", "yield",
+	};
+
+	internal static bool IsInvalidIdentifier (string identifier, bool isTypeName) =>
+		JavaKeywords.Contains (identifier) || isTypeName && RestrictedTypeIdentifiers.Contains (identifier);
+
+	internal static bool TryGetInvalidPackageSegment (string packageName, char separator, out string invalidSegment)
+	{
+		foreach (var segment in packageName.Split (separator)) {
+			if (JavaKeywords.Contains (segment)) {
+				invalidSegment = segment;
+				return true;
+			}
+		}
+
+		invalidSegment = "";
+		return false;
+	}
+
+	internal static bool TryGetInvalidJniNameSegment (string jniName, out string invalidSegment)
+	{
+		var segments = jniName.Split ('/');
+		for (int i = 0; i < segments.Length; i++) {
+			string segment = segments [i];
+			if (IsInvalidIdentifier (segment, i == segments.Length - 1)) {
+				invalidSegment = segment;
+				return true;
+			}
+		}
+
+		invalidSegment = "";
+		return false;
+	}
+}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
@@ -51,9 +51,16 @@ internal static class JavaNameValidator
 	internal static bool TryGetInvalidJniNameSegment (string jniName, out string invalidSegment)
 	{
 		var segments = jniName.Split ('/');
-		for (int i = 0; i < segments.Length; i++) {
-			string segment = segments [i];
-			if (IsInvalidIdentifier (segment, i == segments.Length - 1)) {
+		for (int i = 0; i < segments.Length - 1; i++) {
+			if (JavaKeywords.Contains (segments [i])) {
+				invalidSegment = segments [i];
+				return true;
+			}
+		}
+
+		// '$' separates nested types in a JNI binary name and becomes '.' in Java source.
+		foreach (var segment in segments [segments.Length - 1].Split ('$')) {
+			if (IsInvalidIdentifier (segment, isTypeName: true)) {
 				invalidSegment = segment;
 				return true;
 			}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
@@ -58,15 +58,31 @@ internal static class JavaNameValidator
 			}
 		}
 
-		// '$' separates nested types in a JNI binary name and becomes '.' in Java source.
-		foreach (var segment in segments [segments.Length - 1].Split ('$')) {
+		string typeName = segments [segments.Length - 1];
+		if (IsInvalidIdentifier (typeName, isTypeName: true)) {
+			invalidSegment = typeName;
+			return true;
+		}
+
+		invalidSegment = "";
+		return false;
+	}
+
+	internal static bool TryGetInvalidJniSourceTypeSegment (string jniName, out string invalidSegment)
+	{
+		if (TryGetInvalidJniNameSegment (jniName, out invalidSegment)) {
+			return true;
+		}
+
+		// '$' becomes '.' when a JNI binary name is emitted as a Java source type reference.
+		string typeName = jniName.Substring (jniName.LastIndexOf ('/') + 1);
+		foreach (var segment in typeName.Split ('$')) {
 			if (IsInvalidIdentifier (segment, isTypeName: true)) {
 				invalidSegment = segment;
 				return true;
 			}
 		}
 
-		invalidSegment = "";
 		return false;
 	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
@@ -85,4 +85,45 @@ internal static class JavaNameValidator
 
 		return false;
 	}
+
+	internal static bool TryGetInvalidJniTypeSegment (string jniType, out string typeName, out string invalidSegment)
+	{
+		int typeStart = 0;
+		while (typeStart < jniType.Length && jniType [typeStart] == '[') {
+			typeStart++;
+		}
+
+		if (typeStart < jniType.Length - 1 && jniType [typeStart] == 'L' && jniType [jniType.Length - 1] == ';') {
+			typeName = jniType.Substring (typeStart + 1, jniType.Length - typeStart - 2);
+			return TryGetInvalidJniSourceTypeSegment (typeName, out invalidSegment);
+		}
+
+		typeName = "";
+		invalidSegment = "";
+		return false;
+	}
+
+	internal static bool TryGetInvalidJavaSourceTypeSegment (string javaType, out string invalidSegment)
+	{
+		string typeName = javaType;
+		while (typeName.EndsWith ("[]", StringComparison.Ordinal)) {
+			typeName = typeName.Substring (0, typeName.Length - 2);
+		}
+		if (typeName is "boolean" or "byte" or "char" or "short" or "int" or "long" or "float" or "double" or "void") {
+			invalidSegment = "";
+			return false;
+		}
+
+		var segments = typeName.Split ('.');
+		for (int i = 0; i < segments.Length; i++) {
+			bool isTypeName = i == segments.Length - 1;
+			if (IsInvalidIdentifier (segments [i], isTypeName)) {
+				invalidSegment = segments [i];
+				return true;
+			}
+		}
+
+		invalidSegment = "";
+		return false;
+	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -78,6 +78,9 @@ public class TrimmableTypeMapGenerator
 		bool valid = true;
 		var reportedNames = new HashSet<string> (StringComparer.Ordinal);
 		foreach (var peer in peers) {
+			if (!ShouldGenerateJcw (peer)) {
+				continue;
+			}
 			if (JavaNameValidator.TryGetInvalidJniNameSegment (peer.JavaName, out var invalidIdentifier) && reportedNames.Add (peer.JavaName)) {
 				logger.LogInvalidJavaNameError (peer.JavaName, invalidIdentifier);
 				valid = false;

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -45,6 +45,9 @@ public class TrimmableTypeMapGenerator
 			logger.LogNoJavaPeerTypesFound ();
 			return new TrimmableTypeMapResult ([], [], allPeers);
 		}
+		if (!ValidateJavaNames (allPeers)) {
+			return new TrimmableTypeMapResult ([], [], allPeers);
+		}
 		MarkFrameworkAssemblyPeers (allPeers, frameworkAssemblyNames);
 
 		RootManifestReferencedTypes (allPeers, PrepareManifestForRooting (manifestTemplate, manifestConfig), manifestConfig?.ApplicationJavaClass);
@@ -68,6 +71,19 @@ public class TrimmableTypeMapGenerator
 			: null;
 
 		return new TrimmableTypeMapResult (generatedAssemblies, generatedJavaSources, allPeers, manifest, appRegTypes);
+	}
+
+	internal bool ValidateJavaNames (IReadOnlyList<JavaPeerInfo> peers)
+	{
+		bool valid = true;
+		var reportedNames = new HashSet<string> (StringComparer.Ordinal);
+		foreach (var peer in peers) {
+			if (JavaNameValidator.TryGetInvalidJniNameSegment (peer.JavaName, out var invalidIdentifier) && reportedNames.Add (peer.JavaName)) {
+				logger.LogInvalidJavaNameError (peer.JavaName, invalidIdentifier);
+				valid = false;
+			}
+		}
+		return valid;
 	}
 
 	internal static List<string> CollectApplicationRegistrationTypes (List<JavaPeerInfo> allPeers)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -85,6 +85,25 @@ public class TrimmableTypeMapGenerator
 				logger.LogInvalidJavaNameError (peer.JavaName, invalidIdentifier);
 				valid = false;
 			}
+			if (peer.CannotRegisterInStaticConstructor &&
+					JavaNameValidator.TryGetInvalidJniSourceTypeSegment (peer.JavaName, out invalidIdentifier) &&
+					reportedNames.Add (peer.JavaName)) {
+				logger.LogInvalidJavaNameError (peer.JavaName, invalidIdentifier);
+				valid = false;
+			}
+			if (peer.BaseJavaName is not null &&
+					JavaNameValidator.TryGetInvalidJniSourceTypeSegment (peer.BaseJavaName, out invalidIdentifier) &&
+					reportedNames.Add (peer.BaseJavaName)) {
+				logger.LogInvalidJavaNameError (peer.BaseJavaName, invalidIdentifier);
+				valid = false;
+			}
+			foreach (var interfaceName in peer.ImplementedInterfaceJavaNames) {
+				if (JavaNameValidator.TryGetInvalidJniSourceTypeSegment (interfaceName, out invalidIdentifier) &&
+						reportedNames.Add (interfaceName)) {
+					logger.LogInvalidJavaNameError (interfaceName, invalidIdentifier);
+					valid = false;
+				}
+			}
 		}
 		return valid;
 	}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -45,14 +45,14 @@ public class TrimmableTypeMapGenerator
 			logger.LogNoJavaPeerTypesFound ();
 			return new TrimmableTypeMapResult ([], [], allPeers);
 		}
-		if (!ValidateJavaNames (allPeers)) {
-			return new TrimmableTypeMapResult ([], [], allPeers);
-		}
 		MarkFrameworkAssemblyPeers (allPeers, frameworkAssemblyNames);
 
 		RootManifestReferencedTypes (allPeers, PrepareManifestForRooting (manifestTemplate, manifestConfig), manifestConfig?.ApplicationJavaClass);
 		PropagateDeferredRegistrationToBaseClasses (allPeers);
 		PropagateCannotRegisterToDescendants (allPeers);
+		if (!ValidateJavaNames (allPeers, manifestConfig?.ApplicationJavaClass)) {
+			return new TrimmableTypeMapResult ([], [], allPeers);
+		}
 
 		var generatedAssemblies = generateTypeMapAssemblies
 			? GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion, useSharedTypemapUniverse)
@@ -73,39 +73,88 @@ public class TrimmableTypeMapGenerator
 		return new TrimmableTypeMapResult (generatedAssemblies, generatedJavaSources, allPeers, manifest, appRegTypes);
 	}
 
-	internal bool ValidateJavaNames (IReadOnlyList<JavaPeerInfo> peers)
+	internal bool ValidateJavaNames (IReadOnlyList<JavaPeerInfo> peers, string? applicationJavaClass = null)
 	{
 		bool valid = true;
 		var reportedNames = new HashSet<string> (StringComparer.Ordinal);
+		if (applicationJavaClass is not null &&
+				JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (applicationJavaClass, out var invalidApplicationIdentifier)) {
+			ReportInvalidName (applicationJavaClass, invalidApplicationIdentifier);
+		}
 		foreach (var peer in peers) {
 			if (!ShouldGenerateJcw (peer)) {
 				continue;
 			}
-			if (JavaNameValidator.TryGetInvalidJniNameSegment (peer.JavaName, out var invalidIdentifier) && reportedNames.Add (peer.JavaName)) {
-				logger.LogInvalidJavaNameError (peer.JavaName, invalidIdentifier);
-				valid = false;
-			}
+			ReportInvalidJniName (peer.JavaName);
 			if (peer.CannotRegisterInStaticConstructor &&
-					JavaNameValidator.TryGetInvalidJniSourceTypeSegment (peer.JavaName, out invalidIdentifier) &&
-					reportedNames.Add (peer.JavaName)) {
-				logger.LogInvalidJavaNameError (peer.JavaName, invalidIdentifier);
-				valid = false;
+					JavaNameValidator.TryGetInvalidJniSourceTypeSegment (peer.JavaName, out var invalidIdentifier)) {
+				ReportInvalidName (peer.JavaName, invalidIdentifier);
 			}
-			if (peer.BaseJavaName is not null &&
-					JavaNameValidator.TryGetInvalidJniSourceTypeSegment (peer.BaseJavaName, out invalidIdentifier) &&
-					reportedNames.Add (peer.BaseJavaName)) {
-				logger.LogInvalidJavaNameError (peer.BaseJavaName, invalidIdentifier);
-				valid = false;
+			if (peer.BaseJavaName is not null) {
+				ReportInvalidJniSourceType (peer.BaseJavaName);
 			}
 			foreach (var interfaceName in peer.ImplementedInterfaceJavaNames) {
-				if (JavaNameValidator.TryGetInvalidJniSourceTypeSegment (interfaceName, out invalidIdentifier) &&
-						reportedNames.Add (interfaceName)) {
-					logger.LogInvalidJavaNameError (interfaceName, invalidIdentifier);
-					valid = false;
+				ReportInvalidJniSourceType (interfaceName);
+			}
+			foreach (var constructor in peer.JavaConstructors) {
+				ValidateJniSignature (constructor.JniSignature);
+			}
+			foreach (var method in peer.MarshalMethods) {
+				if (!method.IsConstructor) {
+					ValidateJniSignature (method.JniSignature);
+				}
+				if (method.ThrownNames is not null) {
+					foreach (var thrownName in method.ThrownNames) {
+						if (JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (thrownName, out invalidIdentifier)) {
+							ReportInvalidName (thrownName, invalidIdentifier);
+						}
+					}
+				}
+			}
+			foreach (var field in peer.JavaFields) {
+				if (JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (field.JavaTypeName, out invalidIdentifier)) {
+					ReportInvalidName (field.JavaTypeName, invalidIdentifier);
 				}
 			}
 		}
 		return valid;
+
+		void ValidateJniSignature (string jniSignature)
+		{
+			foreach (var parameter in JniSignatureHelper.ParseParameters (jniSignature)) {
+				ReportInvalidJniType (parameter.JniType);
+			}
+			ReportInvalidJniType (JniSignatureHelper.ParseReturnTypeString (jniSignature));
+		}
+
+		void ReportInvalidJniName (string jniName)
+		{
+			if (JavaNameValidator.TryGetInvalidJniNameSegment (jniName, out var invalidIdentifier)) {
+				ReportInvalidName (jniName, invalidIdentifier);
+			}
+		}
+
+		void ReportInvalidJniSourceType (string jniName)
+		{
+			if (JavaNameValidator.TryGetInvalidJniSourceTypeSegment (jniName, out var invalidIdentifier)) {
+				ReportInvalidName (jniName, invalidIdentifier);
+			}
+		}
+
+		void ReportInvalidJniType (string jniType)
+		{
+			if (JavaNameValidator.TryGetInvalidJniTypeSegment (jniType, out var typeName, out var invalidIdentifier)) {
+				ReportInvalidName (typeName, invalidIdentifier);
+			}
+		}
+
+		void ReportInvalidName (string name, string invalidIdentifier)
+		{
+			if (reportedNames.Add (name)) {
+				logger.LogInvalidJavaNameError (name, invalidIdentifier);
+				valid = false;
+			}
+		}
 	}
 
 	internal static List<string> CollectApplicationRegistrationTypes (List<JavaPeerInfo> allPeers)

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1642,6 +1642,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Java name &apos;{0}&apos; contains reserved Java identifier &apos;{1}&apos;. Change the package or type name..
+        /// </summary>
+        public static string XA4258 {
+            get {
+                return ResourceManager.GetString("XA4258", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Native library &apos;{0}&apos; will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as &apos;libs/armeabi-v7a/&apos;..
         /// </summary>
         public static string XA4300 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1216,6 +1216,12 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {3} - Assembly expected to contain the unresolved type
 {4} - Full path to the resolved assembly file that was expected to contain the unresolved type</comment>
   </data>
+  <data name="XA4258" xml:space="preserve">
+    <value>Java name '{0}' contains reserved Java identifier '{1}'. Change the package or type name.</value>
+    <comment>The following are literal names and should not be translated: Java.
+{0} - Java package or type name
+{1} - Java reserved keyword or restricted identifier</comment>
+  </data>
   <data name="XA0142" xml:space="preserve">
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -57,6 +57,8 @@ public class GenerateTrimmableTypeMap : AndroidTask
 			log.LogCodedWarning ("XA4257", Properties.Resources.XA4257, managedTypeName, assemblyName, unresolvedTypeName, unresolvedAssemblyName, unresolvedAssemblyPath);
 		public void LogJniAddNativeMethodRegistrationAttributeError (string managedTypeName) =>
 			log.LogCodedError ("XA4251", Properties.Resources.XA4251, managedTypeName);
+		public void LogInvalidJavaNameError (string javaName, string invalidIdentifier) =>
+			log.LogCodedError ("XA4258", Properties.Resources.XA4258, javaName, invalidIdentifier);
 		public void LogCustomJavaObjectError (string managedTypeName) =>
 			log.LogError ("{0}", $"XA4212: {string.Format (Properties.Resources.XA4212, managedTypeName)}");
 		public void LogCustomJavaObjectWarning (string managedTypeName) =>
@@ -220,6 +222,9 @@ public class GenerateTrimmableTypeMap : AndroidTask
 				packageNamingPolicy: PackageNamingPolicy,
 				generateTypeMapAssemblies: GenerateTypeMapAssemblies,
 				errorOnCustomJavaObject: ErrorOnCustomJavaObject);
+			if (Log.HasLoggedErrors) {
+				return false;
+			}
 
 			if (GenerateTypeMapAssemblies) {
 				GeneratedAssemblies = WriteAssembliesToDisk (result.GeneratedAssemblies, assemblyInputs.Select (i => i.Path).ToList ());

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
@@ -29,6 +29,7 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using Microsoft.Build.Framework;
+using Microsoft.Android.Sdk.TrimmableTypeMap;
 using Xamarin.Android.Tools;
 using Microsoft.Android.Build.Tasks;
 
@@ -68,6 +69,10 @@ namespace Xamarin.Android.Tasks
 				// If we don't have a manifest, default to using the assembly name
 				// If the assembly doesn't have a period in it, duplicate it so it does
 				PackageName = AndroidAppManifest.CanonicalizePackageName (AssemblyName);
+			}
+
+			if (JavaNameValidator.TryGetInvalidPackageSegment (PackageName, '.', out var invalidIdentifier)) {
+				Log.LogCodedError ("XA4258", Properties.Resources.XA4258, PackageName, invalidIdentifier);
 			}
 
 			Log.LogDebugMessage ($"  PackageName: {PackageName}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetAndroidPackageNameTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetAndroidPackageNameTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests {
+
+	[TestFixture]
+	[Parallelizable (ParallelScope.Children)]
+	public class GetAndroidPackageNameTests {
+
+		[TestCase ("com.example.for", "for")]
+		[TestCase ("com.class.example", "class")]
+		[TestCase ("com.example.true", "true")]
+		public void ReservedJavaIdentifier_FailsWithXA4258 (string packageName, string invalidIdentifier)
+		{
+			var errors = new List<BuildErrorEventArgs> ();
+			var task = new GetAndroidPackageName {
+				BuildEngine = new MockBuildEngine (TestContext.Out, errors),
+				AssemblyName = "Example",
+				PackageName = packageName,
+			};
+
+			Assert.IsFalse (task.Execute ());
+			Assert.That (errors, Has.Exactly (1).Matches<BuildErrorEventArgs> (error =>
+				error.Code == "XA4258" &&
+				error.Message.Contains (packageName) &&
+				error.Message.Contains (invalidIdentifier)));
+		}
+
+		[Test]
+		public void ContextualKeywordInPackage_Succeeds ()
+		{
+			var errors = new List<BuildErrorEventArgs> ();
+			var task = new GetAndroidPackageName {
+				BuildEngine = new MockBuildEngine (TestContext.Out, errors),
+				AssemblyName = "Example",
+				PackageName = "com.example.record",
+			};
+
+			Assert.IsTrue (task.Execute ());
+			Assert.IsEmpty (errors);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -110,6 +110,9 @@
     <Compile Include="..\..\external\Java.Interop\src\utils\NullableAttributes.cs">
       <Link>Utilities\NullableAttributes.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.Android.Sdk.TrimmableTypeMap\JavaNameValidator.cs">
+      <Link>Utilities\JavaNameValidator.cs</Link>
+    </Compile>
     <Compile Include="..\Mono.Android\\Android.App\UsesLibraryAttribute.cs">
       <Link>Mono.Android\UsesLibraryAttribute.cs</Link>
     </Compile>

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JavaNameValidatorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JavaNameValidatorTests.cs
@@ -70,9 +70,10 @@ public class JavaNameValidatorTests
 	[InlineData ("com/example/Outer$for", "for")]
 	[InlineData ("com/example/Outer$record", "record")]
 	[InlineData ("com/example/for$Nested", "for")]
-	public void TryGetInvalidJniNameSegment_ReservedNestedTypeIdentifier_ReturnsTrue (string jniName, string expected)
+	public void TryGetInvalidJniSourceTypeSegment_ReservedNestedTypeIdentifier_ReturnsTrue (string jniName, string expected)
 	{
-		Assert.True (JavaNameValidator.TryGetInvalidJniNameSegment (jniName, out var actual));
+		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment (jniName, out _));
+		Assert.True (JavaNameValidator.TryGetInvalidJniSourceTypeSegment (jniName, out var actual));
 		Assert.Equal (expected, actual);
 	}
 
@@ -114,6 +115,8 @@ public class JavaNameValidatorTests
 		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ("com/example/MainActivity", out var jniIdentifier));
 		Assert.Equal ("", jniIdentifier);
 		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ("com/example/Outer$Inner", out var nestedIdentifier));
+		Assert.Equal ("", nestedIdentifier);
+		Assert.False (JavaNameValidator.TryGetInvalidJniSourceTypeSegment ("com/example/Outer$Inner", out nestedIdentifier));
 		Assert.Equal ("", nestedIdentifier);
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JavaNameValidatorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JavaNameValidatorTests.cs
@@ -119,4 +119,26 @@ public class JavaNameValidatorTests
 		Assert.False (JavaNameValidator.TryGetInvalidJniSourceTypeSegment ("com/example/Outer$Inner", out nestedIdentifier));
 		Assert.Equal ("", nestedIdentifier);
 	}
+
+	[Theory]
+	[InlineData ("Lcom/example/Outer$for;", "com/example/Outer$for", "for")]
+	[InlineData ("[[Lcom/example/Outer$record;", "com/example/Outer$record", "record")]
+	public void TryGetInvalidJniTypeSegment_ReservedTypeIdentifier_ReturnsTrue (string jniType, string expectedTypeName, string expectedIdentifier)
+	{
+		Assert.True (JavaNameValidator.TryGetInvalidJniTypeSegment (jniType, out var typeName, out var invalidIdentifier));
+		Assert.Equal (expectedTypeName, typeName);
+		Assert.Equal (expectedIdentifier, invalidIdentifier);
+	}
+
+	[Theory]
+	[InlineData ("com.example.Outer.for", "for")]
+	[InlineData ("com.example.record", "record")]
+	[InlineData ("com.record.Example", null)]
+	[InlineData ("int[]", null)]
+	public void TryGetInvalidJavaSourceTypeSegment_ValidatesEmittedTypeName (string javaType, string? expectedIdentifier)
+	{
+		bool invalid = JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (javaType, out var invalidIdentifier);
+		Assert.Equal (expectedIdentifier is not null, invalid);
+		Assert.Equal (expectedIdentifier ?? "", invalidIdentifier);
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JavaNameValidatorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JavaNameValidatorTests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+public class JavaNameValidatorTests
+{
+	public static IEnumerable<object []> ReservedIdentifiers {
+		get {
+			string [] identifiers = [
+				"_",
+				"abstract", "assert", "boolean", "break", "byte",
+				"case", "catch", "char", "class", "const", "continue",
+				"default", "do", "double",
+				"else", "enum", "extends",
+				"false", "final", "finally", "float", "for",
+				"goto",
+				"if", "implements", "import", "instanceof", "int", "interface",
+				"long",
+				"native", "new", "null",
+				"package", "private", "protected", "public",
+				"return",
+				"short", "static", "strictfp", "super", "switch", "synchronized",
+				"this", "throw", "throws", "transient", "true", "try",
+				"void", "volatile",
+				"while",
+			];
+
+			foreach (var identifier in identifiers) {
+				yield return [identifier];
+			}
+		}
+	}
+
+	public static IEnumerable<object []> RestrictedTypeIdentifiers {
+		get {
+			yield return ["permits"];
+			yield return ["record"];
+			yield return ["sealed"];
+			yield return ["var"];
+			yield return ["yield"];
+		}
+	}
+
+	[Theory]
+	[MemberData (nameof (ReservedIdentifiers))]
+	public void TryGetInvalidPackageSegment_ReservedIdentifier_ReturnsTrue (string identifier)
+	{
+		Assert.True (JavaNameValidator.TryGetInvalidPackageSegment ($"com.{identifier}.example", '.', out var actual));
+		Assert.Equal (identifier, actual);
+	}
+
+	[Theory]
+	[MemberData (nameof (ReservedIdentifiers))]
+	public void TryGetInvalidJniNameSegment_ReservedPackageIdentifier_ReturnsTrue (string identifier)
+	{
+		Assert.True (JavaNameValidator.TryGetInvalidJniNameSegment ($"com/{identifier}/Example", out var actual));
+		Assert.Equal (identifier, actual);
+	}
+
+	[Theory]
+	[MemberData (nameof (ReservedIdentifiers))]
+	public void TryGetInvalidJniNameSegment_ReservedTypeIdentifier_ReturnsTrue (string identifier)
+	{
+		Assert.True (JavaNameValidator.TryGetInvalidJniNameSegment ($"com/example/{identifier}", out var actual));
+		Assert.Equal (identifier, actual);
+	}
+
+	[Theory]
+	[MemberData (nameof (RestrictedTypeIdentifiers))]
+	public void RestrictedTypeIdentifier_IsValidInPackageButInvalidAsType (string identifier)
+	{
+		Assert.False (JavaNameValidator.TryGetInvalidPackageSegment ($"com.example.{identifier}", '.', out var packageIdentifier));
+		Assert.Equal ("", packageIdentifier);
+		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ($"com/{identifier}/Example", out var jniPackageIdentifier));
+		Assert.Equal ("", jniPackageIdentifier);
+		Assert.True (JavaNameValidator.TryGetInvalidJniNameSegment ($"com/example/{identifier}", out var typeIdentifier));
+		Assert.Equal (identifier, typeIdentifier);
+	}
+
+	[Theory]
+	[InlineData ("module")]
+	[InlineData ("open")]
+	[InlineData ("requires")]
+	[InlineData ("exports")]
+	[InlineData ("opens")]
+	[InlineData ("to")]
+	[InlineData ("uses")]
+	[InlineData ("provides")]
+	[InlineData ("with")]
+	[InlineData ("transitive")]
+	public void ModuleContextualKeyword_IsValidIdentifier (string identifier)
+	{
+		Assert.False (JavaNameValidator.TryGetInvalidPackageSegment ($"com.example.{identifier}", '.', out _));
+		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ($"com/{identifier}/Example", out _));
+		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ($"com/example/{identifier}", out _));
+	}
+
+	[Fact]
+	public void ValidNames_ReturnFalseAndEmptyIdentifier ()
+	{
+		Assert.False (JavaNameValidator.TryGetInvalidPackageSegment ("com.example.app", '.', out var packageIdentifier));
+		Assert.Equal ("", packageIdentifier);
+		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ("com/example/MainActivity", out var jniIdentifier));
+		Assert.Equal ("", jniIdentifier);
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JavaNameValidatorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JavaNameValidatorTests.cs
@@ -67,6 +67,16 @@ public class JavaNameValidatorTests
 	}
 
 	[Theory]
+	[InlineData ("com/example/Outer$for", "for")]
+	[InlineData ("com/example/Outer$record", "record")]
+	[InlineData ("com/example/for$Nested", "for")]
+	public void TryGetInvalidJniNameSegment_ReservedNestedTypeIdentifier_ReturnsTrue (string jniName, string expected)
+	{
+		Assert.True (JavaNameValidator.TryGetInvalidJniNameSegment (jniName, out var actual));
+		Assert.Equal (expected, actual);
+	}
+
+	[Theory]
 	[MemberData (nameof (RestrictedTypeIdentifiers))]
 	public void RestrictedTypeIdentifier_IsValidInPackageButInvalidAsType (string identifier)
 	{
@@ -103,5 +113,7 @@ public class JavaNameValidatorTests
 		Assert.Equal ("", packageIdentifier);
 		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ("com/example/MainActivity", out var jniIdentifier));
 		Assert.Equal ("", jniIdentifier);
+		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ("com/example/Outer$Inner", out var nestedIdentifier));
+		Assert.Equal ("", nestedIdentifier);
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -394,6 +394,9 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 		[InlineData ("C:\\Windows\\System32")]
 		[InlineData ("com/Ex:ample")]
 		[InlineData ("/absolute/path")]
+		[InlineData ("com/for/Example")]
+		[InlineData ("com/example/for")]
+		[InlineData ("com/example/record")]
 		public void ValidateJniName_InvalidName_Throws (string badJniName)
 		{
 			Assert.Throws<ArgumentException> (() => JniSignatureHelper.ValidateJniName (badJniName));

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -397,6 +397,8 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 		[InlineData ("com/for/Example")]
 		[InlineData ("com/example/for")]
 		[InlineData ("com/example/record")]
+		[InlineData ("com/example/Outer$for")]
+		[InlineData ("com/example/Outer$record")]
 		public void ValidateJniName_InvalidName_Throws (string badJniName)
 		{
 			Assert.Throws<ArgumentException> (() => JniSignatureHelper.ValidateJniName (badJniName));

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -131,6 +131,43 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 		}
 
 		[Fact]
+		public void Generate_DeclaredDollarKeyword_PreservesDollar ()
+		{
+			var type = new JavaPeerInfo {
+				JavaName = "com/example/Outer$for",
+				CompatJniName = "com/example/Outer$for",
+				ManagedTypeName = "Example.Type",
+				ManagedTypeNamespace = "Example",
+				ManagedTypeShortName = "Type",
+				AssemblyName = "Example",
+			};
+
+			var java = GenerateToString (type);
+
+			Assert.Contains ("public class Outer$for\n", java);
+		}
+
+		[Fact]
+		public void Generate_ReferencedDollarKeyword_UsesSourceDots ()
+		{
+			var type = new JavaPeerInfo {
+				JavaName = "com/example/Derived",
+				CompatJniName = "com/example/Derived",
+				ManagedTypeName = "Example.Derived",
+				ManagedTypeNamespace = "Example",
+				ManagedTypeShortName = "Derived",
+				AssemblyName = "Example",
+				BaseJavaName = "com/example/Outer$for",
+				ImplementedInterfaceJavaNames = ["com/example/Outer$record"],
+			};
+
+			var java = GenerateToString (type);
+
+			Assert.Contains ("\textends com.example.Outer.for\n", java);
+			Assert.Contains ("\t\tcom.example.Outer.record", java);
+		}
+
+		[Fact]
 		public void Generate_ApplicationSubclass_WithApplicationJavaClass_ExtendsThatClass ()
 		{
 			// When $(AndroidApplicationJavaClass) is set (e.g. android.support.multidex.MultiDexApplication
@@ -397,8 +434,6 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 		[InlineData ("com/for/Example")]
 		[InlineData ("com/example/for")]
 		[InlineData ("com/example/record")]
-		[InlineData ("com/example/Outer$for")]
-		[InlineData ("com/example/Outer$record")]
 		public void ValidateJniName_InvalidName_Throws (string badJniName)
 		{
 			Assert.Throws<ArgumentException> (() => JniSignatureHelper.ValidateJniName (badJniName));
@@ -410,6 +445,8 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 		[InlineData ("SingleSegment")]
 		[InlineData ("com/example/_Private")]
 		[InlineData ("com/example/$Generated")]
+		[InlineData ("com/example/Outer$for")]
+		[InlineData ("com/example/Outer$record")]
 		public void ValidateJniName_ValidName_DoesNotThrow (string validJniName)
 		{
 			JniSignatureHelper.ValidateJniName (validJniName);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -51,10 +51,51 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 				$"'{unresolvedTypeName}' from '{unresolvedAssemblyName}' at '{unresolvedAssemblyPath}' could not be resolved.");
 		public void LogJniAddNativeMethodRegistrationAttributeError (string managedTypeName) =>
 			logMessages.Add ($"XA4251: Type '{managedTypeName}' uses [JniAddNativeMethodRegistrationAttribute], which is not supported by the trimmable type map.");
+		public void LogInvalidJavaNameError (string javaName, string invalidIdentifier) =>
+			logMessages.Add ($"XA4258: Java name '{javaName}' contains reserved Java identifier '{invalidIdentifier}'.");
 		public void LogCustomJavaObjectError (string managedTypeName) =>
 			logMessages.Add ($"XA4212: Type `{managedTypeName}` implements `Android.Runtime.IJavaObject` but does not inherit `Java.Lang.Object` or `Java.Lang.Throwable`. This is not supported.");
 		public void LogCustomJavaObjectWarning (string managedTypeName) =>
 			warnings?.Add ($"XA4212: Type `{managedTypeName}` implements `Android.Runtime.IJavaObject` but does not inherit `Java.Lang.Object` or `Java.Lang.Throwable`. This is not supported.");
+	}
+
+	[Theory]
+	[InlineData ("com/for/Example", "for")]
+	[InlineData ("com/example/for", "for")]
+	[InlineData ("com/example/record", "record")]
+	public void ValidateJavaNames_ReservedIdentifier_LogsError (string javaName, string invalidIdentifier)
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = javaName,
+				CompatJniName = javaName,
+				ManagedTypeName = "Example.Type",
+				ManagedTypeNamespace = "Example",
+				ManagedTypeShortName = "Type",
+				AssemblyName = "Example",
+			},
+		};
+
+		Assert.False (CreateGenerator ().ValidateJavaNames (peers));
+		Assert.Contains (logMessages, message => message.Contains ($"XA4258: Java name '{javaName}' contains reserved Java identifier '{invalidIdentifier}'."));
+	}
+
+	[Fact]
+	public void ValidateJavaNames_ContextualKeywordInPackage_IsValid ()
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/record/Example",
+				CompatJniName = "com/record/Example",
+				ManagedTypeName = "Example.Type",
+				ManagedTypeNamespace = "Example",
+				ManagedTypeShortName = "Type",
+				AssemblyName = "Example",
+			},
+		};
+
+		Assert.True (CreateGenerator ().ValidateJavaNames (peers));
+		Assert.DoesNotContain (logMessages, message => message.Contains ("XA4258"));
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -63,8 +63,6 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	[InlineData ("com/for/Example", "for")]
 	[InlineData ("com/example/for", "for")]
 	[InlineData ("com/example/record", "record")]
-	[InlineData ("com/example/Outer$for", "for")]
-	[InlineData ("com/example/Outer$record", "record")]
 	public void ValidateJavaNames_ReservedIdentifier_LogsError (string javaName, string invalidIdentifier)
 	{
 		var peers = new List<JavaPeerInfo> {
@@ -98,6 +96,73 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 
 		Assert.True (CreateGenerator ().ValidateJavaNames (peers));
 		Assert.DoesNotContain (logMessages, message => message.Contains ("XA4258"));
+	}
+
+	[Theory]
+	[InlineData ("com/example/Outer$for", null, "for")]
+	[InlineData ("com/example/Outer$record", null, "record")]
+	[InlineData (null, "com/example/Outer$for", "for")]
+	[InlineData (null, "com/example/Outer$record", "record")]
+	public void ValidateJavaNames_ReservedReferencedTypeIdentifier_LogsError (string? baseJavaName, string? interfaceName, string invalidIdentifier)
+	{
+		var interfaces = interfaceName is null ? [] : new [] { interfaceName };
+		var referencedName = baseJavaName ?? interfaceName;
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/Derived",
+				CompatJniName = "com/example/Derived",
+				ManagedTypeName = "Example.Derived",
+				ManagedTypeNamespace = "Example",
+				ManagedTypeShortName = "Derived",
+				AssemblyName = "Example",
+				BaseJavaName = baseJavaName,
+				ImplementedInterfaceJavaNames = interfaces,
+			},
+		};
+
+		Assert.False (CreateGenerator ().ValidateJavaNames (peers));
+		Assert.Contains (logMessages, message => message.Contains ($"XA4258: Java name '{referencedName}' contains reserved Java identifier '{invalidIdentifier}'."));
+	}
+
+	[Theory]
+	[InlineData ("com/example/Outer$for")]
+	[InlineData ("com/example/Outer$record")]
+	public void ValidateJavaNames_DollarInDeclaredTypeName_IsValid (string javaName)
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = javaName,
+				CompatJniName = javaName,
+				ManagedTypeName = "Example.Type",
+				ManagedTypeNamespace = "Example",
+				ManagedTypeShortName = "Type",
+				AssemblyName = "Example",
+			},
+		};
+
+		Assert.True (CreateGenerator ().ValidateJavaNames (peers));
+		Assert.DoesNotContain (logMessages, message => message.Contains ("XA4258"));
+	}
+
+	[Theory]
+	[InlineData ("com/example/Outer$for", "for")]
+	[InlineData ("com/example/Outer$record", "record")]
+	public void ValidateJavaNames_ReservedDeferredRegistrationTypeIdentifier_LogsError (string javaName, string invalidIdentifier)
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = javaName,
+				CompatJniName = javaName,
+				ManagedTypeName = "Example.Application",
+				ManagedTypeNamespace = "Example",
+				ManagedTypeShortName = "Application",
+				AssemblyName = "Example",
+				CannotRegisterInStaticConstructor = true,
+			},
+		};
+
+		Assert.False (CreateGenerator ().ValidateJavaNames (peers));
+		Assert.Contains (logMessages, message => message.Contains ($"XA4258: Java name '{javaName}' contains reserved Java identifier '{invalidIdentifier}'."));
 	}
 
 	[Theory]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -63,6 +63,8 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	[InlineData ("com/for/Example", "for")]
 	[InlineData ("com/example/for", "for")]
 	[InlineData ("com/example/record", "record")]
+	[InlineData ("com/example/Outer$for", "for")]
+	[InlineData ("com/example/Outer$record", "record")]
 	public void ValidateJavaNames_ReservedIdentifier_LogsError (string javaName, string invalidIdentifier)
 	{
 		var peers = new List<JavaPeerInfo> {
@@ -91,6 +93,30 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 				ManagedTypeNamespace = "Example",
 				ManagedTypeShortName = "Type",
 				AssemblyName = "Example",
+			},
+		};
+
+		Assert.True (CreateGenerator ().ValidateJavaNames (peers));
+		Assert.DoesNotContain (logMessages, message => message.Contains ("XA4258"));
+	}
+
+	[Theory]
+	[InlineData (true, false, "com/for/Example")]
+	[InlineData (false, true, "com/for/Example")]
+	[InlineData (true, false, "com/example/Outer$record")]
+	[InlineData (false, true, "com/example/Outer$record")]
+	public void ValidateJavaNames_TypeWithoutJcw_IsNotValidated (bool doNotGenerateAcw, bool isInterface, string javaName)
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = javaName,
+				CompatJniName = javaName,
+				ManagedTypeName = "Example.Type",
+				ManagedTypeNamespace = "Example",
+				ManagedTypeShortName = "Type",
+				AssemblyName = "Example",
+				DoNotGenerateAcw = doNotGenerateAcw,
+				IsInterface = isInterface,
 			},
 		};
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -165,6 +165,88 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 		Assert.Contains (logMessages, message => message.Contains ($"XA4258: Java name '{javaName}' contains reserved Java identifier '{invalidIdentifier}'."));
 	}
 
+	[Fact]
+	public void ValidateJavaNames_ReservedEmittedTypeReferences_LogErrors ()
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/Derived",
+				CompatJniName = "com/example/Derived",
+				ManagedTypeName = "Example.Derived",
+				ManagedTypeNamespace = "Example",
+				ManagedTypeShortName = "Derived",
+				AssemblyName = "Example",
+				JavaConstructors = [
+					new JavaConstructorInfo {
+						JniSignature = "(Lcom/example/Outer$for;)V",
+						ConstructorIndex = 0,
+					},
+				],
+				MarshalMethods = [
+					new MarshalMethodInfo {
+						JniName = "method",
+						JniSignature = "([Lcom/example/Outer$record;)Lcom/example/Outer$yield;",
+						ManagedMethodName = "Method",
+						NativeCallbackName = "n_method",
+						ThrownNames = ["com.example.Outer.permits"],
+					},
+				],
+				JavaFields = [
+					new JavaFieldInfo {
+						FieldName = "VALUE",
+						JavaTypeName = "com.example.Outer.sealed",
+						InitializerMethodName = "getValue",
+						Visibility = "public",
+					},
+				],
+			},
+		};
+
+		Assert.False (CreateGenerator ().ValidateJavaNames (peers));
+		Assert.Contains (logMessages, message => message.Contains ("Java name 'com/example/Outer$for' contains reserved Java identifier 'for'."));
+		Assert.Contains (logMessages, message => message.Contains ("Java name 'com/example/Outer$record' contains reserved Java identifier 'record'."));
+		Assert.Contains (logMessages, message => message.Contains ("Java name 'com/example/Outer$yield' contains reserved Java identifier 'yield'."));
+		Assert.Contains (logMessages, message => message.Contains ("Java name 'com.example.Outer.permits' contains reserved Java identifier 'permits'."));
+		Assert.Contains (logMessages, message => message.Contains ("Java name 'com.example.Outer.sealed' contains reserved Java identifier 'sealed'."));
+	}
+
+	[Fact]
+	public void ValidateJavaNames_AfterDeferredRegistrationPropagation_ValidatesRegistrationName ()
+	{
+		var basePeer = new JavaPeerInfo {
+			JavaName = "com/example/Outer$for",
+			CompatJniName = "com/example/Outer$for",
+			ManagedTypeName = "Example.BaseApplication",
+			ManagedTypeNamespace = "Example",
+			ManagedTypeShortName = "BaseApplication",
+			AssemblyName = "Example",
+		};
+		var applicationPeer = new JavaPeerInfo {
+			JavaName = "com/example/Application",
+			CompatJniName = "com/example/Application",
+			ManagedTypeName = "Example.Application",
+			ManagedTypeNamespace = "Example",
+			ManagedTypeShortName = "Application",
+			AssemblyName = "Example",
+			BaseJavaName = basePeer.JavaName,
+			CannotRegisterInStaticConstructor = true,
+		};
+		var peers = new List<JavaPeerInfo> { basePeer, applicationPeer };
+
+		TrimmableTypeMapGenerator.PropagateDeferredRegistrationToBaseClasses (peers);
+
+		Assert.True (basePeer.CannotRegisterInStaticConstructor);
+		Assert.False (CreateGenerator ().ValidateJavaNames (peers));
+		Assert.Contains (logMessages, message => message.Contains ("Java name 'com/example/Outer$for' contains reserved Java identifier 'for'."));
+	}
+
+	[Fact]
+	public void ValidateJavaNames_ReservedApplicationJavaClassIdentifier_LogsError ()
+	{
+		Assert.False (CreateGenerator ().ValidateJavaNames ([], "com.example.Outer.for"));
+		Assert.Contains (logMessages, message => message.Contains ("Java name 'com.example.Outer.for' contains reserved Java identifier 'for'."));
+	}
+
 	[Theory]
 	[InlineData (true, false, "com/for/Example")]
 	[InlineData (false, true, "com/for/Example")]


### PR DESCRIPTION
Java keywords in application package or Java peer type names currently reach generated Java source and fail later in `javac` with an unclear `JAVAC0000` error.

Add early XA4258 validation for application package names and CoreCLR trimmable type-map JNI names. The validator follows the Java SE 21 identifier rules, permits contextual keywords where Java allows them, and rejects restricted identifiers for type names. The typemap task stops before writing outputs after reporting the diagnostic.

Add localized error resources, message documentation, and focused unit tests covering all reserved identifiers, restricted type identifiers, contextual keywords, and valid names.

Fixes #7489

Tests:
- `Microsoft.Android.Sdk.TrimmableTypeMap.Tests`: 771 passed
- `GetAndroidPackageNameTests`: 4 passed
- `Xamarin.Android.Build.Tasks.csproj` isolated compile succeeded