### PR TITLE
[main] Bump System.IO.Hashing to 10.0.11

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-rc.1.26411.119</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <MicrosoftDotNetCecilPackageVersion>0.11.5-preview.26411.119</MicrosoftDotNetCecilPackageVersion>
     <MSTestPackageVersion>4.4.0-preview.26409.6</MSTestPackageVersion>
-    <SystemIOHashingPackageVersion>10.0.10</SystemIOHashingPackageVersion>
+    <SystemIOHashingPackageVersion>10.0.11</SystemIOHashingPackageVersion>
     <SystemReflectionMetadataPackageVersion>11.0.0-preview.1.26104.118</SystemReflectionMetadataPackageVersion>
     <!-- Previous .NET Android version -->
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>


### PR DESCRIPTION
Backports the System.IO.Hashing 10.0.11 dependency update from #12384 to `main`.

The Dependabot PR targeted `release/10.0.1xx`, so this applies the same centralized package version change against the current `main` version of `eng/Versions.props`.

Validated by restoring `Microsoft.Android.Build.BaseTasks.csproj` with a clean NuGet cache.