### PR TITLE
[NativeAOT] Link runtime crypto archive directly

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -113,7 +113,6 @@ projects that use the Microsoft.Android.Runtimes framework in .NET 6+.
     <ItemGroup Condition=" '$(AndroidRuntime)' == 'NativeAOT' ">
       <NativeRuntimeAsset Condition=" Exists('$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.debug-static-debug.a') " Include="$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.debug-static-debug.a" />
       <NativeRuntimeAsset Condition=" Exists('$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.release-static-release.a') " Include="$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.release-static-release.a" />
-      <NativeRuntimeAsset Condition=" Exists('$(XAPackagesDir)\microsoft.netcore.app.runtime.nativeaot.$(AndroidRID)\$(MicrosoftNETCoreAppRefPackageVersion)\runtimes\$(AndroidRID)\native\libSystem.Security.Cryptography.Native.Android.a') " Include="$(XAPackagesDir)\microsoft.netcore.app.runtime.nativeaot.$(AndroidRID)\$(MicrosoftNETCoreAppRefPackageVersion)\runtimes\$(AndroidRID)\native\libSystem.Security.Cryptography.Native.Android.a" />
       <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(AndroidLatestStableApiLevel)\Microsoft.Android.Runtime.NativeAOT.dll" />
     </ItemGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -321,6 +321,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
 
     <!-- Common items (same regardless of linker source) -->
     <ItemGroup>
+      <!-- Supplied by the SDK-resolved NativeAOT runtime pack, including the BCL native archives. -->
       <_NativeAotLinkLibraries Include="@(NativeLibrary)" />
       <_NativeAotAdditionalObjects Include="@(_PrivateJniInitFuncsNativeObjectFile)" />
       <_NativeAotAdditionalObjects Include="@(_PrivateEnvironmentNativeObjectFile)" />
@@ -330,11 +331,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <_NativeAotSystemLibraries Include="m" />
       <_NativeAotSystemLibraries Include="c" />
     </ItemGroup>
-    <ItemGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' == 'true' and Exists('$(_NativeAotRuntimePackNativeDir)libSystem.Security.Cryptography.Native.Android.a') ">
-      <_NativeAotLinkLibraries Remove="$(IlcSdkPath)libSystem.Security.Cryptography.Native.Android.a" />
-      <_NativeAotLinkLibraries Include="$(_NativeAotRuntimePackNativeDir)libSystem.Security.Cryptography.Native.Android.a" />
-    </ItemGroup>
-
     <!-- When using workload linker, resolve libc++/libnaot from runtime pack dir.
          When using NDK, @(_NdkLibs) already has the right NDK sysroot paths. -->
     <ItemGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' == 'true' ">

--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -373,14 +373,6 @@
                          RuntimePackName="$(_RuntimePackName)" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(CMakeRuntimeFlavor)' == 'NativeAOT' ">
-      <_RuntimePackFiles Include="$(XAPackagesDir)\microsoft.netcore.app.runtime.nativeaot.%(AndroidSupportedTargetJitAbi.AndroidRID)\$(MicrosoftNETCoreAppRefPackageVersion)\runtimes\%(AndroidSupportedTargetJitAbi.AndroidRID)\native\libSystem.Security.Cryptography.Native.Android.a"
-                         Condition="Exists('$(XAPackagesDir)\microsoft.netcore.app.runtime.nativeaot.%(AndroidSupportedTargetJitAbi.AndroidRID)\$(MicrosoftNETCoreAppRefPackageVersion)\runtimes\%(AndroidSupportedTargetJitAbi.AndroidRID)\native\libSystem.Security.Cryptography.Native.Android.a')"
-                         AndroidRID="%(AndroidSupportedTargetJitAbi.AndroidRID)"
-                         AndroidRuntime="$(CMakeRuntimeFlavor)"
-                         RuntimePackName="$(_RuntimePackName)" />
-    </ItemGroup>
-
     <Copy
         SourceFiles="%(_RuntimePackFiles.Identity)"
         DestinationFolder="$(MicrosoftAndroidPacksRootDir)Microsoft.Android.Runtime.%(_RuntimePackFiles.RuntimePackName).$(AndroidApiLevel).%(_RuntimePackFiles.AndroidRID)\$(AndroidPackVersion)\runtimes\%(_RuntimePackFiles.AndroidRID)\native"

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -37,11 +37,6 @@ inside xaprepare.
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-x86"   Version="[$(DotNetRuntimePacksVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-x64"   Version="[$(DotNetRuntimePacksVersion)]" />
 
-    <!-- NativeAOT Android runtime packs -->
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-arm"   Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-arm64" Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.NativeAOT.android-x64"   Version="[$(MicrosoftNETCoreAppRefPackageVersion)]" />
-
     <!-- CoreCLR Android runtime packs -->
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm"   Version="[$(DotNetRuntimePacksVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm64" Version="[$(DotNetRuntimePacksVersion)]" />

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -167,6 +167,7 @@
     <Compile Include="System.Net.NetworkInformation\PingTest.cs" />
     <Compile Include="System.Runtime.InteropServices\DllImportTest.cs" />
     <Compile Include="System.Runtime.InteropServices\RuntimeInformationTest.cs" />
+    <Compile Include="System.Security.Cryptography\CryptographyTest.cs" />
     <Compile Include="System.Text\EncodingTests.cs" />
     <Compile Include="System.Text.Json\JsonSerializerTest.cs" />
     <Compile Include="System.Threading\InterlockedTest.cs" />

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System.Security.Cryptography/CryptographyTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System.Security.Cryptography/CryptographyTest.cs
@@ -1,0 +1,35 @@
+using System.Security.Cryptography;
+using System.Text;
+
+using NUnit.Framework;
+
+namespace System.Security.CryptographyTests
+{
+	[TestFixture]
+	public class CryptographyTest
+	{
+		[Test]
+		[Category ("NativeAOTCrypto")]
+		public void AesEncryptDecryptRoundTrip ()
+		{
+			const string plaintext = "NativeAOT crypto smoke test";
+			byte [] plaintextBytes = Encoding.UTF8.GetBytes (plaintext);
+
+			using Aes aes = Aes.Create ();
+			aes.GenerateKey ();
+			aes.GenerateIV ();
+
+			byte [] ciphertext;
+			using (ICryptoTransform encryptor = aes.CreateEncryptor ()) {
+				ciphertext = encryptor.TransformFinalBlock (plaintextBytes, 0, plaintextBytes.Length);
+			}
+
+			byte [] decrypted;
+			using (ICryptoTransform decryptor = aes.CreateDecryptor ()) {
+				decrypted = decryptor.TransformFinalBlock (ciphertext, 0, ciphertext.Length);
+			}
+
+			Assert.AreEqual (plaintext, Encoding.UTF8.GetString (decrypted));
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- link `libSystem.Security.Cryptography.Native.Android.a` directly from the SDK-resolved NativeAOT runtime pack
- stop downloading and copying the archive into `Microsoft.Android.Runtime.NativeAOT` packs
- add an on-device AES encrypt/decrypt round-trip test to the existing NativeAOT lane

## Testing

- built and installed `Mono.Android.NET-Tests` with `PublishAot=true` and the trimmable typemap
- passed `AesEncryptDecryptRoundTrip` on a connected Android device
- confirmed `AndroidCryptoNative_CipherCreate`, `AndroidCryptoNative_CipherUpdate`, and `AndroidCryptoNative_CipherFinalEx` are linked into the arm64 application shared library