### PR TITLE
Enable CoreCLR R2R for custom publish configurations

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
@@ -15,8 +15,8 @@ This file contains the CoreCLR-specific MSBuild logic for .NET for Android.
   </PropertyGroup>
   <!-- Properties for $(OutputType)=Exe (Android Applications) -->
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' ">
-    <!-- Default to R2R Composite for CoreCLR Release mode -->
-    <PublishReadyToRun Condition=" '$(PublishReadyToRun)' == '' and '$(Configuration)' == 'Release' ">true</PublishReadyToRun>
+    <!-- Default to R2R Composite for CoreCLR Release mode and publish builds -->
+    <PublishReadyToRun Condition=" '$(PublishReadyToRun)' == '' and ('$(Configuration)' == 'Release' or '$(_IsPublishing)' == 'true') ">true</PublishReadyToRun>
     <PublishReadyToRunComposite Condition=" '$(PublishReadyToRunComposite)' == '' and '$(PublishReadyToRun)' == 'true' ">true</PublishReadyToRunComposite>
     <_IsPublishing Condition=" '$(_IsPublishing)' == '' and '$(PublishReadyToRun)' == 'true' ">true</_IsPublishing>
     <AllowReadyToRunWithoutRuntimeIdentifier Condition=" '$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifiers)' != '' ">true</AllowReadyToRunWithoutRuntimeIdentifier>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
@@ -15,8 +15,8 @@ This file contains the CoreCLR-specific MSBuild logic for .NET for Android.
   </PropertyGroup>
   <!-- Properties for $(OutputType)=Exe (Android Applications) -->
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' ">
-    <!-- Default PublishReadyToRun to true for CoreCLR Release mode and publish builds -->
-    <PublishReadyToRun Condition=" '$(PublishReadyToRun)' == '' and ('$(Configuration)' == 'Release' or '$(_IsPublishing)' == 'true') ">true</PublishReadyToRun>
+    <!-- Default PublishReadyToRun to true for CoreCLR Release mode and publish builds without debug symbols -->
+    <PublishReadyToRun Condition=" '$(PublishReadyToRun)' == '' and ('$(Configuration)' == 'Release' or ('$(_IsPublishing)' == 'true' and '$(DebugSymbols)' != 'true')) ">true</PublishReadyToRun>
     <PublishReadyToRunComposite Condition=" '$(PublishReadyToRunComposite)' == '' and '$(PublishReadyToRun)' == 'true' ">true</PublishReadyToRunComposite>
     <_IsPublishing Condition=" '$(_IsPublishing)' == '' and '$(PublishReadyToRun)' == 'true' ">true</_IsPublishing>
     <AllowReadyToRunWithoutRuntimeIdentifier Condition=" '$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifiers)' != '' ">true</AllowReadyToRunWithoutRuntimeIdentifier>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
@@ -15,7 +15,7 @@ This file contains the CoreCLR-specific MSBuild logic for .NET for Android.
   </PropertyGroup>
   <!-- Properties for $(OutputType)=Exe (Android Applications) -->
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' ">
-    <!-- Default to R2R Composite for CoreCLR Release mode and publish builds -->
+    <!-- Default PublishReadyToRun to true for CoreCLR Release mode and publish builds -->
     <PublishReadyToRun Condition=" '$(PublishReadyToRun)' == '' and ('$(Configuration)' == 'Release' or '$(_IsPublishing)' == 'true') ">true</PublishReadyToRun>
     <PublishReadyToRunComposite Condition=" '$(PublishReadyToRunComposite)' == '' and '$(PublishReadyToRun)' == 'true' ">true</PublishReadyToRunComposite>
     <_IsPublishing Condition=" '$(_IsPublishing)' == '' and '$(PublishReadyToRun)' == 'true' ">true</_IsPublishing>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -120,7 +120,9 @@ namespace Xamarin.Android.Build.Tests
 			var projBuilder = CreateDllBuilder ();
 			projBuilder.Save (proj);
 			var dotnet = new DotNetCLI (Path.Combine (Root, projBuilder.ProjectDirectory, proj.ProjectFilePath));
