### PR TITLE
[Mono.Android] Fix JNI local reference disposal with ownership flags

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -346,7 +346,7 @@ namespace Android.Runtime {
 
 		internal static void DeleteRef (IntPtr handle, JniHandleOwnership transfer)
 		{
-			switch (transfer) {
+			switch (transfer & (JniHandleOwnership.TransferLocalRef | JniHandleOwnership.TransferGlobalRef)) {
 			case JniHandleOwnership.DoNotTransfer:
 				break;
 			case JniHandleOwnership.TransferLocalRef:

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaConvertTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaConvertTest.cs
@@ -115,6 +115,20 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		public void DeleteLocalRefWithDoNotRegister ()
+		{
+			int initialLocalReferenceCount = Java.Interop.Runtime.LocalReferenceCount;
+
+			using (var value = new Java.Lang.String (
+					JNIEnv.NewString ("value"),
+					JniHandleOwnership.TransferLocalRef | JniHandleOwnership.DoNotRegister)) {
+				Assert.AreEqual ("value", value.ToString ());
+			}
+
+			Assert.AreEqual (initialLocalReferenceCount, Java.Interop.Runtime.LocalReferenceCount);
+		}
+
+		[Test]
 		public void MarshalInt23Array ()
 		{
 			using (var values = new JavaList<int[]>(


### PR DESCRIPTION
## Description

`JavaConvert` creates temporary primitive and string wrappers using `JniHandleOwnership.TransferLocalRef | JniHandleOwnership.DoNotRegister`. `JNIEnv.DeleteRef()` previously switched on the full flags value, so this combination matched no ownership case and the local reference was not deleted.

Mask non-ownership flags before selecting the JNI disposal path. This fixes the local-reference accumulation reached through `JavaDictionary` keys/values, `JavaSet`/`JavaCollection`, `System.Linq.Extensions.ToEnumerator_Dispose`, and `JavaConvert`, including `AndroidMessageHandler` response-header enumeration.

Add a deterministic regression that consumes one local string reference with the affected ownership combination and verifies the thread-local JNI reference count remains unchanged. The old code leaves the count at `initial + 1`, so no table-size-dependent loop or GC/local-frame workaround is needed.

Fixes #10589

## Testing

- [x] Repository source build
- [x] Focused on-device regression: 1 passed, 0 failed on Pixel 7, Android 17 / API 37
- [ ] Android 7 / API 24-25 hardware run (no Android 7 device was attached)

----

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [x] Unit tests