### PR TITLE
[FastDeploy2] Copy staged files into private storage

### DIFF
--- a/Documentation/guides/FastDeploy2.md
+++ b/Documentation/guides/FastDeploy2.md
@@ -20,12 +20,10 @@ properties intended for end users are:
 | Property | Default | Description |
 | --- | --- | --- |
 | `$(_AndroidFastDevStrategy)` | `FastDeploy2` | `FastDeploy` or `FastDeploy2`. Set to `FastDeploy` to fall back to the legacy strategy. |
-| `$(_AndroidFastDeployAppFileTransferMode)` | `Symlink` (for `FastDeploy2`) | How staged files are surfaced in the override directory: `Symlink` or `Copy`. |
 | `$(AndroidFastDeploymentAdbCompressionAlgorithm)` | `any` | The `adb push -z` compression algorithm. `FastDeploy2` relies on a modern Android SDK Platform-Tools `adb` for multi-file `push -z` support. |
 
-The following internal/unsupported properties tune batching. They exist mainly so
-the batching paths can be exercised with smaller batches while testing; their
-defaults match the matching task properties:
+The following internal/unsupported properties tune or disable implementation
+details:
 
 | Property | Default | Description |
 | --- | --- | --- |
@@ -38,22 +36,21 @@ defaults match the matching task properties:
 
 * **Staging directory:** `/data/local/tmp/fastdeploy2/<package-name>/<user-id>`.
   Files are pushed here first (this location is writable by `adb` without
-  `run-as`).
+  `run-as`) and the directory is removed after each deployment attempt.
 * **Override directory:** `files/.__override__` inside the application's private
   data directory (resolved with `run-as`). The runtime loads assemblies from here
   in preference to the ones embedded in the `.apk`.
-* **Manifest markers:** a `.fastdeploy2-manifest-hash` file is written to both the
-  staging and override directories. It records the hash of the last successfully
-  deployed manifest so the next build can detect whether the device is already up
-  to date and skip redundant work.
+* **Manifest marker:** a `.fastdeploy2-manifest-hash` file is written to the
+  override directory. It records the hash of the last successfully deployed
+  manifest so the next build can detect whether the private files match the
+  local manifest and skip redundant work.
 
-Changing `$(_AndroidFastDevStrategy)` or
-`$(_AndroidFastDeployAppFileTransferMode)` invalidates the deployment
-configuration. In particular, switching from `FastDeploy2` to legacy
-`FastDeploy` removes the FastDeploy2-managed override tree before
-`xamarin.sync` runs, so legacy deployment never attempts to overwrite
-FastDeploy2 symlinks. The installed package and unrelated application data are
-preserved.
+Changing `$(_AndroidFastDevStrategy)` invalidates the deployment configuration.
+Switching between `FastDeploy2` and legacy `FastDeploy` removes the managed
+override tree before the selected strategy runs. The installed package and
+unrelated application data are preserved. The first deployment after upgrading
+from a symlink-based FastDeploy2 version also clears the old override tree so
+all files are recreated as private regular files.
 
 ## Stages
 
@@ -67,9 +64,9 @@ is passed to every subsequent command as `adb -s <id> …`.
 
 When the APK and local FastDeploy2 manifest are current, one tagged
 `adb shell` probe performs the warm-path validation. It reads both compatibility
-properties, the staging marker, the app-private path and override marker through
-`run-as`, and the current process id. If the app is running, the same shell
-invocation force-stops it after `run-as` succeeds.
+properties, the app-private path and override marker through `run-as`, and the
+current process id. If the app is running, the same shell invocation force-stops
+it after `run-as` succeeds.
 
 The deployment is aborted with a coded error if either compatibility property
 makes fast deployment unsafe:
@@ -141,58 +138,78 @@ This is the incremental core (`DeployFastDevFilesWithAdbPush`):
    size and last-write time; the set of
    `{ relative-path → (size, mtime) }` forms the manifest. A single SHA256 hash
    over the whole manifest is used as the device readiness marker (see below).
-2. **Compare against the device.** The previous manifest is read from `obj`, and
-   the on-device `.fastdeploy2-manifest-hash` markers are read to confirm the
-   device still matches it. If the staging directory is not in the expected
-   state it is reset:
+2. **Compare against private device state.** The previous manifest is read from
+   `obj`, and the app-private `.fastdeploy2-manifest-hash` marker is read through
+   `run-as`. If it does not match, the override directory is cleared and all
+   current files are treated as changed.
+3. **Reset and create transient staging.** Any staging left by an interrupted
+   deployment is removed, then directories are created for changed files:
    ```
    adb shell rm -rf <staging-dir>
-   ```
-3. **Create staging directories** for the files being deployed. After the
-   initial deployment, this step runs only when a file introduces a new
-   relative directory:
-   ```
    adb shell mkdir -p <dir> [<dir> …]   # batched up to MaxShellCommandLength
    ```
-4. **Remove stale files** that are no longer part of the app:
-   ```
-   adb shell rm -f <file> [<file> …]    # batched up to StaleFileRemovalBatchSize / MaxAdbCommandLength
-   ```
-5. **Upload changed files** (only files whose size or last-write time changed),
+4. **Upload changed files** (only files whose size or last-write time changed),
    grouped by
    directory and batched up to `MaxAdbCommandLength`:
    ```
    adb push -z <algorithm> <local-file> [<local-file> …] <remote-dir>
    ```
-6. **Update the override directory** so it points at the freshly staged files,
-   using one of two modes:
-   * **`Symlink` (default):** for each directory, symlink the staged files into
-     the override directory, leaving subdirectories untouched. Roughly:
-     ```
-     adb shell run-as <package> sh -c \
-       'd=<override-dir>;s=<staging-dir>;mkdir -p "$d"&&cd "$d"&& \
-        for e in ./*;do [ -d "$e" ]||rm -f "$e";done&& \
-        for f in "$s"/*;do [ -d "$f" ]||ln -sf "$f" .;done'
-     ```
-     If the device does not support symlinking into the override directory, the
-     task automatically falls back to `Copy`.
-   * **`Copy`:** the staged files are copied into the override directory instead
-     of symlinked.
-7. **Mark success.** When the override directory is up to date, one
-   `adb shell` invocation writes the current manifest hash to the staging and
-   override markers, and the manifest is saved to `obj` for the next incremental
-   build.
-
-The marker match is intentionally the fast-path filesystem contract; the task
-does not probe every expected directory before each upload. If a push reports
-that an expected remote path is missing or has the wrong file type, FastDeploy2
-discards the incremental state, clears the staging and override trees, and
-retries once as a full deployment. A successful retry rewrites both remote
-markers and the local manifest.
+5. **Update private storage.** Files removed from the manifest are deleted from
+   the override directory. Changed files are copied from staging with
+   `run-as cp -p`; existing destinations are removed first so this also replaces
+   override symlinks created by an older FastDeploy2 version:
+   ```
+   adb shell run-as <package> rm -f <removed-or-changed-file> [...]
+   adb shell run-as <package> cp -p <staged-file> [...] <override-dir>
+   ```
+6. **Mark success and remove staging.** The current manifest hash is written to
+   the private override marker, the manifest is saved to `obj`, and the staging
+   directory is removed. Staging removal also runs when upload or copy fails.
 
 ## Error codes
 
 Install failures are reported with `ADB####` codes; fast-deployment shell
