### PR TITLE
[release/10.0.1xx] Exclude NUnitLite from PoliCheck

### DIFF
--- a/.gdn/policheck/PoliCheck.Exclusions.xml
+++ b/.gdn/policheck/PoliCheck.Exclusions.xml
@@ -1,7 +1,7 @@
 <PoliCheckExclusions>
   <!-- Reminder: you are only allowed one exclusion element of each type, to have multiple values you must pipe separate them in a single element -->
   <!-- Each of these exclusions is a folder name - if \[name]\ exists in the file path, it will be skipped -->
-  <Exclusion Type="FolderPathFull">LICENSE-DATA|LOCALIZE</Exclusion>
+  <Exclusion Type="FolderPathFull">LICENSE-DATA|LOCALIZE|NUNITLITE</Exclusion>
   <!-- Each of these exclusions is a folder name - if any folder or file starts with "\[name]", it will be skipped -->
   <Exclusion Type="FolderPathStart">src\Mono.Android\Profiles|src\Mono.Android\PublicAPI</Exclusion>
   <!-- Each of these file types will be completely skipped for the entire scan -->


### PR DESCRIPTION
## Description

Exclude the imported NUnitLite source folder from PoliCheck terminology scanning.

PoliCheck 7.1.2026071301 began reporting three longstanding `Xbox` references in NUnitLite's `OSPlatform.cs` and `PlatformHelper.cs`. These are third-party API identifiers and compatibility strings imported in 2016, not terms introduced by the triggering PR, so changing the vendor sources would be incorrect.

## Validation

- Parsed `PoliCheck.Exclusions.xml` successfully
- Confirmed all three reported paths match the `FolderPathFull` exclusion
- Ran `git diff --check`