### PR TITLE
[tests] Prevent duplicate logcat messages in uncaught exception test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -359,7 +359,6 @@ namespace Xamarin.Android.Build.Tests
 		{
 			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".exe" : "";
 			string adb = Path.Combine (AndroidSdkPath, "platform-tools", "adb" + ext);
-			// `adb logcat` emits buffered lines before continuing with live output.
 			var info = new ProcessStartInfo (adb, "logcat") {
 				RedirectStandardOutput = true,
 				UseShellExecute = false,
@@ -370,6 +369,13 @@ namespace Xamarin.Android.Build.Tests
 			bool didActionSucceed = false;
 			ManualResetEventSlim stdout_done = new ManualResetEventSlim ();
 			using (var sw = File.CreateText (logcatFilePath)) {
+				// Process already-buffered logcat lines first so startup messages emitted before
+				// this monitor starts are still visible to tests.
+				if (TryMatchLogcatOutput (RunAdbCommand ("logcat -d"), sw, action)) {
+					sw.Flush ();
+					return true;
+				}
+
 				using (var proc = Process.Start (info)) {
 					proc.OutputDataReceived += (sender, e) => {
 						if (e.Data != null) {
@@ -400,6 +406,23 @@ namespace Xamarin.Android.Build.Tests
 					return didActionSucceed;
 				}
 			}
+		}
+
+		static bool TryMatchLogcatOutput (string output, TextWriter logcatOutput, Func<string, bool> action)
+		{
+			bool didActionSucceed = false;
+			using (var sr = new StringReader (output ?? "")) {
+				string line = sr.ReadLine ();
+				while (line != null) {
+					logcatOutput.WriteLine (line);
+					if (action (line)) {
+						didActionSucceed = true;
+						break;
+					}
+					line = sr.ReadLine ();
+				}
+			}
+			return didActionSucceed;
 		}
 
 		protected static bool WaitForDebuggerToStart (string logcatFilePath, int timeout = 120)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -359,6 +359,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".exe" : "";
 			string adb = Path.Combine (AndroidSdkPath, "platform-tools", "adb" + ext);
+			// `adb logcat` emits buffered lines before continuing with live output.
 			var info = new ProcessStartInfo (adb, "logcat") {
 				RedirectStandardOutput = true,
 				UseShellExecute = false,
@@ -369,13 +370,6 @@ namespace Xamarin.Android.Build.Tests
 			bool didActionSucceed = false;
 			ManualResetEventSlim stdout_done = new ManualResetEventSlim ();
 			using (var sw = File.CreateText (logcatFilePath)) {
-				// Process already-buffered logcat lines first so startup messages emitted before
-				// this monitor starts are still visible to tests.
-				if (TryMatchLogcatOutput (RunAdbCommand ("logcat -d"), sw, action)) {
-					sw.Flush ();
-					return true;
-				}
-
 				using (var proc = Process.Start (info)) {
 					proc.OutputDataReceived += (sender, e) => {
 						if (e.Data != null) {
@@ -406,23 +400,6 @@ namespace Xamarin.Android.Build.Tests
 					return didActionSucceed;
 				}
 			}
-		}
-
-		static bool TryMatchLogcatOutput (string output, TextWriter logcatOutput, Func<string, bool> action)
-		{
-			bool didActionSucceed = false;
-			using (var sr = new StringReader (output ?? "")) {
-				string line = sr.ReadLine ();
-				while (line != null) {
-					logcatOutput.WriteLine (line);
-					if (action (line)) {
-						didActionSucceed = true;
-						break;
-					}
-					line = sr.ReadLine ();
-				}
-			}
-			return didActionSucceed;
 		}
 
 		protected static bool WaitForDebuggerToStart (string logcatFilePath, int timeout = 120)

--- a/tests/MSBuildDeviceIntegration/Tests/UncaughtExceptionTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/UncaughtExceptionTests.cs
@@ -170,7 +170,7 @@ namespace Scratch.JMJMException
 			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
 				Assert.True (libBuilder.Build (lib), "Library should have built.");
 				Assert.IsTrue (appBuilder.Install (app), "Install should have succeeded.");
-				AdbStartActivity ($"{app.PackageName}/{app.JavaPackageName}.MainActivity");
+				ClearAdbLogcat ();
 
 				string logcatPath = Path.Combine (Root, appBuilder.ProjectDirectory, "logcat.log");
 				int sequenceCounter = 0;
@@ -186,7 +186,11 @@ namespace Scratch.JMJMException
 							break;
 						}
 						return false; // we must examine all the lines, and returning `true` aborts the monitoring process
-					}, logcatPath, 15);
+					},
+					logcatPath,
+					timeout: 15,
+					onMonitoringStarted: () => StartActivityAndAssert (app)
+				);
 			}
 
 			AssertValidLine (0, 0);


### PR DESCRIPTION
----

Pull Request

`UncaughtExceptionTests.EnsureUncaughtExceptionWorks` can count each expected marker twice because it launches the app before `MonitorAdbLogcat()` performs its buffered dump and starts live monitoring. The live stream replays the same buffered entries, causing identical PID, timestamp, and message records to fail the exact-count assertions.

Clear logcat after installation, begin monitoring first, and launch the activity through the existing `onMonitoringStarted` hook. This keeps the shared buffered pre-scan behavior used by other startup tests while ensuring this test only observes markers from the current launch.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
  - N/A
- [x] Unit tests
  - `git diff --check`
  - Targeted device validation was unavailable because this environment lacks the repository .NET 11 SDK and an Android SDK/device.