### PR TITLE
[Mono.Android] Avoid lock for activation constructor cache

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -407,8 +408,7 @@ namespace Java.Interop {
 
 		static  readonly    Type[]  XAConstructorSignature  = new Type [] { typeof (IntPtr), typeof (JniHandleOwnership) };
 		static  readonly    Type[]  JIConstructorSignature  = new Type [] { typeof (JniObjectReference).MakeByRefType (), typeof (JniObjectReferenceOptions) };
-		static  readonly    Dictionary<Type, ActivationConstructor>  ActivationConstructorCache = new Dictionary<Type, ActivationConstructor> ();
-		static  readonly    Lock    ActivationConstructorCacheLock = new Lock ();
+		static  readonly    ConcurrentDictionary<Type, ActivationConstructor>  ActivationConstructorCache = new ConcurrentDictionary<Type, ActivationConstructor> (1, 3);
 
 		enum ActivationConstructorKind
 		{
@@ -418,6 +418,23 @@ namespace Java.Interop {
 		}
 
 		readonly record struct ActivationConstructor (ConstructorInfo? Constructor, ActivationConstructorKind Kind);
+
+		/// <summary>
+		/// Preserves constructor annotations through the stateful <c>GetOrAdd</c> factory,
+		/// whose <c>Func</c> key parameter cannot carry <see cref="DynamicallyAccessedMembersAttribute"/>.
+		/// </summary>
+		readonly struct AnnotatedType
+		{
+			public AnnotatedType (
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+					Type type)
+			{
+				Type = type;
+			}
+
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			public Type Type { get; }
+		}
 
 		internal static object CreateProxy (
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
@@ -452,23 +469,18 @@ namespace Java.Interop {
 					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 					Type type)
 			{
-				lock (ActivationConstructorCacheLock) {
-					if (ActivationConstructorCache.TryGetValue (type, out var activation))
-						return activation;
+				return ActivationConstructorCache.GetOrAdd (type,
+						static (_, state) => {
+							const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+							var constructor = state.Type.GetConstructor (flags, null, XAConstructorSignature, null);
+							if (constructor != null)
+								return new ActivationConstructor (constructor, ActivationConstructorKind.XA);
 
-					const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-					var constructor = type.GetConstructor (flags, null, XAConstructorSignature, null);
-					if (constructor != null) {
-						activation = new ActivationConstructor (constructor, ActivationConstructorKind.XA);
-					} else {
-						constructor = type.GetConstructor (flags, null, JIConstructorSignature, null);
-						activation = new ActivationConstructor (
+							constructor = state.Type.GetConstructor (flags, null, JIConstructorSignature, null);
+							return new ActivationConstructor (
 								constructor,
 								constructor == null ? ActivationConstructorKind.Missing : ActivationConstructorKind.JI);
-					}
-					ActivationConstructorCache.Add (type, activation);
-					return activation;
-				}
+						}, new AnnotatedType (type));
 			}
 
 			static IJavaPeerable GetUninitializedObject (

--- a/tests/Android.Benchmarks/ActivationConstructorCacheBenchmarks.cs
+++ b/tests/Android.Benchmarks/ActivationConstructorCacheBenchmarks.cs
@@ -10,7 +10,7 @@ public class ActivationConstructorCacheBenchmarks
 	delegate object CreateProxyDelegate (Type type, IntPtr handle, JniHandleOwnership transfer);
 
 	readonly CreateProxyDelegate createProxy;
-	readonly Java.Lang.String peer;
+	IntPtr globalReference;
 
 	public ActivationConstructorCacheBenchmarks ()
 	{
@@ -25,25 +25,30 @@ public class ActivationConstructorCacheBenchmarks
 			throw new InvalidOperationException ("Could not find TypeManager.CreateProxy.");
 
 		createProxy = method.CreateDelegate<CreateProxyDelegate> ();
-		peer = new Java.Lang.String ("benchmark");
 	}
 
 	[GlobalSetup]
 	public void Setup ()
 	{
+		IntPtr reference = JNIEnv.NewString ("benchmark");
+		try {
+			globalReference = JNIEnv.NewGlobalRef (reference);
+		} finally {
+			JNIEnv.DeleteLocalRef (reference);
+		}
 		_ = CreateProxy ();
 	}
 
 	[GlobalCleanup]
 	public void Cleanup ()
 	{
-		peer.Dispose ();
+		JNIEnv.DeleteGlobalRef (globalReference);
 	}
 
 	[Benchmark]
 	public int CreateProxy ()
 	{
-		IntPtr reference = JNIEnv.NewLocalRef (peer.Handle);
+		IntPtr reference = JNIEnv.NewLocalRef (globalReference);
 		Java.Lang.String? proxy = null;
 		try {
 			proxy = (Java.Lang.String) createProxy (typeof (Java.Lang.String), reference, JniHandleOwnership.TransferLocalRef);

--- a/tests/Android.Benchmarks/ActivationConstructorCacheBenchmarks.cs
+++ b/tests/Android.Benchmarks/ActivationConstructorCacheBenchmarks.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Android.Runtime;
+using BenchmarkDotNet.Attributes;
+
+namespace Xamarin.Android.Benchmarks;
+
+public class ActivationConstructorCacheBenchmarks
+{
+	delegate object CreateProxyDelegate (Type type, IntPtr handle, JniHandleOwnership transfer);
+
+	readonly CreateProxyDelegate createProxy;
+	readonly Java.Lang.String peer;
+
+	public ActivationConstructorCacheBenchmarks ()
+	{
+		const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Static;
+		var method = typeof (Java.Interop.TypeManager).GetMethod (
+			"CreateProxy",
+			flags,
+			null,
+			[typeof (Type), typeof (IntPtr), typeof (JniHandleOwnership)],
+			null);
+		if (method == null)
+			throw new InvalidOperationException ("Could not find TypeManager.CreateProxy.");
+
+		createProxy = method.CreateDelegate<CreateProxyDelegate> ();
+		peer = new Java.Lang.String ("benchmark");
+	}
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		_ = CreateProxy ();
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		peer.Dispose ();
+	}
+
+	[Benchmark]
+	public int CreateProxy ()
+	{
+		IntPtr reference = JNIEnv.NewLocalRef (peer.Handle);
+		Java.Lang.String? proxy = null;
+		try {
+			proxy = (Java.Lang.String) createProxy (typeof (Java.Lang.String), reference, JniHandleOwnership.TransferLocalRef);
+			reference = IntPtr.Zero;
+			return RuntimeHelpers.GetHashCode (proxy);
+		} finally {
+			if (reference != IntPtr.Zero)
+				JNIEnv.DeleteLocalRef (reference);
+			proxy?.Dispose ();
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- replace the monitor-protected `TypeManager` activation-constructor cache with a deliberately small `ConcurrentDictionary`
- use one stateful `GetOrAdd` call while preserving constructor trimming annotations without suppressions
- add an Android in-process BenchmarkDotNet benchmark for the exact cached `CreateProxy` path

Follow-up to #12377.

## Results

Measured on a Pixel 10 running Android 16 with CoreCLR:

| Check | Baseline | Changed | Difference |
| --- | ---: | ---: | ---: |
| Cached `CreateProxy` benchmark | 1,435.996 ns | 1,341.401 ns | -94.594 ns (-6.59%) |
| MAUI cold-start mean, 40 paired runs | 371.750 ms | 369.925 ms | -1.825 ms |
| Final APK size | 19,262,495 bytes | 19,262,495 bytes | 0 bytes |

The benchmark uses an unregistered JNI `jstring` global reference so each iteration exercises normal managed activation without duplicate-peer detection. The cold-start paired changed-minus-base 95% confidence interval is [-7.842, +4.192] ms, indicating no measurable startup regression.

`apkdiff` reports only a 32-byte uncompressed increase in `libassembly-store.so`; this does not change final APK size. Extracted `Mono.Android.dll` remains 1,913,344 bytes.

## Validation

- Release SDK build, with no new trim warnings
- `ReflectionCreateProxy` device fixture: 3 passed, 0 failed
- Android in-process BenchmarkDotNet run
- controlled MAUI/CoreCLR APK build with the baseline package lock
- 40 counterbalanced AB/BA cold-start pairs