-			Assert.IsTrue (dotnet.Publish (), "`dotnet publish` should have succeeded.");
+			// `dotnet publish` defaults $(Configuration) to Release unless told otherwise, which would
+			// override the project's own custom "AppStore" configuration default.
+			Assert.IsTrue (dotnet.Publish (parameters: new [] { $"Configuration={proj.Configuration}" }), "`dotnet publish` should have succeeded.");
 
 			var assemblyName = proj.ProjectName;
 			var apk = Path.Combine (Root, projBuilder.ProjectDirectory, proj.OutputPath, rid, "publish", $"{proj.PackageName}-Signed.apk");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -113,7 +113,8 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetRuntime (AndroidRuntime.CoreCLR);
 			proj.SetProperty ("RuntimeIdentifier", rid);
 			proj.SetProperty ("AndroidEnableAssemblyCompression", "false");
-			proj.SetProperty ("DebugSymbols", "false");
+			proj.SetProperty ("Optimize", "true");
+			proj.SetProperty ("DebugType", "None");
 			proj.SetProperty ("PublishReadyToRunComposite", isComposite.ToString ());
 
 			// Use `dotnet publish` rather than `msbuild /t:Publish`: only the `dotnet publish` CLI

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -115,14 +115,15 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty ("AndroidEnableAssemblyCompression", "false");
 			proj.SetProperty ("PublishReadyToRunComposite", isComposite.ToString ());
 
-			var b = CreateApkBuilder ();
-			b.Target = "Publish";
-			b.BuildingInsideVisualStudio = false; // Publish's inner Build must produce & sign the .apk
-			// `dotnet publish` sets _IsPublishing=true itself; emulate that since we invoke MSBuild directly.
-			Assert.IsTrue (b.Build (proj, parameters: new [] { "_IsPublishing=true" }), "Publish should have succeeded.");
+			// Use `dotnet publish` rather than `msbuild /t:Publish`: only the `dotnet publish` CLI
+			// sets $(_IsPublishing)=true, which the CoreCLR R2R default (issue #11069) relies on.
+			var projBuilder = CreateDllBuilder ();
+			projBuilder.Save (proj);
+			var dotnet = new DotNetCLI (Path.Combine (Root, projBuilder.ProjectDirectory, proj.ProjectFilePath));
+			Assert.IsTrue (dotnet.Publish (), "`dotnet publish` should have succeeded.");
 
 			var assemblyName = proj.ProjectName;
-			var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, rid, "publish", $"{proj.PackageName}-Signed.apk");
+			var apk = Path.Combine (Root, projBuilder.ProjectDirectory, proj.OutputPath, rid, "publish", $"{proj.PackageName}-Signed.apk");
 			FileAssert.Exists (apk);
 
 			var helper = new ArchiveAssemblyHelper (apk, true);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -104,12 +104,13 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void BasicApplicationPublishReadyToRunCustomConfiguration ([Values] bool isComposite, [Values ("android-x64", "android-arm64")] string rid)
 		{
-			var proj = new XamarinAndroidApplicationProject {
-				IsRelease = false,
+			// Use a non-standard release configuration name to validate PublishReadyToRun
+			// defaults on for publish builds, not just $(Configuration)=='Release'.
+			var proj = new XamarinAndroidApplicationProject (releaseConfigurationName: "AppStore") {
+				IsRelease = true,
 			};
 
 			proj.SetRuntime (AndroidRuntime.CoreCLR);
-			proj.SetProperty ("Configuration", "AppStore");
 			proj.SetProperty ("RuntimeIdentifier", rid);
 			proj.SetProperty ("AndroidEnableAssemblyCompression", "false");
 			proj.SetProperty ("PublishReadyToRunComposite", isComposite.ToString ());

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -113,6 +113,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetRuntime (AndroidRuntime.CoreCLR);
 			proj.SetProperty ("RuntimeIdentifier", rid);
 			proj.SetProperty ("AndroidEnableAssemblyCompression", "false");
+			proj.SetProperty ("DebugSymbols", "false");
 			proj.SetProperty ("PublishReadyToRunComposite", isComposite.ToString ());
 
 			// Use `dotnet publish` rather than `msbuild /t:Publish`: only the `dotnet publish` CLI

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -120,7 +120,7 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (b.Build (proj), "Publish should have succeeded.");
 
 			var assemblyName = proj.ProjectName;
-			var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, rid, $"{proj.PackageName}-Signed.apk");
+			var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, rid, "publish", $"{proj.PackageName}-Signed.apk");
 			FileAssert.Exists (apk);
 
 			var helper = new ArchiveAssemblyHelper (apk, true);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -117,7 +117,9 @@ namespace Xamarin.Android.Build.Tests
 
 			var b = CreateApkBuilder ();
 			b.Target = "Publish";
