### PR TITLE
[build] Add explicit fast deployment property

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-process.md
+++ b/Documentation/docs-mobile/building-apps/build-process.md
@@ -52,7 +52,7 @@ Only the updated assemblies are resynchronized to the target device.
 
 Fast deployment is supported for both `.apk` and `.aab` package formats.
 It is enabled by default, and may be disabled in Debug builds
-by setting the `$(EmbedAssembliesIntoApk)` property to `True`.
+by setting the `$(AndroidEnableFastDeployment)` property to `False`.
 Note that using `.aab` with fast deployment will be slower than `.apk`
 because the `.aab` file must be processed through `bundletool` for
 packaging and installation.
@@ -185,4 +185,3 @@ written correctly, build extensions can affect your build
 performance, especially if they run on every build. It is
 highly recommended that you read the MSBuild [documentation](/visualstudio/msbuild/msbuild)
 before implementing such extensions.
-

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -372,6 +372,17 @@ called `desugar`, on the output of the `javac` compiler. The default value is
 `False` if using `$(AndroidDexTool)=dx` and `True` if
 using [`$(AndroidDexTool)`](#androiddextool)=`d8`.
 
+## AndroidEnableFastDeployment
+
+A boolean property that determines whether [Fast Deployment](build-process.md#Fast_Deployment)
+is enabled. Fast Deployment installs assemblies outside of the application
+package, which can reduce deployment and rebuild times.
+
+The default value is `True` for Debug builds and `False` for Release builds.
+Setting this property is equivalent to setting the inverse value of
+[`$(EmbedAssembliesIntoApk)`](#embedassembliesintoapk). If both properties
+are set, `$(EmbedAssembliesIntoApk)` takes precedence.
+
 ## AndroidEnableGooglePlayStoreChecks
 
 A bool property
@@ -1597,6 +1608,11 @@ Defaults to `false`.
 A boolean property that
 determines whether or not the app's assemblies should be embedded
 into the Application package.
+
+This property is the inverse of
+[`$(AndroidEnableFastDeployment)`](#androidenablefastdeployment). New projects
+should use `$(AndroidEnableFastDeployment)` to control Fast Deployment. If both
+properties are set, `$(EmbedAssembliesIntoApk)` takes precedence.
 
 This property should be `True` for Release builds and `False` for
 Debug builds. It *may* need to be `True` in Debug builds if Fast

--- a/Documentation/docs-mobile/messages/xa0119.md
+++ b/Documentation/docs-mobile/messages/xa0119.md
@@ -38,12 +38,12 @@ Remove the following from `Release` configurations:
 *DO* use the following options for `Debug` configurations:
 
 * `<AndroidLinkMode>None</AndroidLinkMode>`
-* `<EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>`
+* `<AndroidEnableFastDeployment>True</AndroidEnableFastDeployment>`
 * `<UseInterpreter>true</UseInterpreter>`
 
 *DO* use the following options for `Release` configurations:
 
-* `<EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>`
+* `<AndroidEnableFastDeployment>False</AndroidEnableFastDeployment>`
 * `<AotAssemblies>True</AotAssemblies>` or in .NET 6 `<RunAOTCompilation>True</RunAOTCompilation>`
 * `<PublishReadyToRun>True</PublishReadyToRun>` (for CoreCLR)
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -82,7 +82,7 @@
     <UseInterpreter Condition=" '$(UseInterpreter)' == '' and '$(AndroidUseInterpreter)' == '' and '$(_AndroidRuntime)' == 'MonoVM' ">true</UseInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">true</EmbedAssembliesIntoApk>
+    <AndroidEnableFastDeployment Condition=" '$(AndroidEnableFastDeployment)' == '' ">false</AndroidEnableFastDeployment>
     <AndroidManagedSymbols Condition=" '$(AndroidManagedSymbols)' == '' ">true</AndroidManagedSymbols>
     <AndroidPackageFormats Condition=" '$(AndroidPackageFormats)' == '' " >aab;apk</AndroidPackageFormats>
   </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1375,6 +1375,36 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 		}
 
 		[Test]
+		public void AndroidEnableFastDeployment (
+			[Values (true, false)] bool enabled,
+			[Values (true, false)] bool isRelease,
+			[Values (true, false)] bool globalProperty,
+			[Values (AndroidRuntime.CoreCLR)] AndroidRuntime runtime)
+		{
+			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+			};
+			proj.SetRuntime (runtime);
+			if (!globalProperty) {
+				proj.AndroidEnableFastDeployment = enabled;
+			}
+			using (var b = CreateApkBuilder ()) {
+				var parameters = globalProperty ? new [] { $"{KnownProperties.AndroidEnableFastDeployment}={enabled}" } : null;
+				Assert.IsTrue (b.Build (proj, parameters: parameters), "Build should have succeeded.");
+
+				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk");
+				FileAssert.Exists (apk);
+				var helper = new ArchiveAssemblyHelper (apk);
+				using var assembly = helper.ReadEntry ($"assemblies/{proj.ProjectName}.dll");
+				Assert.AreEqual (!enabled, assembly != null, $"{proj.ProjectName}.dll should {(!enabled ? "" : "not ")}be embedded in {apk}.");
+			}
+		}
+
+		[Test]
 		public void FastDeploymentDoesNotAddContentProvider ([Values (AndroidRuntime.CoreCLR)] AndroidRuntime runtime)
 		{
 			if (IgnoreUnsupportedConfiguration (runtime)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/InvalidConfigTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/InvalidConfigTests.cs
@@ -25,6 +25,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty (proj.DebugProperties, "AndroidLinkMode", "Full");
+			proj.EmbedAssembliesIntoApk = false;
 			using (var b = CreateApkBuilder ()) {
 				b.Target = "Build"; // SignAndroidPackage would fail for OSS builds
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -8,6 +8,7 @@ namespace Xamarin.ProjectTools
 		public const string TargetFrameworkVersion = "TargetFrameworkVersion";
 
 		public const string AndroidLinkMode = "AndroidLinkMode";
+		public const string AndroidEnableFastDeployment = "AndroidEnableFastDeployment";
 		public const string EmbedAssembliesIntoApk = "EmbedAssembliesIntoApk";
 		public const string AndroidCreatePackagePerAbi = "AndroidCreatePackagePerAbi";
 		public const string AndroidEnableMarshalMethods = "AndroidEnableMarshalMethods";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -139,6 +139,11 @@ namespace Xamarin.ProjectTools
 			set { SetProperty (KnownProperties.Deterministic, value.ToString ()); }
 		}
 
+		public bool AndroidEnableFastDeployment {
+			get { return string.Equals (GetProperty (KnownProperties.AndroidEnableFastDeployment), "True", StringComparison.OrdinalIgnoreCase); }
+			set { SetProperty (KnownProperties.AndroidEnableFastDeployment, value.ToString ()); }
+		}
+
 		public bool EmbedAssembliesIntoApk {
 			get { return string.Equals (GetProperty (KnownProperties.EmbedAssembliesIntoApk), "True", StringComparison.OrdinalIgnoreCase); }
 			set { SetProperty (KnownProperties.EmbedAssembliesIntoApk, value.ToString ()); }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -158,7 +158,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">MonoAndroid</TargetFrameworkIdentifier>
 	<MonoAndroidVersion>v$(_XAMajorVersionNumber).0</MonoAndroidVersion>
 	<AndroidUpdateResourceReferences Condition="'$(AndroidUpdateResourceReferences)' == ''">True</AndroidUpdateResourceReferences>
-	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' And '$(Optimize)' != 'True' ">False</EmbedAssembliesIntoApk>
+	<AndroidEnableFastDeployment Condition=" '$(EmbedAssembliesIntoApk)' != '' And '$(EmbedAssembliesIntoApk)' != 'True' ">True</AndroidEnableFastDeployment>
+	<AndroidEnableFastDeployment Condition=" '$(EmbedAssembliesIntoApk)' == 'True' ">False</AndroidEnableFastDeployment>
+	<AndroidEnableFastDeployment Condition=" '$(AndroidEnableFastDeployment)' == '' And '$(Optimize)' != 'True' ">True</AndroidEnableFastDeployment>
+	<AndroidEnableFastDeployment Condition=" '$(AndroidEnableFastDeployment)' == '' ">False</AndroidEnableFastDeployment>
+	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' And '$(AndroidEnableFastDeployment)' == 'True' ">False</EmbedAssembliesIntoApk>
 	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">True</EmbedAssembliesIntoApk>
   <AndroidPreferNativeLibrariesWithDebugSymbols Condition=" '$(AndroidPreferNativeLibrariesWithDebugSymbols)' == '' ">False</AndroidPreferNativeLibrariesWithDebugSymbols>
 	<AndroidSkipJavacVersionCheck Condition="'$(AndroidSkipJavacVersionCheck)' == ''">False</AndroidSkipJavacVersionCheck>
@@ -506,15 +510,15 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     Condition=" '$(AndroidApplication)' == 'true' ">
   <AndroidWarning Code="XA0119"
       ResourceName="XA0119_AOT"
-      Condition=" '$(EmbedAssembliesIntoApk)' != 'True' And '$(AotAssemblies)' == 'True' "
+      Condition=" '$(AndroidEnableFastDeployment)' == 'True' And '$(AotAssemblies)' == 'True' "
   />
   <AndroidWarning Code="XA0119"
       ResourceName="XA0119_LinkMode"
-      Condition=" '$(EmbedAssembliesIntoApk)' != 'True' And '$(AndroidLinkMode)' != 'None' "
+      Condition=" '$(AndroidEnableFastDeployment)' == 'True' And '$(AndroidLinkMode)' != 'None' "
   />
   <AndroidWarning Code="XA0119"
       ResourceName="XA0119_LinkTool"
-      Condition=" '$(EmbedAssembliesIntoApk)' != 'True' And '$(AndroidLinkTool)' != '' "
+      Condition=" '$(AndroidEnableFastDeployment)' == 'True' And '$(AndroidLinkTool)' != '' "
   />
   <AndroidWarning Code="XA0119"
       ResourceName="XA0119_Interpreter"
@@ -522,7 +526,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   />
   <AndroidWarning Code="XA0119"
       ResourceName="XA0119_ReadyToRun"
-      Condition=" '$(EmbedAssembliesIntoApk)' != 'True' And '$(PublishReadyToRun)' == 'True' "
+      Condition=" '$(AndroidEnableFastDeployment)' == 'True' And '$(PublishReadyToRun)' == 'True' "
   />
   <AndroidWarning Code="XA1027"
       ResourceName="XA1027"


### PR DESCRIPTION
## Changes

- add `$(AndroidEnableFastDeployment)` as the explicit inverse of `$(EmbedAssembliesIntoApk)`
- preserve compatibility and precedence for projects using the legacy property
- use the explicit property in `_CheckNonIdealAppConfigurations` so existing and new projects continue receiving XA0119 warnings
- add build coverage for enabled and disabled fast deployment
- document the property in build properties, the build process, and XA0119 guidance

Closes #9495