### PR TITLE
[Java.Interop] Fix inherited JCW interfaces

### DIFF
--- a/external/Java.Interop/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/CecilImporter.cs
+++ b/external/Java.Interop/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/CecilImporter.cs
@@ -61,15 +61,18 @@ public class CecilImporter
 		cwt.ExtendsType = GetJavaTypeName (type.BaseType, resolver);
 
 		// Implemented interfaces
-		foreach (var ifaceInfo in type.Interfaces) {
-			var iface = resolver.Resolve (ifaceInfo.InterfaceType);
-			if (iface is null)
+		var interfaces = type.Interfaces
+			.Select (iface => resolver.Resolve (iface.InterfaceType))
+			.Where (iface => iface is not null && CecilExtensions.GetTypeRegistrationAttributes (iface).Any ())
+			.ToList ();
+		var addedInterfaces = new HashSet<string> ();
+		foreach (var iface in interfaces) {
+			if (interfaces.Any (other => iface.FullName != other.FullName && iface.IsAssignableFrom (other, resolver)))
 				continue;
 
-			if (!CecilExtensions.GetTypeRegistrationAttributes (iface).Any ())
-				continue;
-
-			cwt.ImplementedInterfaces.Add (GetJavaTypeName (iface, resolver));
+			var javaTypeName = GetJavaTypeName (iface, resolver);
+			if (addedInterfaces.Add (javaTypeName))
+				cwt.ImplementedInterfaces.Add (javaTypeName);
 		}
 
 		// Application constructor

--- a/external/Java.Interop/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/external/Java.Interop/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -153,6 +153,15 @@ public class Name_ActivityLifecycleCallbacks
 			Assert.AreEqual (expected, actual);
 		}
 
