### PR TITLE
[TrimmableTypeMap] Skip redundant assembly reference scans

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
@@ -185,6 +185,9 @@
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         <PostprocessAssembly>true</PostprocessAssembly>
         <RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
+        <!-- These generated assemblies always reference Mono.Android. Preserve this known fact so
+             ProcessAssemblies does not reopen and scan every per-assembly typemap DLL. -->
+        <HasMonoAndroidReference>true</HasMonoAndroidReference>
       </ResolvedFileToPublish>
     </ItemGroup>
   </Target>
@@ -201,6 +204,7 @@
         <RelativePath>%(Filename)%(Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         <RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
+        <HasMonoAndroidReference>true</HasMonoAndroidReference>
       </ResolvedFileToPublish>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Related: #10958

## Summary

- mark generated trimmable typemap publish items with `HasMonoAndroidReference=true`
- preserve information already known by the typemap generator instead of reopening every generated DLL
- apply the same metadata when replacing linked typemaps with ReadyToRun outputs

`ProcessAssemblies` determines whether each publish assembly references `Mono.Android`. When the item metadata is absent, it opens the DLL with `PEReader` and scans its assembly-reference table. Trimmable Debug builds add approximately 82 generated typemap DLLs to `ResolvedFileToPublish`; all of them are known to reference `Mono.Android`, making those file opens redundant.

This issue and fix both exist independently on `main`; no pregenerated framework typemap changes are required.

## Performance

Five clean MAUI Debug Android builds before and after the metadata change:

| `ProcessAssemblies` | Before | After | Improvement |
|---|---:|---:|---:|
| Mean | 2.731s | 0.162s | **2.569s / 94.1%** |
| Median | 3.132s | 0.122s | **3.010s / 96.1%** |
| Runs | 3.384, 3.132, 2.454, 3.723, 0.964s | 0.383, 0.123, 0.092, 0.122, 0.089s | |

A separate clean validation build from this `main`-based branch measured `ProcessAssemblies` at 0.187s.

## Validation

- built `Xamarin.Android.Build.Tasks`
- clean `dotnet new maui` Debug Android build with the trimmable typemap
- captured a binlog and confirmed `ProcessAssemblies` completed in 0.187s