### PR TITLE
[NativeAOT] Let SDK select ILCompiler version

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -37,9 +37,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
 
   <!-- Outer restores use RuntimeIdentifiers; RuntimeIdentifier is only set in per-RID inner builds. -->
   <ItemGroup>
-    <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler">
-      <ILCompilerPackVersion>$(MicrosoftNETCoreAppRefPackageVersion)</ILCompilerPackVersion>
-    </KnownILCompilerPack>
     <_AndroidNetCoreAppNativeAotKnownRuntimePack Include="@(KnownRuntimePack->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('RuntimePackLabels', 'NativeAOT'))" />
     <KnownRuntimePack Remove="@(_AndroidNetCoreAppNativeAotKnownRuntimePack)" />
     <KnownRuntimePack Include="@(_AndroidNetCoreAppNativeAotKnownRuntimePack)">


### PR DESCRIPTION
## Summary

The Android workload currently pins `Microsoft.DotNet.ILCompiler` to the runtime version used to build the workload. This couples NativeAOT compiler updates to Android workload rebuilds instead of allowing the installed .NET SDK to select its compiler pack.

Remove the ILCompiler version override. Android runtime-pack RID and version selection remain unchanged and can intentionally diverge from the SDK-selected compiler version.

----

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: N/A
- [x] Unit tests: N/A; this removes a version-policy override without changing runtime-pack restore logic.