### PR TITLE
[Java.Interop] Avoid locks for cached JNI member lookups

### DIFF
--- a/Xamarin.Android-Tests.slnx
+++ b/Xamarin.Android-Tests.slnx
@@ -27,6 +27,7 @@
     <Project Path="samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Android.Benchmarks/Android.Benchmarks.csproj" />
     <Project Path="tests/StartupHook/StartupHook.csproj" />
   </Folder>
   <Folder Name="/tests/Mono.Android-Tests/" />

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Java.Interop
 {
@@ -15,7 +15,7 @@ namespace Java.Interop
 
 		readonly JniPeerMembers                             Members;
 
-		Dictionary<string, JniFieldInfo>                    InstanceFields  = new Dictionary<string, JniFieldInfo>(StringComparer.Ordinal);
+		readonly ConcurrentDictionary<string, JniFieldInfo> InstanceFields = new ConcurrentDictionary<string, JniFieldInfo> (1, 3, StringComparer.Ordinal);
 
 		internal void Dispose ()
 		{
@@ -24,16 +24,11 @@ namespace Java.Interop
 
 		public JniFieldInfo GetFieldInfo (string encodedMember)
 		{
-			lock (InstanceFields) {
-				if (!InstanceFields.TryGetValue (encodedMember, out var f)) {
-					string field, signature;
-					JniPeerMembers.GetNameAndSignature (encodedMember, out field, out signature);
-					f = Members.JniPeerType.GetInstanceField (field, signature);
-					InstanceFields.Add (encodedMember, f);
-				}
-				return f;
-			}
+			return InstanceFields.GetOrAdd (encodedMember, static (member, fields) => {
+				string field, signature;
+				JniPeerMembers.GetNameAndSignature (member, out field, out signature);
+				return fields.Members.JniPeerType.GetInstanceField (field, signature);
+			}, this);
 		}
 	}}
 }
