### PR TITLE
[build] Serialize Gradle wrapper projects

### DIFF
--- a/src/proguard-android/proguard-android.csproj
+++ b/src/proguard-android/proguard-android.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\androidsdk\androidsdk.csproj" ReferenceOutputAssembly="False" />
+    <!-- Serialize projects that invoke the shared Gradle wrapper. -->
+    <ProjectReference Include="..\r8\r8.csproj" ReferenceOutputAssembly="False" />
   </ItemGroup>
 
   <Import Project="..\..\Configuration.props" />


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.

  Parallel solution builds can launch `proguard-android` alongside other projects using the shared Gradle wrapper. Gradle 9.4.1 can then fail while starting a single-use daemon with `Timeout waiting to connect to the Gradle daemon` as the processes contend on the shared daemon registry.

  Add an ordering-only reference from `proguard-android` to `r8`. Since `r8` already waits on `manifestmerger`, this places all wrapper projects in one serialized chain while preserving the direct `androidsdk` dependency.

- [ ] Links to issues fixed

  N/A

- [ ] Unit tests

  N/A - this changes only MSBuild project ordering. The `proguard-android` project chain builds successfully.