### PR TITLE
[tests] Track evaluation time across performance runs

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -62,11 +62,12 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			double total = 0;
-			StructuredBuild build = null;
+			double maxEvaluationTime = 0;
 			for (int i=0; i < iterations; i++) {
 				action (builder);
-				build = ReadBinLog (builder);
+				var build = ReadBinLog (builder);
 				var actual = GetDuration (build, builder);
+				maxEvaluationTime = Math.Max (maxEvaluationTime, GetMaxEvaluationTime (build));
 				TestContext.Out.WriteLine ($"run {i} took: {actual}ms");
 				total += actual;
 				if (afterRun is not null)
@@ -75,7 +76,7 @@ namespace Xamarin.Android.Build.Tests
 			total /= iterations;
 			TestContext.Out.WriteLine ($"expected: {expected}ms, actual: {total}ms");
 			if (total > expected) {
-				AssertSlowMachine (build, expected, total);
+				AssertSlowMachine (maxEvaluationTime, expected, total);
 				Assert.Fail ($"Exceeded expected time of {expected}ms, actual {total}ms");
 			}
 		}
@@ -86,30 +87,35 @@ namespace Xamarin.Android.Build.Tests
 				Assert.Fail ($"No timeout value found for a key of {caller}");
 			}
 			double total = 0;
-			StructuredBuild build = null;
+			double maxEvaluationTime = 0;
 			for (int i=0; i < iterations; i++) {
 				action (builder);
-				build = ReadBinLog (builder);
+				var build = ReadBinLog (builder);
 				var duration = GetTaskDuration (build, builder, task);
+				maxEvaluationTime = Math.Max (maxEvaluationTime, GetMaxEvaluationTime (build));
 				TestContext.Out.WriteLine($"run {i} took: {duration}ms");
 				total += duration;
 			}
 			total /= iterations;
 			TestContext.Out.WriteLine($"expected: {expected}ms, actual: {total}ms");
 			if (total > expected) {
-				AssertSlowMachine (build, expected, total);
+				AssertSlowMachine (maxEvaluationTime, expected, total);
 				Assert.Fail ($"Exceeded expected time of {expected}ms, actual {total}ms");
 			}
 		}
 
-		void AssertSlowMachine (StructuredBuild build, int expected, double actual)
+		void AssertSlowMachine (double maxEvaluationTime, int expected, double actual)
+		{
+			TestContext.Out.WriteLine ($"max evaluation time: {maxEvaluationTime}ms (threshold: {MaxEvaluationTimeInMs}ms)");
+			if (maxEvaluationTime > MaxEvaluationTimeInMs) {
+				Assert.Inconclusive ($"Exceeded expected time of {expected}ms, actual {actual}ms, but evaluation time was {maxEvaluationTime:F0}ms (threshold: {MaxEvaluationTimeInMs}ms), indicating a slow CI machine.");
+			}
+		}
+
+		double GetMaxEvaluationTime (StructuredBuild build)
 		{
 			var evaluations = build.FindChildrenRecursive<ProjectEvaluation> ();
-			var maxEval = evaluations.Any () ? evaluations.Max (e => e.Duration.TotalMilliseconds) : 0;
-			TestContext.Out.WriteLine ($"max evaluation time: {maxEval}ms (threshold: {MaxEvaluationTimeInMs}ms)");
-			if (maxEval > MaxEvaluationTimeInMs) {
-				Assert.Inconclusive ($"Exceeded expected time of {expected}ms, actual {actual}ms, but evaluation time was {maxEval:F0}ms (threshold: {MaxEvaluationTimeInMs}ms), indicating a slow CI machine.");
-			}
+			return evaluations.Any () ? evaluations.Max (e => e.Duration.TotalMilliseconds) : 0;
 		}
 
 		StructuredBuild ReadBinLog (ProjectBuilder builder)


### PR DESCRIPTION
## Summary

- track the maximum MSBuild project evaluation duration across every `Profile` iteration
- apply the same aggregation to `ProfileTask`
- use the aggregate for slow-machine classification instead of only the final binlog

Fixes the valid finding in https://github.com/dotnet/android/pull/12389#discussion_r3785640982.

## Testing

- `dotnet build tests\MSBuildDeviceIntegration\MSBuildDeviceIntegration.csproj --no-restore -v:minimal -p:JavaCPath='C:\Program Files\Microsoft\jdk-17.0.16.8-hotspot\bin\javac.exe' -p:JarPath='C:\Program Files\Microsoft\jdk-17.0.16.8-hotspot\bin\jar.exe'` (succeeded; 16 existing warnings, 0 errors)