### PR TITLE
[build] Disable CoreCLR ReadyToRun without trimming

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1869,6 +1869,11 @@ For Android applications that use CoreCLR, this property defaults to
 `Debug` configuration. ReadyToRun does not apply when using Mono or
 NativeAOT.
 
+ReadyToRun requires trimming. If `$(PublishTrimmed)` is not `true`,
+.NET for Android disables `PublishReadyToRun` and
+[`$(PublishReadyToRunComposite)`](#publishreadytoruncomposite) and emits
+warning XA0119.
+
 ReadyToRun compilation is composite by default. See
 [`$(PublishReadyToRunComposite)`](#publishreadytoruncomposite).
 .NET MAUI also uses partial ReadyToRun with default MIBC profiles. See
@@ -1889,6 +1894,8 @@ time.
 
 For Android applications that use CoreCLR, this property defaults to
 `true` when [`$(PublishReadyToRun)`](#publishreadytorun) is `true`.
+ReadyToRun, including composite ReadyToRun, requires
+`$(PublishTrimmed)` to be `true`.
 
 ## RunAOTCompilation
 

--- a/Documentation/docs-mobile/messages/xa0119.md
+++ b/Documentation/docs-mobile/messages/xa0119.md
@@ -45,7 +45,7 @@ Remove the following from `Release` configurations:
 
 * `<AndroidEnableFastDeployment>False</AndroidEnableFastDeployment>`
 * `<AotAssemblies>True</AotAssemblies>` or in .NET 6 `<RunAOTCompilation>True</RunAOTCompilation>`
-* `<PublishReadyToRun>True</PublishReadyToRun>` (for CoreCLR)
+* `<PublishReadyToRun>True</PublishReadyToRun>` (for CoreCLR, when trimming is enabled)
 
 Consider submitting a [bug][bug] if you are getting one of these
 warnings under normal circumstances.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.CoreCLR.targets
@@ -17,6 +17,9 @@ This file contains the CoreCLR-specific MSBuild logic for .NET for Android.
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' ">
     <!-- Default PublishReadyToRun to true for CoreCLR Release mode and publish builds without debug symbols -->
     <PublishReadyToRun Condition=" '$(PublishReadyToRun)' == '' and ('$(Configuration)' == 'Release' or ('$(_IsPublishing)' == 'true' and '$(DebugSymbols)' != 'true')) ">true</PublishReadyToRun>
+    <_AndroidReadyToRunWithoutTrimming Condition=" '$(PublishReadyToRun)' == 'true' and '$(PublishTrimmed)' != 'true' ">true</_AndroidReadyToRunWithoutTrimming>
+    <PublishReadyToRun Condition=" '$(_AndroidReadyToRunWithoutTrimming)' == 'true' ">false</PublishReadyToRun>
+    <PublishReadyToRunComposite Condition=" '$(_AndroidReadyToRunWithoutTrimming)' == 'true' ">false</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition=" '$(PublishReadyToRunComposite)' == '' and '$(PublishReadyToRun)' == 'true' ">true</PublishReadyToRunComposite>
     <_IsPublishing Condition=" '$(_IsPublishing)' == '' and '$(PublishReadyToRun)' == 'true' ">true</_IsPublishing>
     <AllowReadyToRunWithoutRuntimeIdentifier Condition=" '$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifiers)' != '' ">true</AllowReadyToRunWithoutRuntimeIdentifier>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -317,6 +317,10 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <value>Using fast deployment and ReadyToRun at the same time is not recommended. Use fast deployment for Debug configurations and ReadyToRun for Release configurations.</value>
     <comment>The following are literal names and should not be translated: ReadyToRun, Debug, Release.</comment>
   </data>
+  <data name="XA0119_ReadyToRunWithoutTrimming" xml:space="preserve">
+    <value>ReadyToRun has been disabled because trimming is disabled. Set the 'PublishTrimmed' MSBuild property to 'true' to use ReadyToRun.</value>
+    <comment>The following are literal names and should not be translated: ReadyToRun, 'PublishTrimmed', 'true'.</comment>
+  </data>
   <data name="XA0121" xml:space="preserve">
     <value>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</value>
     <comment>The following are literal names and should not be translated: [assembly: {1}], NuGet

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2302,6 +2302,7 @@ public class ToolbarEx {
 
 		[Test]
 		[TestCase (true, AndroidRuntime.CoreCLR)]
+		[TestCase (false, AndroidRuntime.CoreCLR)]
 		// TODO: [TestCase (false, AndroidRuntime.NativeAOT)]
 		public void SimilarAndroidXAssemblyNames (bool publishTrimmed, AndroidRuntime runtime)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2336,6 +2336,7 @@ public class ToolbarEx {
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", "AndroidX.CustomView.PoolingContainer.PoolingContainer.IsPoolingContainer (null);");
 			using var builder = CreateApkBuilder ();
 			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+			StringAssertEx.Contains ("warning XA0119: ReadyToRun has been disabled because trimming is disabled.", builder.LastBuildOutput);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2302,25 +2302,9 @@ public class ToolbarEx {
 
 		[Test]
 		[TestCase (true, AndroidRuntime.CoreCLR)]
-		[TestCase (false, AndroidRuntime.CoreCLR)]
 		// TODO: [TestCase (false, AndroidRuntime.NativeAOT)]
 		public void SimilarAndroidXAssemblyNames (bool publishTrimmed, AndroidRuntime runtime)
 		{
-			if (!publishTrimmed && runtime == AndroidRuntime.CoreCLR) {
-				// This currently fails with the following exception:
-				//
-				// error XALNS7015: System.NotSupportedException: Writing mixed-mode assemblies is not supported
-				//  at Mono.Cecil.ModuleWriter.Write(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
-				//  at Mono.Cecil.ModuleWriter.WriteModule(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
-				//  at Mono.Cecil.ModuleDefinition.Write(String fileName, WriterParameters parameters)
-				//  at Mono.Cecil.AssemblyDefinition.Write(String fileName, WriterParameters parameters)
-				//  at Xamarin.Android.Tasks.SaveChangedAssemblyStep.ProcessAssembly(AssemblyDefinition assembly, StepContext context) in src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs:line 197
-				//  at Xamarin.Android.Tasks.AssemblyPipeline.Run(AssemblyDefinition assembly, StepContext context) in src/Xamarin.Android.Build.Tasks/Utilities/AssemblyPipeline.cs:line 26
-				//  at Xamarin.Android.Tasks.AssemblyModifierPipeline.RunPipeline(AssemblyPipeline pipeline, ITaskItem source, ITaskItem destination) in src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs:line 175
-				Assert.Ignore ("CoreCLR: fails because of a Mono.Cecil lack of support");
-				return;
-			}
-
 			bool aotAssemblies = runtime == AndroidRuntime.MonoVM && publishTrimmed;
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
@@ -2332,6 +2316,23 @@ public class ToolbarEx {
 			};
 			proj.SetRuntime (runtime);
 			proj.SetProperty (KnownProperties.PublishTrimmed, publishTrimmed.ToString());
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", "AndroidX.CustomView.PoolingContainer.PoolingContainer.IsPoolingContainer (null);");
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+		}
+
+		[Test]
+		public void FixAbstractMethodsOnReadyToRunAssembly ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+				PackageReferences = {
+					new Package { Id = "Xamarin.AndroidX.CustomView", Version = "1.1.0.17" },
+					new Package { Id = "Xamarin.AndroidX.CustomView.PoolingContainer", Version = "1.0.0.4" },
+				}
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty (KnownProperties.PublishTrimmed, false.ToString ());
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", "AndroidX.CustomView.PoolingContainer.PoolingContainer.IsPoolingContainer (null);");
 			using var builder = CreateApkBuilder ();
 			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -115,6 +115,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty ("AndroidEnableAssemblyCompression", "false");
 			proj.SetProperty ("Optimize", "true");
 			proj.SetProperty ("DebugType", "None");
+			proj.SetProperty ("PublishTrimmed", "true");
 			proj.SetProperty ("PublishReadyToRunComposite", isComposite.ToString ());
 
 			// Use `dotnet publish` rather than `msbuild /t:Publish`: only the `dotnet publish` CLI

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -528,6 +528,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ResourceName="XA0119_ReadyToRun"
       Condition=" '$(AndroidEnableFastDeployment)' == 'True' And '$(PublishReadyToRun)' == 'True' "
   />
+  <AndroidWarning Code="XA0119"
+      ResourceName="XA0119_ReadyToRunWithoutTrimming"
+      Condition=" '$(_AndroidReadyToRunWithoutTrimming)' == 'true' "
+  />
   <AndroidWarning Code="XA1027"
       ResourceName="XA1027"
       Condition=" $(_AndroidXA1027) == 'true' "


### PR DESCRIPTION
## Summary

- disable CoreCLR ReadyToRun and composite ReadyToRun when trimming is disabled
- emit XA0119 explaining that `PublishTrimmed=true` is required to use ReadyToRun
- keep non-trimmed assemblies as IL so `_LinkAssembliesNoShrink` can safely apply `FixAbstractMethodsStep`
- add coverage for the binding-assembly rewrite that previously failed with XALNS7015

## Testing

- `Xamarin.Android.Build.Tests` builds successfully
- `FixAbstractMethodsOnReadyToRunAssembly` passes and asserts the XA0119 warning

Fixes: #11025