-failures (`mkdir`/`rm`/`push`/`ln`) are reported with `XA0129`. `run-as`
+failures (`mkdir`/`rm`/`push`/`cp`) are reported with `XA0129`. `run-as`
 diagnostics map to `XA0131`–`XA0137`. See the
 [build/deploy message docs](../docs-mobile/messages/index.md) for details.
+
+## Command Compatibility
+
+.NET for Android supports Android 7.0 (API level 24) and later. FastDeploy2's
+device-side commands are available by Android 6.0 (API level 23), before the
+supported device floor. The API levels below are approximate because shell
+utilities are not Android SDK APIs.
+
+Host-side `adb` commands depend on the installed Android SDK Platform-Tools
+version rather than the device API level:
+
+| Command | FastDeploy2 use | Compatibility |
+| --- | --- | --- |
+| `adb devices`, `adb -s <device> shell ...` | Device selection and all device-side operations | Standard Platform-Tools commands |
+| `adb install -r -d [-t] [--user <id>]` | APK installation and replacement | Standard Platform-Tools command; `--user` corresponds to Android multi-user support introduced in API 17 |
+| `adb push -z <algorithm>` | Batched compressed staging-file upload | Modern Platform-Tools capability; not controlled by the device application API level |
+
+FastDeploy2 uses these device-side commands and shell features:
+
+| Command or shell feature | FastDeploy2 use | Approximate availability |
+| --- | --- | --- |
+| `sh`/mksh syntax, `[ ... ]`, `test`, `pwd`, `echo`, command substitution, and redirection | Combined checks, private marker reads/writes, and warm-state validation | API 14; Android has used mksh since Android 4.0 |
+| `getprop` | Validate `run-as` compatibility properties | API 1 |
+| `run-as <package>` | Access the private data directory of a debuggable app | Early Android; availability alone is insufficient because the package must be debuggable and the device must permit `run-as` |
+| `su <user>` | Access files for a system application when adbd is not root | Not guaranteed on production devices; used only for the system-app fallback |
+| `cat`, `true`, `rm -f`, `rm -rf`, `mkdir -p`, and `cp -p` | Read markers and manage transient staging and private override files | API 21 or earlier; supplied by toolbox/BSD utilities before toybox |
+| `readlink -f`, `whoami` | Resolve system-app paths and determine whether adbd is root | Reliably available by API 23 |
+| `pidof` | Find the running application process | Reliably available by API 23 |
+| `printf %s` | Write manifest hash markers without a trailing newline | API 23; supplied by toybox starting in Android 6.0 |
+| `pm uninstall [-k] [--user <id>]` | Remove an incompatible package before retrying installation | Base command predates the supported floor; `--user` requires API 17 multi-user support |
+| `am force-stop <package>` | Stop the app before replacing fast-deployment files | API 8 or earlier |
+| `am start-user -w <id>` | Ensure a secondary Android user is running before `run-as` | API 17 multi-user support |
+
+These estimates are based on the
+[AOSP shell and utility inventories][aosp-shell-utilities], the
+[Android 6.0 toybox build][aosp-marshmallow-toybox], and the
+[Android Debug Bridge documentation][adb-docs].
+
+[aosp-shell-utilities]: https://android.googlesource.com/platform/system/core/+/refs/heads/main/shell_and_utilities/README.md
+[aosp-marshmallow-toybox]: https://android.googlesource.com/platform/external/toybox/+/android-6.0.1_r81/Android.mk
+[adb-docs]: https://developer.android.com/tools/adb

