### PR TITLE
Group Dependabot updates by Gradle project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,11 @@ updates:
       interval: "weekly"
     groups:
       java-source-utils-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      java-source-utils-security-updates:
+        applies-to: security-updates
         patterns:
           - "*"
   - package-ecosystem: "gradle"
@@ -70,6 +75,11 @@ updates:
       interval: "weekly"
     groups:
       manifestmerger-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      manifestmerger-security-updates:
+        applies-to: security-updates
         patterns:
           - "*"
   - package-ecosystem: "gitsubmodule"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,9 +43,7 @@ updates:
   - package-ecosystem: "gradle"
     directories:
       - "/external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle"
-      - "/external/Java.Interop/tools/java-source-utils"
       - "/src/r8"
-      - "/src/manifestmerger"
       - "/src/proguard-android"
       - "/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib"
     # Google Maven does not publish per-version release dates for R8, so the
@@ -54,6 +52,26 @@ updates:
       default-days: 0
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/external/Java.Interop/tools/java-source-utils"
+    cooldown:
+      default-days: 0
+    schedule:
+      interval: "weekly"
+    groups:
+      java-source-utils-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "gradle"
+    directory: "/src/manifestmerger"
+    cooldown:
+      default-days: 0
+    schedule:
+      interval: "weekly"
+    groups:
+      manifestmerger-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- group all Dependabot updates for `src/manifestmerger` into one PR
- group all Dependabot updates for `external/Java.Interop/tools/java-source-utils` into one PR
- preserve the existing weekly schedule and disabled cooldown behavior

This prevents related dependencies such as `manifest-merger`/`common` and the JavaParser artifacts from producing separate pull requests.