### PR TITLE
[CA5350] Scope-suppress weak-crypto warning for SHA1 file-integrity checks

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
@@ -98,7 +98,12 @@ namespace Xamarin.Android.Tools
 
 		static HashAlgorithm CreateHashAlgorithm (ChecksumType checksumType) => checksumType switch {
 			ChecksumType.Sha256 => (HashAlgorithm) SHA256.Create (),
+			// SHA1 is used only to verify externally-published file-integrity checksums (Android SDK
+			// repository manifests publish SHA1 checksums) and to match Google's on-disk license hashes,
+			// not as a security or authentication boundary. See ChecksumType / SdkManager.Manifest.cs.
+#pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms
 			ChecksumType.Sha1 => SHA1.Create (),
+#pragma warning restore CA5350
 			_ => throw new NotSupportedException ($"Unsupported checksum type: '{checksumType}'."),
 		};
 


### PR DESCRIPTION
Addresses **CA5350** (`Do Not Use Weak Cryptographic Algorithms`) flagged by DevDiv work item **3012464** (`[roslynanalyzers:Warning]`) on `CreateHashAlgorithm` in `DownloadUtils.cs`.

### Rationale
SHA1 here is **not** a security or authentication boundary. It is used only to:
- verify externally-published file-integrity checksums (the Android SDK repository manifest publishes SHA1 checksums, see `SdkManager.Manifest.cs`), and
- compute Android SDK license hashes that must match Google's on-disk `licenses/` format (`SdkManager.Licenses.cs` `ComputeLicenseHash`).

Removing SHA1 would break checksum/license verification against Google-published data, so the algorithm is preserved and the warning is **narrowly scope-suppressed** to just the `SHA1.Create()` switch arm with a clear justification.

Originally scoped against the archived `dotnet/android-tools`; retargeted here since that source now lives in `dotnet/android`.