### PR TITLE
[tests] Route XASdk Maven dependency through public feed

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -178,8 +178,8 @@ public class JavaSourceTest {
 				WebContent = $"{TestEnvironment.DotNetPublicMaven}/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar",
 				MetadataValues = "Pack=false;Bind=false",
 			});
-			proj.OtherBuildItems.Add (new AndroidItem.AndroidMavenLibrary ("com.google.auto.value:auto-value-annotations") {
-				MetadataValues = $"Version=1.10.4;Bind=false;Repository={TestEnvironment.DotNetPublicMaven}",
+			proj.OtherBuildItems.Add (new AndroidItem.AndroidMavenLibrary ("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm") {
+				MetadataValues = $"Version=1.3.3;Bind=false;Repository={TestEnvironment.DotNetPublicMaven}",
 				BinaryContent = () => [],
 			});
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -178,8 +178,8 @@ public class JavaSourceTest {
 				WebContent = $"{TestEnvironment.DotNetPublicMaven}/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar",
 				MetadataValues = "Pack=false;Bind=false",
 			});
-			proj.OtherBuildItems.Add (new AndroidItem.AndroidMavenLibrary ("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm") {
-				MetadataValues = $"Version=1.3.3;Bind=false;Repository={TestEnvironment.DotNetPublicMaven}",
+			proj.OtherBuildItems.Add (new AndroidItem.AndroidMavenLibrary ("com.google.auto.value:auto-value-annotations") {
+				MetadataValues = $"Version=1.10.4;Bind=false;Repository={TestEnvironment.DotNetPublicMaven}",
 				BinaryContent = () => [],
 			});
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -179,7 +179,7 @@ public class JavaSourceTest {
 				MetadataValues = "Pack=false;Bind=false",
 			});
 			proj.OtherBuildItems.Add (new AndroidItem.AndroidMavenLibrary ("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm") {
-				MetadataValues = "Version=1.3.3;Bind=false",
+				MetadataValues = $"Version=1.3.3;Bind=false;Repository={TestEnvironment.DotNetPublicMaven}",
 				BinaryContent = () => [],
 			});
 


### PR DESCRIPTION
----

`XASdkTests.DotNetPack` could contact `repo1.maven.org` because its Kotlin serialization `AndroidMavenLibrary` did not specify a repository. Mirror the existing fixture into `dotnet-public-maven` and route the test dependency through `TestEnvironment.DotNetPublicMaven`, keeping CFSClean validation on the approved feed without changing the package under test.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: N/A (CFSClean build audit finding)
- [x] Unit tests: `dotnet test bin\TestDebug\net10.0\Xamarin.Android.Build.Tests.dll --filter "Name~DotNetPack&Name~net11.0"` (4 passed: CoreCLR and NativeAOT across both .NET 11 target-framework forms).