-

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Java.Interop
 {
@@ -39,8 +39,8 @@ namespace Java.Interop
 
 		readonly Type                                       DeclaringType;
 
-		Dictionary<string, JniMethodInfo>                   InstanceMethods = new Dictionary<string, JniMethodInfo>(StringComparer.Ordinal);
-		Dictionary<Type, JniInstanceMethods>                SubclassConstructors = new Dictionary<Type, JniInstanceMethods> ();
+		readonly ConcurrentDictionary<string, JniMethodInfo>    InstanceMethods      = new ConcurrentDictionary<string, JniMethodInfo> (1, 3, StringComparer.Ordinal);
+		readonly ConcurrentDictionary<Type, JniInstanceMethods> SubclassConstructors = new ConcurrentDictionary<Type, JniInstanceMethods> (1, 1);
 
 		internal void Dispose ()
 		{
@@ -58,13 +58,8 @@ namespace Java.Interop
 		{
 			if (signature == null)
 				throw new ArgumentNullException (nameof (signature));
-			lock (InstanceMethods) {
-				if (!InstanceMethods.TryGetValue (signature, out var m)) {
-					m = JniPeerType.GetConstructor (signature);
-					InstanceMethods.Add (signature, m);
-				}
-				return m;
-			}
+			return InstanceMethods.GetOrAdd (signature, static (member, methods) =>
+					methods.JniPeerType.GetConstructor (member), this);
 		}
 
 		internal JniInstanceMethods GetConstructorsForType (Type declaringType)
@@ -72,13 +67,7 @@ namespace Java.Interop
 			if (declaringType == DeclaringType)
 				return this;
 
-			JniInstanceMethods? methods;
-
-			lock (SubclassConstructors) {
-				if (SubclassConstructors.TryGetValue (declaringType, out methods))
-					return methods;
-			}
-			// Init outside of `lock` in case we have recursive access:
+			// Initialize before publication in case construction recursively accesses this cache:
 			// System.ArgumentException: An item with the same key has already been added. Key: Java.Interop.JavaProxyThrowable
 			//    at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
 			//    at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
@@ -100,32 +89,16 @@ namespace Java.Interop
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods..ctor(Type declaringType) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 27
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods.GetConstructorsForType(Type declaringType) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 77
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods.StartCreateInstance(String constructorSignature, Type declaringType, JniArgumentValue* parameters) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 146
-			methods = new JniInstanceMethods (declaringType);
-			lock (SubclassConstructors) {
-				if (SubclassConstructors.TryGetValue (declaringType, out var m))
-					return m;
-				SubclassConstructors.Add (declaringType, methods);
-				return methods;
-			}
+			return SubclassConstructors.GetOrAdd (declaringType, static type => new JniInstanceMethods (type));
 		}
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)
 		{
-			lock (InstanceMethods) {
-				if (InstanceMethods.TryGetValue (encodedMember, out var m)) {
-					return m;
-				}
-			}
-			string method, signature;
-			JniPeerMembers.GetNameAndSignature (encodedMember, out method, out signature);
-			var info = GetMethodInfo (method, signature);
-			lock (InstanceMethods) {
-				if (InstanceMethods.TryGetValue (encodedMember, out var m)) {
-					return m;
-				}
-				InstanceMethods.Add (encodedMember, info);
-			}
-			return info;
+			return InstanceMethods.GetOrAdd (encodedMember, static (member, methods) => {
+				string method, signature;
+				JniPeerMembers.GetNameAndSignature (member, out method, out signature);
+				return methods.GetMethodInfo (method, signature);
+			}, this);
 		}
 
 		JniMethodInfo GetMethodInfo (string method, string signature)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Java.Interop
 {
@@ -15,19 +15,15 @@ namespace Java.Interop
 
 		readonly JniPeerMembers                             Members;
 
-		Dictionary<string, JniFieldInfo>                    StaticFields  = new Dictionary<string, JniFieldInfo>(StringComparer.Ordinal);
+		readonly ConcurrentDictionary<string, JniFieldInfo> StaticFields = new ConcurrentDictionary<string, JniFieldInfo> (1, 3, StringComparer.Ordinal);
 
 		public JniFieldInfo GetFieldInfo (string encodedMember)
 		{
-			lock (StaticFields) {
-				if (!StaticFields.TryGetValue (encodedMember, out var f)) {
-					string field, signature;
-					JniPeerMembers.GetNameAndSignature (encodedMember, out field, out signature);
-					f = Members.JniPeerType.GetStaticField (field, signature);
-					StaticFields.Add (encodedMember, f);
-				}
-				return f;
-			}
+			return StaticFields.GetOrAdd (encodedMember, static (member, fields) => {
+				string field, signature;
+				JniPeerMembers.GetNameAndSignature (member, out field, out signature);
+				return fields.Members.JniPeerType.GetStaticField (field, signature);
+			}, this);
 		}
 
 		internal void Dispose ()
@@ -36,4 +32,3 @@ namespace Java.Interop
 		}
 	}}
 }
-

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Java.Interop
 {
@@ -15,7 +15,7 @@ namespace Java.Interop
 
 		internal    readonly    JniPeerMembers              Members;
 
-		Dictionary<string, JniMethodInfo>                   StaticMethods   = new Dictionary<string, JniMethodInfo>(StringComparer.Ordinal);
+		readonly ConcurrentDictionary<string, JniMethodInfo> StaticMethods = new ConcurrentDictionary<string, JniMethodInfo> (1, 3, StringComparer.Ordinal);
 
 		internal void Dispose ()
 		{
@@ -24,21 +24,11 @@ namespace Java.Interop
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)
 		{
-			lock (StaticMethods) {
-				if (StaticMethods.TryGetValue (encodedMember, out var m)) {
-					return m;
-				}
-			}
-			string method, signature;
-			JniPeerMembers.GetNameAndSignature (encodedMember, out method, out signature);
-			var info = GetMethodInfo (method, signature);
-			lock (StaticMethods) {
-				if (StaticMethods.TryGetValue (encodedMember, out var m)) {
-					return m;
-				}
-				StaticMethods.Add (encodedMember, info);
-			}
-			return info;
+			return StaticMethods.GetOrAdd (encodedMember, static (member, methods) => {
+				string method, signature;
+				JniPeerMembers.GetNameAndSignature (member, out method, out signature);
+				return methods.GetMethodInfo (method, signature);
+			}, this);
 		}
 
 		JniMethodInfo GetMethodInfo (string method, string signature)
@@ -160,4 +150,3 @@ namespace Java.Interop
 		}
 	}}
 }
-

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Reflection;
 
 using Java.Interop;
