### PR TITLE
Fix NativeAOT custom release configurations

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -33,6 +33,7 @@
     <_AndroidRuntime Condition=" '$(_AndroidRuntime)' == '' and '$(PublishAot)' == 'true' and ('$(_IsPublishing)' == 'true' or '$(Optimize)' == 'true') ">NativeAOT</_AndroidRuntime>
     <_AndroidRuntime Condition=" '$(_AndroidRuntime)' == '' and '$(UseMonoRuntime)' == 'true' ">MonoVM</_AndroidRuntime>
     <_AndroidRuntime Condition=" '$(_AndroidRuntime)' == '' ">CoreCLR</_AndroidRuntime>
+    <NativeCompilationDuringPublish Condition=" '$(NativeCompilationDuringPublish)' == '' and '$(PublishAot)' == 'true' and '$(_AndroidRuntime)' != 'NativeAOT' ">false</NativeCompilationDuringPublish>
     <PublishAotUsingRuntimePack Condition=" '$(PublishAotUsingRuntimePack)' == '' and '$(_AndroidRuntime)' == 'NativeAOT' ">true</PublishAotUsingRuntimePack>
 
     <!-- Use $(AndroidMinimumSupportedApiLevel) for $(SupportedOSPlatformVersion) if unset -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -29,8 +29,9 @@
       See: https://github.com/dotnet/sdk/blob/955c0fc7b06e2fa34bacd076ed39f61e4fb61716/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L16
     -->
     <_GetChildProjectCopyToPublishDirectoryItems>false</_GetChildProjectCopyToPublishDirectoryItems>
-    <_AndroidRuntime Condition=" '$(PublishAot)' == 'true' ">NativeAOT</_AndroidRuntime>
-    <_AndroidRuntime Condition=" '$(PublishAot)' != 'true' and '$(UseMonoRuntime)' == 'true' ">MonoVM</_AndroidRuntime>
+    <!-- PublishAot enables analyzers for every build, but NativeAOT compilation only applies to publish or optimized builds. -->
+    <_AndroidRuntime Condition=" '$(_AndroidRuntime)' == '' and '$(PublishAot)' == 'true' and ('$(_IsPublishing)' == 'true' or '$(Optimize)' == 'true') ">NativeAOT</_AndroidRuntime>
+    <_AndroidRuntime Condition=" '$(_AndroidRuntime)' == '' and '$(UseMonoRuntime)' == 'true' ">MonoVM</_AndroidRuntime>
     <_AndroidRuntime Condition=" '$(_AndroidRuntime)' == '' ">CoreCLR</_AndroidRuntime>
     <PublishAotUsingRuntimePack Condition=" '$(PublishAotUsingRuntimePack)' == '' and '$(_AndroidRuntime)' == 'NativeAOT' ">true</PublishAotUsingRuntimePack>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -100,10 +100,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('windows')) ">windows-x86_64</_NdkPrebuiltAbi>
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('osx')) ">darwin-x86_64</_NdkPrebuiltAbi>
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('linux')) ">linux-x86_64</_NdkPrebuiltAbi>
-      <!-- Runtime packs contain debug and release flavors, independent of the project's configuration name. -->
-      <_AndroidNativeAotRuntimeFlavor Condition=" '$(Optimize)' == 'true' ">release</_AndroidNativeAotRuntimeFlavor>
-      <_AndroidNativeAotRuntimeFlavor Condition=" '$(_AndroidNativeAotRuntimeFlavor)' == '' ">debug</_AndroidNativeAotRuntimeFlavor>
-      <_AndroidNativeAotRuntimeLibraryName>libnaot-android.$(_AndroidNativeAotRuntimeFlavor)-static-$(_AndroidNativeAotRuntimeFlavor)</_AndroidNativeAotRuntimeLibraryName>
 
       <!-- We need to explicitly specify the extension on Windows, since some Android NDK versions
            for Windows contain bash shell scripts without the extension, in addition to the
