### PR TITLE
[dependabot] Disable Gradle update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,10 @@ updates:
       - "/src/manifestmerger"
       - "/src/proguard-android"
       - "/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib"
+    # Google Maven does not publish per-version release dates for R8, so the
+    # default cooldown filters every available R8 update.
+    cooldown:
+      default-days: 0
     schedule:
       interval: "weekly"
   - package-ecosystem: "gitsubmodule"


### PR DESCRIPTION
## Description

Set the Gradle Dependabot cooldown to zero.

Google Maven does not publish per-version release dates for R8. Dependabot therefore applies its default cooldown conservatively and filters every available R8 version, even though version discovery now reaches Google Maven.

In [update job 1531167521](https://github.com/dotnet/android/actions/runs/32162243023/job/95793595079), Dependabot successfully fetched the R8 metadata but reported `Release date not available` for each version before concluding `No update possible for com.android.tools:r8 9.1.31`.

This override only affects the Gradle updater; the default cooldown remains in place for the other ecosystems.