### PR TITLE
[tests] Improve apkdiff invocation reliability

### DIFF
--- a/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
+++ b/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
@@ -2,24 +2,30 @@ parameters:
   toolName: ''
   version: ''
   condition: succeeded()
-  continueOnError: true
 
 steps:
 - powershell: dotnet tool uninstall ${{ parameters.toolName }} -g
-  displayName: uninstall ${{ parameters.toolName }}
+  displayName: uninstall global ${{ parameters.toolName }}
+  ignoreLASTEXITCODE: true
+  condition: ${{ parameters.condition }}
+
+- powershell: dotnet tool uninstall ${{ parameters.toolName }} --tool-path "$(Agent.ToolsDirectory)"
+  displayName: uninstall cached ${{ parameters.toolName }}
   ignoreLASTEXITCODE: true
   condition: ${{ parameters.condition }}
 
 - task: DotNetCoreCLI@2
   displayName: install ${{ parameters.toolName }} ${{ parameters.version }}
   condition: ${{ parameters.condition }}
-  continueOnError: ${{ parameters.continueOnError }}
   inputs:
     command: custom
     custom: tool
     arguments: >-
-      update ${{ parameters.toolName }} -v:diag
-      --tool-path $(Agent.ToolsDirectory)
+      install ${{ parameters.toolName }} -v:diag
+      --tool-path "$(Agent.ToolsDirectory)"
       --version ${{ parameters.version }}
       --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
 
+- powershell: Write-Host "##vso[task.prependpath]$(Agent.ToolsDirectory)"
+  displayName: add dotnet tools to PATH
+  condition: ${{ parameters.condition }}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -103,24 +103,31 @@ namespace Xamarin.Android.Build.Tests
 
 		protected static (int code, string stdOutput, string stdError) RunApkDiffCommand (string args, string logFilePath)
 		{
-			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".exe" : "";
-			(int code, string stdOutput, string stdError) result;
-
+			var executableName = OperatingSystem.IsWindows () ? "apkdiff.exe" : "apkdiff";
+			var info = new ProcessStartInfo (executableName, $"--verbose {args}") {
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
+			};
+			using var stdOutput = new StringWriter ();
+			using var stdError = new StringWriter ();
+			using var cancellationTokenSource = new CancellationTokenSource (TimeSpan.FromSeconds (30));
+			int processId = -1;
+			int exitCode;
 			try {
-				result = RunProcessWithExitCode ("apkdiff" + ext, args);
-			} catch (System.ComponentModel.Win32Exception) {
-				// apkdiff's location might not be in the $PATH, try known locations
-				var profileDir = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
-				var apkdiffPath = Path.Combine (profileDir, ".dotnet", "tools", "apkdiff" + ext);
-				if (!File.Exists (apkdiffPath)) {
-					var agentToolsDir = Environment.GetEnvironmentVariable ("AGENT_TOOLSDIRECTORY");
-					if (Directory.Exists (agentToolsDir)) {
-						apkdiffPath = Path.Combine (agentToolsDir, "apkdiff" + ext);
-					}
-				}
-				result = RunProcessWithExitCode (apkdiffPath, args);
+				exitCode = Xamarin.Android.Tools.ProcessUtils.StartProcess (
+					info,
+					stdOutput,
+					stdError,
+					cancellationTokenSource.Token,
+					onStarted: process => processId = process.Id
+				).GetAwaiter ().GetResult ();
+			} catch (OperationCanceledException) {
+				exitCode = -1;
+				stdError.WriteLine ($"apkdiff timed out after 30 seconds (PID {processId}).");
 			}
-			var logContent = $"apkdiff exited with code: {result.code}" +
+
+			var result = (code: exitCode, stdOutput: stdOutput.ToString ().Trim (), stdError: stdError.ToString ().Trim ());
+			var logContent = $"apkdiff exited with code: {exitCode}" +
 				$"\ncontext: https://github.com/xamarin/xamarin-android/blob/main/Documentation/project-docs/ApkSizeRegressionChecks.md" +
 				$"\nstdOut:\n{result.stdOutput}\nstdErr:\n{result.stdError}";
 			File.WriteAllText (logFilePath, logContent);


### PR DESCRIPTION
## Summary

- cleanly reinstall the pinned .NET tool into `$(Agent.ToolsDirectory)`, expose that directory through `PATH`, and fail fast if installation fails
- run apkdiff through the shared `Xamarin.Android.Tools.ProcessUtils` helper
- enable apkdiff verbose output and preserve partial stdout/stderr with a concise PID message on timeout

The intermittent Windows failure could not be reproduced directly: apkdiff 0.0.17 started but produced no output or `.apkdesc` before the existing 30-second timeout. This change removes stale/PATH installation ambiguity and makes a future timeout identify apkdiff's last completed operation.

## Validation

- focused `Xamarin.Android.Build.Tests` project build
- apkdiff 0.0.17 smoke invocation with paths containing spaces