--- a/Documentation/release-notes/11795.md
+++ b/Documentation/release-notes/11795.md
@@ -2,23 +2,20 @@
 
 - [GitHub PR #11795](https://github.com/dotnet/android/pull/11795):
   Added a faster `FastDeploy2` fast-deployment strategy, now the default for
-  app install fast deployment. Three new MSBuild properties control it:
+  app install fast deployment. Two MSBuild properties control it:
   - `$(_AndroidFastDevStrategy)`: `FastDeploy` or `FastDeploy2` (default).
     Set to `FastDeploy` to fall back to the legacy strategy.
-  - `$(_AndroidFastDeployAppFileTransferMode)`: `Symlink` (default for
-    `FastDeploy2`) or `Copy`.
   - `$(AndroidFastDeploymentAdbCompressionAlgorithm)`: the `adb push -z`
     compression algorithm, `any` by default. `FastDeploy2` relies on a modern
     Android SDK Platform-Tools `adb` for multi-file `push -z` support.
 
   Warm incremental deployments combine compatibility checks, package/marker
   inspection, process detection, and app termination into one live `adb shell`
-  probe. They also skip redundant staging-directory creation and update both
-  success markers in one command. Switching between `FastDeploy2` and legacy
-  `FastDeploy` now clears incompatible override state without uninstalling the
-  app or deleting unrelated app data. If an incremental upload discovers that
-  expected remote staging paths are missing or have the wrong type, FastDeploy2
-  retries once with a fresh staging and override deployment.
+  probe. Changed files are pushed to transient `/data/local/tmp` staging,
+  copied into app-private storage with `run-as`, and removed from staging after
+  each deployment. Switching between `FastDeploy2` and legacy `FastDeploy`
+  clears incompatible override state without uninstalling the app or deleting
+  unrelated app data.
 
   See the [FastDeploy2 guide](../guides/FastDeploy2.md) for a detailed
   description of the deployment stages and the `adb` commands they run.

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.Manifest.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.Manifest.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Android.Tasks
 
 		string RemoteStagingRoot => RemoteStagingRootPath;
 
-		async Task<bool> DeployFastDevFilesWithAdbPush (string overridePath, bool forceFreshDeployment = false)
+		async Task<bool> DeployFastDevFilesWithAdbPush (string overridePath)
 		{
 			var files = PrepareDirectPushFiles ();
 			var currentManifest = CreateManifest (files);
@@ -30,22 +30,20 @@ namespace Xamarin.Android.Tasks
 			var previousManifest = LoadPreviousManifest ();
 			string previousManifestHash = previousManifest == null ? "" : ComputeManifestHash (previousManifest);
 			DeviceManifestState deviceManifestState;
-			if (forceFreshDeployment || previousManifest == null) {
+			if (previousManifest == null) {
 				deviceManifestState = new DeviceManifestState ();
 			} else if (warmDeviceManifestState != null && string.Equals (warmDeviceManifestHash, previousManifestHash, StringComparison.Ordinal)) {
 				deviceManifestState = warmDeviceManifestState;
 			} else {
-				deviceManifestState = await GetDeviceManifestState (remoteStagingPath, overridePath);
+				deviceManifestState = await GetDeviceManifestState (overridePath);
 			}
-			bool remoteReady = previousManifest != null && string.Equals (deviceManifestState.RemoteHash, previousManifestHash, StringComparison.Ordinal);
-			bool overrideSymlinksReady = previousManifest != null && string.Equals (deviceManifestState.OverrideHash, previousManifestHash, StringComparison.Ordinal);
-			if (forceFreshDeployment || !remoteReady) {
+			bool overrideReady =
+				!ResetOverrideDirectory &&
+				previousManifest != null &&
+				string.Equals (deviceManifestState.OverrideHash, previousManifestHash, StringComparison.Ordinal);
+			if (!overrideReady) {
 				previousManifest = null;
-				overrideSymlinksReady = false;
-				if (!await ResetRemoteStagingDirectory (remoteStagingPath)) {
-					return false;
-				}
-				if (forceFreshDeployment && !await ClearOverrideDirectory (overridePath)) {
+				if (!await ClearOverrideDirectory (overridePath)) {
 					return false;
 				}
 			}
@@ -62,198 +60,63 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			HashSet<string> filesRequiringDirectories = GetFilesRequiringStagingDirectories (
-				currentManifest.Files.Keys,
-				previousManifest?.Files.Keys);
-			if (filesRequiringDirectories.Count > 0) {
-				string output = await CreateRemoteStagingDirectories (remoteStagingPath, filesRequiringDirectories);
+			if (!await ResetRemoteStagingDirectory (remoteStagingPath)) {
+				return false;
+			}
+
+			bool deployed;
+			bool stagingRemoved;
+			try {
+				deployed = await DeployStagedFiles (
+					remoteStagingPath,
+					overridePath,
+					files,
+					changedFiles,
+					removedFiles,
+					currentManifest);
+			} finally {
+				stagingRemoved = await ResetRemoteStagingDirectory (remoteStagingPath);
+			}
+
+			return deployed && stagingRemoved;
+		}
+
+		async Task<bool> DeployStagedFiles (
+			string remoteStagingPath,
+			string overridePath,
+			List<DirectPushFile> files,
+			HashSet<string> changedFiles,
+			List<string> removedFiles,
+			ManifestData currentManifest)
+		{
+			if (changedFiles.Count > 0) {
+				string output = await CreateRemoteStagingDirectories (remoteStagingPath, changedFiles);
 				if (!string.IsNullOrEmpty (output) && IsShellError (output, "mkdir")) {
 					LogFastDeploy2Error ("XA0129", output, remoteStagingPath);
 					return false;
 				}
-			}
 
-			if (!await RemoveRemoteStaleFiles (remoteStagingPath, removedFiles)) {
-				return false;
-			}
-
-			UploadFilesResult uploadResult = await UploadChangedFiles (remoteStagingPath, files, changedFiles);
-			if (!uploadResult.Success) {
-				if (uploadResult.RemoteStateInvalid && !forceFreshDeployment) {
-					LogDiagnostic ($"FastDeploy2 remote staging state was incomplete. Retrying with a fresh deployment. Output: {uploadResult.Output}");
-					return await DeployFastDevFilesWithAdbPush (overridePath, forceFreshDeployment: true);
-				}
-				LogFastDeploy2Error ("XA0129", uploadResult.Output, uploadResult.RemoteDirectory);
-				return false;
-			}
-
-			bool result;
-			if (UseShellSymlinkAppFileTransfer ()) {
-				result = await UpdateOverrideShellSymlinks (remoteStagingPath, overridePath, currentManifest, previousManifest, overrideSymlinksReady, removedFiles);
-			} else {
-				result = await UpdateOverrideCopies (remoteStagingPath, overridePath);
-			}
-
-			if (result) {
-				string currentManifestHash = ComputeManifestHash (currentManifest);
-				bool manifestsAlreadyMarked =
-					string.Equals (deviceManifestState.RemoteHash, currentManifestHash, StringComparison.Ordinal) &&
-					(!UseShellSymlinkAppFileTransfer () || string.Equals (deviceManifestState.OverrideHash, currentManifestHash, StringComparison.Ordinal));
-				if (!manifestsAlreadyMarked && !await MarkRemoteManifests (remoteStagingPath, overridePath, currentManifestHash)) {
+				UploadFilesResult uploadResult = await UploadChangedFiles (remoteStagingPath, files, changedFiles);
+				if (!uploadResult.Success) {
+					LogFastDeploy2Error ("XA0129", uploadResult.Output, uploadResult.RemoteDirectory);
 					return false;
 				}
-				WriteManifest (currentManifest);
-			}
-			return result;
-		}
-
-		bool UseShellSymlinkAppFileTransfer ()
-		{
-			return string.Equals (AppFileTransferMode, "Symlink", StringComparison.OrdinalIgnoreCase);
-		}
-
-		async Task<bool> UpdateOverrideShellSymlinks (string remoteStagingPath, string overridePath, ManifestData currentManifest, ManifestData previousManifest, bool overrideSymlinksReady, List<string> removedFiles)
-		{
-			var previousSymlinkManifest = overrideSymlinksReady ? previousManifest : null;
-			var newFiles = previousSymlinkManifest == null ?
-				new HashSet<string> (currentManifest.Files.Keys, StringComparer.Ordinal) :
-				new HashSet<string> (currentManifest.Files.Keys.Where (file => !previousSymlinkManifest.Files.ContainsKey (file)), StringComparer.Ordinal);
-			LogDiagnostic ($"FastDeploy2 symlink update new files: {newFiles.Count}; removed files: {removedFiles.Count}.");
-
-			if (!await RunCombinedShellSymlinkUpdate (remoteStagingPath, overridePath, currentManifest, previousSymlinkManifest, newFiles, removedFiles)) {
-				return await FallbackToCopy (remoteStagingPath, overridePath);
 			}
 
+			if (!await RemoveStaleOverrideFiles (overridePath, removedFiles)) {
+				return false;
+			}
+			if (!await CopyChangedFiles (remoteStagingPath, overridePath, changedFiles)) {
+				return false;
+			}
+
+			string currentManifestHash = ComputeManifestHash (currentManifest);
+			if (!await MarkOverrideManifest (overridePath, currentManifestHash)) {
+				return false;
+			}
+
+			WriteManifest (currentManifest);
 			return true;
-		}
-
-		async Task<bool> RunCombinedShellSymlinkUpdate (string remoteStagingPath, string overridePath, ManifestData currentManifest, ManifestData previousManifest, HashSet<string> newFiles, List<string> removedFiles)
-		{
-			var currentByDirectory = GroupFilesByDirectory (currentManifest.Files.Keys);
-			var newByDirectory = GroupFilesByDirectory (newFiles);
-			var removedByDirectory = GroupFilesByDirectory (removedFiles);
-			var directories = new HashSet<string> (currentByDirectory.Keys, StringComparer.Ordinal);
-			directories.UnionWith (removedByDirectory.Keys);
-
-			foreach (string directory in directories) {
-				var currentInDirectory = GetFilesInDirectory (currentByDirectory, directory);
-				var newInDirectory = GetFilesInDirectory (newByDirectory, directory);
-				var removedInDirectory = GetFilesInDirectory (removedByDirectory, directory);
-				string targetDirectory = CombineRemotePath (overridePath, directory);
-				string sourceDirectory = CombineRemotePath (remoteStagingPath, directory);
-
-				if (currentInDirectory.Count > 0 && (previousManifest == null || newInDirectory.Count == currentInDirectory.Count)) {
-					// Clear and symlink only the files that live directly in this directory, never
-					// the subdirectories. A plain `rm -rf ./*` + `ln -sf "$s"/* .` would (a) delete
-					// child directories that other iterations populate and (b) create symlinks to
-					// staging subdirectories; processing those children would then follow the symlink
-					// back into the shell-owned staging area and fail with "Permission denied" under
-					// run-as. Each subdirectory is handled by its own iteration instead.
-					string script = $"d={QuoteShellArgument (targetDirectory)};s={QuoteShellArgument (sourceDirectory)};mkdir -p \"$d\"&&cd \"$d\"&&for e in ./*;do [ -d \"$e\" ]||rm -f \"$e\";done&&for f in \"$s\"/*;do [ -d \"$f\" ]||ln -sf \"$f\" .;done";
-					string output = await RunAsShell (script);
-					if (RaiseRunAsError (output) || IsShellError (output, "rm") || IsShellError (output, "mkdir") || IsShellError (output, "ln")) {
-						LogDiagnostic ($"Shell symlink glob update failed with '{output}'.");
-						return false;
-					}
-					continue;
-				}
-
-				foreach (string script in CreateShellSymlinkScripts (remoteStagingPath, overridePath, newInDirectory, removedInDirectory)) {
-					string output = await RunAsShell (script);
-					if (RaiseRunAsError (output) || IsShellError (output, "rm") || IsShellError (output, "mkdir") || IsShellError (output, "ln")) {
-						LogDiagnostic ($"Shell symlink batch update failed with '{output}'.");
-						return false;
-					}
-				}
-			}
-
-			return true;
-		}
-
-		static List<string> GetFilesInDirectory (Dictionary<string, List<string>> filesByDirectory, string directory)
-		{
-			return filesByDirectory.TryGetValue (directory, out List<string> files) ? files : [];
-		}
-
-		IEnumerable<string> CreateShellSymlinkScripts (string remoteStagingPath, string overridePath, List<string> newFiles, List<string> removedFiles)
-		{
-			foreach (var group in removedFiles.Concat (newFiles).GroupBy (GetDirectoryName, StringComparer.Ordinal)) {
-				string targetDirectory = CombineRemotePath (overridePath, group.Key);
-				var prefix = $"d={QuoteShellArgument (targetDirectory)};mkdir -p \"$d\"&&cd \"$d\"&&rm -f";
-				foreach (var batch in BatchShellWords (prefix, group.Select (file => QuoteShellArgument (Path.GetFileName (file))))) {
-					yield return batch;
-				}
-			}
-
-			foreach (var group in newFiles.GroupBy (GetDirectoryName, StringComparer.Ordinal)) {
-				string targetDirectory = CombineRemotePath (overridePath, group.Key);
-				string sourceDirectory = CombineRemotePath (remoteStagingPath, group.Key);
-				var prefix = $"d={QuoteShellArgument (targetDirectory)};s={QuoteShellArgument (sourceDirectory)};mkdir -p \"$d\"&&cd \"$d\"&&ln -sf";
-				var sources = group.Select (file => "\"$s\"/" + QuoteShellArgument (Path.GetFileName (file)));
-				foreach (var batch in BatchShellWords (prefix, sources, " .")) {
-					yield return batch;
-				}
-			}
-		}
-
-		IEnumerable<string> BatchShellWords (string prefix, IEnumerable<string> words, string suffix = "")
-		{
-			var builder = new StringBuilder (prefix);
-			int count = 0;
-			foreach (string word in words) {
-				string argument = " " + word;
-				if (count > 0 && builder.Length + argument.Length + suffix.Length >= MaxAdbCommandLength) {
-					if (!string.IsNullOrEmpty (suffix)) {
-						builder.Append (suffix);
-					}
-					yield return builder.ToString ();
-					builder.Clear ();
-					builder.Append (prefix);
-					count = 0;
-				}
-				builder.Append (argument);
-				count++;
-			}
-			if (count > 0) {
-				if (!string.IsNullOrEmpty (suffix)) {
-					builder.Append (suffix);
-				}
-				yield return builder.ToString ();
-			}
-		}
-
-		async Task<bool> FallbackToCopy (string remoteStagingPath, string overridePath)
-		{
-			LogDiagnostic ("FastDeploy2 symlink update failed; falling back to copy mode.");
-			return await UpdateOverrideCopies (remoteStagingPath, overridePath, clearOverrideDirectory: true);
-		}
-
-		async Task<bool> UpdateOverrideCopies (string remoteStagingPath, string overridePath, bool clearOverrideDirectory = false)
-		{
-			if (clearOverrideDirectory) {
-				if (!await ClearOverrideDirectory (overridePath)) {
-					return false;
-				}
-			} else if (!await ClearOverrideSymlinkState (overridePath)) {
-				return false;
-			}
-
-			var stagedFileData = await GetRemoteFileData (remoteStagingPath, runAs: false);
-			if (stagedFileData == null) {
-				return false;
-			}
-			stagedFileData.Remove (ManifestHashMarker);
-
-			var overrideFileData = await GetRemoteFileData (overridePath, runAs: true);
-			if (overrideFileData == null) {
-				return false;
-			}
-
-			if (!await RemoveStaleOverrideFiles (overridePath, stagedFileData, overrideFileData)) {
-				return false;
-			}
-
-			return await CopyChangedFiles (remoteStagingPath, overridePath, stagedFileData, overrideFileData);
 		}
 
 		ManifestData CreateManifest (List<DirectPushFile> files)
@@ -308,23 +171,6 @@ namespace Xamarin.Android.Tasks
 			return removedFiles;
 		}
 
-		internal static HashSet<string> GetFilesRequiringStagingDirectories (IEnumerable<string> currentFiles, IEnumerable<string> previousFiles)
-		{
-			if (previousFiles == null) {
-				return new HashSet<string> (currentFiles, StringComparer.Ordinal);
-			}
-
-			var previousDirectories = new HashSet<string> (
-				previousFiles.Select (GetDirectoryName),
-				StringComparer.Ordinal);
-			return new HashSet<string> (
-				currentFiles.Where (file => {
-					string directory = GetDirectoryName (file);
-					return directory.Length > 0 && !previousDirectories.Contains (directory);
-				}),
-				StringComparer.Ordinal);
-		}
-
 		async Task<UploadFilesResult> UploadChangedFiles (string remoteStagingPath, List<DirectPushFile> files, HashSet<string> changedFiles)
 		{
 			var changedFileList = files.Where (file => changedFiles.Contains (file.RelativePath)).ToList ();
@@ -335,34 +181,12 @@ namespace Xamarin.Android.Tasks
 					if (result.ExitCode != 0) {
 						return new UploadFilesResult (
 							success: false,
-							remoteStateInvalid: IsUnexpectedRemoteFilesystemError (result.Output),
 							output: result.Output,
 							remoteDirectory: remoteDirectory);
 					}
 				}
 			}
-			return new UploadFilesResult (success: true, remoteStateInvalid: false, output: "", remoteDirectory: "");
-		}
-
-		internal static bool IsUnexpectedRemoteFilesystemError (string output)
-		{
-			return IsMissingDirectoryError (output) ||
-				(!string.IsNullOrEmpty (output) &&
-					(output.IndexOf ("not a directory", StringComparison.OrdinalIgnoreCase) >= 0 ||
-					 output.IndexOf ("is a directory", StringComparison.OrdinalIgnoreCase) >= 0));
-		}
-
-		async Task<bool> RemoveRemoteStaleFiles (string remoteStagingPath, List<string> removedFiles)
-		{
-			foreach (var batch in BatchArguments ("rm", "-f", removedFiles.Select (file => CombineRemotePath (remoteStagingPath, file)))) {
-				var args = new [] { "shell" }.Concat (batch).ToArray ();
-				var result = await RunAdbCommand (args);
-				if (result.ExitCode != 0 || IsShellError (result.Output, "rm")) {
-					LogFastDeploy2Error ("XA0129", result.Output, remoteStagingPath);
-					return false;
-				}
-			}
-			return true;
+			return new UploadFilesResult (success: true, output: "", remoteDirectory: "");
 		}
 
 		async Task<bool> ResetRemoteStagingDirectory (string remoteStagingPath)
@@ -402,34 +226,11 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		async Task<DeviceManifestState> GetDeviceManifestState (string remoteStagingPath, string overridePath)
+		async Task<DeviceManifestState> GetDeviceManifestState (string overridePath)
 		{
-			string remoteMarkerPath = CombineRemotePath (remoteStagingPath, ManifestHashMarker);
 			string overrideMarkerPath = CombineRemotePath (overridePath, ManifestHashMarker);
-			string runAsCommand = string.Join (" ", BuildRunAsArgs ().Concat (new [] {
-				"sh",
-				"-c",
-				$"cat {QuoteShellArgument (overrideMarkerPath)} 2>/dev/null || true"
-			}).Select (QuoteShellArgument));
-			// Use `echo` (which emits a real newline) with command substitution rather than
-			// `printf '\n'`: the backslash escape does not reliably survive the adb/shell quoting
-			// layers and can arrive at the device as a literal "\n", which merges both values onto
-			// a single line so ParseDeviceManifestState can never read the override hash and the
-			// readiness check always fails (forcing a full redeploy on every incremental install).
-			string script = $"echo \"remote=$(cat {QuoteShellArgument (remoteMarkerPath)} 2>/dev/null)\"; echo \"override=$({runAsCommand} 2>/dev/null)\"";
-			var result = await RunAdbShellCommand (script);
-			return ParseDeviceManifestState (result.Output);
-		}
-
-		async Task<bool> ClearOverrideSymlinkState (string overridePath)
-		{
-			string markerPath = CombineRemotePath (overridePath, ManifestHashMarker);
-			string output = await RunAsShell ($"if test -f {QuoteShellArgument (markerPath)}; then rm -rf {QuoteShellArgument (overridePath)}; else rm -f {QuoteShellArgument (markerPath)}; fi");
-			if (RaiseRunAsError (output) || IsShellError (output, "rm")) {
-				LogFastDeploy2Error ("XA0129", output, overridePath);
-				return false;
-			}
-			return true;
+			string output = await RunAsShell ($"cat {QuoteShellArgument (overrideMarkerPath)} 2>/dev/null || true");
+			return new DeviceManifestState { OverrideHash = output.Trim () };
 		}
 
 		async Task<bool> ClearOverrideDirectory (string overridePath)
@@ -442,44 +243,19 @@ namespace Xamarin.Android.Tasks
 			return true;
 		}
 
-		async Task<bool> MarkRemoteManifests (string remoteStagingPath, string overridePath, string manifestHash)
+		async Task<bool> MarkOverrideManifest (string overridePath, string manifestHash)
 		{
-			string remoteMarkerPath = CombineRemotePath (remoteStagingPath, ManifestHashMarker);
-			string script = $"printf %s {QuoteShellArgument (manifestHash)} > {QuoteShellArgument (remoteMarkerPath)}";
-			if (UseShellSymlinkAppFileTransfer ()) {
-				string overrideScript =
-					$"mkdir -p {QuoteShellArgument (overridePath)}; " +
-					$"printf %s {QuoteShellArgument (manifestHash)} > {QuoteShellArgument (CombineRemotePath (overridePath, ManifestHashMarker))}";
-				string runAsCommand = string.Join (" ", BuildRunAsArgs ().Concat (new [] {
-					"sh",
-					"-c",
-					overrideScript,
-				}).Select (QuoteShellArgument));
-				script += $" && {runAsCommand}";
-			}
-
-			AdbCommandResult result = await RunAdbShellCommand (script);
-			if ((UseShellSymlinkAppFileTransfer () && RaiseRunAsError (result.Output)) ||
-					result.ExitCode != 0 ||
-					IsShellError (result.Output, "mkdir") ||
-					IsShellError (result.Output, "printf")) {
-				LogFastDeploy2Error ("XA0129", result.Output, remoteMarkerPath);
+			string markerPath = CombineRemotePath (overridePath, ManifestHashMarker);
+			string output = await RunAsShell (
+				$"mkdir -p {QuoteShellArgument (overridePath)} && " +
+				$"printf %s {QuoteShellArgument (manifestHash)} > {QuoteShellArgument (markerPath)}");
+			if (RaiseRunAsError (output) ||
+					IsShellError (output, "mkdir") ||
+					IsShellError (output, "printf")) {
+				LogFastDeploy2Error ("XA0129", output, markerPath);
 				return false;
 			}
 			return true;
-		}
-
-		static DeviceManifestState ParseDeviceManifestState (string output)
-		{
-			var state = new DeviceManifestState ();
-			foreach (string line in output.Split (new char [] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
-				if (line.StartsWith ("remote=", StringComparison.Ordinal)) {
-					state.RemoteHash = line.Substring ("remote=".Length).Trim ();
-				} else if (line.StartsWith ("override=", StringComparison.Ordinal)) {
-					state.OverrideHash = line.Substring ("override=".Length).Trim ();
-				}
-			}
-			return state;
 		}
 
 		ManifestData LoadPreviousManifest ()
@@ -557,20 +333,17 @@ namespace Xamarin.Android.Tasks
 		}
 
 		class DeviceManifestState {
-			public string RemoteHash { get; set; } = "";
 			public string OverrideHash { get; set; } = "";
 		}
 
 		readonly struct UploadFilesResult {
 			public bool Success { get; }
-			public bool RemoteStateInvalid { get; }
 			public string Output { get; }
 			public string RemoteDirectory { get; }
 
-			public UploadFilesResult (bool success, bool remoteStateInvalid, string output, string remoteDirectory)
+			public UploadFilesResult (bool success, string output, string remoteDirectory)
 			{
 				Success = success;
-				RemoteStateInvalid = remoteStateInvalid;
 				Output = output;
 				RemoteDirectory = remoteDirectory;
 			}

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.WarmState.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.WarmState.cs
@@ -11,7 +11,6 @@ namespace Xamarin.Android.Tasks
 	{
 		const string WarmRedirectTag = "__XA_FD2_REDIRECT__=";
 		const string WarmRunAsDisabledTag = "__XA_FD2_RUN_AS_DISABLED__=";
-		const string WarmRemoteHashTag = "__XA_FD2_REMOTE_HASH__=";
 		const string WarmPathTag = "__XA_FD2_PATH__=";
 		const string WarmOverrideHashTag = "__XA_FD2_OVERRIDE_HASH__=";
 		const string WarmPidTag = "__XA_FD2_PID__=";
@@ -28,8 +27,6 @@ namespace Xamarin.Android.Tasks
 				return WarmStateProbeOutcome.NotEligible;
 			}
 
-			string remoteStagingPath = GetRemoteAdbPushStagingPath ();
-			string remoteMarkerPath = CombineRemotePath (remoteStagingPath, ManifestHashMarker);
 			string overrideMarkerPath = CombineRemotePath (OverridePath, ManifestHashMarker);
 			string packageName = QuoteShellArgument (PackageName);
 
@@ -48,7 +45,6 @@ namespace Xamarin.Android.Tasks
 			string script =
 				$"fd2_redirect=$(getprop log.redirect-stdio); echo {QuoteShellArgument (WarmRedirectTag)}$fd2_redirect; " +
 				$"fd2_run_as_disabled=$(getprop ro.boot.disable_runas); echo {QuoteShellArgument (WarmRunAsDisabledTag)}$fd2_run_as_disabled; " +
-				$"echo {QuoteShellArgument (WarmRemoteHashTag)}$(cat {QuoteShellArgument (remoteMarkerPath)} 2>/dev/null); " +
 				"if [ \"$fd2_redirect\" != true ] && [ \"$fd2_run_as_disabled\" != true ]; then " +
 				$"fd2_pid=$(pidof {packageName} 2>/dev/null || true); echo {QuoteShellArgument (WarmPidTag)}$fd2_pid; " +
 				$"{runAsCommand}; fd2_run_as_status=$?; echo {QuoteShellArgument (WarmRunAsStatusTag)}$fd2_run_as_status; " +
@@ -82,7 +78,6 @@ namespace Xamarin.Android.Tasks
 			packageInfo.ProcessId = 0;
 			warmDeviceManifestHash = ComputeManifestHash (previousManifest);
 			warmDeviceManifestState = new DeviceManifestState {
-				RemoteHash = data.RemoteHash,
 				OverrideHash = data.OverrideHash,
 			};
 			warmProbeStoppedApp = true;
@@ -113,9 +108,6 @@ namespace Xamarin.Android.Tasks
 				} else if (TryGetTaggedValue (line, WarmRunAsDisabledTag, out value)) {
 					data.HasRunAsDisabled = true;
 					data.RunAsDisabled = value;
-				} else if (TryGetTaggedValue (line, WarmRemoteHashTag, out value)) {
-					data.HasRemoteHash = true;
-					data.RemoteHash = value;
 				} else if (TryGetTaggedValue (line, WarmPathTag, out value)) {
 					data.HasInternalPath = true;
 					data.InternalPath = value;
@@ -168,8 +160,6 @@ namespace Xamarin.Android.Tasks
 			public string RedirectStdio { get; set; } = "";
 			public bool HasRunAsDisabled { get; set; }
 			public string RunAsDisabled { get; set; } = "";
-			public bool HasRemoteHash { get; set; }
-			public string RemoteHash { get; set; } = "";
 			public bool HasInternalPath { get; set; }
 			public string InternalPath { get; set; } = "";
 			public bool HasOverrideHash { get; set; }
@@ -184,7 +174,6 @@ namespace Xamarin.Android.Tasks
 			public bool HasRequiredState =>
 				HasRedirectStdio &&
 				HasRunAsDisabled &&
-				HasRemoteHash &&
 				HasInternalPath &&
 				HasOverrideHash &&
 				HasProcessId &&

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Tasks/FastDeploy2.cs
@@ -62,6 +62,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool DiagnosticLogging { get; set; } = false;
 
+		public bool ResetOverrideDirectory { get; set; } = false;
+
 		public string UserID { get; set; }
 
 		public bool IsTestOnly { get; set; }
@@ -76,8 +78,6 @@ namespace Xamarin.Android.Tasks
 		public string AdbToolExe { get; set; }
 
 		public string AdbPushCompressionAlgorithm { get; set; } = "any";
-
-		public string AppFileTransferMode { get; set; } = "Copy";
 
 		string DeviceId = "";
 		PackageInfo packageInfo = new PackageInfo ();
@@ -101,11 +101,6 @@ namespace Xamarin.Android.Tasks
 			public string UserId { get; set; } = null;
 			public string PackageName { get; set; } = null;
 			public int ProcessId { get; set; } = 0;
-		}
-
-		class RemoteFileInfo {
-			public long Size { get; set; }
-			public long ModifiedTime { get; set; }
 		}
 
 		class DirectPushFile {
@@ -185,7 +180,8 @@ namespace Xamarin.Android.Tasks
 
 		async Task RunInstall ()
 		{
-			WarmStateProbeOutcome warmState = await TryRunWarmStateProbe (LoadPreviousManifest ());
+			ManifestData previousManifest = LoadPreviousManifest ();
+			WarmStateProbeOutcome warmState = await TryRunWarmStateProbe (previousManifest);
 			if (warmState == WarmStateProbeOutcome.Failed) {
 				return;
 			}
@@ -500,72 +496,10 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		async Task<Dictionary<string, RemoteFileInfo>> GetRemoteFileData (string rootPath, bool runAs)
+		async Task<bool> RemoveStaleOverrideFiles (string overridePath, List<string> removedFiles)
 		{
-			// The stat format must be quoted so that the `|` separators survive to the device
-			// shell. `adb shell` re-parses its arguments, so passing the format as an argv element
-			// (e.g. via RunAdbShellCommand (params string [])) would let the device shell treat the
-			// `|` characters as pipes. Building a single, explicitly quoted command string avoids it.
-			string findCommand = $"find {QuoteShellArgument (rootPath)} -type f -exec stat -c '%n|%s|%Y' {{}} +";
-			string output;
-			if (runAs) {
-				output = await RunAsShell (findCommand);
-				if (RaiseRunAsError (output)) {
-					return null;
-				}
-			} else {
-				var result = await RunAdbShellCommand (findCommand);
-				output = result.Output;
-			}
-
-			if (IsMissingDirectoryError (output)) {
-				return new Dictionary<string, RemoteFileInfo> (StringComparer.Ordinal);
-			}
-			if (IsShellError (output, "find") || IsShellError (output, "stat")) {
-				LogFastDeploy2Error ("XA0129", output, rootPath);
-				return null;
-			}
-
-			return ParseRemoteFileData (rootPath, output);
-		}
-
-		Dictionary<string, RemoteFileInfo> ParseRemoteFileData (string rootPath, string output)
-		{
-			var files = new Dictionary<string, RemoteFileInfo> (StringComparer.Ordinal);
-			string prefix = rootPath.TrimEnd ('/') + "/";
-			foreach (string line in output.Split (new char [] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
-				var entries = line.Split (new char [] { '|' }, 3);
-				if (entries.Length != 3) {
-					LogDebugMessage ($"Ignoring remote file entry '{line}'. Line is incorrectly formatted.");
-					continue;
-				}
-				string remoteFile = entries [0].Trim ();
-				if (!remoteFile.StartsWith (prefix, StringComparison.Ordinal)) {
-					LogDebugMessage ($"Ignoring remote file entry '{line}'. Path is outside '{rootPath}'.");
-					continue;
-				}
-				if (!long.TryParse (entries [1].Trim (), out long size) || !long.TryParse (entries [2].Trim (), out long mtime)) {
-					LogDebugMessage ($"Ignoring remote file entry '{line}'. Size or timestamp is invalid.");
-					continue;
-				}
-				files [remoteFile.Substring (prefix.Length)] = new RemoteFileInfo {
-					Size = size,
-					ModifiedTime = mtime,
-				};
-			}
-			return files;
-		}
-
-		async Task<bool> RemoveStaleOverrideFiles (string overridePath, Dictionary<string, RemoteFileInfo> stagedFiles, Dictionary<string, RemoteFileInfo> overrideFiles)
-		{
-			var staleFiles = new List<string> ();
-			foreach (var file in overrideFiles.Keys) {
-				if (!stagedFiles.ContainsKey (file)) {
-					staleFiles.Add (CombineRemotePath (overridePath, file));
-				}
-			}
-
-			LogDiagnostic ($"FastDeploy2 removing {staleFiles.Count} stale override files.");
+			LogDiagnostic ($"FastDeploy2 removing {removedFiles.Count} stale override files.");
+			var staleFiles = removedFiles.Select (file => CombineRemotePath (overridePath, file));
 			foreach (var batch in BatchShellArguments (new [] { "rm", "-f" }, staleFiles, StaleFileRemovalBatchSize)) {
 				string output = await RunAs (batch.ToArray ());
 				if (RaiseRunAsError (output) || IsShellError (output, "rm")) {
@@ -576,17 +510,8 @@ namespace Xamarin.Android.Tasks
 			return true;
 		}
 
-		async Task<bool> CopyChangedFiles (string remoteStagingPath, string overridePath, Dictionary<string, RemoteFileInfo> stagedFiles, Dictionary<string, RemoteFileInfo> overrideFiles)
+		async Task<bool> CopyChangedFiles (string remoteStagingPath, string overridePath, HashSet<string> changedFiles)
 		{
-			var changedFiles = new List<string> ();
-			foreach (var file in stagedFiles) {
-				if (!overrideFiles.TryGetValue (file.Key, out RemoteFileInfo existing) ||
-						existing.Size != file.Value.Size ||
-						existing.ModifiedTime != file.Value.ModifiedTime) {
-					changedFiles.Add (file.Key);
-				}
-			}
-
 			LogDiagnostic ($"FastDeploy2 copying {changedFiles.Count} changed override files.");
 			var filesByDirectory = GroupFilesByDirectory (changedFiles);
 
@@ -598,9 +523,8 @@ namespace Xamarin.Android.Tasks
 					return false;
 				}
 
-				// Remove the current destination files, then copy the freshly staged files in.
-				// `cp` overwrites anyway, so removing first (rather than interleaving per batch)
-				// is equivalent and lets each command batch independently by length.
+				// Remove destinations first so `cp` cannot follow symlinks left by an older
+				// FastDeploy2 deployment. Separate removal also lets each command batch by length.
 				var destinationFiles = group.Value.Select (file => CombineRemotePath (targetDirectory, Path.GetFileName (file)));
 				foreach (var batch in BatchShellArguments (new [] { "rm", "-f" }, destinationFiles, CopyBatchSize)) {
 					output = await RunAs (batch.ToArray ());

--- a/src/Xamarin.Android.Build.Debugging.Tasks/Xamarin.Android.Common.Debugging.targets
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Xamarin.Android.Common.Debugging.targets
@@ -62,8 +62,6 @@ Copyright (C) 2016 Xamarin. All rights reserved.
 	<_UploadFlag>$(IntermediateOutputPath)upload.flag</_UploadFlag>
 	<_ConfigurationCacheDirectory>$(BaseIntermediateOutputPath).cache\</_ConfigurationCacheDirectory>
 	<_AndroidFastDevStrategy Condition=" '$(_AndroidFastDevStrategy)' == '' ">FastDeploy2</_AndroidFastDevStrategy>
-	<_AndroidFastDeployAppFileTransferMode Condition=" '$(_AndroidFastDeployAppFileTransferMode)' == '' And '$(_AndroidFastDevStrategy)' == 'FastDeploy2' ">Symlink</_AndroidFastDeployAppFileTransferMode>
-	<_AndroidFastDeployAppFileTransferMode Condition=" '$(_AndroidFastDeployAppFileTransferMode)' == '' ">Copy</_AndroidFastDeployAppFileTransferMode>
 </PropertyGroup>
 
 <PropertyGroup>
@@ -258,7 +256,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
 
 <Target Name="_CheckForConfigurationChange">
 	<ItemGroup>
-		<_ConfigurationCacheItems Include="$(Configuration)|$(Platform)|$(AdbTarget)|$(_AndroidFastDevStrategy)|$(_AndroidFastDeployAppFileTransferMode)" />
+		<_ConfigurationCacheItems Include="$(Configuration)|$(Platform)|$(AdbTarget)|$(_AndroidFastDevStrategy)" />
 	</ItemGroup>
 	<ReadLinesFromFile File="$(_ConfigurationCacheDirectory)$(_AndroidPackage).flag"
 			Condition="Exists('$(_ConfigurationCacheDirectory)$(_AndroidPackage).flag')">
@@ -342,9 +340,6 @@ Copyright (C) 2016 Xamarin. All rights reserved.
     <Error
       Condition=" '$(_AndroidFastDevStrategy)' != 'FastDeploy' And '$(_AndroidFastDevStrategy)' != 'FastDeploy2' "
       Text="Invalid _AndroidFastDevStrategy value '$(_AndroidFastDevStrategy)'. Supported values are 'FastDeploy' and 'FastDeploy2'." />
-    <Error
-      Condition=" '$(_AndroidFastDeployAppFileTransferMode)' != 'Copy' And '$(_AndroidFastDeployAppFileTransferMode)' != 'Symlink' "
-      Text="Invalid _AndroidFastDeployAppFileTransferMode value '$(_AndroidFastDeployAppFileTransferMode)'. Supported values are 'Copy' and 'Symlink'." />
     <RemoveDuplicates
         Inputs="@(_FastDevFiles)">
       <Output TaskParameter="Filtered" ItemName="_FilteredFastDevFiles"/>
@@ -389,7 +384,6 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       AdbToolPath="$(AdbToolPath)"
       AdbToolExe="$(AdbToolExe)"
       AdbPushCompressionAlgorithm="$(AndroidFastDeploymentAdbCompressionAlgorithm)"
-      AppFileTransferMode="$(_AndroidFastDeployAppFileTransferMode)"
       UploadFlagFile="$(_UploadFlag)"
       UserID="$(AndroidDeviceUserId)"
       IsTestOnly="$(_AndroidIsTestOnlyPackage)"
@@ -399,6 +393,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       CopyBatchSize="$(_AndroidFastDeployCopyBatchSize)"
       MaxShellCommandLength="$(_AndroidFastDeployMaxShellCommandLength)"
       MaxAdbCommandLength="$(_AndroidFastDeployMaxAdbCommandLength)"
+      ResetOverrideDirectory="$(_FastDeploymentConfigurationChanged)"
     />
     <Touch Files="$(_UploadFlag)" AlwaysCreate="True" />
     <MakeDir Directories="$(_ConfigurationCacheDirectory)" Condition="!Exists('$(_ConfigurationCacheDirectory)')" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
@@ -80,16 +80,13 @@ namespace Xamarin.Android.Build.Tests
 				"""
 				__XA_FD2_REDIRECT__=
 				__XA_FD2_RUN_AS_DISABLED__=
-				__XA_FD2_REMOTE_HASH__=remote-hash
 				__XA_FD2_PID__=123 456
 				__XA_FD2_PATH__=/data/user/0/com.example
 				__XA_FD2_OVERRIDE_HASH__=override-hash
 				__XA_FD2_RUN_AS_STATUS__=0
 				__XA_FD2_FORCE_STOP_STATUS__=0
 				""");
-
 			Assert.IsTrue (state.HasRequiredState);
-			Assert.AreEqual ("remote-hash", state.RemoteHash);
 			Assert.AreEqual ("override-hash", state.OverrideHash);
 			Assert.AreEqual ("/data/user/0/com.example", state.InternalPath);
 			Assert.AreEqual (123, state.ProcessId);
@@ -110,55 +107,6 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsFalse (state.HasRequiredState);
 			Assert.IsTrue (state.HasRunAsDisabled);
 			Assert.AreEqual ("true", state.RunAsDisabled);
-		}
-
-		[Test]
-		public void FastDeploy2PlansOnlyNewStagingDirectories ()
-		{
-			var previousFiles = new [] {
-				"arm64-v8a/App.dll",
-				"arm64-v8a/en-US/App.resources.dll",
-			};
-			var currentFiles = new [] {
-				"arm64-v8a/App.dll",
-				"arm64-v8a/New.dll",
-				"arm64-v8a/en-US/App.resources.dll",
-				"arm64-v8a/fr/App.resources.dll",
-			};
-
-			HashSet<string> files = FastDeploy2.GetFilesRequiringStagingDirectories (currentFiles, previousFiles);
-
-			CollectionAssert.AreEquivalent (
-				new [] { "arm64-v8a/fr/App.resources.dll" },
-				files);
-		}
-
-		[Test]
-		public void FastDeploy2PlansAllStagingDirectoriesAfterReset ()
-		{
-			var currentFiles = new [] {
-				"App.dll",
-				"arm64-v8a/App.dll",
-				"arm64-v8a/fr/App.resources.dll",
-			};
-
-			HashSet<string> files = FastDeploy2.GetFilesRequiringStagingDirectories (currentFiles, previousFiles: null);
-
-			CollectionAssert.AreEquivalent (currentFiles, files);
-		}
-
-		[TestCase ("adb: error: failed to copy: No such file or directory")]
-		[TestCase ("adb: error: target '/data/local/tmp/app/arm64-v8a' is not a directory")]
-		[TestCase ("remote couldn't create file: Is a directory")]
-		public void FastDeploy2DetectsInvalidRemoteFilesystem (string output)
-		{
-			Assert.IsTrue (FastDeploy2.IsUnexpectedRemoteFilesystemError (output));
-		}
-
-		[Test]
-		public void FastDeploy2DoesNotResetForUnrelatedPushFailure ()
-		{
-			Assert.IsFalse (FastDeploy2.IsUnexpectedRemoteFilesystemError ("adb: error: device offline"));
 		}
 
 	}

--- a/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
@@ -273,7 +273,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (builder.Install (proj), "FastDeploy2 install should have succeeded.");
 
 				string assemblyPath = $"files/.__override__/{DeviceAbi}/UnnamedProject.dll";
-				Assert.AreEqual ("symlink", GetOverrideFileKind (proj.PackageName, assemblyPath));
+				Assert.AreEqual ("regular", GetOverrideFileKind (proj.PackageName, assemblyPath));
 				RunAdbCommand ($"shell run-as {proj.PackageName} sh -c 'echo preserved > files/fastdeploy-strategy-marker'");
 				Assert.IsTrue (builder.Clean (proj), "clean should have succeeded.");
 
@@ -288,7 +288,7 @@ namespace Xamarin.Android.Build.Tests
 				proj.Touch ("MainActivity.cs");
 				proj.SetProperty ("_AndroidFastDevStrategy", "FastDeploy2");
 				Assert.IsTrue (builder.Install (proj, doNotCleanupOnUpdate: true), "FastDeploy2 install should have succeeded after FastDeploy.");
-				Assert.AreEqual ("symlink", GetOverrideFileKind (proj.PackageName, assemblyPath));
+				Assert.AreEqual ("regular", GetOverrideFileKind (proj.PackageName, assemblyPath));
 				Assert.AreEqual ("preserved", RunAdbCommand ($"shell run-as {proj.PackageName} cat files/fastdeploy-strategy-marker").Trim ());
 
 				Assert.IsTrue (builder.Uninstall (proj), "uninstall should have succeeded.");
@@ -296,10 +296,10 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void FastDeploy2RestoresMissingRemoteDirectory ()
+		public void FastDeploy2RemovesRemoteStagingDirectory ()
 		{
 			var proj = new XamarinAndroidApplicationProject {
-				PackageName = "com.xamarin.fastdeploy2_restore_remote",
+				PackageName = "com.xamarin.fastdeploy2_removes_staging",
 			};
 			proj.MainActivity = proj.DefaultMainActivity;
 			proj.SetDefaultTargetDevice ();
@@ -307,16 +307,16 @@ namespace Xamarin.Android.Build.Tests
 				builder.Verbosity = LoggerVerbosity.Detailed;
 				Assert.IsTrue (builder.Install (proj), "initial install should have succeeded.");
 
-				string remoteDirectory = $"/data/local/tmp/fastdeploy2/{proj.PackageName}/0/{DeviceAbi}";
-				RunAdbCommand ($"shell rm -rf {remoteDirectory}");
+				string remoteDirectory = $"/data/local/tmp/fastdeploy2/{proj.PackageName}/0";
+				Assert.AreEqual ("missing", RunAdbCommand ($"shell if test -e {remoteDirectory}; then echo exists; else echo missing; fi").Trim ());
 
 				proj.MainActivity = proj.MainActivity.Replace ("clicks", "CLICKS");
 				proj.Touch ("MainActivity.cs");
-				Assert.IsTrue (builder.Install (proj, doNotCleanupOnUpdate: true), "fresh deployment fallback should have succeeded.");
+				Assert.IsTrue (builder.Install (proj, doNotCleanupOnUpdate: true), "incremental deployment should have succeeded.");
 
 				string assemblyPath = $"files/.__override__/{DeviceAbi}/UnnamedProject.dll";
-				Assert.AreEqual ("symlink", GetOverrideFileKind (proj.PackageName, assemblyPath));
-				Assert.AreEqual ("exists", RunAdbCommand ($"shell if test -f {remoteDirectory}/UnnamedProject.dll; then echo exists; else echo missing; fi").Trim ());
+				Assert.AreEqual ("regular", GetOverrideFileKind (proj.PackageName, assemblyPath));
+				Assert.AreEqual ("missing", RunAdbCommand ($"shell if test -e {remoteDirectory}; then echo exists; else echo missing; fi").Trim ());
 				Assert.IsTrue (builder.Uninstall (proj), "uninstall should have succeeded.");
 			}
 		}


### PR DESCRIPTION
## Summary

Alternative to #12310:

- push changed FastDeploy2 files to transient `/data/local/tmp/fastdeploy2/<package>/<user>` staging
- copy them into the app-private override directory with `run-as cp -p`
- remove staging after every deployment attempt, including failures
- store regular private files instead of persistent symlinks, so uninstall removes the deployed files with the application's data
- remove the symlink/copy mode and orphan-staging cleanup machinery
- invalidate the previous configuration-cache shape so existing symlink-based installations are recreated safely

Existing destination files are removed before copying so `cp` cannot follow symlinks left by an older FastDeploy2 deployment.

## Performance

Head-to-head measurements on `emulator-5554` (`arm64-v8a`), alternating implementation order:

| Scenario | Runs | Previous symlink | Private copy | Difference |
| --- | ---: | ---: | ---: | ---: |
| Assembly-only incremental install | 12 each | 3.821 s | 4.074 s | +0.253 s (+6.6%) |
| Forced full FastDeploy redeploy | 6 each | 7.098 s | 7.390 s | +0.292 s (+4.1%) |

The corresponding median `FastDeploy2` task times increased by 220 ms for an assembly-only update and 356 ms for a full redeploy. This is the cost of the additional private copy and staging cleanup commands.

## Validation

- `dotnet build src/Xamarin.Android.Build.Debugging.Tasks/Xamarin.Android.Build.Debugging.Tasks.csproj`
- `dotnet test bin/TestDebug/net10.0/Xamarin.Android.Build.Tests.dll --filter 'Name~FastDeploy2'` — 2 passed
- `FastDeploy2RemovesRemoteStagingDirectory` device test — passed
- `FastDeploymentStrategyCanBeChanged` device test — passed
- verified deployed override assemblies are regular files and transient staging is absent after initial and incremental installs
- `git diff --check`
