### PR TITLE
[tests] use dotnet/android-samples raw URL for ActionBarSherlock zip

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -646,7 +646,7 @@ public class UsesDependency {
 				IsRelease = isRelease,
 				Jars = {
 					new AndroidItem.LibraryProjectZip ("Jars\\ActionBarSherlock-4.3.1.zip") {
-						WebContent = "https://github.com/xamarin/monodroid-samples/blob/archived-xamarin/ActionBarSherlock/ActionBarSherlock/Jars/ActionBarSherlock-4.3.1.zip?raw=true"
+						WebContent = "https://raw.githubusercontent.com/dotnet/android-samples/archived-xamarin/ActionBarSherlock/ActionBarSherlock/Jars/ActionBarSherlock-4.3.1.zip"
 					}
 				},
 				AndroidClassParser = "class-parse",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -646,7 +646,7 @@ public class UsesDependency {
 				IsRelease = isRelease,
 				Jars = {
 					new AndroidItem.LibraryProjectZip ("Jars\\ActionBarSherlock-4.3.1.zip") {
-						WebContent = "https://raw.githubusercontent.com/dotnet/android-samples/archived-xamarin/ActionBarSherlock/ActionBarSherlock/Jars/ActionBarSherlock-4.3.1.zip"
+						WebContent = "https://raw.githubusercontent.com/dotnet/android-samples/1d6b56f205205f587f4fb496a7c7e6633048507e/ActionBarSherlock/ActionBarSherlock/Jars/ActionBarSherlock-4.3.1.zip"
 					}
 				},
 				AndroidClassParser = "class-parse",


### PR DESCRIPTION
The `BindingBuildTest` "download a .zip binding" test pulled the ActionBarSherlock jar from an archived `xamarin/monodroid-samples` GitHub blob URL using a `?raw=true` redirect. During AzDO build 1555661 a transient GitHub outage caused that redirect to return HTTP 404, failing the test for reasons unrelated to the change under test.

The asset now lives in the canonical `dotnet/android-samples` repository, so this switches to a direct `raw.githubusercontent.com` URL. That both points at the current repo and skips the blob-to-raw redirect hop, removing one failure mode from the download path.

Verified the new URL returns HTTP 200.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed: N/A
- [x] Unit tests: this only changes a URL used by an existing test.