### PR TITLE
[CA1310] Specify StringComparison in SdkManager.Licenses.cs

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.Licenses.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.Licenses.cs
@@ -175,7 +175,7 @@ public partial class SdkManager
 			var line = rawLine.TrimEnd ('\r');
 
 			// License header: "License android-sdk-license:"
-			if (line.StartsWith ("License ", StringComparison.OrdinalIgnoreCase) && line.TrimEnd ().EndsWith (":")) {
+			if (line.StartsWith ("License ", StringComparison.OrdinalIgnoreCase) && line.TrimEnd ().EndsWith (":", StringComparison.Ordinal)) {
 				// Save previous license if any
 				if (currentLicenseId is not null && currentLicenseText.Length > 0) {
 					licenses.Add (new SdkLicense (currentLicenseId, currentLicenseText.ToString ().Trim ()));


### PR DESCRIPTION
Fixes **CA1310** (`Specify StringComparison for correctness`) flagged by DevDiv work item **3012463** (`[roslynanalyzers:Warning]`).

### Change
In `SdkManager.Licenses.cs`, `ParseLicenseOutput` matched a license-header line with `line.TrimEnd().EndsWith(":")` without an explicit `StringComparison`. This adds `StringComparison.Ordinal` (a delimiter/token match, so ordinal is correct and culture-invariant). No behavioral change.

Originally scoped against the archived `dotnet/android-tools`; retargeted here since that source now lives in `dotnet/android`.