### PR TITLE
[build] Avoid archiving extracted library resources

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -609,6 +609,15 @@ namespace Microsoft.Android.Build.Tasks
 			}
 		}
 
+		public static void TryDeleteFile (string filename, Action<string> log)
+		{
+			try {
+				File.Delete (filename);
+			} catch (Exception ex) {
+				log ($"Could not delete '{filename}': {ex}");
+			}
+		}
+
 		const uint ppdb_signature = 0x424a5342;
 
 		public static bool IsPortablePdb (string filename)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -13,6 +13,7 @@ using Microsoft.Build.Framework;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using Xamarin.Android.Tools;
+using Xamarin.Tools.Zip;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks {
@@ -22,6 +23,7 @@ namespace Xamarin.Android.Tasks {
 
 		List<ITaskItem> archives = new List<ITaskItem> ();
 		List<ITaskItem> files = new List<ITaskItem> ();
+		List<string> temporaryArchives = new List<string> ();
 
 		public string? ExtraArgs { get; set; }
 
@@ -43,14 +45,21 @@ namespace Xamarin.Android.Tasks {
 
 		public async override System.Threading.Tasks.Task RunTaskAsync ()
 		{
-			await this.WhenAllWithLock (ResourcesToCompile ?? ResourceDirectories ?? [], ProcessDirectory);
+			try {
+				await this.WhenAllWithLock (ResourcesToCompile ?? ResourceDirectories ?? [], ProcessDirectory);
 
-			ProcessOutput ();
+				ProcessOutput ();
 
-			for (int i = archives.Count -1; i > 0; i-- ) {
-				if (!File.Exists (archives[i].ItemSpec)) {
-					archives.RemoveAt (i);
+				for (int i = archives.Count -1; i > 0; i-- ) {
+					if (!File.Exists (archives[i].ItemSpec)) {
+						archives.RemoveAt (i);
+					}
 				}
+			} finally {
+				foreach (var archive in temporaryArchives) {
+					File.Delete (archive);
+				}
+				temporaryArchives.Clear ();
 			}
 		}
 
@@ -80,6 +89,16 @@ namespace Xamarin.Android.Tasks {
 				outputArchive = GetFullPath (targetDir);
 			}
 			Directory.CreateDirectory (outputArchive);
+			if (isDirectory && OS.IsWindows && !IsPathOnlyASCII (fileOrDirectory)) {
+				var temporaryArchive = Path.Combine (outputArchive, $"{Path.GetRandomFileName ()}.zip");
+				lock (lockObject)
+					temporaryArchives.Add (temporaryArchive);
+				using (var zip = new ZipArchiveEx (temporaryArchive, FileMode.CreateNew)) {
+					zip.AddDirectory (fileOrDirectory, "res");
+				}
+				fileOrDirectory = temporaryArchive;
+				isArchive = true;
+			}
 			string expectedOutputFile;
 			if (isDirectory) {
 				if (flatFile.IsNullOrEmpty ())

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Android.Tasks {
 				}
 			} finally {
 				foreach (var archive in temporaryArchives) {
-					File.Delete (archive);
+					Files.TryDeleteFile (archive, LogDebugMessage);
 				}
 				temporaryArchives.Clear ();
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -89,12 +89,6 @@ namespace Xamarin.Android.Tasks {
 					filename = $"{filename}.flata";
 				outputArchive = Path.Combine (outputArchive, filename);
 				expectedOutputFile = outputArchive;
-				string archive = item.GetMetadata (ResolveLibraryProjectImports.ResourceDirectoryArchive);
-				if (!archive.IsNullOrEmpty () && File.Exists (archive)) {
-					LogDebugMessage ($"Found Compressed Resource Archive '{archive}'.");
-					fileOrDirectory = archive;
-					isArchive = true;
-				}
 			} else {
 				if (IsInvalidFilename (fileOrDirectory)) {
 					LogDebugMessage ($"Invalid filename, ignoring: {fileOrDirectory}");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -109,7 +109,6 @@ namespace Xamarin.Android.Tasks {
 						}
 						var fileTaskItem = new TaskItem (file, new Dictionary<string, string> () {
 							{ "ResourceDirectory", directory.ItemSpec },
-							{ ResolveLibraryProjectImports.ResourceDirectoryArchive, directory.GetMetadata (ResolveLibraryProjectImports.ResourceDirectoryArchive) },
 							{ "StampFile", generateArchive ? stampFile : file },
 							{ "FilesCache", filesCache},
 							{ "Hash", stampFile },

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -71,8 +71,6 @@ namespace Xamarin.Android.Tasks
 		internal const string OriginalFile = "OriginalFile";
 		internal const string AndroidSkipResourceProcessing = "AndroidSkipResourceProcessing";
 
-		internal const string ResourceDirectoryArchive = "ResourceDirectoryArchive";
-
 		internal const string NuGetPackageVersion = "NuGetPackageVersion";
 
 		internal const string NuGetPackageId = "NuGetPackageId";
@@ -80,7 +78,6 @@ namespace Xamarin.Android.Tasks
 		internal static readonly string [] KnownMetadata = new [] {
 			OriginalFile,
 			AndroidSkipResourceProcessing,
-			ResourceDirectoryArchive,
 			NuGetPackageId,
 			NuGetPackageVersion,
 		};
@@ -121,12 +118,14 @@ namespace Xamarin.Android.Tasks
 				.Select (s => new TaskItem (Path.GetFullPath (Path.Combine (s.ItemSpec, "../..")) + ".stamp"))
 				.ToArray ();
 
-			foreach (var directory in ResolvedResourceDirectories) {
-				Files.SetDirectoryWriteable (directory.ItemSpec);
-			}
+			if (OS.IsWindows) {
+				foreach (var directory in ResolvedResourceDirectories) {
+					Files.SetDirectoryWriteable (directory.ItemSpec);
+				}
 
-			foreach (var directory in ResolvedAssetDirectories) {
-				Files.SetDirectoryWriteable (directory.ItemSpec);
+				foreach (var directory in ResolvedAssetDirectories) {
+					Files.SetDirectoryWriteable (directory.ItemSpec);
+				}
 			}
 
 			if (!CacheFile.IsNullOrEmpty ()) {
@@ -204,7 +203,6 @@ namespace Xamarin.Android.Tasks
 				string importsDir = Path.Combine (outDirForDll, ImportsDirectory);
 				string nativeimportsDir = Path.Combine (outDirForDll, NativeImportsDirectory);
 				string resDir = Path.Combine (importsDir, "res");
-				string resDirArchive = Path.Combine (resDir, "..", "res.zip");
 				string assetsDir = Path.Combine (importsDir, "assets");
 				string nuGetPackageId = assemblyItem.GetMetadata (NuGetPackageId) ?? "";
 				string nuGetPackageVersion = assemblyItem.GetMetadata (NuGetPackageVersion) ?? "";
@@ -229,7 +227,6 @@ namespace Xamarin.Android.Tasks
 					if (Directory.Exists (resDir)) {
 						var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 							[OriginalFile] = assemblyPath,
-							[ResourceDirectoryArchive] = Path.GetFullPath (resDirArchive),
 							[NuGetPackageId] = nuGetPackageId,
 							[NuGetPackageVersion] = nuGetPackageVersion,
 						});
@@ -327,10 +324,8 @@ namespace Xamarin.Android.Tasks
 							// which resulted in missing resource issue.
 							// Here we replaced copy with use of '-S' option and made it to work.
 							if (Directory.Exists (resDir)) {
-								CreateResourceArchive (resDir, resDirArchive);
 								var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 									[OriginalFile] = assemblyPath,
-									[ResourceDirectoryArchive] = Path.GetFullPath (resDirArchive),
 									[NuGetPackageId] = nuGetPackageId,
 									[NuGetPackageVersion] = nuGetPackageVersion,
 								});
@@ -378,7 +373,6 @@ namespace Xamarin.Android.Tasks
 				string outDirForDll = Path.Combine (OutputImportDirectory, aarIdentityName);
 				string importsDir = Path.Combine (outDirForDll, ImportsDirectory);
 				string resDir = Path.Combine (importsDir, "res");
-				string resDirArchive = Path.Combine (resDir, "..", "res.zip");
 				string rTxt = Path.Combine (importsDir, "R.txt");
 				string assetsDir = Path.Combine (importsDir, "assets");
 				string proguardFile = Path.Combine (importsDir, "proguard.txt");
@@ -410,7 +404,6 @@ namespace Xamarin.Android.Tasks
 						resolvedResourceDirectories.Add (new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 							[OriginalFile] = Path.GetFullPath (aarFile.ItemSpec),
 							[AndroidSkipResourceProcessing] = skipProcessing,
-							[ResourceDirectoryArchive] = Path.GetFullPath (resDirArchive),
 							[NuGetPackageId] = nuGetPackageId,
 							[NuGetPackageVersion] = nuGetPackageVersion,
 						}));
@@ -466,8 +459,6 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 				if (Directory.Exists (resDir) || File.Exists (rTxt)) {
-					if (Directory.Exists (resDir))
-						CreateResourceArchive (resDir, resDirArchive);
 					var skipProcessing = aarFile.GetMetadata (AndroidSkipResourceProcessing);
 					if (skipProcessing.IsNullOrEmpty ()) {
 						skipProcessing = "True";
@@ -475,7 +466,6 @@ namespace Xamarin.Android.Tasks
 					resolvedResourceDirectories.Add (new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 						[OriginalFile] = aarFullPath,
 						[AndroidSkipResourceProcessing] = skipProcessing,
-						[ResourceDirectoryArchive] = Path.GetFullPath (resDirArchive),
 						[NuGetPackageId] = nuGetPackageId,
 						[NuGetPackageVersion] = nuGetPackageVersion,
 					}));
@@ -494,16 +484,6 @@ namespace Xamarin.Android.Tasks
 					}));
 				}
 			}
-		}
-
-		void CreateResourceArchive (string resDir, string outputFile)
-		{
-			var fileMode = File.Exists (outputFile) ? FileMode.Open : FileMode.CreateNew;
-			Files.ArchiveZipUpdate (outputFile, f => {
-				using (var zip = new ZipArchiveEx (f, fileMode)) {
-					zip.AddDirectory (resDir, "res");
-				}
-			});
 		}
 
 		static void AddJar (IDictionary<string, ITaskItem> jars, string destination, string path, string? originalFile = null, string? nuGetPackageId = null, string? nuGetPackageVersion = null)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -188,7 +188,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void Aapt2Compile ()
 		{
-			var path = Path.Combine (Root, "temp", "Aapt2Compile");
+			var path = Path.Combine (Root, "temp", "Aapt2CompileÜmläüt");
 			Directory.CreateDirectory (path);
 			var resPath = Path.Combine (path, "res");
 			var archivePath = Path.Combine(path, "flata");
@@ -220,6 +220,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var apk = ZipHelper.OpenZip (flatArchive)) {
 				Assert.AreEqual (2, apk.EntryCount, $"{flatArchive} should have 2 entries.");
 			}
+			Assert.AreEqual (0, Directory.GetFiles (path, "*.zip", SearchOption.AllDirectories).Length, "Temporary resource archives should have been deleted.");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -185,10 +185,11 @@ namespace Xamarin.Android.Build.Tests
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 
-		[Test]
-		public void Aapt2Compile ()
+		[TestCase ("Aapt2Compile")]
+		[TestCase ("Aapt2CompileÜmläüt")]
+		public void Aapt2Compile (string directoryName)
 		{
-			var path = Path.Combine (Root, "temp", "Aapt2CompileÜmläüt");
+			var path = Path.Combine (Root, "temp", directoryName);
 			Directory.CreateDirectory (path);
 			var resPath = Path.Combine (path, "res");
 			var archivePath = Path.Combine(path, "flata");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -67,10 +67,6 @@ This file is used by all project types, including binding projects.
       <Output TaskParameter="ProguardConfigFiles" ItemName="ProguardConfiguration" />
       <Output TaskParameter="ExtractedDirectories" ItemName="_ExtractedDirectories" />
     </ReadLibraryProjectImportsCache>
-    <ItemGroup>
-      <FileWrites Include="@(ResolvedResourceDirectories->'%(ResourceDirectoryArchive)')"
-          Condition=" '%(ResolvedResourceDirectories.ResourceDirectoryArchive)' != '' And Exists ('%(ResolvedResourceDirectories.ResourceDirectoryArchive)')" />
-    </ItemGroup>
   </Target>
 
   <Target Name="_BuildLibraryImportsCache"

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -815,5 +815,16 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 			Directory.CreateDirectory (path);
 			Assert.DoesNotThrow (() => Files.DeleteFile (path, "not a TaskLoggingHelper"));
 		}
+
+		[Test]
+		public void TryDeleteFile_LogsFailure ()
+		{
+			var path = Path.Combine (tempDir, "directory-instead-of-file-try-delete");
+			Directory.CreateDirectory (path);
+			string message = "";
+
+			Assert.DoesNotThrow (() => Files.TryDeleteFile (path, value => message = value));
+			Assert.That (message, Does.Contain (path));
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- compile extracted AAR and embedded-library resources directly from their resource directories
- stop creating duplicate `res.zip` archives under `obj/lp`
- avoid recursively checking and clearing read-only attributes on non-Windows systems
- remove the obsolete resource-archive metadata path so stale archives from older builds cannot be consumed

## Performance

In a clean MAUI Debug build, `ResolveLibraryProjectImports` fell from a median of about 5.8s to 3.3s. Compiling directories directly added only about 0.12s to AAPT2, for a net saving around 2.4s in this phase.

## Validation

- built `Xamarin.Android.Build.Tasks.csproj`
- clean and no-op MAUI LLVM-IR builds
- changed a resource inside a local AAR and confirmed the updated value in the packaged APK
- confirmed clean builds produce no `res.zip` files

Related: #10958