### PR TITLE
GitHub Actions: Isolate Copilot code review setup

### DIFF
--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -1,0 +1,14 @@
+name: Copilot Code Review Setup Steps
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Complete setup
+        run: echo "No additional setup required."


### PR DESCRIPTION
----

Copilot code review currently inherits the cloud agent setup workflow, including a recursive checkout and a full Android build. This can prevent the agentic review from starting before its timeout, as observed in https://github.com/dotnet/android/pull/12350#pullrequestreview-4910055125.

This adds a dedicated lightweight `copilot-code-review.yml` workflow on `ubuntu-latest`. The no-op setup step keeps the workflow valid while allowing Copilot to perform its automatic checkout without running the cloud agent bootstrap.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: N/A; addresses the review warning linked above.
- [x] Unit tests: N/A; workflow configuration only.