### PR TITLE
[build] Increase release assembly store compression

### DIFF
--- a/Documentation/docs-mobile/messages/xa5304.md
+++ b/Documentation/docs-mobile/messages/xa5304.md
@@ -1,7 +1,7 @@
 ---
 title: .NET for Android error XA5304
 description: XA5304 error code
-ms.date: 07/03/2026
+ms.date: 08/18/2026
 f1_keywords:
   - "XA5304"
 ---
@@ -20,4 +20,8 @@ The `$(_AndroidAssemblyStoreCompressionLevel)` MSBuild property was set to a val
 
 ## Solution
 
-Set `$(_AndroidAssemblyStoreCompressionLevel)` to an integer between 1 and 22 (inclusive). The default value is `3`, which matches the Zstandard library default. Higher values produce a smaller AssemblyStore at the cost of longer build times; Zstandard decompression speed is independent of the compression level, so higher values have no runtime cost.
+Set `$(_AndroidAssemblyStoreCompressionLevel)` to an integer between 1 and 22 (inclusive).
+
+Optimized builds (`$(Optimize)` is `true`) default to the maximum compression level of `22` to reduce application size. Non-optimized builds default to level `3`, which matches the Zstandard library default and provides faster build times. You can explicitly set `$(_AndroidAssemblyStoreCompressionLevel)` to override either default.
+
+Higher values produce a smaller AssemblyStore at the cost of longer build times. Zstandard decompression speed is independent of the compression level, so the selected level does not affect application startup performance.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -202,6 +202,30 @@ namespace Xamarin.Android.Build.Tests
 				builder.Output.GetIntermediaryPath (Path.Combine ("android", "assets", filename));
 		}
 
+		[TestCase (false, "", 3)]
+		[TestCase (true, "", 22)]
+		[TestCase (true, "7", 7)]
+		public void BuildAssemblyStoreCompressionLevel (bool isRelease, string compressionLevel, int expectedCompressionLevel)
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: isRelease)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			if (!compressionLevel.IsNullOrEmpty ()) {
+				proj.SetProperty ("_AndroidAssemblyStoreCompressionLevel", compressionLevel);
+			}
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+
+			var buildProperties = File.ReadAllLines (builder.Output.GetIntermediaryPath ("build.props"));
+			CollectionAssert.Contains (buildProperties, $"_androidassemblystorecompressionlevel={expectedCompressionLevel}");
+		}
+
 		[Test]
 		public void BuildReleaseArm64 ([Values] bool forms, [Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime, [Values] bool r8)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.R8.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.R8.apkdesc
@@ -5,34 +5,34 @@
       "Size": 3036
     },
     "classes.dex": {
-      "Size": 400952
+      "Size": 404092
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 2831944
+      "Size": 2542344
     },
     "lib/arm64-v8a/libclrjit.so": {
-      "Size": 2761136
+      "Size": 2807600
     },
     "lib/arm64-v8a/libcoreclr.so": {
-      "Size": 4839560
+      "Size": 4843864
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 1184912
+      "Size": 1184800
     },
     "lib/arm64-v8a/libSystem.Globalization.Native.so": {
       "Size": 72432
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
-      "Size": 1258776
+      "Size": 1259088
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 99776
+      "Size": 99808
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 169768
+      "Size": 171584
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 20312
+      "Size": 20432
     },
     "res/drawable-hdpi-v4/icon.png": {
       "Size": 2178
@@ -59,5 +59,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 7321019
+  "PackageSize": 7058875
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.apkdesc
@@ -5,34 +5,34 @@
       "Size": 3036
     },
     "classes.dex": {
-      "Size": 403380
+      "Size": 406748
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 2831944
+      "Size": 2542368
     },
     "lib/arm64-v8a/libclrjit.so": {
-      "Size": 2761136
+      "Size": 2807600
     },
     "lib/arm64-v8a/libcoreclr.so": {
-      "Size": 4839560
+      "Size": 4843864
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 1184912
+      "Size": 1184800
     },
     "lib/arm64-v8a/libSystem.Globalization.Native.so": {
       "Size": 72432
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
-      "Size": 1258776
+      "Size": 1259088
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 99776
+      "Size": 99808
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 169768
+      "Size": 171584
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 20312
+      "Size": 20432
     },
     "res/drawable-hdpi-v4/icon.png": {
       "Size": 2178
@@ -59,5 +59,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 7321019
+  "PackageSize": 7058875
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.R8.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.R8.apkdesc
@@ -5,7 +5,7 @@
       "Size": 6652
     },
     "classes.dex": {
-      "Size": 3242876
+      "Size": 3242640
     },
     "kotlin/annotation/annotation.kotlin_builtins": {
       "Size": 928
@@ -29,13 +29,13 @@
       "Size": 2396
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 11415872
+      "Size": 9435968
     },
     "lib/arm64-v8a/libclrjit.so": {
-      "Size": 2788736
+      "Size": 2807600
     },
     "lib/arm64-v8a/libcoreclr.so": {
-      "Size": 4841976
+      "Size": 4843864
     },
     "lib/arm64-v8a/libmonodroid.so": {
       "Size": 1184800
@@ -47,7 +47,7 @@
       "Size": 1259088
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 99792
+      "Size": 99808
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
       "Size": 171584
@@ -2231,5 +2231,5 @@
       "Size": 794696
     }
   },
