### PR TITLE
[build] Stabilize Android define constant ordering

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -967,7 +967,9 @@ printf ""%d"" x
 		}
 
 		[Test]
-		public void DesignTimeBuildHasAndroidDefines ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
+		public void DesignTimeBuildHasAndroidDefines (
+			[Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime,
+			[Values (false, true)] bool disableImplicitFrameworkDefines)
 		{
 			bool isRelease = runtime == AndroidRuntime.NativeAOT;
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
@@ -977,6 +979,7 @@ printf ""%d"" x
 				IsRelease = isRelease,
 			};
 			proj.SetRuntime (runtime);
+			proj.SetProperty ("DisableImplicitFrameworkDefines", disableImplicitFrameworkDefines.ToString ());
 			var androidDefines = new List<string> ();
 			for (int i = 1; i <= XABuildConfig.AndroidDefaultTargetDotnetApiLevel.Major; ++i) {
 				androidDefines.Add ($"!__ANDROID_{i}__");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -154,6 +154,44 @@ namespace Xamarin.Android.Build.Tests
 			Assert.AreEqual (expectedMethodCount, appConfig.jni_remapping_replacement_method_index_entry_count, "jni_remapping_replacement_method_index_entry_count should be preserved.");
 		}
 
+		[Test]
+		public void NoChangeBuildPreservesJniAddNativeMethodRegistrationAttributePresent ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				OtherBuildItems = {
+					new AndroidItem._AndroidRemapMembers ("Remap.xml") {
+						Encoding = Encoding.UTF8,
+						TextContent = () => """
+<replacements>
+  <replace-type from="android/app/Activity" to="example/RemapActivity" />
+</replacements>
+""",
+					},
+				},
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetRuntimeIdentifiers (new [] { "arm64-v8a" });
+			proj.SetProperty ("_SkipJniAddNativeMethodRegistrationAttributeScan", "true");
+
+			using (var builder = CreateApkBuilder ()) {
+				Assert.IsTrue (builder.Build (proj), "first build should have succeeded.");
+				AssertJniAddNativeMethodRegistrationAttributePresent (proj, builder);
+
+				Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true), "second build should have succeeded.");
+				builder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
+				builder.Output.AssertTargetIsSkipped ("_GeneratePackageManagerJava");
+				AssertJniAddNativeMethodRegistrationAttributePresent (proj, builder);
+			}
+		}
+
+		void AssertJniAddNativeMethodRegistrationAttributePresent (XamarinAndroidApplicationProject proj, ProjectBuilder builder)
+		{
+			string objDirPath = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath);
+			var envFiles = EnvironmentHelper.GatherEnvironmentFiles (objDirPath, string.Join (";", proj.GetRuntimeIdentifiersAsAbis ()), required: true, runtime: AndroidRuntime.CoreCLR);
+			var appConfig = (EnvironmentHelper.ApplicationConfig_CoreCLR) EnvironmentHelper.ReadApplicationConfig (envFiles, AndroidRuntime.CoreCLR);
+			Assert.IsTrue (appConfig.jni_add_native_method_registration_attribute_present, "JNI native method registration should remain enabled.");
+		}
+
 		Dictionary<string, DateTime> GetJniRemappingSourceTimestamps (XamarinAndroidApplicationProject proj, ProjectBuilder builder)
 		{
 			string objDirPath = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "android");
@@ -790,6 +828,45 @@ namespace Lib2
 				// Build with no changes
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "third build should succeed");
 				b.Output.AssertTargetIsSkipped ("_ManifestMerger");
