### PR TITLE
Fix CodeBehind NuGet config placement

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
@@ -736,7 +736,7 @@ namespace Xamarin.Android.Build.Tests
 			CopyFile (Path.Combine (XABuildPaths.TopDirectory, "Directory.Build.props"), Path.Combine (tempRoot, "Directory.Build.props" ));
 			CopyFile (Path.Combine (XABuildPaths.TopDirectory, "eng", "Versions.props"), Path.Combine (tempRoot, "eng", "Versions.props"));
 			var project = new XamarinAndroidApplicationProject ();
-			project.CopyNuGetConfig (Path.Combine (tempRoot, "NuGet.config"));
+			project.CopyNuGetConfig (tempRoot);
 
 			PatchProject (Path.Combine (tempRoot, CommonSampleLibraryName, $"{CommonSampleLibraryName}.NET.csproj"));
 			PatchProject (Path.Combine (temporaryProjectPath, $"{ProjectName}.csproj"));


### PR DESCRIPTION
----

`CodeBehindTests` passed a file path to `CopyNuGetConfig`, which expects a directory and appends `NuGet.config`. This placed the repository configuration in a nested path, so generated projects could miss it and contact external package feeds. Pass the temporary project root instead.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed: N/A
- [ ] Unit tests: Focused CodeBehind tests require an in-tree local SDK, which was unavailable. `git diff --check` passed.