@@ -167,7 +163,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <!-- Satellite assemblies -->
       <IlcSatelliteAssembly Include="$(_OuterIntermediateSatelliteAssembliesWithTargetPath)" />
 
-      <_NdkLibs Include="@(RuntimePackAsset->WithMetadataValue('Filename', '$(_AndroidNativeAotRuntimeLibraryName)'))" />
+      <_NdkLibs Include="@(RuntimePackAsset->WithMetadataValue('Filename', 'libnaot-android.release-static-release'))" />
 
       <!-- Include libc++ -->
       <_NdkLibs Include="$(_NdkSysrootDir)libc++_static.a" />
@@ -282,7 +278,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
          _RuntimePackLibraryDirectory is not populated for NativeAOT, so derive the path from
          the libnaot-android RuntimePackAsset item. -->
     <ItemGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' == 'true' ">
-      <_NativeAotRuntimePackAsset Include="@(RuntimePackAsset->WithMetadataValue('Filename', '$(_AndroidNativeAotRuntimeLibraryName)'))" />
+      <_NativeAotRuntimePackAsset Include="@(RuntimePackAsset->WithMetadataValue('Filename', 'libnaot-android.release-static-release'))" />
     </ItemGroup>
     <PropertyGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' == 'true' ">
       <_NativeAotRuntimePackNativeDir>@(_NativeAotRuntimePackAsset->'%(RootDir)%(Directory)')</_NativeAotRuntimePackNativeDir>
@@ -338,7 +334,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
     <!-- When using workload linker, resolve libc++/libnaot from runtime pack dir.
          When using NDK, @(_NdkLibs) already has the right NDK sysroot paths. -->
     <ItemGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' == 'true' ">
-      <_NativeAotLinkLibraries Include="@(RuntimePackAsset->WithMetadataValue('Filename', '$(_AndroidNativeAotRuntimeLibraryName)'))" />
+      <_NativeAotLinkLibraries Include="@(RuntimePackAsset->WithMetadataValue('Filename', 'libnaot-android.release-static-release'))" />
       <_NativeAotLinkLibraries Include="$(_NativeAotRuntimePackNativeDir)libc++_static.a" />
       <_NativeAotLinkLibraries Include="$(_NativeAotRuntimePackNativeDir)libc++abi.a" />
     </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -100,6 +100,10 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('windows')) ">windows-x86_64</_NdkPrebuiltAbi>
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('osx')) ">darwin-x86_64</_NdkPrebuiltAbi>
       <_NdkPrebuiltAbi Condition=" $([MSBuild]::IsOSPlatform('linux')) ">linux-x86_64</_NdkPrebuiltAbi>
+      <!-- Runtime packs contain debug and release flavors, independent of the project's configuration name. -->
+      <_AndroidNativeAotRuntimeFlavor Condition=" '$(Optimize)' == 'true' ">release</_AndroidNativeAotRuntimeFlavor>
+      <_AndroidNativeAotRuntimeFlavor Condition=" '$(_AndroidNativeAotRuntimeFlavor)' == '' ">debug</_AndroidNativeAotRuntimeFlavor>
+      <_AndroidNativeAotRuntimeLibraryName>libnaot-android.$(_AndroidNativeAotRuntimeFlavor)-static-$(_AndroidNativeAotRuntimeFlavor)</_AndroidNativeAotRuntimeLibraryName>
 
       <!-- We need to explicitly specify the extension on Windows, since some Android NDK versions
            for Windows contain bash shell scripts without the extension, in addition to the
@@ -163,7 +167,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <!-- Satellite assemblies -->
       <IlcSatelliteAssembly Include="$(_OuterIntermediateSatelliteAssembliesWithTargetPath)" />
 
-      <_NdkLibs Include="@(RuntimePackAsset->WithMetadataValue('Filename', 'libnaot-android.$(Configuration.ToLower())-static-$(Configuration.ToLower())'))" />
+      <_NdkLibs Include="@(RuntimePackAsset->WithMetadataValue('Filename', '$(_AndroidNativeAotRuntimeLibraryName)'))" />
 
       <!-- Include libc++ -->
       <_NdkLibs Include="$(_NdkSysrootDir)libc++_static.a" />