+			}
+		}
+
+		[Test]
+		public void AndroidDefineConstantsAreOrderIndependent ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var lib = new XamarinAndroidLibraryProject {
+				ProjectName = "Library",
+			};
+			lib.Imports.Add (new Import ("DefineConstants.targets") {
+				TextContent = () => """
+<Project>
+  <Target Name="_AddTestDefineConstant">
+    <PropertyGroup>
+      <DefineConstants>$(DefineConstants);TEST_DEFINE</DefineConstants>
+    </PropertyGroup>
+  </Target>
+  <Target Name="_WriteTestDefineConstants">
+    <WriteLinesToFile File="$(IntermediateOutputPath)define-constants.txt" Lines="$(DefineConstants)" Overwrite="true" />
+  </Target>
+</Project>
+"""
+			});
+
+			using (var builder = CreateDllBuilder (Path.Combine (path, lib.ProjectName))) {
+				builder.Target = "_ResolveMonoAndroidSdks,_AddTestDefineConstant,Compile,_WriteTestDefineConstants";
+				Assert.IsTrue (builder.Build (lib), "first library build should have succeeded.");
+				var firstDefineConstants = builder.Output.GetIntermediaryAsText ("define-constants.txt");
+
+				builder.Target = "_AddTestDefineConstant,_ResolveMonoAndroidSdks,Compile,_WriteTestDefineConstants";
+				Assert.IsTrue (builder.Build (lib, doNotCleanupOnUpdate: true, saveProject: false), "second library build should have succeeded.");
+				Assert.AreEqual (firstDefineConstants, builder.Output.GetIntermediaryAsText ("define-constants.txt"),
+					"DefineConstants should not depend on target execution order.");
+				var defines = firstDefineConstants.Split (new [] { ';', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+				Assert.Less (Array.IndexOf (defines, "__ANDROID__"), Array.IndexOf (defines, "NET"),
+					"Android define constants should retain their historical position before the .NET implicit constants.");
+				Assert.IsFalse (builder.LastBuildOutput.Any (line => line.Contains ("Building target \"CoreCompile\" completely.")),
+					"CoreCompile should not run when define constants are reordered.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -810,16 +810,20 @@ because xbuild doesn't support framework reference assemblies.
 		<Output TaskParameter="AndroidDefineConstants" ItemName="AndroidDefineConstants" />
 	</GetAndroidDefineConstants>
 
-	<PropertyGroup>
-		<DefineConstants>$(DefineConstants);@(AndroidDefineConstants)</DefineConstants>
-	</PropertyGroup>
-
 	<!-- Setup $(AndroidApplicationJavaClass) -->
 	<PropertyGroup>
 		<AndroidApplicationJavaClass Condition="'$(AndroidApplicationJavaClass)' == '' And $(AndroidEnableMultiDex)">android.support.multidex.MultiDexApplication</AndroidApplicationJavaClass>
 		<AndroidApplicationJavaClass Condition="'$(AndroidApplicationJavaClass)' == ''">android.app.Application</AndroidApplicationJavaClass>
 	</PropertyGroup>
 	<Message Text="Application Java class: $(AndroidApplicationJavaClass)" />
+</Target>
+
+<Target Name="_AddAndroidDefineConstants"
+    BeforeTargets="AddImplicitDefineConstants;CoreCompile"
+    DependsOnTargets="_ResolveMonoAndroidSdks">
+	<PropertyGroup>
+		<DefineConstants>$(DefineConstants);@(AndroidDefineConstants)</DefineConstants>
+	</PropertyGroup>
 </Target>
 
 <Target Name="AndroidPrepareForBuild" DependsOnTargets="$(_OnResolveMonoAndroidSdks);$(AndroidPrepareForBuildDependsOn)" />
@@ -1721,6 +1725,7 @@ because xbuild doesn't support framework reference assemblies.
     _PrepareEnvironmentAssemblySources;
     _GenerateEnvironmentFiles;
     _GenerateAndroidRemapNativeCode;
+    UpdateAndroidAssets;
     _GenerateEmptyAndroidRemapNativeCode;
     _IncludeNativeSystemLibraries;
     _GetGeneratePackageManagerJavaInputs;


### PR DESCRIPTION
## Summary

- append Android define constants at a fixed compiler stage after the .NET SDK implicit defines
- prevent equivalent project configurations from producing different compile dependency hashes
- add regression coverage for opposite target execution orders and disabled implicit framework defines

## Testing

- `PATH="/opt/homebrew/bin:$PATH" make all`
- `./dotnet-local.sh test bin/TestDebug/net10.0/Xamarin.Android.Build.Tests.dll --filter 'Name~AndroidDefineConstantsAreOrderIndependent|Name~DesignTimeBuildHasAndroidDefines'`

Fixes #12304