### PR TITLE
`$(AndroidPackVersionSuffix)=rc.2`

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,6 +44,6 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>37.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/11.0.1xx-rc1

We branched for .NET 11 RC 1 from 9b471e939 into `release/11.0.1xx-rc1`; the main branch is now .NET 11 RC 2. This updates the Android pack suffix from `rc.1` to `rc.2`.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: N/A
- [x] Unit tests: N/A (version metadata only)