### PR TITLE
[Java.Interop] Cache peer activation constructors

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Java.Interop.Tools.TypeNameMappings;
 
 using Android.Runtime;
@@ -406,6 +407,17 @@ namespace Java.Interop {
 
 		static  readonly    Type[]  XAConstructorSignature  = new Type [] { typeof (IntPtr), typeof (JniHandleOwnership) };
 		static  readonly    Type[]  JIConstructorSignature  = new Type [] { typeof (JniObjectReference).MakeByRefType (), typeof (JniObjectReferenceOptions) };
+		static  readonly    Dictionary<Type, ActivationConstructor>  ActivationConstructorCache = new Dictionary<Type, ActivationConstructor> ();
+		static  readonly    Lock    ActivationConstructorCacheLock = new Lock ();
+
+		enum ActivationConstructorKind
+		{
+			Missing,
+			XA,
+			JI,
+		}
+
+		readonly record struct ActivationConstructor (ConstructorInfo? Constructor, ActivationConstructorKind Kind);
 
 		internal static object CreateProxy (
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
@@ -416,17 +428,18 @@ namespace Java.Interop {
 			// Skip Activator.CreateInstance() as that requires public constructors,
 			// and we want to hide some constructors for sanity reasons.
 			var peer = GetUninitializedObject (type);
-			BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-			var c = type.GetConstructor (flags, null, XAConstructorSignature, null);
-			if (c != null) {
-				c.Invoke (peer, new object[] { handle, transfer });
+			// XA constructors are the normal activation path; resolve XA first and cache the result.
+			var activation = GetActivationConstructor (type);
+			var constructor = activation.Constructor;
+			if (constructor != null && activation.Kind == ActivationConstructorKind.XA) {
+				constructor.Invoke (peer, new object[] { handle, transfer });
 				return peer;
 			}
-			c = type.GetConstructor (flags, null, JIConstructorSignature, null);
-			if (c != null) {
+			// JI constructors are a legacy fallback slated for removal, but cache them while supported.
+			if (constructor != null && activation.Kind == ActivationConstructorKind.JI) {
 				JniObjectReference          r = new JniObjectReference (handle);
 				JniObjectReferenceOptions   o = JniObjectReferenceOptions.Copy;
-				c.Invoke (peer, new object [] { r, o });
+				constructor.Invoke (peer, new object [] { r, o });
 				JNIEnv.DeleteRef (handle, transfer);
 				return peer;
 			}
@@ -434,6 +447,29 @@ namespace Java.Interop {
 			throw new MissingMethodException (
 					"No constructor found for " + type.FullName + "::.ctor(System.IntPtr, Android.Runtime.JniHandleOwnership)",
 					CreateJavaLocationException ());
+
+			static ActivationConstructor GetActivationConstructor (
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+					Type type)
+			{
+				lock (ActivationConstructorCacheLock) {
+					if (ActivationConstructorCache.TryGetValue (type, out var activation))
+						return activation;
+
+					const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+					var constructor = type.GetConstructor (flags, null, XAConstructorSignature, null);
+					if (constructor != null) {
+						activation = new ActivationConstructor (constructor, ActivationConstructorKind.XA);
+					} else {
+						constructor = type.GetConstructor (flags, null, JIConstructorSignature, null);
+						activation = new ActivationConstructor (
+								constructor,
+								constructor == null ? ActivationConstructorKind.Missing : ActivationConstructorKind.JI);
+					}
+					ActivationConstructorCache.Add (type, activation);
+					return activation;
+				}
+			}
 
 			static IJavaPeerable GetUninitializedObject (
 					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ConstructorActivationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ConstructorActivationTests.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System;
 using System.Reflection;
 
@@ -635,7 +637,7 @@ namespace Java.InteropTests
 			return containsKey.Invoke (cache, new object [] { type }) is true;
 		}
 
-		static ConstructorInfo GetCachedReflectionActivationConstructor (Type type)
+		static ConstructorInfo? GetCachedReflectionActivationConstructor (Type type)
 		{
 			var cache = GetReflectionActivationConstructorCache ();
 			var item = cache.GetType ().GetProperty ("Item");

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ConstructorActivationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ConstructorActivationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 using Android.App;
 using Android.Content;
@@ -15,6 +16,63 @@ namespace Java.InteropTests
 	[TestFixture]
 	public class ConstructorActivationTests
 	{
+		[Test]
+		[Category ("ReflectionCreateProxy")]
+		public void ReflectionCreateProxyCachesXAConstructor ()
+		{
+			AssumeReflectionActivation ();
+			ReflectionXAActivationPeer.Reset ();
+
+			Assert.IsFalse (IsReflectionActivationConstructorCached (typeof (ReflectionXAActivationPeer)));
+
+			using (CreateReflectionProxy<ReflectionXAActivationPeer> ())
+			using (CreateReflectionProxy<ReflectionXAActivationPeer> ()) {
+				Assert.AreEqual (2, ReflectionXAActivationPeer.XAConstructorInvocations);
+				Assert.AreEqual (0, ReflectionXAActivationPeer.JIConstructorInvocations);
+				Assert.IsTrue (IsReflectionActivationConstructorCached (typeof (ReflectionXAActivationPeer)));
+				var constructor = GetCachedReflectionActivationConstructor (typeof (ReflectionXAActivationPeer));
+				Assert.IsNotNull (constructor);
+				Assert.AreEqual (typeof (IntPtr), constructor.GetParameters () [0].ParameterType);
+			}
+		}
+
+		[Test]
+		[Category ("ReflectionCreateProxy")]
+		public void ReflectionCreateProxyCachesJIConstructorFallback ()
+		{
+			AssumeReflectionActivation ();
+			ReflectionJIActivationPeer.Reset ();
+
+			Assert.IsFalse (IsReflectionActivationConstructorCached (typeof (ReflectionJIActivationPeer)));
+
+			using (CreateReflectionProxy<ReflectionJIActivationPeer> ())
+			using (CreateReflectionProxy<ReflectionJIActivationPeer> ()) {
+				Assert.AreEqual (2, ReflectionJIActivationPeer.ConstructorInvocations);
+				Assert.AreEqual (JniObjectReferenceOptions.Copy, ReflectionJIActivationPeer.Options);
+				Assert.IsTrue (IsReflectionActivationConstructorCached (typeof (ReflectionJIActivationPeer)));
+				var constructor = GetCachedReflectionActivationConstructor (typeof (ReflectionJIActivationPeer));
+				Assert.IsNotNull (constructor);
+				Assert.IsTrue (constructor.GetParameters () [0].ParameterType.IsByRef);
+			}
+		}
+
+		[Test]
+		[Category ("ReflectionCreateProxy")]
+		public void ReflectionCreateProxyCachesMissingConstructor ()
+		{
+			AssumeReflectionActivation ();
+
+			Assert.IsFalse (IsReflectionActivationConstructorCached (typeof (ReflectionMissingActivationPeer)));
+
+			for (int i = 0; i < 2; i++) {
+				var exception = Assert.Throws<TargetInvocationException> (() => CreateReflectionProxy<ReflectionMissingActivationPeer> ());
+				Assert.IsInstanceOf<MissingMethodException> (exception?.InnerException);
+			}
+
+			Assert.IsTrue (IsReflectionActivationConstructorCached (typeof (ReflectionMissingActivationPeer)));
+			Assert.IsNull (GetCachedReflectionActivationConstructor (typeof (ReflectionMissingActivationPeer)));
+		}
+
 		[Test]
 		public void JavaSideDefaultConstructorRunsOnceAndRegistersPeer ()
 		{
@@ -533,6 +591,79 @@ namespace Java.InteropTests
 			}
 		}
 
+		static void AssumeReflectionActivation ()
+		{
+			if (Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap) {
+				Assert.Ignore ("This test validates the reflection-based TypeManager.CreateProxy activation path.");
+			}
+		}
+
+		static T CreateReflectionProxy<T> ()
+			where T : IJavaPeerable
+		{
+			IntPtr handle = JNIEnv.StartCreateInstance ("java/lang/Object", "()V");
+			JNIEnv.FinishCreateInstance (handle, "()V");
+			try {
+				const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Static;
+				var createProxy = typeof (Java.Interop.TypeManager).GetMethod (
+						"CreateProxy",
+						flags,
+						null,
+						new [] { typeof (Type), typeof (IntPtr), typeof (JniHandleOwnership) },
+						null);
+				if (createProxy == null)
+					throw new InvalidOperationException ("Could not find TypeManager.CreateProxy.");
+
+				var proxy = createProxy.Invoke (null, new object [] { typeof (T), handle, JniHandleOwnership.TransferLocalRef });
+				handle = IntPtr.Zero;
+				if (proxy is not T result)
+					throw new InvalidOperationException ($"TypeManager.CreateProxy returned an unexpected peer for {typeof (T)}.");
+				return result;
+			} finally {
+				if (handle != IntPtr.Zero)
+					JNIEnv.DeleteLocalRef (handle);
+			}
+		}
+
+		static bool IsReflectionActivationConstructorCached (Type type)
+		{
+			var cache = GetReflectionActivationConstructorCache ();
+			var containsKey = cache.GetType ().GetMethod ("ContainsKey", new [] { typeof (Type) });
+			if (containsKey == null)
+				throw new InvalidOperationException ("Could not inspect the reflection activation constructor cache.");
+
+			return containsKey.Invoke (cache, new object [] { type }) is true;
+		}
+
+		static ConstructorInfo GetCachedReflectionActivationConstructor (Type type)
+		{
+			var cache = GetReflectionActivationConstructorCache ();
+			var item = cache.GetType ().GetProperty ("Item");
+			if (item == null)
+				throw new InvalidOperationException ("Could not inspect a reflection activation constructor cache entry.");
+
+			var activation = item.GetValue (cache, new object [] { type });
+			if (activation == null)
+				throw new InvalidOperationException ("The reflection activation constructor cache entry is null.");
+
+			var constructor = activation.GetType ().GetProperty ("Constructor");
+			if (constructor == null)
+				throw new InvalidOperationException ("Could not inspect the cached reflection activation constructor.");
+
+			return constructor.GetValue (activation) as ConstructorInfo;
+		}
+
+		static object GetReflectionActivationConstructorCache ()
+		{
+			const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Static;
+			var cacheField = typeof (Java.Interop.TypeManager).GetField ("ActivationConstructorCache", flags);
+			if (cacheField == null)
+				throw new InvalidOperationException ("Could not find the reflection activation constructor cache.");
+
+			return cacheField.GetValue (null) ??
+					throw new InvalidOperationException ("The reflection activation constructor cache is null.");
+		}
+
 		static T CreateFromJava<T> (string constructorSignature, params JValue [] arguments)
 			where T : Java.Lang.Object
 		{
@@ -589,6 +720,58 @@ namespace Java.InteropTests
 			Assert.IsTrue (
 				JniEnvironment.Types.IsSameObject (expected.PeerReference, actual.PeerReference),
 				$"Expected Java object identity to match. Expected handle: {expected.Handle}, actual handle: {actual.Handle}.");
+		}
+	}
+
+	sealed class ReflectionXAActivationPeer : Java.Lang.Object
+	{
+		public static int XAConstructorInvocations;
+		public static int JIConstructorInvocations;
+
+		public ReflectionXAActivationPeer (IntPtr handle, JniHandleOwnership transfer)
+			: base (handle, transfer)
+		{
+			XAConstructorInvocations++;
+		}
+
+		public ReflectionXAActivationPeer (ref JniObjectReference reference, JniObjectReferenceOptions options)
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			JIConstructorInvocations++;
+			Construct (ref reference, options);
+		}
+
+		public static void Reset ()
+		{
+			XAConstructorInvocations = 0;
+			JIConstructorInvocations = 0;
+		}
+	}
+
+	sealed class ReflectionJIActivationPeer : Java.Lang.Object
+	{
+		public static int ConstructorInvocations;
+		public static JniObjectReferenceOptions Options;
+
+		public ReflectionJIActivationPeer (ref JniObjectReference reference, JniObjectReferenceOptions options)
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			ConstructorInvocations++;
+			Options = options;
+			Construct (ref reference, options);
+		}
+
+		public static void Reset ()
+		{
+			ConstructorInvocations = 0;
+			Options = JniObjectReferenceOptions.None;
+		}
+	}
+
+	sealed class ReflectionMissingActivationPeer : Java.Lang.Object
+	{
+		public ReflectionMissingActivationPeer ()
+		{
 		}
 	}
 


### PR DESCRIPTION
## Description

Cache reflection-based peer activation constructor resolution once per managed `Type` in `TypeManager.CreateProxy`.

The cache:
- prefers the `(IntPtr, JniHandleOwnership)` constructor
- falls back to `(ref JniObjectReference, JniObjectReferenceOptions)`
- records missing constructors
- uses a dedicated `System.Threading.Lock`
- keeps peer instances, JNI references, and invocation argument arrays per activation

Add focused reflection activation tests for XA preference, Java.Interop fallback, and missing-constructor caching.

Fixes #7479

## Validation

- `make all CONFIGURATION=Debug`
- Pixel 5, LLVM-IR typemap, CoreCLR: `ReflectionCreateProxy` tests passed (3/3)
- Release MAUI/CoreCLR startup, 10 `ActivityTaskManager Displayed` runs after a 5-second warmup:
  - before: 1115.0 ms average
  - after: 1104.9 ms average
  - delta: -10.1 ms (-0.91%)

The startup result is indicative and within observed run-to-run variance.
