### PR TITLE
[generator] Honor metadata JNI signature overrides

### DIFF
--- a/external/Java.Interop/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/external/Java.Interop/src/Java.Interop.Localization/Resources.Designer.cs
@@ -437,6 +437,15 @@ namespace Java.Interop.Localization {
                 return ResourceManager.GetString("Generator_BG8C02", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to JNI signature override &apos;{0}&apos; is invalid or does not match the parameter count for member &apos;{1}&apos;..
+        /// </summary>
+        public static string Generator_BG8C03 {
+            get {
+                return ResourceManager.GetString("Generator_BG8C03", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Cannot generate Java wrapper for type &apos;{0}&apos;. Only &apos;class&apos; types are supported..

--- a/external/Java.Interop/src/Java.Interop.Localization/Resources.resx
+++ b/external/Java.Interop/src/Java.Interop.Localization/Resources.resx
@@ -312,6 +312,10 @@ The following terms should not be translated: Metadata.xml, path.</comment>
     <value>For type '{0}', the Kotlin name-mangled method '{1}' (originally '{2}') has multiple hash-suffixed siblings that erase to the same C# signature. Only the first will be emitted; remove the duplicate via Metadata.xml to suppress this warning.</value>
     <comment>{0} - .NET type. {1} - C# method name. {2} - Original (mangled) JVM method name.</comment>
   </data>
+  <data name="Generator_BG8C03" xml:space="preserve">
+    <value>JNI signature override '{0}' is invalid or does not match the parameter count for member '{1}'.</value>
+    <comment>{0} - JNI method signature. {1} - .NET member.</comment>
+  </data>
   <data name="JavaCallableWrappers_XA4200" xml:space="preserve">
     <value>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</value>
     <comment>{0} - Java type.

--- a/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -81,6 +81,7 @@ namespace Java.Interop.Tools.Generator
 							// BG8A01
 							Report.LogCodedWarning (0, Report.WarningAddNodeMatchedNoNodes, null, metaitem, $"<add-node path=\"{path}\" />");
 						else {
+							PreserveJniOverrides (metaitem);
 							foreach (var node in nodes)
 								node.Add (metaitem.Nodes ());
 						}
@@ -125,6 +126,7 @@ namespace Java.Interop.Tools.Generator
 
 						foreach (var n in nodes) {
 							n.SetAttributeValue (attr_name, metaitem.Value);
+							PreserveJniOverride (n, attr_name, metaitem.Value);
 							attr_matched++;
 						}
 						if (attr_matched == 0)
@@ -166,6 +168,7 @@ namespace Java.Interop.Tools.Generator
 
 						foreach (var node in nodes) {
 							node.Attributes (name).Remove ();
+							RemoveJniOverride (node, name);
 							matched = true;
 						}
 						
@@ -179,6 +182,33 @@ namespace Java.Interop.Tools.Generator
 					break;
 				}
 			}
+		}
+
+		static void PreserveJniOverrides (XElement element)
+		{
+			// Class-parser JNI values are normally recomputed; only metadata-authored values are explicit overrides.
+			foreach (var method in element.Descendants ("method"))
+				PreserveJniOverride (method, "jni-signature", method.XGetAttribute ("jni-signature"));
+			foreach (var parameter in element.Descendants ("parameter"))
+				PreserveJniOverride (parameter, "jni-type", parameter.XGetAttribute ("jni-type"));
+		}
+
+		static void PreserveJniOverride (XElement element, string name, string? value)
+		{
+			if (value is null)
+				return;
+			if (element.Name.LocalName == "method" && name == "jni-signature")
+				element.SetAttributeValue ("managed-jni-signature", value);
+			else if (element.Name.LocalName == "parameter" && name == "jni-type")
+				element.SetAttributeValue ("managed-jni-type", value);
+		}
+
+		static void RemoveJniOverride (XElement element, string? name)
+		{
+			if (element.Name.LocalName == "method" && name == "jni-signature")
+				element.Attributes ("managed-jni-signature").Remove ();
+			else if (element.Name.LocalName == "parameter" && name == "jni-type")
+				element.Attributes ("managed-jni-type").Remove ();
 		}
 
 		public IList<NamespaceTransform> GetNamespaceTransforms ()

--- a/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -101,6 +101,7 @@ namespace Java.Interop.Tools.Generator
 						var matched = false;
 
 						foreach (var node in nodes) {
+							InvalidateContainingMethodJniSignature (node, metaitem.Value);
 							var newChild = new XElement (metaitem.Value);
 							newChild.Add (node.Attributes ());
 							newChild.Add (node.Nodes ());
@@ -153,9 +154,13 @@ namespace Java.Interop.Tools.Generator
 
 						foreach (var parent_node in parents) {
 							var nodes = parent_node.XPathSelectElements (path).ToArray ();
-							foreach (var node in nodes)
+							foreach (var node in nodes) {
+								InvalidateContainingMethodJniSignature (node);
 								node.Remove ();
+							}
 							parent_node.Add (nodes);
+							foreach (var node in nodes)
+								InvalidateContainingMethodJniSignature (node);
 							matched = true;
 						}
 						if (!matched)
@@ -224,9 +229,9 @@ namespace Java.Interop.Tools.Generator
 			}
 		}
 
-		static void InvalidateContainingMethodJniSignature (XElement element)
+		static void InvalidateContainingMethodJniSignature (XElement element, string? replacementName = null)
 		{
-			if (element.Name.LocalName == "parameter" && element.Parent?.Name.LocalName == "method")
+			if ((element.Name.LocalName == "parameter" || replacementName == "parameter") && element.Parent?.Name.LocalName == "method")
 				element.Parent.Attributes ("managed-jni-signature").Remove ();
 		}
 

--- a/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -199,10 +199,11 @@ namespace Java.Interop.Tools.Generator
 		static void PreserveJniOverrides (XElement element)
 		{
 			// Class-parser JNI values are normally recomputed; only metadata-authored values are explicit overrides.
-			foreach (var method in element.Descendants ("method"))
+			foreach (var method in element.Descendants ("method")) {
 				PreserveJniOverride (method, "jni-signature", method.XGetAttribute ("jni-signature"));
-			foreach (var parameter in element.Descendants ("parameter"))
-				PreserveJniOverride (parameter, "jni-type", parameter.XGetAttribute ("jni-type"));
+				foreach (var parameter in method.Elements ("parameter"))
+					PreserveJniOverride (parameter, "jni-type", parameter.XGetAttribute ("jni-type"));
+			}
 		}
 
 		static void PreserveJniOverride (XElement element, string name, string? value)
@@ -215,7 +216,7 @@ namespace Java.Interop.Tools.Generator
 			}
 			if (element.Name.LocalName == "method" && name == "jni-signature")
 				element.SetAttributeValue ("managed-jni-signature", value);