+		[Test]
+		public void GenerateOnlyMostDerivedInterfaces ()
+		{
+			var actual = Generate (typeof (OnTabSelectedListener));
+
+			Assert.That (actual, Does.Contain ("\t\tcom.xamarin.android.OnTabSelectedListener"));
+			Assert.That (actual, Does.Not.Contain ("\t\tcom.xamarin.android.BaseOnTabSelectedListener"));
+		}
+
 		static string Generate (Type type, string applicationJavaClass = null, string monoRuntimeInit = null, JavaPeerStyle style = JavaPeerStyle.XAJavaInterop1)
 		{
 			var reader_options = new CallableWrapperReaderOptions {

--- a/external/Java.Interop/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/external/Java.Interop/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -161,6 +161,20 @@ namespace Xamarin.Android.ToolsTests {
 	{
 	}
 
+	[Register ("com/xamarin/android/BaseOnTabSelectedListener")]
+	interface IBaseOnTabSelectedListener : global::Android.Runtime.IJavaObject
+	{
+	}
+
+	[Register ("com/xamarin/android/OnTabSelectedListener")]
+	interface IOnTabSelectedListener : IBaseOnTabSelectedListener
+	{
+	}
+
+	class OnTabSelectedListener : Java.Lang.Object, IOnTabSelectedListener
+	{
+	}
+
 	[Activity (Name = "activity.Name")]
 	class ActivityName : Java.Lang.Object
 	{

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -972,8 +972,12 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 			proj.SetRuntime (AndroidRuntime.CoreCLR);
 			proj.SetRuntimeIdentifiers (new [] { DeviceAbi });
 			proj.SetDefaultTargetDevice ();
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\styles.xml") {
+				TextContent = () => "<resources><style name=\"AppTheme\" parent=\"Theme.MaterialComponents.DayNight.NoActionBar\" /></resources>",
+			});
 			proj.MainActivity = proj.DefaultMainActivity
 				.Replace ("//${USINGS}", "using Google.Android.Material.Tabs;")
+				.Replace ("MainLauncher = true", "MainLauncher = true, Theme = \"@style/AppTheme\"")
 				.Replace ("public class MainActivity : Activity", "public class MainActivity : Activity, TabLayout.IOnTabSelectedListener2")
 				.Replace ("//${AFTER_ONCREATE}",
 """

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -960,6 +960,53 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 		}
 
 		[Test]
+		public void TabLayoutOnTabSelectedListener2_ShouldFire_OnActivityLaunch ()
+		{
+			const string expectedLogcatOutput = "OnTabSelected called!";
+
+			var proj = new XamarinAndroidApplicationProject {
+				PackageReferences = {
+					KnownPackages.XamarinGoogleAndroidMaterial,
+				},
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetRuntimeIdentifiers (new [] { DeviceAbi });
+			proj.SetDefaultTargetDevice ();
+			proj.MainActivity = proj.DefaultMainActivity
+				.Replace ("//${USINGS}", "using Google.Android.Material.Tabs;")
+				.Replace ("public class MainActivity : Activity", "public class MainActivity : Activity, TabLayout.IOnTabSelectedListener2")
+				.Replace ("//${AFTER_ONCREATE}",
+$$"""
+			var tabLayout = new TabLayout (this);
+			tabLayout.AddOnTabSelectedListener (this);
+			tabLayout.AddTab (tabLayout.NewTab (), true);
+			SetContentView (tabLayout);
+		}
+
+		public void OnTabSelected (TabLayout.Tab tab)
+		{
+			Android.Util.Log.Debug ("TabLayoutTest", "{{expectedLogcatOutput}}");
+		}
+
+		public void OnTabUnselected (TabLayout.Tab tab)
+		{
+		}
+
+		public void OnTabReselected (TabLayout.Tab tab)
+		{
+""");
+
+			builder = CreateApkBuilder (Path.Combine ("temp", "TabLayoutOnTabSelectedListener2"));
+			Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
+			ClearAdbLogcat ();
+			RunProjectAndAssert (proj, builder);
+			Assert.IsTrue (WaitForActivityToStart (proj.PackageName, "MainActivity",
+				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"), ActivityStartTimeoutInSeconds), "Activity should have started.");
+			Assert.IsTrue (MonitorAdbLogcat (line => line.Contains (expectedLogcatOutput),
+				Path.Combine (Root, builder.ProjectDirectory, "tab-selected-logcat.log"), 60), $"Output did not contain {expectedLogcatOutput}!");
+		}
+
+		[Test]
 		public void SubscribeToAppDomainUnhandledException ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 		{
 			const bool isRelease = true;

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -976,7 +976,7 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 				.Replace ("//${USINGS}", "using Google.Android.Material.Tabs;")
 				.Replace ("public class MainActivity : Activity", "public class MainActivity : Activity, TabLayout.IOnTabSelectedListener2")
 				.Replace ("//${AFTER_ONCREATE}",
-$$"""
+"""
 			var tabLayout = new TabLayout (this);
 			tabLayout.AddOnTabSelectedListener (this);
 			tabLayout.AddTab (tabLayout.NewTab (), true);
@@ -985,7 +985,7 @@ $$"""
 
 		public void OnTabSelected (TabLayout.Tab tab)
 		{
-			Android.Util.Log.Debug ("TabLayoutTest", "{{expectedLogcatOutput}}");
+			Android.Util.Log.Debug ("TabLayoutTest", "OnTabSelected called!");
 		}
 
 		public void OnTabUnselected (TabLayout.Tab tab)


### PR DESCRIPTION
Fixes #11917.

Java callable wrapper generation now omits registered interfaces already inherited through a more-derived registered interface. This prevents generated Java classes from implementing both `TabLayout.OnTabSelectedListener` and its raw generic `BaseOnTabSelectedListener`, which javac rejects.

Adds:
- a focused JCW generator regression test for retaining only the most-derived interface
- an `MSBuildDeviceIntegration` test that builds and launches an app implementing `TabLayout.IOnTabSelectedListener2`, selects a tab, and verifies `OnTabSelected` runs

Validation:
- `Java.Interop.Tools.JavaCallableWrappers-Tests`: 48 passed
- Device integration compile/run not completed locally: current `main` targets .NET 11, while this machine has a .NET 10 SDK, and no Android device was connected