### PR TITLE
[ci] Prevent isolated NuGet access

### DIFF
--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -59,8 +59,8 @@ variables:
   value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1)) ]
 - name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE
   value: 'true'
-- name: DOTNET_SDK_VULNERABILITY_CHECK_DISABLE
-  value: 'true'
+- name: NuGetAudit
+  value: 'false'
 # Override for internal pipeline
 - name: DefaultJavaSdkMajorVersion
   value: 21
@@ -903,7 +903,7 @@ stages:
     - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
       parameters:
         command: new
-        arguments: maui -o $(Build.StagingDirectory)/MauiTestProj
+        arguments: maui -o $(Build.StagingDirectory)/MauiTestProj --no-restore
         xaSourcePath: $(Build.SourcesDirectory)/android
         displayName: Create MAUI template
         continueOnError: false

--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -591,7 +591,7 @@ stages:
     - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
       parameters:
         command: new
-        arguments: maui -o $(Build.StagingDirectory)/MauiTestProj
+        arguments: maui -o $(Build.StagingDirectory)/MauiTestProj --no-restore
         xaSourcePath: $(Build.SourcesDirectory)/android
         displayName: Create MAUI template
         continueOnError: false

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -207,7 +207,7 @@ extends:
         - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
           parameters:
             command: new
-            arguments: maui -o $(Build.StagingDirectory)/MauiTestProj
+            arguments: maui -o $(Build.StagingDirectory)/MauiTestProj --no-restore
             xaSourcePath: $(Build.SourcesDirectory)/android
             displayName: Create MAUI template
             continueOnError: false

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -80,5 +80,5 @@ variables:
 # See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
 - name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE
   value: 'true'
-- name: DOTNET_SDK_VULNERABILITY_CHECK_DISABLE
-  value: 'true'
+- name: NuGetAudit
+  value: 'false'


### PR DESCRIPTION
## Why

Internal [build 14925232](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14925232) reported CFSClean violations during **Create MAUI template**. Two independent behaviors allowed network access:

1. `DOTNET_SDK_VULNERABILITY_CHECK_DISABLE` is not NuGet's supported restore-audit switch and did not prevent the build from requesting NuGet's vulnerability index. NuGet audit is controlled by the MSBuild property `NuGetAudit`; Azure Pipeline variables are exported to the task environment and imported by MSBuild as properties, so `NuGetAudit=false` disables that advisory lookup pipeline-wide.
2. `dotnet new maui` runs a restore post-action by default. That restore had no project-specific `NuGet.config`, so it contacted public NuGet and workload advertising-manifest hosts. Passing `--no-restore` creates the template without running that post-action.

This does not remove the intended MAUI restore/build. The following Debug and Release build steps remain unchanged and explicitly pass `--configfile $(Build.SourcesDirectory)/maui/NuGet.config`, keeping package acquisition on the configured sources. Disabling NuGet audit also does not disable package hash/signature validation; it only suppresses the external vulnerability-advisory lookup in these network-isolated jobs.

## Changes

- Use `NuGetAudit=false` in the shared pipeline variables and internal override.
- Add `--no-restore` to MAUI template creation in the main, public, and internal pipeline definitions.

## Validation

- Parsed all four changed YAML files successfully.
- Ran `git diff --check`.
- Verified every MAUI template-creation variant uses `--no-restore` and no obsolete audit variable remains.
- Verified `dotnet new --no-restore` creates a project without producing a restore assets file.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed (build link above; no GitHub issue).
- [x] Unit tests (not applicable to pipeline-only YAML; targeted checks listed above).