-			else if (element.Name.LocalName == "parameter" && name == "jni-type")
+			else if (element.Name.LocalName == "parameter" && element.Parent?.Name.LocalName == "method" && name == "jni-type")
 				element.SetAttributeValue ("managed-jni-type", value);
 		}
 

--- a/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -77,17 +77,22 @@ namespace Java.Interop.Tools.Generator
 					break;
 				case "add-node":
 					try {
-						var nodes = apiDocument.ApiDocument.XPathSelectElements (path);
+						var nodes = apiDocument.ApiDocument.XPathSelectElements (path).ToArray ();
 
 						if (!nodes.Any ())
 							// BG8A01
 							Report.LogCodedWarning (0, Report.WarningAddNodeMatchedNoNodes, null, metaitem, $"<add-node path=\"{path}\" />");
 						else {
-							PreserveJniOverrides (metaitem);
 							foreach (var node in nodes) {
-								if (node.Name.LocalName == "method" && metaitem.Elements ("parameter").Any ())
-									node.Attributes ("managed-jni-signature").Remove ();
-								node.Add (metaitem.Nodes ());
+								var content = new XElement ("content", metaitem.Nodes ());
+								PreserveJniOverrides (content);
+								if (node.Name.LocalName == "method") {
+									foreach (var parameter in content.Elements ("parameter"))
+										PreserveJniOverride (parameter, "jni-type", parameter.XGetAttribute ("jni-type"), isMethodParameter: true);
+									if (content.Elements ("parameter").Any ())
+										node.Attributes ("managed-jni-signature").Remove ();
+								}
+								node.Add (content.Nodes ());
 							}
 						}
 					} catch (XPathException) {
@@ -206,7 +211,7 @@ namespace Java.Interop.Tools.Generator
 			}
 		}
 
-		static void PreserveJniOverride (XElement element, string name, string? value)
+		static void PreserveJniOverride (XElement element, string name, string? value, bool isMethodParameter = false)
 		{
 			if (value is null)
 				return;
@@ -216,7 +221,7 @@ namespace Java.Interop.Tools.Generator
 			}
 			if (element.Name.LocalName == "method" && name == "jni-signature")
 				element.SetAttributeValue ("managed-jni-signature", value);
-			else if (element.Name.LocalName == "parameter" && element.Parent?.Name.LocalName == "method" && name == "jni-type")
+			else if (element.Name.LocalName == "parameter" && (isMethodParameter || element.Parent?.Name.LocalName == "method") && name == "jni-type")
 				element.SetAttributeValue ("managed-jni-type", value);
 		}
 

--- a/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -63,8 +63,10 @@ namespace Java.Interop.Tools.Generator
 						var nodes = apiDocument.ApiDocument.XPathSelectElements (path).ToArray ();
 
 						if (nodes.Any ())
-							foreach (var node in nodes)
+							foreach (var node in nodes) {
+								InvalidateContainingMethodJniSignature (node);
 								node.Remove ();
+							}
 						else
 							// BG8A00
 							Report.LogCodedWarning (0, Report.WarningRemoveNodeMatchedNoNodes, null, metaitem, $"<remove-node path=\"{path}\" />");
