### PR TITLE
[XABT] Fix stale shrunk assemblies in the llvm-ir typemap path

### DIFF
--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -158,8 +158,6 @@ stages:
         extraBuildArgs: -p:UseMonoRuntime=true -p:_DisableCheckForUnsupportedMonoMobileRuntime=true
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: $(DotNetTargetFramework)-Mono
-        # https://github.com/dotnet/runtime/issues/131760
-        condition: false
 
     - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -377,10 +377,25 @@
     </ItemGroup>
   </Target>
 
-  <!-- Override _RemoveRegisterAttribute to strip [Register] attributes from shrunk assemblies -->
+  <!--
+    Override _RemoveRegisterAttribute to strip [Register] attributes from shrunk assemblies.
+
+    The shrunk copies must be taken from the *final* linked assemblies. `_GenerateJavaStubs`
+    runs `RewriteMarshalMethods`, which rewrites @(_ResolvedAssemblies) in place (removing the
+    `cb_*` JNI callback fields), and `_PostTrimmingPipeline` rewrites them again after ILLink.
+    Depending on `_GenerateJavaStubs` keeps this copy ordered after those rewrites.
+
+    Inputs track the assemblies themselves rather than `$(_AndroidLinkFlag)`: the link flag is
+    only touched by ILLink, so it does not change when the post-link rewrites modify the
+    assemblies. Keying on the flag let the shrunk copies go stale while @(_ResolvedAssemblies)
+    moved on, so mono-aot-cross compiled the rewritten assemblies while packaging shipped the
+    pre-rewrite copies. Their metadata field tables then disagreed, and AOT `SFLDA` patches
+    resolved to the wrong MonoClassField at runtime. This mirrors `_RemoveRegisterAttributeCoreClr`
+    in Microsoft.Android.Sdk.TypeMap.Trimmable.targets.
+  -->
   <Target Name="_RemoveRegisterAttribute"
-      DependsOnTargets="_PrepareAssemblies"
-      Inputs="$(_AndroidLinkFlag)"
+      DependsOnTargets="_PrepareAssemblies;_GenerateJavaStubs"
+      Inputs="@(_ResolvedAssemblies);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
       Outputs="$(_RemoveRegisterFlag)"
       Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidIncludeDebugSymbols)' != 'true'">
     <CopyIfChanged
@@ -394,6 +409,9 @@
         ShrunkFrameworkAssemblies="@(_ShrunkAssemblies)" />
     <MakeDir Directories="$(MonoAndroidIntermediateAssemblyDir)shrunk" />
     <Touch Files="$(_RemoveRegisterFlag)" AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_RemoveRegisterFlag)" />
+    </ItemGroup>
   </Target>
 
   <!-- Collect native typemap files for archive (FastDev) -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -385,17 +385,17 @@
     `cb_*` JNI callback fields), and `_PostTrimmingPipeline` rewrites them again after ILLink.
     Depending on `_GenerateJavaStubs` keeps this copy ordered after those rewrites.
 
-    Inputs track the assemblies themselves rather than `$(_AndroidLinkFlag)`: the link flag is
-    only touched by ILLink, so it does not change when the post-link rewrites modify the
-    assemblies. Keying on the flag let the shrunk copies go stale while @(_ResolvedAssemblies)
-    moved on, so mono-aot-cross compiled the rewritten assemblies while packaging shipped the
-    pre-rewrite copies. Their metadata field tables then disagreed, and AOT `SFLDA` patches
-    resolved to the wrong MonoClassField at runtime. This mirrors `_RemoveRegisterAttributeCoreClr`
-    in Microsoft.Android.Sdk.TypeMap.Trimmable.targets.
+    `$(_AndroidLinkFlag)` tracks ILLink, while @(_ResolvedAssemblies) tracks the later in-place
+    rewrites that the link flag cannot observe. The assembly hash also invalidates the target when
+    the resolved assembly set changes. Without the final assemblies as inputs, the shrunk copies
+    could go stale while @(_ResolvedAssemblies) moved on, so mono-aot-cross compiled the rewritten
+    assemblies while packaging shipped the pre-rewrite copies. Their metadata field tables then
+    disagreed, and AOT `SFLDA` patches resolved to the wrong MonoClassField at runtime. This mirrors
+    `_RemoveRegisterAttributeCoreClr` in Microsoft.Android.Sdk.TypeMap.Trimmable.targets.
   -->
   <Target Name="_RemoveRegisterAttribute"
       DependsOnTargets="_PrepareAssemblies;_GenerateJavaStubs"