@@ -278,7 +282,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
          _RuntimePackLibraryDirectory is not populated for NativeAOT, so derive the path from
          the libnaot-android RuntimePackAsset item. -->
     <ItemGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' == 'true' ">
-      <_NativeAotRuntimePackAsset Include="@(RuntimePackAsset->WithMetadataValue('Filename', 'libnaot-android.$(Configuration.ToLower())-static-$(Configuration.ToLower())'))" />
+      <_NativeAotRuntimePackAsset Include="@(RuntimePackAsset->WithMetadataValue('Filename', '$(_AndroidNativeAotRuntimeLibraryName)'))" />
     </ItemGroup>
     <PropertyGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' == 'true' ">
       <_NativeAotRuntimePackNativeDir>@(_NativeAotRuntimePackAsset->'%(RootDir)%(Directory)')</_NativeAotRuntimePackNativeDir>
@@ -334,7 +338,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
     <!-- When using workload linker, resolve libc++/libnaot from runtime pack dir.
          When using NDK, @(_NdkLibs) already has the right NDK sysroot paths. -->
     <ItemGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' == 'true' ">
-      <_NativeAotLinkLibraries Include="@(RuntimePackAsset->WithMetadataValue('Filename', 'libnaot-android.$(Configuration.ToLower())-static-$(Configuration.ToLower())'))" />
+      <_NativeAotLinkLibraries Include="@(RuntimePackAsset->WithMetadataValue('Filename', '$(_AndroidNativeAotRuntimeLibraryName)'))" />
       <_NativeAotLinkLibraries Include="$(_NativeAotRuntimePackNativeDir)libc++_static.a" />
       <_NativeAotLinkLibraries Include="$(_NativeAotRuntimePackNativeDir)libc++abi.a" />
     </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1585,7 +1585,8 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 					});
 				}
 
-				Assert.IsTrue (sb.Build (), "Solution should have built.");
+				var parameters = isRelease ? new [] { "Configuration=Release" } : [];
+				Assert.IsTrue (sb.Build (parameters), "Solution should have built.");
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -414,8 +414,9 @@ namespace Xamarin.Android.Build.Tests
 			};
 			app2.SetRuntime (runtime);
 			sb.Projects.Add (app2);
-			Assert.IsTrue (sb.Build (), "Build of solution should have succeeded");
-			Assert.IsTrue (sb.ReBuild (), "ReBuild of solution should have succeeded");
+			var parameters = isRelease ? new [] { "Configuration=Release" } : [];
+			Assert.IsTrue (sb.Build (parameters), "Build of solution should have succeeded");
+			Assert.IsTrue (sb.ReBuild (parameters), "ReBuild of solution should have succeeded");
 			sb.Dispose ();
 		}
 
@@ -453,8 +454,9 @@ namespace Xamarin.Android.Build.Tests
 				sb.Projects.Add (app1);
 			}
 			sb.BuildingInsideVisualStudio = false;
-			Assert.IsTrue (sb.Build (), "Build of solution should have succeeded");
-			Assert.IsTrue (sb.ReBuild (), "ReBuild of solution should have succeeded");
+			var parameters = runtime == AndroidRuntime.NativeAOT ? new [] { "Configuration=Release" } : [];
+			Assert.IsTrue (sb.Build (parameters), "Build of solution should have succeeded");
+			Assert.IsTrue (sb.ReBuild (parameters), "ReBuild of solution should have succeeded");
 			sb.Dispose ();
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -48,7 +48,6 @@ namespace Xamarin.Android.Build.Tests {
 			};
 			proj.SetRuntime (AndroidRuntime.CoreCLR);
 			proj.SetProperty (KnownProperties.PublishAot, "true");