@@ -82,8 +84,11 @@ namespace Java.Interop.Tools.Generator
 							Report.LogCodedWarning (0, Report.WarningAddNodeMatchedNoNodes, null, metaitem, $"<add-node path=\"{path}\" />");
 						else {
 							PreserveJniOverrides (metaitem);
-							foreach (var node in nodes)
+							foreach (var node in nodes) {
+								if (node.Name.LocalName == "method" && metaitem.Elements ("parameter").Any ())
+									node.Attributes ("managed-jni-signature").Remove ();
 								node.Add (metaitem.Nodes ());
+							}
 						}
 					} catch (XPathException) {
 						// BG4302
@@ -127,6 +132,7 @@ namespace Java.Interop.Tools.Generator
 						foreach (var n in nodes) {
 							n.SetAttributeValue (attr_name, metaitem.Value);
 							PreserveJniOverride (n, attr_name, metaitem.Value);
+							InvalidateJniOverrides (n, attr_name);
 							attr_matched++;
 						}
 						if (attr_matched == 0)
@@ -169,6 +175,7 @@ namespace Java.Interop.Tools.Generator
 						foreach (var node in nodes) {
 							node.Attributes (name).Remove ();
 							RemoveJniOverride (node, name);
+							InvalidateJniOverrides (node, name);
 							matched = true;
 						}
 						
@@ -197,10 +204,30 @@ namespace Java.Interop.Tools.Generator
 		{
 			if (value is null)
 				return;
+			if (value.Length == 0) {
+				RemoveJniOverride (element, name);
+				return;
+			}
 			if (element.Name.LocalName == "method" && name == "jni-signature")
 				element.SetAttributeValue ("managed-jni-signature", value);
 			else if (element.Name.LocalName == "parameter" && name == "jni-type")
 				element.SetAttributeValue ("managed-jni-type", value);
+		}
+
+		static void InvalidateJniOverrides (XElement element, string? name)
+		{
+			if (element.Name.LocalName == "method" && name == "return") {
+				element.Attributes ("managed-jni-signature").Remove ();
+			} else if (element.Name.LocalName == "parameter" && name == "type") {
+				element.Attributes ("managed-jni-type").Remove ();
+				element.Parent?.Attributes ("managed-jni-signature").Remove ();
+			}
+		}
+
+		static void InvalidateContainingMethodJniSignature (XElement element)
+		{
+			if (element.Name.LocalName == "parameter" && element.Parent?.Name.LocalName == "method")
+				element.Parent.Attributes ("managed-jni-signature").Remove ();
 		}
 
 		static void RemoveJniOverride (XElement element, string? name)

--- a/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/external/Java.Interop/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -210,7 +210,7 @@ namespace Java.Interop.Tools.Generator
 		{
 			if (value is null)
 				return;
-			if (value.Length == 0) {
+			if (value.Length == 0 || (element.Name.LocalName == "parameter" && name == "jni-type" && IsGenericJniType (value))) {
 				RemoveJniOverride (element, name);
 				return;
 			}
@@ -218,6 +218,14 @@ namespace Java.Interop.Tools.Generator
 				element.SetAttributeValue ("managed-jni-signature", value);
 			else if (element.Name.LocalName == "parameter" && element.Parent?.Name.LocalName == "method" && name == "jni-type")
 				element.SetAttributeValue ("managed-jni-type", value);
+		}
+
+		static bool IsGenericJniType (string value)
+		{
+			int index = 0;
+			while (index < value.Length && value [index] == '[')
+				index++;
+			return index < value.Length && value [index] == 'T';
 		}
 
 		static void InvalidateJniOverrides (XElement element, string? name)

--- a/external/Java.Interop/src/Java.Interop.Tools.Generator/Utilities/Report.cs
+++ b/external/Java.Interop/src/Java.Interop.Tools.Generator/Utilities/Report.cs
@@ -75,6 +75,7 @@ namespace Java.Interop.Tools.Generator
 		public static LocalizedMessage WarningBaseInterfaceNotFound => new LocalizedMessage (0x8C00, Localization.Resources.Generator_BG8C00);
 		public static LocalizedMessage WarningBaseInterfaceInvalid => new LocalizedMessage (0x8C01, Localization.Resources.Generator_BG8C01);
 		public static LocalizedMessage WarningKotlinNameMangledCollision => new LocalizedMessage (0x8C02, Localization.Resources.Generator_BG8C02);
+		public static LocalizedMessage WarningInvalidJniSignatureOverride => new LocalizedMessage (0x8C03, Localization.Resources.Generator_BG8C03);
 
 		public static void LogCodedErrorAndExit (LocalizedMessage message, params string [] args)
 			=> LogCodedErrorAndExit (message, null, null, args);

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 using generator.SourceWriters;
 using Java.Interop.Tools.Generator;
 using MonoDroid.Generation;
@@ -15,6 +16,49 @@ namespace generatortests
 {
 	abstract class AnyJavaInteropCodeGeneratorTests : CodeGeneratorTests
 	{
+		[Test]
+		public void WriteMethodJniSignatureOverrides ()
+		{
+			var api = """
+				<api>
+				  <package name='java.lang' jni-name='java/lang'>
+				    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+				  </package>
+				  <package name='com.example' jni-name='com/example'>
+				    <interface abstract='true' deprecated='not deprecated' final='false' name='BaseListener' static='false' visibility='public' jni-signature='Lcom/example/BaseListener;' />
+				    <interface abstract='true' deprecated='not deprecated' final='false' name='TypedListener' static='false' visibility='public' jni-signature='Lcom/example/TypedListener;' />
+				    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' final='false' name='Slider' static='false' visibility='public' jni-signature='Lcom/example/Slider;' />
+				  </package>
+				</api>
+				""";
+			var metadata = """
+				<metadata>
+				  <add-node path="/api/package[@name='com.example']/class[@name='Slider']">
+				      <method abstract='false' deprecated='not deprecated' final='false' name='addOnChangeListener' jni-signature='(Lcom/example/BaseListener;)V' return='void' static='false' visibility='public'>
+				        <parameter name='listener' type='com.example.TypedListener' jni-type='Lcom/example/BaseListener;' />
+				      </method>
+				      <method abstract='false' deprecated='not deprecated' final='false' name='removeOnChangeListener' return='void' static='false' visibility='public'>
+				        <parameter name='listener' type='com.example.TypedListener' jni-type='Lcom/example/BaseListener;' />
+				      </method>
+				  </add-node>
+				</metadata>
+				""";
+			var apiDocument = new ApiXmlDocument (XDocument.Parse (api), "37", 0);
+			apiDocument.ApplyFixupFile (new FixupXmlDocument (XDocument.Parse (metadata)));
+
+			var gens = ParseApiDefinition (apiDocument.ApiDocument.ToString ());
+			var klass = gens.Single (g => g.Name == "Slider");
+
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			var source = writer.ToString ();
+			Assert.True (source.Contains ("addOnChangeListener.(Lcom/example/BaseListener;)V"), source);
+			Assert.True (source.Contains ("removeOnChangeListener.(Lcom/example/BaseListener;)V"), source);
+			Assert.True (source.Contains ("AddOnChangeListener (Com.Example.ITypedListener"), source);
+		}
+
 		[Test]
 		public void WriteKotlinUnsignedTypeMethodsClass ()
 		{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
@@ -45,6 +45,21 @@ namespace generatortests
 		}
 
 		[Test]
+		public void AddNode_GenericJniTypeUsesErasedMethodSignature ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument ("<add-node path=\"/api/package[@name='android']\"><method name='onNext' jni-signature='(Ljava/lang/Object;)V' return='void'><parameter name='value' type='T' jni-type='TT;' /></method></add-node>");
+
+			api.ApplyFixupFile (fixup);
+
+			var method = api.ApiDocument.Root.Element ("package").Element ("method");
+			Assert.Multiple (() => {
+				Assert.AreEqual ("(Ljava/lang/Object;)V", method.Attribute ("managed-jni-signature").Value);
+				Assert.IsNull (method.Element ("parameter").Attribute ("managed-jni-type"));
+			});
+		}
+
+		[Test]
 		public void AddNode_DoesNotPreserveConstructorJniType ()
 		{
 			var api = GetXmlApiDocument ();

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
@@ -137,6 +137,23 @@ namespace generatortests
 		}
 
 		[Test]
+		public void AddNode_DirectParameterPreservesJniTypeOverride ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument (
+				"<add-node path=\"/api/package[@name='android']\"><method name='test' jni-signature='()V' return='void' /></add-node>" +
+				"<add-node path=\"/api/package[@name='android']/method[@name='test']\"><parameter name='value' type='java.lang.String' jni-type='Ljava/lang/Object;' /></add-node>");
+
+			api.ApplyFixupFile (fixup);
+
+			var method = api.ApiDocument.Root.Element ("package").Element ("method");
+			Assert.Multiple (() => {
+				Assert.IsNull (method.Attribute ("managed-jni-signature"));
+				Assert.AreEqual ("Ljava/lang/Object;", method.Element ("parameter").Attribute ("managed-jni-type").Value);
+			});
+		}
+
+		[Test]
 		public void RemoveNode_ParameterInvalidatesJniSignatureOverride ()
 		{
 			var api = GetXmlApiDocument ();

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
@@ -45,6 +45,18 @@ namespace generatortests
 		}
 
 		[Test]
+		public void AddNode_DoesNotPreserveConstructorJniType ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument ("<add-node path=\"/api/package[@name='android']\"><constructor name='test'><parameter name='value' type='java.lang.String' jni-type='TT;' /></constructor></add-node>");
+
+			api.ApplyFixupFile (fixup);
+
+			var constructor = api.ApiDocument.Root.Element ("package").Element ("constructor");
+			Assert.IsNull (constructor.Element ("parameter").Attribute ("managed-jni-type"));
+		}
+
+		[Test]
 		public void AddNode_ParameterTransformInvalidatesJniOverrides ()
 		{
 			var api = GetXmlApiDocument ();

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
@@ -151,6 +151,20 @@ namespace generatortests
 		}
 
 		[Test]
+		public void ChangeNode_ParameterInvalidatesJniSignatureOverride ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument (
+				"<add-node path=\"/api/package[@name='android']\"><method name='test' jni-signature='(I)V' return='void'><parameter name='value' type='int' jni-type='I' /></method></add-node>" +
+				"<change-node path=\"/api/package[@name='android']/method[@name='test']/parameter[@name='value']\">field</change-node>");
+
+			api.ApplyFixupFile (fixup);
+
+			var method = api.ApiDocument.Root.Element ("package").Element ("method");
+			Assert.IsNull (method.Attribute ("managed-jni-signature"));
+		}
+
+		[Test]
 		public void MoveNode ()
 		{
 			var api = GetXmlApiDocument ();
@@ -159,6 +173,24 @@ namespace generatortests
 			api.ApplyFixupFile (fixup);
 
 			Assert.AreEqual ("<api><package name='android' jni-name='android'><package name='java' jni-name='java' /></package></api>", api.ApiDocument.ToString (SaveOptions.DisableFormatting).Replace ('\"', '\''));
+		}
+
+		[Test]
+		public void MoveNode_ParameterInvalidatesJniSignatureOverrides ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument (
+				"<add-node path=\"/api/package[@name='android']\"><method name='source' jni-signature='(I)V' return='void'><parameter name='value' type='int' jni-type='I' /></method><method name='destination' jni-signature='()V' return='void' /></add-node>" +
+				"<move-node path=\"/api/package[@name='android']/method[@name='source']/parameter\">/api/package[@name='android']/method[@name='destination']</move-node>");
+
+			api.ApplyFixupFile (fixup);
+
+			var methods = api.ApiDocument.Root.Element ("package").Elements ("method").ToArray ();
+			Assert.Multiple (() => {
+				Assert.IsNull (methods [0].Attribute ("managed-jni-signature"));
+				Assert.IsNull (methods [1].Attribute ("managed-jni-signature"));
+				Assert.AreEqual ("I", methods [1].Element ("parameter").Attribute ("managed-jni-type").Value);
+			});
 		}
 
 		[Test]

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
@@ -31,6 +31,19 @@ namespace generatortests
 		}
 
 		[Test]
