### PR TITLE
[build] Do not modify assemblies in the NuGet package cache

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2301,6 +2301,54 @@ public class ToolbarEx {
 		}
 
 		[Test]
+		public void BuildDoesNotModifyNuGetPackageCache ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+				GlobalPackagesFolder = Path.Combine (Root, TestName, "packages"),
+				TargetFramework = "net10.0-android",
+				PackageReferences = {
+					new Package { Id = "Humanizer.Core", Version = "2.14.1" },
+					new Package { Id = "Humanizer.Core.es", Version = "2.14.1" },
+				},
+			};
+			proj.SetRuntime (AndroidRuntime.MonoVM);
+			proj.SetProperty ("AndroidTypeMapImplementation", "llvm-ir");
+			proj.SetProperty (KnownProperties.PublishTrimmed, true.ToString ());
+			proj.MainActivity = proj.DefaultMainActivity
+				.Replace ("//${USINGS}", "using Humanizer;")
+				.Replace ("//${AFTER_ONCREATE}", "System.Console.WriteLine (System.DateTime.UtcNow.Humanize ());");
+
+			using var builder = CreateApkBuilder ();
+			var buildParameters = new [] { $"RestorePackagesPath={proj.GlobalPackagesFolder}" };
+			Assert.IsTrue (builder.Restore (proj, parameters: buildParameters), "Package restore should have succeeded.");
+
+			var satelliteAssemblies = Directory.GetFiles (proj.GlobalPackagesFolder, "*.resources.dll", SearchOption.AllDirectories);
+			Assert.IsNotEmpty (satelliteAssemblies, "The NuGet package should contain satellite assemblies.");
+
+			var originalWriteTimes = new Dictionary<string, DateTime> ();
+			foreach (string assembly in satelliteAssemblies) {
+				File.SetLastWriteTimeUtc (assembly, new DateTime (2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+				originalWriteTimes.Add (assembly, File.GetLastWriteTimeUtc (assembly));
+			}
+
+			// A package cache is immutable: deny write sharing and verify timestamps remain unchanged.
+			var packageLocks = satelliteAssemblies
+				.Select (assembly => File.Open (assembly, FileMode.Open, FileAccess.Read, FileShare.Read))
+				.ToList ();
+			try {
+				Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false, parameters: buildParameters), "Build should have succeeded.");
+				foreach (string assembly in satelliteAssemblies) {
+					Assert.AreEqual (originalWriteTimes [assembly], File.GetLastWriteTimeUtc (assembly), $"Build should not modify '{assembly}'.");
+				}
+			} finally {
+				foreach (var packageLock in packageLocks) {
+					packageLock.Dispose ();
+				}
+			}
+		}
+
+		[Test]
 		[TestCase (true, AndroidRuntime.CoreCLR)]
 		[TestCase (false, AndroidRuntime.CoreCLR)]
 		// TODO: [TestCase (false, AndroidRuntime.NativeAOT)]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2306,13 +2306,29 @@ public class ToolbarEx {
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
 				GlobalPackagesFolder = Path.Combine (Root, TestName, "packages"),
-				TargetFramework = "net10.0-android",
+				Imports = {
+					new Import (() => "EnableMarshalMethodsForPostLink.targets") {
+						TextContent = () =>
+"""
+<Project>
+	<!-- Exercise the in-place post-link path without enabling marshal methods for later CoreCLR targets. -->
+	<Target Name="_EnableMarshalMethodsForPostLink"
+		BeforeTargets="_RunAfterILLinkAdditionalSteps"
+		Condition=" '$(TestEnableMarshalMethodsForPostLink)' == 'true' ">
+		<PropertyGroup>
+			<_AndroidUseMarshalMethods>true</_AndroidUseMarshalMethods>
+		</PropertyGroup>
+	</Target>
+</Project>
+"""
+					},
+				},
 				PackageReferences = {
 					new Package { Id = "Humanizer.Core", Version = "2.14.1" },
 					new Package { Id = "Humanizer.Core.es", Version = "2.14.1" },
 				},
 			};
-			proj.SetRuntime (AndroidRuntime.MonoVM);
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
 			proj.SetProperty ("AndroidTypeMapImplementation", "llvm-ir");
 			proj.SetProperty (KnownProperties.PublishTrimmed, true.ToString ());
 			proj.MainActivity = proj.DefaultMainActivity
@@ -2322,6 +2338,8 @@ public class ToolbarEx {
 			using var builder = CreateApkBuilder ();
 			var buildParameters = new [] { $"RestorePackagesPath={proj.GlobalPackagesFolder}" };
 			Assert.IsTrue (builder.Restore (proj, parameters: buildParameters), "Package restore should have succeeded.");
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false, parameters: buildParameters),
+				"Initial build should have succeeded.");
 
 			var satelliteAssemblies = Directory.GetFiles (proj.GlobalPackagesFolder, "*.resources.dll", SearchOption.AllDirectories);
 			Assert.IsNotEmpty (satelliteAssemblies, "The NuGet package should contain satellite assemblies.");
