### PR TITLE
[tests] Keep GetObjectArray peer alive

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Runtime/JnienvArrayMarshaling.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Runtime/JnienvArrayMarshaling.cs
@@ -330,15 +330,16 @@ namespace Android.RuntimeTests {
 				object[] data = JNIEnv.GetObjectArray (byteArray.Handle, new[]{typeof (byte), typeof (byte), typeof (byte)});
 				AssertArrays ("GetObjectArray", data, (object) 1, (object) 2, (object) 3);
 			}
+			var context = Application.Context;
 			using (var objectArray =
 					new Java.Lang.Object (
 							JNIEnv.NewArray (
-								new Java.Lang.Object[]{Application.Context, 42L, "string"},
+								new Java.Lang.Object[]{context, 42L, "string"},
 								typeof (Java.Lang.Object)),
 						JniHandleOwnership.TransferLocalRef)) {
 				object[] values = JNIEnv.GetObjectArray (objectArray.Handle, new[]{typeof(Context), typeof (int)});
 				Assert.AreEqual (3, values.Length);
-				Assert.AreSame (Application.Context, values [0], $"Expected existing Context peer, got {values [0]?.GetType ()}.");
+				Assert.AreSame (context, values [0], $"Expected existing Context peer, got {values [0]?.GetType ()}.");
 				Assert.IsInstanceOf<int> (values [1], $"Expected converted Int32, got {values [1]?.GetType ()}: {values [1]}.");
 				Assert.AreEqual (42, (int)values [1]);
 				Assert.AreEqual ("string", values [2].ToString ());


### PR DESCRIPTION
`JnienvArrayMarshaling.GetObjectArray` intermittently compared two managed wrappers for the same Java context because the wrapper inserted into the JNI array was not explicitly retained. Java peer registration uses weak references, so this could fail under CoreCLRTrimmable GC timing even though JNI marshaling returned the correct Java object.

Capture `Application.Context` in a local, use that instance to construct the JNI object array, and assert that the roundtrip returns the same known-live managed peer. This preserves the intended peer-identity coverage without requiring a runtime change.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [x] Unit tests: source diff and whitespace validation passed. Focused on-device validation was unavailable because the worktree has no local .NET for Android SDK build or `adb`.