-			Assert.IsTrue (b.Build (proj), "Publish should have succeeded.");
+			b.BuildingInsideVisualStudio = false; // Publish's inner Build must produce & sign the .apk
+			// `dotnet publish` sets _IsPublishing=true itself; emulate that since we invoke MSBuild directly.
+			Assert.IsTrue (b.Build (proj, parameters: new [] { "_IsPublishing=true" }), "Publish should have succeeded.");
 
 			var assemblyName = proj.ProjectName;
 			var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, rid, "publish", $"{proj.PackageName}-Signed.apk");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -102,6 +102,38 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void BasicApplicationPublishReadyToRunCustomConfiguration ([Values] bool isComposite, [Values ("android-x64", "android-arm64")] string rid)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = false,
+			};
+
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("Configuration", "AppStore");
+			proj.SetProperty ("RuntimeIdentifier", rid);
+			proj.SetProperty ("AndroidEnableAssemblyCompression", "false");
+			proj.SetProperty ("PublishReadyToRunComposite", isComposite.ToString ());
+
+			var b = CreateApkBuilder ();
+			b.Target = "Publish";
+			Assert.IsTrue (b.Build (proj), "Publish should have succeeded.");
+
+			var assemblyName = proj.ProjectName;
+			var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, rid, $"{proj.PackageName}-Signed.apk");
+			FileAssert.Exists (apk);
+
+			var helper = new ArchiveAssemblyHelper (apk, true);
+			var abi = MonoAndroidHelper.RidToAbi (rid);
+			Assert.IsTrue (helper.Exists ($"assemblies/{abi}/{assemblyName}.dll"), $"{assemblyName}.dll should exist in apk!");
+
+			using var stream = helper.ReadEntry ($"assemblies/{assemblyName}.dll");
+			stream.Position = 0;
+			using var peReader = new System.Reflection.PortableExecutable.PEReader (stream);
+			Assert.IsTrue (peReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory.Size > 0,
+				$"ReadyToRun image not found in {assemblyName}.dll! ManagedNativeHeaderDirectory should not be empty!");
+		}
+
+		[Test]
 		public void IncompatiblePlatformTargetAndRuntimeIdentifiersFailsBuild ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();


### PR DESCRIPTION
Useful description of *why the change is necessary*:
Custom Android publish configurations such as `AppStore` were not getting CoreCLR ReadyToRun by default, because our logic only enabled it for `$(Configuration)==Release`. This caused publish behavior to differ from the expected release-like publish scenario for non-standard configuration names.

This change is a narrow stopgap for dotnet/android while upstream .NET SDK configuration-name handling is being improved. It defaults `PublishReadyToRun` to `true` when unset and either the configuration is `Release` or the build is a publish (`$(_IsPublishing)==true`). Explicit user `PublishReadyToRun` values are preserved.

Links to issues fixed:
- https://github.com/dotnet/android/issues/11069
- https://github.com/dotnet/sdk/issues/31918

Unit tests:
- Added `BasicApplicationPublishReadyToRunCustomConfiguration` in `BuildTest2.cs`.
- The test publishes with `Configuration=AppStore` on CoreCLR and asserts ReadyToRun output by checking `ManagedNativeHeaderDirectory.Size > 0` in the app assembly.
- Targeted test execution was attempted in this environment but blocked by missing Android workload (`NETSDK1147`).