-			proj.SetProperty ("NativeCompilationDuringPublish", "false");
 
 			using var builder = CreateApkBuilder ();
 			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Android.Build.Tests {
 			proj.SetProperty ("NativeCompilationDuringPublish", "false");
 
 			using var builder = CreateApkBuilder ();
-			Assert.IsTrue (builder.Build (proj, parameters: [ "_AndroidRuntime=CoreCLR" ]), "Build should have succeeded.");
+			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 
 			var intermediateDir = builder.Output.GetIntermediaryPath ("typemap");
 			AssertTrimmableTypeMapOutputs (intermediateDir);

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2783,7 +2783,7 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 			}
 			var apk = Path.Combine (outputDirectory, $"{proj.PackageName}-Signed.apk");
 			FileAssert.Exists (apk);
-			Assert.AreEqual ("Success", RunAdbCommand ($"install -r \"{apk}\"").Trim (), "APK should install.");
+			Assert.That (RunAdbCommand ($"install -r \"{apk}\"").Trim (), Does.EndWith ("Success"), "APK should install.");
 
 			ClearAdbLogcat ();
 			StartActivityAndAssert (proj);

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2755,6 +2755,44 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 		}
 
 		[Test]
+		public void NativeAOTCustomReleaseConfiguration ([Values] bool publish)
+		{
+			const string configuration = "AppStore";
+			var proj = new XamarinAndroidApplicationProject (releaseConfigurationName: configuration) {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.NativeAOT);
+			var rid = MonoAndroidHelper.AbiToRid (DeviceAbi);
+			proj.SetProperty ("RuntimeIdentifier", rid);
+			proj.SetProperty (proj.ReleaseProperties, "Optimize", "true");
+			proj.SetProperty (proj.ReleaseProperties, "DebugType", "None");
+
+			using var builder = CreateApkBuilder ();
+			builder.Save (proj);
+
+			var dotnet = new DotNetCLI (Path.Combine (Root, builder.ProjectDirectory, proj.ProjectFilePath));
+			var arguments = new [] { "-c", configuration };
+			var succeeded = publish
+				? dotnet.Publish (runtimeIdentifier: rid, msbuildArguments: arguments)
+				: dotnet.Build (runtimeIdentifier: rid, msbuildArguments: arguments);
+			Assert.IsTrue (succeeded, $"`dotnet {(publish ? "publish" : "build")} -c {configuration}` should succeed");
+
+			var outputDirectory = Path.Combine (Root, builder.ProjectDirectory, proj.OutputPath, rid);
+			if (publish) {
+				outputDirectory = Path.Combine (outputDirectory, "publish");
+			}
+			var apk = Path.Combine (outputDirectory, $"{proj.PackageName}-Signed.apk");
+			FileAssert.Exists (apk);
+			Assert.AreEqual ("Success", RunAdbCommand ($"install -r \"{apk}\"").Trim (), "APK should install.");
+
+			ClearAdbLogcat ();
+			StartActivityAndAssert (proj);
+			Assert.IsTrue (WaitForActivityToStart (proj.PackageName, "MainActivity",
+				Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), ActivityStartTimeoutInSeconds),
+				"Activity should have started.");
+		}
+
+		[Test]
 		public void NativeAOTSample ()
 		{
 			string [] properties = [


### PR DESCRIPTION
NativeAOT runtime-pack libraries only have `debug` and `release` flavors, but the Android targets derived their names from `$(Configuration)`. Custom release-like configurations such as `AppStore` therefore tried to resolve nonexistent runtime libraries.

This change:
- selects the NativeAOT runtime for publish or optimized builds with `PublishAot=true`
- keeps ordinary unoptimized Debug builds on CoreCLR while retaining NativeAOT analyzers and preventing ILC publish targets from running during build
- selects the runtime-pack library flavor from `$(Optimize)` instead of the configuration name
- makes NativeAOT solution tests explicitly build their Release configurations
- adds build and publish device coverage for a release-like `AppStore` configuration, including install and launch verification

Fixes: #10851