+		public void AddNode_PreservesJniOverrides ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument ("<add-node path=\"/api/package[@name='android']\"><method name='test' jni-signature='(Ljava/lang/Object;)V'><parameter name='value' type='java.lang.String' jni-type='Ljava/lang/Object;' /></method></add-node>");
+
+			api.ApplyFixupFile (fixup);
+
+			var method = api.ApiDocument.Root.Element ("package").Element ("method");
+			Assert.AreEqual ("(Ljava/lang/Object;)V", method.Attribute ("managed-jni-signature").Value);
+			Assert.AreEqual ("Ljava/lang/Object;", method.Element ("parameter").Attribute ("managed-jni-type").Value);
+		}
+
+		[Test]
 		public void ChangeNode ()
 		{
 			var api = GetXmlApiDocument ();

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Xml.Linq;
 using Java.Interop.Tools.Generator;
 using NUnit.Framework;
@@ -41,6 +42,101 @@ namespace generatortests
 			var method = api.ApiDocument.Root.Element ("package").Element ("method");
 			Assert.AreEqual ("(Ljava/lang/Object;)V", method.Attribute ("managed-jni-signature").Value);
 			Assert.AreEqual ("Ljava/lang/Object;", method.Element ("parameter").Attribute ("managed-jni-type").Value);
+		}
+
+		[Test]
+		public void AddNode_ParameterTransformInvalidatesJniOverrides ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument (
+				"<add-node path=\"/api/package[@name='android']\"><method name='test' jni-signature='(I)V' return='void'><parameter name='value' type='int' jni-type='I' /></method></add-node>" +
+				"<attr path=\"/api/package[@name='android']/method[@name='test']/parameter[@name='value']\" name='type'>java.lang.String</attr>");
+
+			api.ApplyFixupFile (fixup);
+
+			var method = api.ApiDocument.Root.Element ("package").Element ("method");
+			Assert.Multiple (() => {
+				Assert.IsNull (method.Attribute ("managed-jni-signature"));
+				Assert.IsNull (method.Element ("parameter").Attribute ("managed-jni-type"));
+			});
+		}
+
+		[Test]
+		public void AddNode_ReturnTransformInvalidatesJniOverride ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument (
+				"<add-node path=\"/api/package[@name='android']\"><method name='test' jni-signature='()I' return='int' /></add-node>" +
+				"<attr path=\"/api/package[@name='android']/method[@name='test']\" name='return'>java.lang.String</attr>");
+
+			api.ApplyFixupFile (fixup);
+
+			var method = api.ApiDocument.Root.Element ("package").Element ("method");
+			Assert.IsNull (method.Attribute ("managed-jni-signature"));
+		}
+
+		[Test]
+		public void AddNode_EnumTransformsPreserveJniOverrides ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument (
+				"<add-node path=\"/api/package[@name='android']\"><method name='test' jni-signature='(Lexample/Listener;I)I' return='int'><parameter name='listener' type='example.Listener' jni-type='Lexample/Listener;' /><parameter name='value' type='int' jni-type='I' /></method></add-node>" +
+				"<attr path=\"/api/package[@name='android']/method[@name='test']/parameter[@name='value']\" name='enumType'>Example.MyEnum</attr>" +
+				"<attr path=\"/api/package[@name='android']/method[@name='test']\" name='enumReturn'>Example.MyEnum</attr>");
+
+			api.ApplyFixupFile (fixup);
+
+			var method = api.ApiDocument.Root.Element ("package").Element ("method");
+			Assert.Multiple (() => {
+				Assert.AreEqual ("(Lexample/Listener;I)I", method.Attribute ("managed-jni-signature").Value);
+				Assert.AreEqual ("Lexample/Listener;", method.Elements ("parameter").First ().Attribute ("managed-jni-type").Value);
+				Assert.AreEqual ("I", method.Elements ("parameter").Last ().Attribute ("managed-jni-type").Value);
+			});
+		}
+
+		[Test]
+		public void AddNode_ParameterInvalidatesJniSignatureOverride ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument (
+				"<add-node path=\"/api/package[@name='android']\"><method name='test' jni-signature='(Ljava/lang/String;)V' return='void'><parameter name='value' type='java.lang.String' jni-type='Ljava/lang/String;' /></method></add-node>" +
+				"<add-node path=\"/api/package[@name='android']/method[@name='test']\"><parameter name='flags' type='int' /></add-node>");
+
+			api.ApplyFixupFile (fixup);
+
+			var method = api.ApiDocument.Root.Element ("package").Element ("method");
+			Assert.IsNull (method.Attribute ("managed-jni-signature"));
+			Assert.AreEqual ("Ljava/lang/String;", method.Elements ("parameter").First ().Attribute ("managed-jni-type").Value);
+		}
+
+		[Test]
+		public void RemoveNode_ParameterInvalidatesJniSignatureOverride ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument (
+				"<add-node path=\"/api/package[@name='android']\"><method name='test' jni-signature='(Ljava/lang/String;I)V' return='void'><parameter name='value' type='java.lang.String' jni-type='Ljava/lang/String;' /><parameter name='flags' type='int' jni-type='I' /></method></add-node>" +
+				"<remove-node path=\"/api/package[@name='android']/method[@name='test']/parameter[@name='flags']\" />");
+
+			api.ApplyFixupFile (fixup);
+
+			var method = api.ApiDocument.Root.Element ("package").Element ("method");
+			Assert.IsNull (method.Attribute ("managed-jni-signature"));
+			Assert.AreEqual ("Ljava/lang/String;", method.Element ("parameter").Attribute ("managed-jni-type").Value);
+		}
+
+		[Test]
+		public void AddNode_DoesNotPreserveEmptyJniOverrides ()
+		{
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument ("<add-node path=\"/api/package[@name='android']\"><method name='test' jni-signature='' return='void'><parameter name='value' type='int' jni-type='' /></method></add-node>");
+
+			api.ApplyFixupFile (fixup);
+
+			var method = api.ApiDocument.Root.Element ("package").Element ("method");
+			Assert.Multiple (() => {
+				Assert.IsNull (method.Attribute ("managed-jni-signature"));
+				Assert.IsNull (method.Element ("parameter").Attribute ("managed-jni-type"));
+			});
 		}
 
 		[Test]

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -249,6 +249,17 @@ namespace generatortests
 		}
 
 		[Test]
