### PR TITLE
[dependabot] Expose Google Maven to Gradle updater

### DIFF
--- a/.github/instructions/gradle.instructions.md
+++ b/.github/instructions/gradle.instructions.md
@@ -6,15 +6,32 @@ applyTo: "**/*.gradle,**/*.gradle.kts"
 
 All `src/*` Gradle projects share two repo config files: **`eng/gradle/plugin-repositories.gradle`** (for `pluginManagement.repositories`) and **`eng/gradle/dependency-repositories.gradle`** (for `dependencyResolutionManagement.repositories`). Never hard-code Maven URLs (`mavenCentral()`, `google()`, `pkgs.dev.azure.com/...`, etc.) in `build.gradle`/`settings.gradle`.
 
+Dependabot's Gradle updater does not inspect repository declarations in scripts
+loaded with `apply from`. Each configured `settings.gradle` must repeat the
+public repository declarations behind a `DEPENDABOT_JOB_ID` environment check
+so version discovery queries Google Maven. Dependabot already probes Maven
+Central and the Gradle Plugin Portal by default, and sets this variable inside
+its updater container.
+
 ## settings.gradle template
 
 ```groovy
 // See: eng/gradle/plugin-repositories.gradle, eng/gradle/dependency-repositories.gradle
 pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 rootProject.name = '<project>'
 ```
@@ -30,9 +47,19 @@ the receiver as `to = this`:
 // See: eng/gradle/plugin-repositories.gradle, eng/gradle/dependency-repositories.gradle
 pluginManagement {
     apply(from = "$rootDir/../../eng/gradle/plugin-repositories.gradle", to = this)
+    if (System.getenv("DEPENDABOT_JOB_ID") != null) {
+        repositories {
+            google()
+        }
+    }
 }
 dependencyResolutionManagement {
     apply(from = "$rootDir/../../eng/gradle/dependency-repositories.gradle", to = this)
+    if (System.getenv("DEPENDABOT_JOB_ID") != null) {
+        repositories {
+            google()
+        }
+    }
 }
 rootProject.name = "<project>"
 ```

--- a/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/settings.gradle.kts
+++ b/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/settings.gradle.kts
@@ -1,9 +1,19 @@
 // See: eng/gradle/plugin-repositories.gradle, eng/gradle/dependency-repositories.gradle
 pluginManagement {
     apply(from = "$rootDir/../../../../../eng/gradle/plugin-repositories.gradle", to = this)
+    if (System.getenv("DEPENDABOT_JOB_ID") != null) {
+        repositories {
+            google()
+        }
+    }
 }
 dependencyResolutionManagement {
     apply(from = "$rootDir/../../../../../eng/gradle/dependency-repositories.gradle", to = this)
+    if (System.getenv("DEPENDABOT_JOB_ID") != null) {
+        repositories {
+            google()
+        }
+    }
 }
 
 rootProject.name = "kotlin-inline-class-fixtures"

--- a/external/Java.Interop/tools/java-source-utils/settings.gradle
+++ b/external/Java.Interop/tools/java-source-utils/settings.gradle
@@ -1,9 +1,19 @@
 // See: eng/gradle/plugin-repositories.gradle, eng/gradle/dependency-repositories.gradle
 pluginManagement {
     apply from: "${rootDir}/../../../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 
 rootProject.name = 'java-source-utils'

--- a/src/manifestmerger/settings.gradle
+++ b/src/manifestmerger/settings.gradle
@@ -1,9 +1,19 @@
 // See: eng/gradle/plugin-repositories.gradle, eng/gradle/dependency-repositories.gradle
 pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 
 rootProject.name = 'manifestmerger'

--- a/src/proguard-android/settings.gradle
+++ b/src/proguard-android/settings.gradle
@@ -1,9 +1,19 @@
 // See: eng/gradle/plugin-repositories.gradle, eng/gradle/dependency-repositories.gradle
 pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 
 rootProject.name = 'proguard-android'

--- a/src/r8/settings.gradle
+++ b/src/r8/settings.gradle
@@ -1,9 +1,19 @@
 // See: eng/gradle/plugin-repositories.gradle, eng/gradle/dependency-repositories.gradle
 pluginManagement {
     apply from: "${rootDir}/../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 
 rootProject.name = 'r8'

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/settings.gradle
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/settings.gradle
@@ -1,9 +1,19 @@
 // See: eng/gradle/plugin-repositories.gradle, eng/gradle/dependency-repositories.gradle
 pluginManagement {
     apply from: "${rootDir}/../../../../../eng/gradle/plugin-repositories.gradle", to: pluginManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 dependencyResolutionManagement {
     apply from: "${rootDir}/../../../../../eng/gradle/dependency-repositories.gradle", to: dependencyResolutionManagement
+    if (System.getenv('DEPENDABOT_JOB_ID') != null) {
+        repositories {
+            google()
+        }
+    }
 }
 
 rootProject.name = 'JavaLib'


### PR DESCRIPTION
----

Dependabot's Gradle updater does not inspect repository declarations loaded through `apply from`. Since the Gradle repository configuration was centralized, Dependabot has queried only Maven Central and therefore misses dependencies published exclusively to Google Maven, including newer R8 releases.

Add `google()` directly to each Dependabot-managed Gradle settings file when `DEPENDABOT_JOB_ID` is set. Normal local and CI builds continue to use the shared repository scripts, so the workaround is isolated to Dependabot version discovery.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: related to #11672 and confirmed by [Dependabot update run 1529829366](https://github.com/dotnet/android/network/updates/1529829366).
- [x] Unit tests: configuration-only change; configured all six Gradle projects with a simulated `DEPENDABOT_JOB_ID`.