### PR TITLE
[main] Bump System.CodeDom from 10.0.10 to 10.0.11

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,7 +7,7 @@
   <!-- NuGet Package Versions -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Win32.Registry"                     Version="5.0.0" />
-    <PackageReference Update="System.CodeDom"                               Version="10.0.10" />
+    <PackageReference Update="System.CodeDom"                               Version="10.0.11" />
     <PackageReference Update="Irony"                                        Version="1.5.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Backports #12383 from `release/10.0.1xx` to `main`.

The original PR included line-ending-only churn; this backport contains only the semantic package version update.