+		public void CreateMethod_JniSignatureOverride ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test'><method name='test' managed-jni-signature='(Ljava/lang/Object;)V' return='void'><parameter name='value' type='java.lang.String' managed-jni-type='Ljava/lang/CharSequence;' /></method></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+			var method = klass.Methods [0];
+
+			Assert.AreEqual ("(Ljava/lang/Object;)V", method.JniSignature);
+			Assert.AreEqual ("Ljava/lang/CharSequence;", method.Parameters [0].JniType);
+		}
+
+		[Test]
 		public void CreateParameter_EnsureValidName ()
 		{
 			var xml = XDocument.Parse ("<parameter name=\"$3\" />");

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlTests.cs
@@ -98,6 +98,28 @@ namespace generatortests
 		}
 
 		[Test]
+		public void Method_InvalidJniParameterOverride ()
+		{
+			var element = package.Element ("class");
+			var @class = XmlApiImporter.CreateClass (package, element, options);
+			var methodElement = XElement.Parse ("<method name='test' return='void'><parameter name='value' type='int' managed-jni-type='Ljava/lang/Object;' /></method>");
+			var method = XmlApiImporter.CreateMethod (@class, methodElement);
+
+			Assert.IsFalse (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()));
+		}
+
+		[Test]
+		public void Method_InvalidJniSignatureOverride ()
+		{
+			var element = package.Element ("class");
+			var @class = XmlApiImporter.CreateClass (package, element, options);
+			var methodElement = XElement.Parse ("<method name='test' return='int' managed-jni-signature='()Ljava/lang/Object;' />");
+			var method = XmlApiImporter.CreateMethod (@class, methodElement);
+
+			Assert.IsFalse (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()));
+		}
+
+		[Test]
 		public void Method_Matches_True ()
 		{
 			var element = package.Element ("class");

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlTests.cs
@@ -153,6 +153,29 @@ namespace generatortests
 			Assert.IsFalse (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()));
 		}
 