@@ -30,10 +30,10 @@ namespace Java.InteropTests
 			}
 		}
 
-		static Dictionary<string, JniMethodInfo> GetInstanceMethods (JniPeerMembers.JniInstanceMethods methods)
+		static ConcurrentDictionary<string, JniMethodInfo> GetInstanceMethods (JniPeerMembers.JniInstanceMethods methods)
 		{
 			var f   = typeof (JniPeerMembers.JniInstanceMethods).GetField ("InstanceMethods", BindingFlags.NonPublic | BindingFlags.Instance);
-			return (Dictionary<string, JniMethodInfo>) f.GetValue (methods);
+			return (ConcurrentDictionary<string, JniMethodInfo>) f.GetValue (methods);
 		}
 
 		[Test]

--- a/tests/Android.Benchmarks/Android.Benchmarks.csproj
+++ b/tests/Android.Benchmarks/Android.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DotNetAndroidTargetFramework)</TargetFramework>
+    <SupportedOSPlatformVersion>$(AndroidMinimumDotNetApiLevel)</SupportedOSPlatformVersion>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ApplicationId>net.dot.android.benchmarks</ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <RootNamespace>Xamarin.Android.Benchmarks</RootNamespace>
+    <AndroidPackageFormat>apk</AndroidPackageFormat>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Android.Benchmarks/AndroidManifest.xml
+++ b/tests/Android.Benchmarks/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:label=".NET for Android Benchmarks" />
+</manifest>

--- a/tests/Android.Benchmarks/BenchmarkInstrumentation.cs
+++ b/tests/Android.Benchmarks/BenchmarkInstrumentation.cs
@@ -1,0 +1,83 @@
+using Android.Runtime;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Csv;
+using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+
+namespace Xamarin.Android.Benchmarks;
+
+[Instrumentation (Name = "net.dot.android.benchmarks.BenchmarkInstrumentation")]
+public class BenchmarkInstrumentation : Instrumentation
+{
+	protected BenchmarkInstrumentation (IntPtr handle, JniHandleOwnership ownership)
+		: base (handle, ownership)
+	{
+	}
+
+	public override void OnCreate (Bundle? arguments)
+	{
+		base.OnCreate (arguments);
+		Filter = GetFilter (arguments);
+		Start ();
+	}
+
+	public override void OnStart ()
+	{
+		base.OnStart ();
+
+		var results = new Bundle ();
+		try {
+			var externalFiles = Application.Context.GetExternalFilesDir (null)?.AbsolutePath;
+			var artifactsPath = Path.Combine (externalFiles ?? Path.GetTempPath (), "BenchmarkDotNet.Artifacts");
+			var config = ManualConfig.CreateEmpty ()
+				.AddJob (Job.ShortRun
+					.WithToolchain (InProcessNoEmitToolchain.Instance)
+					.WithId ("Android"))
+				.AddLogger (ConsoleLogger.Default)
+				.AddColumnProvider (DefaultColumnProviders.Instance)
+				.AddExporter (CsvExporter.Default, MarkdownExporter.GitHub)
+				.WithArtifactsPath (artifactsPath)
+				.WithOptions (ConfigOptions.DisableOptimizationsValidator);
+			if (Filter != null)
+				config.AddFilter (new GlobFilter ([Filter]));
+
+			var summaries = BenchmarkRunner.Run (GetType ().Assembly, config);
+			var reportCount = summaries.Sum (summary => summary.Reports.Length);
+			var hasErrors = summaries.Any (summary => summary.HasCriticalValidationErrors);
+
+			results.PutInt ("reports", reportCount);
+			results.PutString ("artifactsPath", artifactsPath);
+			Console.WriteLine ($"BENCHMARKS_COMPLETE reports={reportCount} artifacts={artifactsPath}");
+			Finish (hasErrors ? Result.Canceled : Result.Ok, results);
+		} catch (Exception ex) {
+			results.PutString ("error", ex.ToString ());
+			Console.WriteLine ($"BENCHMARKS_FAILED {ex}");
+			Finish (Result.Canceled, results);
+		}
+	}
+
+	string? Filter { get; set; }
+
+	static string? GetFilter (Bundle? arguments)
+	{
+		var filter = arguments?.GetString ("filter");
+		if (!string.IsNullOrWhiteSpace (filter))
+			return filter;
+
+		var value = arguments?.GetString ("args");
+		if (string.IsNullOrWhiteSpace (value))
+			return null;
+
+		var values = value.Split (' ', StringSplitOptions.RemoveEmptyEntries);
+		for (int i = 0; i < values.Length - 1; i++) {
+			if (values [i] == "--filter")
+				return values [i + 1];
+		}
+		return null;
+	}
+}