-  "PackageSize": 18116115
+  "PackageSize": 16346643
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.apkdesc
@@ -5,10 +5,10 @@
       "Size": 6652
     },
     "classes.dex": {
-      "Size": 9412464
+      "Size": 9415020
     },
     "classes2.dex": {
-      "Size": 132684
+      "Size": 132628
     },
     "kotlin/annotation/annotation.kotlin_builtins": {
       "Size": 928
@@ -32,31 +32,31 @@
       "Size": 2396
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 11217040
+      "Size": 9435912
     },
     "lib/arm64-v8a/libclrjit.so": {
-      "Size": 2761136
+      "Size": 2807600
     },
     "lib/arm64-v8a/libcoreclr.so": {
-      "Size": 4839560
+      "Size": 4843864
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 1184912
+      "Size": 1184800
     },
     "lib/arm64-v8a/libSystem.Globalization.Native.so": {
       "Size": 72432
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
-      "Size": 1258776
+      "Size": 1259088
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 99776
+      "Size": 99808
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 169768
+      "Size": 171584
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 119656
+      "Size": 119776
     },
     "META-INF/androidx.activity_activity.version": {
       "Size": 6
@@ -2234,5 +2234,5 @@
       "Size": 794696
     }
   },
-  "PackageSize": 20262477
+  "PackageSize": 18497101
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -170,6 +170,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidGenerateLayoutBindings Condition=" '$(AndroidGenerateLayoutBindings)' == '' ">False</AndroidGenerateLayoutBindings>
 	<AndroidFragmentType Condition=" '$(AndroidFragmentType)' == '' ">Android.App.Fragment</AndroidFragmentType>
 	<AndroidEnableAssemblyCompression Condition=" '$(AndroidEnableAssemblyCompression)' == '' ">True</AndroidEnableAssemblyCompression>
+	<_AndroidAssemblyStoreCompressionLevel Condition=" '$(_AndroidAssemblyStoreCompressionLevel)' == '' And '$(Optimize)' == 'True' ">22</_AndroidAssemblyStoreCompressionLevel>
 	<_AndroidAssemblyStoreCompressionLevel Condition=" '$(_AndroidAssemblyStoreCompressionLevel)' == '' ">3</_AndroidAssemblyStoreCompressionLevel>
 	<AndroidEnableAssemblyStoreDecompressionCache Condition=" '$(AndroidEnableAssemblyStoreDecompressionCache)' == '' ">False</AndroidEnableAssemblyStoreDecompressionCache>
 	<AndroidIncludeWrapSh Condition=" '$(AndroidIncludeWrapSh)' == '' ">False</AndroidIncludeWrapSh>


### PR DESCRIPTION
## Summary

- use the maximum Zstandard compression level (`22`) for optimized builds
- retain compression level `3` for non-optimized builds
- preserve explicit `$(_AndroidAssemblyStoreCompressionLevel)` overrides
- add build-test coverage for Debug, Release, and explicit compression-level selection
- update CoreCLR APK size references for the intended assembly-store size reduction

## Results

Measured using an `android-arm64` Release build of `dotnet new maui --sample-content` on an Android 16 arm64 emulator.

| | Level 3 | Level 22 |
|---|---:|---:|
| APK size | 22,547,511 bytes | 21,494,839 bytes |
| Startup median (30 runs) | 1,274.5 ms | 1,277.5 ms |

The APK decreased by **1,052,672 bytes (4.67%)**. The 3 ms startup median difference is measurement noise: the bootstrapped 95% confidence interval for the median difference was **-14.5 ms to +20.5 ms**.

## Testing

- `make prepare && make all CONFIGURATION=Debug`
- `./dotnet-local.sh test bin/TestDebug/net10.0/Xamarin.Android.Build.Tests.dll --filter "Name~BuildAssemblyStoreCompressionLevel"` — 3 passed
- `./dotnet-local.sh test bin/TestDebug/net10.0/Xamarin.Android.Build.Tests.dll --filter "Name~BuildReleaseArm64"` — 4 CoreCLR cases passed, 4 unsupported NativeAOT cases skipped
- published the sample with level `3` explicitly and with the new Release default
- ran two alternating rounds of 15 measured cold-process launches per APK, with three warmups per round