+		[TestCase ("(Ljava.lang.String;)V")]
+		[TestCase ("([Ljava.lang.String;)V")]
+		public void Method_DottedJniSignatureOverrideIsInvalid (string signature)
+		{
+			var element = package.Element ("class");
+			var @class = XmlApiImporter.CreateClass (package, element, options);
+			var methodElement = XElement.Parse ($"<method name='test' return='void' managed-jni-signature='{signature}'><parameter name='value' type='java.lang.String' /></method>");
+			var method = XmlApiImporter.CreateMethod (@class, methodElement);
+
+			Assert.IsFalse (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()));
+		}
+
+		[Test]
+		public void Method_DottedJniParameterOverrideIsInvalid ()
+		{
+			var element = package.Element ("class");
+			var @class = XmlApiImporter.CreateClass (package, element, options);
+			var methodElement = XElement.Parse ("<method name='test' return='void'><parameter name='value' type='java.lang.String' managed-jni-type='Ljava.lang.String;' /></method>");
+			var method = XmlApiImporter.CreateMethod (@class, methodElement);
+
+			Assert.IsFalse (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()));
+		}
+
 		[Test]
 		public void Method_EmptyJniOverridesAreIgnored ()
 		{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlTests.cs
@@ -119,6 +119,18 @@ namespace generatortests
 			Assert.IsFalse (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()));
 		}
 
+		[TestCase ("(L;)V")]
+		[TestCase ("(T;)V")]
+		public void Method_EmptyReferenceDescriptorIsInvalid (string signature)
+		{
+			var element = package.Element ("class");
+			var @class = XmlApiImporter.CreateClass (package, element, options);
+			var methodElement = XElement.Parse ($"<method name='test' return='void' managed-jni-signature='{signature}'><parameter name='value' type='java.lang.String' /></method>");
+			var method = XmlApiImporter.CreateMethod (@class, methodElement);
+
+			Assert.IsFalse (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()));
+		}
+
 		[Test]
 		public void Method_EmptyJniOverridesAreIgnored ()
 		{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlTests.cs
@@ -120,6 +120,19 @@ namespace generatortests
 		}
 
 		[Test]
+		public void Method_EmptyJniOverridesAreIgnored ()
+		{
+			var element = package.Element ("class");
+			var @class = XmlApiImporter.CreateClass (package, element, options);
+			var methodElement = XElement.Parse ("<method name='test' return='void' managed-jni-signature=''><parameter name='value' type='int' managed-jni-type='' /></method>");
+			var method = XmlApiImporter.CreateMethod (@class, methodElement);
+
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()));
+			Assert.AreEqual ("(I)V", method.JniSignature);
+			Assert.AreEqual ("I", method.Parameters [0].JniType);
+		}
+
+		[Test]
 		public void Method_Matches_True ()
 		{
 			var element = package.Element ("class");

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/XmlTests.cs
@@ -132,6 +132,28 @@ namespace generatortests
 		}
 
 		[Test]
