### PR TITLE
[tests] Keep XASdk restores on approved feeds

### DIFF
--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/dotnetcli.host.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
@@ -15,6 +15,19 @@
   "primaryOutputs": [
     { "path": "AndroidBinding1.csproj" }
   ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ],
   "symbols": {
     "supportedOSVersion": {
       "type": "parameter",
@@ -22,6 +35,12 @@
       "datatype": "string",
       "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
       "defaultValue": "24"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
     }
   },
   "defaultName": "AndroidBinding1"

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
@@ -15,19 +15,6 @@
   "primaryOutputs": [
     { "path": "AndroidBinding1.csproj" }
   ],
-  "postActions": [
-    {
-      "condition": "(!skipRestore)",
-      "description": "Restore NuGet packages required by this project.",
-      "manualInstructions": [
-        {
-          "text": "Run 'dotnet restore'"
-        }
-      ],
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "continueOnError": true
-    }
-  ],
   "symbols": {
     "supportedOSVersion": {
       "type": "parameter",

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/dotnetcli.host.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/template.json
@@ -22,19 +22,6 @@
   "primaryOutputs": [
     { "path": "AndroidApp1.csproj" }
   ],
-  "postActions": [
-    {
-      "condition": "(!skipRestore)",
-      "description": "Restore NuGet packages required by this project.",
-      "manualInstructions": [
-        {
-          "text": "Run 'dotnet restore'"
-        }
-      ],
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "continueOnError": true
-    }
-  ],
   "symbols": {
     "packageName": {
       "type": "parameter",

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/template.json
@@ -22,6 +22,19 @@
   "primaryOutputs": [
     { "path": "AndroidApp1.csproj" }
   ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ],
   "symbols": {
     "packageName": {
       "type": "parameter",
@@ -35,6 +48,12 @@
       "datatype": "string",
       "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
       "defaultValue": "24"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
     }
   },
   "defaultName": "AndroidApp1"

--- a/src/Microsoft.Android.Templates/android/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/dotnetcli.host.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/template.json
@@ -22,19 +22,6 @@
   "primaryOutputs": [
     { "path": "AndroidApp1.csproj" }
   ],
-  "postActions": [
-    {
-      "condition": "(!skipRestore)",
-      "description": "Restore NuGet packages required by this project.",
-      "manualInstructions": [
-        {
-          "text": "Run 'dotnet restore'"
-        }
-      ],
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "continueOnError": true
-    }
-  ],
   "symbols": {
     "packageName": {
       "type": "parameter",

--- a/src/Microsoft.Android.Templates/android/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/template.json
@@ -22,6 +22,19 @@
   "primaryOutputs": [
     { "path": "AndroidApp1.csproj" }
   ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ],
   "symbols": {
     "packageName": {
       "type": "parameter",
@@ -35,6 +48,12 @@
       "datatype": "string",
       "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
       "defaultValue": "24"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
     }
   },
   "defaultName": "AndroidApp1"

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/dotnetcli.host.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
@@ -15,6 +15,19 @@
   "primaryOutputs": [
     { "path": "AndroidLib1.csproj" }
   ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ],
   "symbols": {
     "supportedOSVersion": {
       "type": "parameter",
@@ -22,6 +35,12 @@
       "datatype": "string",
       "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
       "defaultValue": "24"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
     }
   },
   "defaultName": "AndroidLib1"

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
@@ -15,19 +15,6 @@
   "primaryOutputs": [
     { "path": "AndroidLib1.csproj" }
   ],
-  "postActions": [
-    {
-      "condition": "(!skipRestore)",
-      "description": "Restore NuGet packages required by this project.",
-      "manualInstructions": [
-        {
-          "text": "Run 'dotnet restore'"
-        }
-      ],
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "continueOnError": true
-    }
-  ],
   "symbols": {
     "supportedOSVersion": {
       "type": "parameter",

--- a/src/Microsoft.Android.Templates/androidtest/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.Android.Templates/androidtest/.template.config/dotnetcli.host.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/src/Microsoft.Android.Templates/androidtest/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/androidtest/.template.config/template.json
@@ -15,19 +15,6 @@
   "primaryOutputs": [
     { "path": "AndroidTest1.csproj" }
   ],
-  "postActions": [
-    {
-      "condition": "(!skipRestore)",
-      "description": "Restore NuGet packages required by this project.",
-      "manualInstructions": [
-        {
-          "text": "Run 'dotnet restore'"
-        }
-      ],
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "continueOnError": true
-    }
-  ],
   "symbols": {
     "packageName": {
       "type": "parameter",

--- a/src/Microsoft.Android.Templates/androidtest/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/androidtest/.template.config/template.json
@@ -15,6 +15,19 @@
   "primaryOutputs": [
     { "path": "AndroidTest1.csproj" }
   ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ],
   "symbols": {
     "packageName": {
       "type": "parameter",
@@ -28,6 +41,12 @@
       "datatype": "string",
       "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
       "defaultValue": "24"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
     }
   },
   "defaultName": "AndroidTest1"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Xml.Linq;
 using System.Reflection;
 using System.Text;
 using NUnit.Framework;
@@ -32,18 +31,43 @@ namespace Xamarin.Android.Build.Tests
 
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = templatePath;
 			var dotnet = new DotNetCLI (Path.Combine (templatePath, $"{templateName}.csproj"));
-			Assert.IsTrue (dotnet.New (template), $"`dotnet new {template}` should succeed");
+			Assert.IsTrue (dotnet.New (template, noRestore: true), $"`dotnet new {template} --no-restore` should succeed");
+
+			var repoNuGetConfig = Path.Combine (XABuildPaths.TopDirectory, "NuGet.config");
+			var projectNuGetConfig = Path.Combine (dotnet.ProjectDirectory, "NuGet.config");
+			File.Copy (repoNuGetConfig, projectNuGetConfig);
+			FileAssert.AreEqual (repoNuGetConfig, projectNuGetConfig);
+
 			File.WriteAllBytes (Path.Combine (dotnet.ProjectDirectory, "foo.jar"), ResourceData.JavaSourceJarTestJar);
 			Assert.IsTrue (dotnet.New ("android-activity"), "`dotnet new android-activity` should succeed");
 			Assert.IsTrue (dotnet.New ("android-layout", Path.Combine (dotnet.ProjectDirectory, "Resources", "layout")), "`dotnet new android-layout` should succeed");
 
 			// Debug build
-			Assert.IsTrue (dotnet.Build (parameters: new [] { "Configuration=Debug", "TrimmerSingleWarn=false" }), "`dotnet build` should succeed");
+			Assert.IsTrue (dotnet.Build (parameters: GetBuildParameters ("Debug")), "`dotnet build` should succeed");
 			dotnet.AssertHasNoWarnings ();
 
 			// Release build
-			Assert.IsTrue (dotnet.Build (parameters: new [] { "Configuration=Release", "TrimmerSingleWarn=false" }), "`dotnet build` should succeed");
+			Assert.IsTrue (dotnet.Build (parameters: GetBuildParameters ("Release")), "`dotnet build` should succeed");
 			dotnet.AssertHasNoWarnings ();
+
+			string [] GetBuildParameters (string configuration)
+			{
+				var parameters = new List<string> {
+					$"Configuration={configuration}",
+					"TrimmerSingleWarn=false",
+				};
+				if (template == "androidwear") {
+					var mavenTargets = Path.Combine (
+						XABuildPaths.TopDirectory,
+						"src",
+						"Xamarin.Android.Build.Tasks",
+						"Tests",
+						"Xamarin.Android.Build.Tests",
+						"dotnet-public-maven.targets");
+					parameters.Add ($"CustomAfterMicrosoftCommonTargets=\"{mavenTargets}\"");
+				}
+				return parameters.ToArray ();
+			}
 		}
 
 		static IEnumerable<object[]> Get_DotNetPack_Data ()

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/dotnet-public-maven.targets
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/dotnet-public-maven.targets
@@ -1,0 +1,10 @@
+<Project>
+  <Target Name="_UseDotNetPublicMaven" BeforeTargets="_MavenRestore">
+    <ItemGroup>
+      <AndroidMavenLibrary
+          Update="@(AndroidMavenLibrary)"
+          Repository="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1"
+          Condition="'%(AndroidMavenLibrary.Repository)' == ''" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -154,13 +154,16 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		public bool New (string template, string output = null)
+		public bool New (string template, string output = null, bool noRestore = false)
 		{
 			var arguments = new List<string> {
 				"new",
 				template,
 				"--output", $"\"{output ?? ProjectDirectory}\"",
 			};
+			if (noRestore) {
+				arguments.Add ("--no-restore");
+			}
 			return Execute (arguments.ToArray ());
 		}
 


### PR DESCRIPTION
## Changes

- declare the standard `skipRestore` symbol in every Android project template
- map `skipRestore` to the user-facing `--no-restore` option through each template's `dotnetcli.host.json`
- prevent `XASdkTests.DotNetNew` from restoring generated projects implicitly
- copy the repository `NuGet.config` into generated projects before builds restore
- route `AndroidMavenLibrary` items with blank repository metadata through `dotnet-public-maven` in test scope

## Why templates declare `skipRestore`

`--no-restore` is presented as a standard `dotnet new` option, but project templates must opt into accepting it by declaring a `skipRestore` boolean symbol and mapping that symbol to `--no-restore` in `dotnetcli.host.json`. This follows the symbol/mapping convention used by the .NET SDK and .NET MAUI templates.

The Android templates intentionally do not add a restore post-action. They therefore preserve their existing default behavior and avoid restoring before test call sites configure approved package versions and feeds. The new option lets `XASdkTests` explicitly document and enforce that expectation before copying the repository `NuGet.config` into generated projects.

## Validation

- packed and installed `Microsoft.Android.Templates`
- verified all five project templates create without producing `obj/project.assets.json` or reporting a restore by default
- passed `XASdkTests.DotNetNew` for `android`, `androidlib`, `android-bindinglib`, and `androidwear`
- verified the wear binlog contains no `api.nuget.org` or `repo1.maven.org` references

- [x] Useful description of why the change is necessary
- [ ] Links to issues fixed
- [x] Unit tests