### PR TITLE
[release/10.0.1xx] Use approved feed for .NET tools

### DIFF
--- a/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
+++ b/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
@@ -21,5 +21,4 @@ steps:
       update ${{ parameters.toolName }} -v:diag
       --tool-path $(Agent.ToolsDirectory)
       --version ${{ parameters.version }}
-      --add-source "https://api.nuget.org/v3/index.json"
-
+      --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"


### PR DESCRIPTION
## Description

Backports the `install-dotnet-tool.yaml` portion of fa00357649bb3b4ff4bf9a46da615de26b72668d so `apkdiff` and `dotnet-test-slicer` are installed exclusively from the approved `dotnet-public` feed instead of appending `api.nuget.org`.

## Validation

- Confirmed the branch contains exactly one commit on top of `origin/release/10.0.1xx`
- Validated expanded commands for `apkdiff` 0.0.17 and `dotnet-test-slicer` 0.1.0-alpha7
- Installed both exact versions from `dotnet-public` only
- Confirmed no `api.nuget.org` or `--add-source` remains in the template
- `git diff --check` passes