@@ -2337,7 +2355,9 @@ public class ToolbarEx {
 				.Select (assembly => File.Open (assembly, FileMode.Open, FileAccess.Read, FileShare.Read))
 				.ToList ();
 			try {
-				Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false, parameters: buildParameters), "Build should have succeeded.");
+				var postLinkParameters = buildParameters.Append ("TestEnableMarshalMethodsForPostLink=true").ToArray ();
+				Assert.IsTrue (builder.RunTarget (proj, "_PrepareAssemblies", doNotCleanupOnUpdate: true, saveProject: false, parameters: postLinkParameters),
+					"Preparing assemblies should have succeeded.");
 				foreach (string assembly in satelliteAssemblies) {
 					Assert.AreEqual (originalWriteTimes [assembly], File.GetLastWriteTimeUtc (assembly), $"Build should not modify '{assembly}'.");
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2350,6 +2350,10 @@ public class ToolbarEx {
 				originalWriteTimes.Add (assembly, File.GetLastWriteTimeUtc (assembly));
 			}
 
+			var postLinkStamp = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "stamp", "_AdditionalPostLinkerSteps.stamp");
+			FileAssert.Exists (postLinkStamp);
+			File.Delete (postLinkStamp);
+
 			// A package cache is immutable: deny write sharing and verify timestamps remain unchanged.
 			var packageLocks = satelliteAssemblies
 				.Select (assembly => File.Open (assembly, FileMode.Open, FileAccess.Read, FileShare.Read))
@@ -2358,6 +2362,7 @@ public class ToolbarEx {
 				var postLinkParameters = buildParameters.Append ("TestEnableMarshalMethodsForPostLink=true").ToArray ();
 				Assert.IsTrue (builder.RunTarget (proj, "_PrepareAssemblies", doNotCleanupOnUpdate: true, saveProject: false, parameters: postLinkParameters),
 					"Preparing assemblies should have succeeded.");
+				FileAssert.Exists (postLinkStamp);
 				foreach (string assembly in satelliteAssemblies) {
 					Assert.AreEqual (originalWriteTimes [assembly], File.GetLastWriteTimeUtc (assembly), $"Build should not modify '{assembly}'.");
 				}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1472,8 +1472,10 @@ because xbuild doesn't support framework reference assemblies.
     Outputs="$(_AdditionalPostLinkerStepsFlag)">
   <MakeDir Directories="$(_AfterILLinkOutputDir)" Condition=" '$(_AndroidUseMarshalMethods)' != 'True' " />
   <ItemGroup>
-    <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' != 'True' " Include="@(ResolvedAssemblies->'$(_AfterILLinkOutputDir)%(DestinationSubPath)')" />
-    <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' == 'True' " Include="@(ResolvedAssemblies)" />
+    <_AfterILLinkSourceFiles Include="@(ResolvedAssemblies)"
+        Condition=" '$(_AndroidUseMarshalMethods)' != 'True' or !$([System.String]::Copy('%(ResolvedAssemblies.Filename)').ToLowerInvariant().EndsWith('.resources')) " />
+    <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' != 'True' " Include="@(_AfterILLinkSourceFiles->'$(_AfterILLinkOutputDir)%(DestinationSubPath)')" />
+    <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' == 'True' " Include="@(_AfterILLinkSourceFiles)" />
   </ItemGroup>
   <AssemblyModifierPipeline
       ApplicationJavaClass="$(AndroidApplicationJavaClass)"
@@ -1487,11 +1489,12 @@ because xbuild doesn't support framework reference assemblies.
       ReadSymbols="$(_AndroidLinkAssembliesReadSymbols)"
       ResolvedAssemblies="@(_AllResolvedAssemblies)"
       ResolvedUserAssemblies="@(ResolvedUserAssemblies)"
-      SourceFiles="@(ResolvedAssemblies)"
+      SourceFiles="@(_AfterILLinkSourceFiles)"
       TargetName="$(TargetName)">
   </AssemblyModifierPipeline>
   <Touch Files="$(_AdditionalPostLinkerStepsFlag)" AlwaysCreate="true" />
   <ItemGroup>
+    <_AfterILLinkSourceFiles Remove="@(_AfterILLinkSourceFiles)" />
     <_AfterILLinkDestFiles Remove="@(_AfterILLinkDestFiles)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(_AndroidUseMarshalMethods)' != 'True' ">


### PR DESCRIPTION
## Description

Android builds must treat the NuGet global package cache as read-only. However, satellite `*.resources.dll` files from NuGet packages were included in `ResolvedAssemblies` and passed to `AssemblyModifierPipeline` using their original package-cache paths.

When marshal methods were enabled, `_RunAfterILLinkAdditionalSteps` ran this pipeline in place. Even unchanged assemblies had their timestamps updated, and concurrent builds could fail when they attempted to write the same cached file.

Exclude satellite resource assemblies from the post-link modifier input only when the pipeline operates in place. The assemblies remain in the normal resolved-assembly flow, so they are still packaged, and non-in-place post-link processing is unchanged.

Add a regression test using `Humanizer.Core.es` from the public `dotnet-public` feed. It locks the package's resource assemblies and verifies that the build neither writes to them nor changes their timestamps.

## Tests

- `BuildDoesNotModifyNuGetPackageCache`
- `CheckIncludedAssemblies(True, CoreCLR)`

Fixes #11022