--- a/tests/Android.Benchmarks/JniMethodInfoBenchmarks.cs
+++ b/tests/Android.Benchmarks/JniMethodInfoBenchmarks.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Xamarin.Android.Benchmarks;
+
+public unsafe class JniMethodInfoBenchmarks
+{
+	const string EncodedMember = "hashCode.()I";
+
+	readonly Java.Lang.String peer;
+	readonly Java.Interop.JniPeerMembers.JniInstanceMethods methods;
+
+	public JniMethodInfoBenchmarks ()
+	{
+		peer = new Java.Lang.String ("benchmark");
+		methods = peer.JniPeerMembers.InstanceMethods;
+	}
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		_ = InvokeWithStringCache ();
+		_ = InvokeGeneratedBinding ();
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		peer.Dispose ();
+	}
+
+	[Benchmark (Baseline = true)]
+	public int InvokeWithStringCache ()
+	{
+		return methods.InvokeVirtualInt32Method (EncodedMember, peer, null);
+	}
+
+	[Benchmark]
+	public int InvokeGeneratedBinding ()
+	{
+		return peer.GetHashCode ();
+	}
+}

--- a/tests/Android.Benchmarks/README.md
+++ b/tests/Android.Benchmarks/README.md
@@ -1,0 +1,19 @@
+# Android benchmarks
+
+This instrumentation-only app runs BenchmarkDotNet in-process on an Android
+device. It has no activity.
+
+Run every benchmark:
+
+```sh
+./dotnet-local.sh run --project tests/Android.Benchmarks/Android.Benchmarks.csproj -c Release
+```
+
+Filter benchmarks by passing BenchmarkDotNet's `--filter` argument:
+
+```sh
+./dotnet-local.sh run --project tests/Android.Benchmarks/Android.Benchmarks.csproj -c Release -- --filter '*JniMethodInfoBenchmarks*'
+```
+
+The instrumentation result reports the on-device artifacts directory. Results
+are also streamed through logcat by `dotnet run`.


### PR DESCRIPTION
## Description

`JniPeerMembers` cached JNI method and field IDs in dictionaries protected by
monitor locks. Every generated binding invocation paid that lock cost even
after the JNI member had already been resolved.

Use `ConcurrentDictionary` for the instance/static method and field caches,
plus subclass constructor dispatch. Cached reads no longer enter a monitor,
while first field resolution remains serialized and existing method
replacement, fallback, exception, and lifetime behavior is preserved.

This also adds an instrumentation-only Android BenchmarkDotNet app for
measuring JNI invocation changes on-device.

Related to #11885.

## Performance

Pixel 5, .NET 11 CoreCLR:

| Path | Before | After | Change |
|---|---:|---:|---:|
| Cached virtual JNI invocation | 221.4 ns | 180.7 ns | -18% |

Pixel 5 MAUI/CoreCLR cold startup, 40 counterbalanced pairs built from
identical restored packages:

| APK | Mean startup |
|---|---:|
| Base | 835.62 ms |
| Changed | 832.85 ms |

Paired changed-minus-base delta: **-2.77 ms**, with a 95% confidence
interval of **-7.61 to +2.06 ms**.

Both APKs are exactly **19,278,879 bytes**, so this change has no measurable
APK size impact. `apkdiff` reports a 1,952-byte decrease in uncompressed
shared-library payload, but that is generated-output/layout variation rather
than a size improvement attributable to this change: `Java.Interop.dll` grew
by 512 bytes while the app's R2R image shrank by 2,048 bytes, and ZIP
alignment/padding eliminates the internal difference in the final APK.

## Testing

- Java.Interop managed build
- `JniPeerMembersTests`: 8 passed, 1 skipped
- Android BenchmarkDotNet instrumentation run
- 40-pair counterbalanced MAUI/CoreCLR cold-start comparison
- `apkdiff` package comparison

- [x] Useful description of why the change is necessary
- [x] Links to related issues
- [x] Unit tests