+		public void Method_GenericJniSignatureOverrideIsInvalid ()
+		{
+			var element = package.Element ("class");
+			var @class = XmlApiImporter.CreateClass (package, element, options);
+			var methodElement = XElement.Parse ("<method name='test' return='void' managed-jni-signature='(TT;)V'><parameter name='value' type='java.lang.String' /></method>");
+			var method = XmlApiImporter.CreateMethod (@class, methodElement);
+
+			Assert.IsFalse (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()));
+		}
+
+		[Test]
+		public void Method_GenericJniParameterOverrideIsInvalid ()
+		{
+			var element = package.Element ("class");
+			var @class = XmlApiImporter.CreateClass (package, element, options);
+			var methodElement = XElement.Parse ("<method name='test' return='void'><parameter name='value' type='java.lang.String' managed-jni-type='TT;' /></method>");
+			var method = XmlApiImporter.CreateMethod (@class, methodElement);
+
+			Assert.IsFalse (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()));
+		}
+
+		[Test]
 		public void Method_EmptyJniOverridesAreIgnored ()
 		{
 			var element = package.Element ("class");

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -390,6 +390,7 @@ namespace MonoDroid.Generation
 				IsReturnEnumified = elem.Attribute ("enumReturn") != null,
 				IsStatic = elem.XGetAttribute ("static") == "true",
 				JavaName = elem.XGetAttribute ("name"),
+				JniSignatureOverride = elem.XGetAttribute ("managed-jni-signature"),
 				ManagedOverride = elem.XGetAttribute ("managedOverride"),
 				ManagedReturn = elem.XGetAttribute ("managedReturn"),
 				KotlinInlineClassReturnJniType = elem.Attribute ("kotlin-inline-class-return-jni-type") != null ? elem.XGetAttribute ("kotlin-inline-class-return-jni-type") : null,
@@ -451,6 +452,7 @@ namespace MonoDroid.Generation
 			string kotlin_inline_jni = elem.Attribute ("kotlin-inline-class-jni-type") != null ? elem.XGetAttribute ("kotlin-inline-class-jni-type") : null;
 			// FIXME: "enum_type ?? java_type" should be extraneous. Somewhere in generator uses it improperly.
 			var result = new Parameter (name, enum_type ?? java_type, enum_type ?? managed_type, enum_type != null, java_type, not_null) {
+				JniTypeOverride = elem.XGetAttribute ("managed-jni-type"),
 				KotlinInlineClassJniType = kotlin_inline_jni,
 			};
 			if (elem.Attribute ("sender") != null)

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JniSignatureUtilities.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JniSignatureUtilities.cs
@@ -65,7 +65,7 @@ namespace MonoDroid.Generation
 			char kind = signature [index++];
 			if (kind == 'L' || kind == 'T') {
 				int end = signature.IndexOf (';', index);
-				if (end < index)
+				if (end <= index)
 					return false;
 				index = end + 1;
 			} else if ("ZBCSIJFD".IndexOf (kind) < 0 && (kind != 'V' || !allowVoid || isArray)) {

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JniSignatureUtilities.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JniSignatureUtilities.cs
@@ -7,8 +7,8 @@ namespace MonoDroid.Generation
 	{
 		public static bool AreAbiCompatible (string expected, string actual)
 		{
-			if (!TryParseType (expected, allowVoid: true, out var expectedType) ||
-					!TryParseType (actual, allowVoid: true, out var actualType))
+			if (!TryParseType (expected, allowVoid: true, allowTypeVariable: true, out var expectedType) ||
+					!TryParseType (actual, allowVoid: true, allowTypeVariable: false, out var actualType))
 				return false;
 
 			return GetAbiType (expectedType) == GetAbiType (actualType);
@@ -25,7 +25,7 @@ namespace MonoDroid.Generation
 
 			int index = 1;
 			while (index < signature.Length && signature [index] != ')') {
-				if (!TryReadType (signature, ref index, allowVoid: false, out var parameter))
+				if (!TryReadType (signature, ref index, allowVoid: false, allowTypeVariable: false, out var parameter))
 					return false;
 				types.Add (parameter);
 			}
@@ -33,7 +33,7 @@ namespace MonoDroid.Generation
 				return false;
 
 			index++;
-			if (!TryReadType (signature, ref index, allowVoid: true, out returnType) || index != signature.Length)
+			if (!TryReadType (signature, ref index, allowVoid: true, allowTypeVariable: false, out returnType) || index != signature.Length)
 				return false;
 
 			parameters = types.ToArray ();
@@ -45,13 +45,13 @@ namespace MonoDroid.Generation
 			return type [0] == 'L' || type [0] == '[' || type [0] == 'T' ? "L" : type;
 		}
 
-		static bool TryParseType (string signature, bool allowVoid, out string type)
+		static bool TryParseType (string signature, bool allowVoid, bool allowTypeVariable, out string type)
 		{
 			int index = 0;
-			return TryReadType (signature, ref index, allowVoid, out type) && index == signature.Length;
+			return TryReadType (signature, ref index, allowVoid, allowTypeVariable, out type) && index == signature.Length;
 		}
 
-		static bool TryReadType (string signature, ref int index, bool allowVoid, out string type)
+		static bool TryReadType (string signature, ref int index, bool allowVoid, bool allowTypeVariable, out string type)
 		{
 			type = "";
 			int start = index;
@@ -63,7 +63,7 @@ namespace MonoDroid.Generation
 
 			bool isArray = index > start;
 			char kind = signature [index++];
-			if (kind == 'L' || kind == 'T') {
+			if (kind == 'L' || (kind == 'T' && allowTypeVariable)) {
 				int end = signature.IndexOf (';', index);
 				if (end <= index)
 					return false;

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JniSignatureUtilities.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JniSignatureUtilities.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+
+namespace MonoDroid.Generation
+{
+	static class JniSignatureUtilities
+	{
+		public static bool AreAbiCompatible (string expected, string actual)
+		{
+			if (!TryParseType (expected, allowVoid: true, out var expectedType) ||
+					!TryParseType (actual, allowVoid: true, out var actualType))
+				return false;
+
+			return GetAbiType (expectedType) == GetAbiType (actualType);
+		}
+
+		public static bool TryParseMethodSignature (string signature, out string [] parameters, out string returnType)
+		{
+			var types = new List<string> ();
+			parameters = [];
+			returnType = "";
+
+			if (signature.Length < 3 || signature [0] != '(')
+				return false;
+
+			int index = 1;
+			while (index < signature.Length && signature [index] != ')') {
+				if (!TryReadType (signature, ref index, allowVoid: false, out var parameter))
+					return false;
+				types.Add (parameter);
+			}
+			if (index >= signature.Length || signature [index] != ')')
+				return false;
+
+			index++;
+			if (!TryReadType (signature, ref index, allowVoid: true, out returnType) || index != signature.Length)
+				return false;
+
+			parameters = types.ToArray ();
+			return true;
+		}
+
+		static string GetAbiType (string type)
+		{
+			return type [0] == 'L' || type [0] == '[' || type [0] == 'T' ? "L" : type;
+		}
+
+		static bool TryParseType (string signature, bool allowVoid, out string type)
+		{
+			int index = 0;
+			return TryReadType (signature, ref index, allowVoid, out type) && index == signature.Length;
+		}
+
+		static bool TryReadType (string signature, ref int index, bool allowVoid, out string type)
+		{
+			type = "";
+			int start = index;
+
+			while (index < signature.Length && signature [index] == '[')
+				index++;
+			if (index >= signature.Length)
+				return false;
+
+			bool isArray = index > start;
+			char kind = signature [index++];
+			if (kind == 'L' || kind == 'T') {
+				int end = signature.IndexOf (';', index);
+				if (end < index)
+					return false;
+				index = end + 1;
+			} else if ("ZBCSIJFD".IndexOf (kind) < 0 && (kind != 'V' || !allowVoid || isArray)) {
+				return false;
+			}
+
+			type = signature.Substring (start, index - start);
+			return true;
+		}
+	}
+}

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JniSignatureUtilities.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JniSignatureUtilities.cs
@@ -67,6 +67,10 @@ namespace MonoDroid.Generation
 				int end = signature.IndexOf (';', index);
 				if (end <= index)
 					return false;
+				for (int i = index; i < end; i++) {
+					if (signature [i] == '.' || signature [i] == '[')
+						return false;
+				}
 				index = end + 1;
 			} else if ("ZBCSIJFD".IndexOf (kind) < 0 && (kind != 'V' || !allowVoid || isArray)) {
 				return false;

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -27,6 +27,7 @@ namespace MonoDroid.Generation
 		public bool IsStatic { get; set; }
 		public bool IsVirtual { get; set; }
 		public string JavaName { get; set; }
+		public string JniSignatureOverride { get; set; }
 		public string ManagedOverride { get; set; }
 		public string ManagedReturn { get; set; }
 		public string KotlinInlineClassReturnJniType { get; set; }
@@ -152,6 +153,7 @@ namespace MonoDroid.Generation
 			clone.IsStatic = IsStatic;
 			clone.IsVirtual = IsVirtual;
 			clone.JavaName = JavaName;
+			clone.JniSignatureOverride = JniSignatureOverride;
 			clone.ManagedOverride = ManagedOverride;
 			clone.ManagedReturn = ManagedReturn;
 			clone.KotlinInlineClassReturnJniType = KotlinInlineClassReturnJniType;
@@ -216,7 +218,7 @@ namespace MonoDroid.Generation
 
 		public bool IsVoid => RetVal.JavaName == "void";
 
-		public string JniSignature => "(" + Parameters.JniSignature + ")" + RetVal.JniName;
+		public string JniSignature => JniSignatureOverride ?? "(" + Parameters.JniSignature + ")" + RetVal.JniName;
 
 		public InterfaceGen ListenerType => Parameters [0].ListenerType;
 

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Java.Interop.Tools.Generator;
 using Java.Interop.Tools.JavaCallableWrappers;
 using MonoDroid.Generation.Utilities;
 
@@ -265,7 +266,28 @@ namespace MonoDroid.Generation
 			if (!RetVal.Validate (opt, tpl, context))
 				return false;
 
-			return base.OnValidate (opt, tpl, context);
+			if (!base.OnValidate (opt, tpl, context))
+				return false;
+
+			if (JniSignatureOverride == null)
+				return true;
+
+			if (!JniSignatureUtilities.TryParseMethodSignature (JniSignatureOverride, out var parameters, out var returnType) || parameters.Length != Parameters.Count) {
+				Report.LogCodedWarning (0, Report.WarningInvalidJniSignatureOverride, this, JniSignatureOverride, context.GetContextTypeMember ());
+				return false;
+			}
+			for (int i = 0; i < parameters.Length; i++) {
+				if (!JniSignatureUtilities.AreAbiCompatible (Parameters [i].Symbol.JniName, parameters [i])) {
+					Report.LogCodedWarning (0, Report.WarningInvalidParameterType, Parameters [i], parameters [i], context.GetContextTypeMember ());
+					return false;
+				}
+			}
+			if (!JniSignatureUtilities.AreAbiCompatible (RetVal.Symbol.JniName, returnType)) {
+				Report.LogCodedWarning (0, Report.WarningInvalidReturnType, this, returnType, context.GetContextTypeMember ());
+				return false;
+			}
+
+			return true;
 		}
 	}
 }

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -219,7 +219,7 @@ namespace MonoDroid.Generation
 
 		public bool IsVoid => RetVal.JavaName == "void";
 
-		public string JniSignature => JniSignatureOverride ?? "(" + Parameters.JniSignature + ")" + RetVal.JniName;
+		public string JniSignature => string.IsNullOrEmpty (JniSignatureOverride) ? "(" + Parameters.JniSignature + ")" + RetVal.JniName : JniSignatureOverride;
 
 		public InterfaceGen ListenerType => Parameters [0].ListenerType;
 
@@ -269,7 +269,7 @@ namespace MonoDroid.Generation
 			if (!base.OnValidate (opt, tpl, context))
 				return false;
 
-			if (JniSignatureOverride == null)
+			if (string.IsNullOrEmpty (JniSignatureOverride))
 				return true;
 
 			if (!JniSignatureUtilities.TryParseMethodSignature (JniSignatureOverride, out var parameters, out var returnType) || parameters.Length != Parameters.Count) {

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -296,6 +296,10 @@ namespace MonoDroid.Generation {
 				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, this, type, context.GetContextTypeMember ());
 				return false;
 			}
+			if (JniTypeOverride != null && !JniSignatureUtilities.AreAbiCompatible (sym.JniName, JniTypeOverride)) {
+				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, this, JniTypeOverride, context.GetContextTypeMember ());
+				return false;
+			}
 			ApplyKotlinInlineClassProjection (opt, type_params);
 			return true;
 		}

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -108,7 +108,7 @@ namespace MonoDroid.Generation {
 		}
 
 		public string JniType { 
-			get { return JniTypeOverride ?? sym.JniName; }
+			get { return string.IsNullOrEmpty (JniTypeOverride) ? sym.JniName : JniTypeOverride; }
 		}
 
 		public InterfaceGen ListenerType {
@@ -296,7 +296,7 @@ namespace MonoDroid.Generation {
 				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, this, type, context.GetContextTypeMember ());
 				return false;
 			}
-			if (JniTypeOverride != null && !JniSignatureUtilities.AreAbiCompatible (sym.JniName, JniTypeOverride)) {
+			if (!string.IsNullOrEmpty (JniTypeOverride) && !JniSignatureUtilities.AreAbiCompatible (sym.JniName, JniTypeOverride)) {
 				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, this, JniTypeOverride, context.GetContextTypeMember ());
 				return false;
 			}

--- a/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/external/Java.Interop/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -38,10 +38,12 @@ namespace MonoDroid.Generation {
 		// with the wrapper struct's full name so the C# parameter signature uses the
 		// struct, while JNI marshaling stays on the underlying primitive (the `type`).
 		public string KotlinInlineClassJniType { get; set; }
+		public string JniTypeOverride { get; set; }
 
 		public Parameter Clone ()
 		{
 			return new Parameter (name, type, managed_type, is_enumified, rawtype, NotNull) {
+				JniTypeOverride = JniTypeOverride,
 				KotlinInlineClassJniType = KotlinInlineClassJniType,
 			};
 		}
@@ -106,7 +108,7 @@ namespace MonoDroid.Generation {
 		}
 
 		public string JniType { 
-			get { return sym.JniName; }
+			get { return JniTypeOverride ?? sym.JniName; }
 		}
 
 		public InterfaceGen ListenerType {


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [x] Unit tests

`<add-node>` methods currently derive their JNI signature from managed parameter types even when metadata supplies explicit `jni-signature` and `jni-type` values. This breaks bindings where Java erasure differs from the strongly typed managed API and can cause `NoSuchMethodError` at runtime.

Preserve metadata-authored JNI overrides through XML import and use them consistently for registration and invocation IDs while leaving managed parameter types unchanged. Compatibility safeguards invalidate stale overrides after signature-changing transforms, ignore empty values, preserve enum-safe overrides, and reject malformed or ABI-incompatible signatures with a coded diagnostic.

The complete standalone generator suite passes with 478 tests.

Fixes #11841