### PR TITLE
[ci] Use repo NuGet config for template smoke build

### DIFF
--- a/build-tools/automation/yaml-templates/build-windows-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-windows-steps.yaml
@@ -164,7 +164,6 @@ steps:
     arguments: >-
       build -v:n "$(Build.StagingDirectory)\LocalWorkloadTest"
       -p:RestoreConfigFile="$(System.DefaultWorkingDirectory)\NuGet.config"
-      -p:NuGetAudit=false
       -p:AndroidSdkDirectory="$(USERPROFILE)\android-toolchain\sdk"
       -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\build-template.binlog
 

--- a/build-tools/automation/yaml-templates/build-windows-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-windows-steps.yaml
@@ -162,7 +162,9 @@ steps:
   inputs:
     filename: dotnet-local.cmd
     arguments: >-
-      build -v:n $(Build.StagingDirectory)/LocalWorkloadTest
+      build -v:n "$(Build.StagingDirectory)\LocalWorkloadTest"
+      -p:RestoreConfigFile="$(System.DefaultWorkingDirectory)\NuGet.config"
+      -p:NuGetAudit=false
       -p:AndroidSdkDirectory="$(USERPROFILE)\android-toolchain\sdk"
       -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\build-template.binlog
 

--- a/build-tools/automation/yaml-templates/build-windows-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-windows-steps.yaml
@@ -155,7 +155,7 @@ steps:
   displayName: Test dotnet-local.cmd - create template
   inputs:
     filename: dotnet-local.cmd
-    arguments: new android -o $(Build.StagingDirectory)/LocalWorkloadTest
+    arguments: new android -o "$(Build.StagingDirectory)\LocalWorkloadTest"
 
 - task: BatchScript@1
   displayName: Test dotnet-local.cmd - build template


### PR DESCRIPTION
## Why

Depends on #12336.

The Windows template smoke project is generated under `$(Build.StagingDirectory)`, outside the repository `NuGet.config` hierarchy. Its implicit build restore therefore falls back to the agent's machine NuGet configuration and may access unapproved package feeds.

#12336 disables NuGet auditing pipeline-wide. This dependent change keeps the smoke build's restore on the repository's approved sources.

## Changes

- Pass `RestoreConfigFile=$(System.DefaultWorkingDirectory)\NuGet.config` to the template build.
- Quote the template creation and build staging paths using Windows path syntax.

## Validation

- Parsed `build-windows-steps.yaml` successfully.
- Ran `git diff --check`.
- Verified the Windows create and build commands with generated project paths containing spaces.
- Verified restore used only the repository `NuGet.config` feeds and `binlogtool` reported the expected `RestoreConfigFile`.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed (depends on #12336; no GitHub issue).
- [x] Unit tests (not applicable to pipeline-only YAML; targeted validation listed above).