### PR TITLE
[dependabot] Ignore Arcade SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,8 @@ updates:
     target-branch: "release/10.0.1xx"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "Microsoft.DotNet.Arcade.Sdk"
   - package-ecosystem: "gradle"
     directories:
       - "/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle"


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.

  Dependabot discovers `Microsoft.DotNet.Arcade.Sdk` through the repository-level `global.json` even though NuGet scanning is scoped to selected directories. Ignore this package explicitly to prevent unwanted Arcade SDK update PRs such as #12430.

- [x] Links to issues fixed

  Related: #12430

- [x] Unit tests

  N/A - configuration-only change.