-      Inputs="@(_ResolvedAssemblies);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
+      Inputs="$(_AndroidLinkFlag);@(_ResolvedAssemblies);$(_ResolvedUserAssembliesHashFile);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
       Outputs="$(_RemoveRegisterFlag)"
       Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidIncludeDebugSymbols)' != 'true'">
     <CopyIfChanged


### PR DESCRIPTION
## Summary

Fix stale shrunk assemblies in the llvm-ir typemap path and restore the Release MonoVM APK smoke test disabled in #12267.

`_RemoveRegisterAttribute` copies `@(_ResolvedAssemblies)` into `@(_ShrunkAssemblies)`. Packaging reads the shrunk copies, while `mono-aot-cross` compiles the resolved assemblies. The two sets could diverge because:

* **Ordering:** `_RemoveRegisterAttribute` ran before `_GenerateJavaStubs`, which invokes `RewriteMarshalMethods` and rewrites `@(_ResolvedAssemblies)` in place, removing the `cb_*` JNI callback fields. `_PostTrimmingPipeline` can also rewrite the linked assemblies after ILLink.
* **Invalidation:** `$(_AndroidLinkFlag)` tracks ILLink, but it does not observe those later in-place rewrites. Tracking only the link flag allowed the shrunk copies to remain up to date while the resolved assemblies changed.

## Changes

* Make `_RemoveRegisterAttribute` depend on `_GenerateJavaStubs` so it copies the final rewritten assemblies.
* Preserve `$(_AndroidLinkFlag)` as an input for ILLink invalidation and additionally track:
  * `@(_ResolvedAssemblies)` for post-link in-place rewrites.
  * `$(_ResolvedUserAssembliesHashFile)` for changes to the resolved assembly set.
  * `$(_AndroidBuildPropertiesCache)` and `@(_AndroidMSBuildAllProjects)` for relevant build/project changes.
* Add `$(_RemoveRegisterFlag)` to `@(FileWrites)` so clean/incremental-clean behavior tracks the stamp.
* Re-enable the `Mono.Android.NET_Tests-Mono` Release MonoVM instrumentation lane that #12267 temporarily disabled.

This aligns the llvm-ir path with the incremental-input model used by `_RemoveRegisterAttributeCoreClr` in `Microsoft.Android.Sdk.TypeMap.Trimmable.targets`, while retaining the existing ILLink sentinel.

## Failure mechanism

In #12267, the packaged `Mono.Android.dll` retained `Android.Widget.AbsListView::cb_getAdapter` while the AOT input did not. This shifted the metadata `Field` table rows for `Android.Runtime.AndroidTypeManager`. `AndroidTypeManager..cctor` then resolved an AOT `SFLDA` patch to the instance field `jniAddNativeMethodRegistrationAttributePresent` instead of the static `prevent_delegate_gc_lock`, causing Mono to abort during startup before any tests ran:

```text
Assertion at mono/metadata/object.c:3109,
condition `field->type->attrs & FIELD_ATTRIBUTE_STATIC' not met
```

Mono's AOT staleness check did not catch the mismatch because it compares assembly MVIDs, and Cecil preserves the MVID across these rewrites.

## Validation

Validated on a Pixel 7a (arm64, API 36) with `Mono.Android.NET-Tests`, Release + `-p:UseMonoRuntime=true`, from clean `obj` directories:

* Before: deterministic crash in 5 runs; linked assembly had 1767 field rows while the shrunk copy had 1768.
* After: 281 tests passed with 0 failures in 2 runs; linked and shrunk assemblies both had 1767 field rows.
* Control: reverting the target ordering/input changes restored both the crash and the 1767/1768 mismatch.
* Azure DevOps: all 44 PR checks pass, including the restored Mono APK smoke lane.

Fixes https://github.com/dotnet/runtime/issues/131760