### PR TITLE
Fix concurrent creation of duplicate Java peers

### DIFF
--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -200,13 +200,30 @@ namespace Java.Interop
 					return null;
 				}
 
-				var peeked  = PeekPeer (reference);
-				if (peeked != null &&
-						(targetType == null ||
-							targetType.IsAssignableFrom (peeked.GetType ()))) {
-					return peeked;
+				while (true) {
+					var peeked = PeekPeer (reference);
+					if (peeked != null &&
+							(targetType == null ||
+								targetType.IsAssignableFrom (peeked.GetType ()))) {
+						return peeked;
+					}
+
+					var created = CreatePeer (ref reference, JniObjectReferenceOptions.Copy, targetType);
+					var registered = PeekPeer (reference);
+					if (registered != null &&
+							(targetType == null ||
+								targetType.IsAssignableFrom (registered.GetType ()))) {
+						if (created != null && !ReferenceEquals (created, registered)) {
+							DisposePeerUnlessReferenced (created);
+						}
+						return registered;
+					}
+					if (registered != null || created == null) {
+						return created;
+					}
+
+					DisposePeerUnlessReferenced (created);
 				}
-				return CreatePeer (ref reference, JniObjectReferenceOptions.Copy, targetType);
 			}
 
 			public abstract IJavaPeerable? CreatePeer (

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace Java.Interop
 {
@@ -46,7 +45,6 @@ namespace Java.Interop
 			internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
 			JniRuntime?             runtime;
-			readonly Lock           peerCreationLock = new ();
 			bool                    disposed;
 			public      JniRuntime  Runtime {
 				get => runtime ?? throw new NotSupportedException ();
@@ -207,16 +205,24 @@ namespace Java.Interop
 					return existing;
 				}
 
-				lock (peerCreationLock) {
-					// CreatePeer registers the new peer before returning. Check again while
-					// holding the lock so only one caller creates a peer for this reference.
-					existing = PeekPeer (reference);
-					if (IsCompatiblePeer (existing, targetType)) {
-						return existing;
-					}
+				var created = CreatePeer (ref reference, JniObjectReferenceOptions.Copy, targetType);
 
-					return CreatePeer (ref reference, JniObjectReferenceOptions.Copy, targetType);
+				// Creating a peer registers it, and registration -- not creation -- decides
+				// which peer is canonical for a given Java instance. Concurrent callers can
+				// therefore each create a peer while only one of them wins registration, so
+				// always hand back the registered winner and discard the loser. Serializing
+				// creation instead is not an option: CreatePeer() runs activation
+				// constructors and Java class loading, so a lock held across it would invert
+				// against Java monitors.
+				var registered = PeekPeer (reference);
+				if (!ReferenceEquals (created, registered) && IsCompatiblePeer (registered, targetType)) {
+					if (created != null) {
+						DisposePeerUnlessReferenced (created);
+					}
+					return registered;
 				}
+
+				return created;
 			}
 
 			static bool IsCompatiblePeer (IJavaPeerable? peer, Type? targetType)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace Java.Interop
 {
@@ -45,7 +46,7 @@ namespace Java.Interop
 			internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
 			JniRuntime?             runtime;
-			readonly object         peerCreationLock = new ();
+			readonly Lock           peerCreationLock = new ();
 			bool                    disposed;
 			public      JniRuntime  Runtime {
 				get => runtime ?? throw new NotSupportedException ();

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -200,31 +200,28 @@ namespace Java.Interop
 					return null;
 				}
 
-				while (true) {
-					var peeked = PeekPeer (reference);
-					if (peeked != null &&
-							(targetType == null ||
-								targetType.IsAssignableFrom (peeked.GetType ()))) {
-						return peeked;
-					}
-
-					var created = CreatePeer (ref reference, JniObjectReferenceOptions.Copy, targetType);
-					var registered = PeekPeer (reference);
-					if (registered != null &&
-							(targetType == null ||
-								targetType.IsAssignableFrom (registered.GetType ()))) {
-						if (created != null && !ReferenceEquals (created, registered)) {
-							DisposePeerUnlessReferenced (created);
-						}
-						return registered;
-					}
-					if (registered != null || created == null) {
-						return created;
-					}
-
-					DisposePeerUnlessReferenced (created);
+				var existing = PeekPeer (reference);
+				if (IsCompatiblePeer (existing, targetType)) {
+					return existing;
 				}
+
+				var created = CreatePeer (ref reference, JniObjectReferenceOptions.Copy, targetType);
+
+				// Peer construction registers the new instance. Another thread may have
+				// registered its own instance first, so always return the registered winner.
+				var registered = PeekPeer (reference);
+				if (IsCompatiblePeer (registered, targetType)) {
+					if (created != null && !ReferenceEquals (created, registered)) {
+						DisposePeerUnlessReferenced (created);
+					}
+					return registered;
+				}
+
+				return created;
 			}
+
+			static bool IsCompatiblePeer (IJavaPeerable? peer, Type? targetType)
+				=> peer != null && (targetType == null || targetType.IsAssignableFrom (peer.GetType ()));
 
 			public abstract IJavaPeerable? CreatePeer (
 				ref JniObjectReference reference,

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -45,6 +45,7 @@ namespace Java.Interop
 			internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
 			JniRuntime?             runtime;
+			readonly object         peerCreationLock = new ();
 			bool                    disposed;
 			public      JniRuntime  Runtime {
 				get => runtime ?? throw new NotSupportedException ();
@@ -205,19 +206,16 @@ namespace Java.Interop
 					return existing;
 				}
 
-				var created = CreatePeer (ref reference, JniObjectReferenceOptions.Copy, targetType);
-
-				// Peer construction registers the new instance. Another thread may have
-				// registered its own instance first, so always return the registered winner.
-				var registered = PeekPeer (reference);
-				if (IsCompatiblePeer (registered, targetType)) {
-					if (created != null && !ReferenceEquals (created, registered)) {
-						DisposePeerUnlessReferenced (created);
+				lock (peerCreationLock) {
+					// CreatePeer registers the new peer before returning. Check again while
+					// holding the lock so only one caller creates a peer for this reference.
+					existing = PeekPeer (reference);
+					if (IsCompatiblePeer (existing, targetType)) {
+						return existing;
 					}
-					return registered;
-				}
 
-				return created;
+					return CreatePeer (ref reference, JniObjectReferenceOptions.Copy, targetType);
+				}
 			}
 
 			static bool IsCompatiblePeer (IJavaPeerable? peer, Type? targetType)

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
@@ -45,8 +45,7 @@ namespace Java.InteropTests {
 				var second = Task.Run (() => vm.GetPeer (source.PeerReference));
 				Task.WaitAll (first, second);
 
-				Assert.AreEqual (2, vm.CreatePeerCount);
-				Assert.AreEqual (1, vm.DisposePeerCount);
+				Assert.AreEqual (1, vm.CreatePeerCount);
 				Assert.AreSame (first.Result, second.Result);
 			}
 		}
@@ -57,7 +56,6 @@ namespace Java.InteropTests {
 			IJavaPeerable registeredPeer;
 			int peekPeerCount;
 			int createPeerCount;
-			int disposePeerCount;
 
 			public ConcurrentGetPeerValueManager (JniPeerMembers peerMembers)
 			{
@@ -67,7 +65,6 @@ namespace Java.InteropTests {
 			public Barrier InitialPeekBarrier { get; set; }
 
 			public int CreatePeerCount => createPeerCount;
-			public int DisposePeerCount => disposePeerCount;
 
 			public override IJavaPeerable PeekPeer (JniObjectReference reference)
 			{
@@ -93,11 +90,6 @@ namespace Java.InteropTests {
 				return peer;
 			}
 
-			public override void DisposePeerUnlessReferenced (IJavaPeerable value)
-			{
-				Interlocked.Increment (ref disposePeerCount);
-				value.Dispose ();
-			}
 		}
 
 		class TestPeer : IJavaPeerable {

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
@@ -46,6 +46,7 @@ namespace Java.InteropTests {
 				Task.WaitAll (first, second);
 
 				Assert.AreEqual (2, vm.CreatePeerCount);
+				Assert.AreEqual (1, vm.DisposePeerCount);
 				Assert.AreSame (first.Result, second.Result);
 			}
 		}
@@ -56,6 +57,7 @@ namespace Java.InteropTests {
 			IJavaPeerable registeredPeer;
 			int peekPeerCount;
 			int createPeerCount;
+			int disposePeerCount;
 
 			public ConcurrentGetPeerValueManager (JniPeerMembers peerMembers)
 			{
@@ -65,6 +67,7 @@ namespace Java.InteropTests {
 			public Barrier InitialPeekBarrier { get; set; }
 
 			public int CreatePeerCount => createPeerCount;
+			public int DisposePeerCount => disposePeerCount;
 
 			public override IJavaPeerable PeekPeer (JniObjectReference reference)
 			{
@@ -92,6 +95,7 @@ namespace Java.InteropTests {
 
 			public override void DisposePeerUnlessReferenced (IJavaPeerable value)
 			{
+				Interlocked.Increment (ref disposePeerCount);
 				value.Dispose ();
 			}
 		}

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Java.Interop;
 
@@ -27,6 +29,126 @@ namespace Java.InteropTests {
 				x = vm.CreateValue<IJavaPeerable> (ref r, JniObjectReferenceOptions.Copy);
 				Assert.AreNotSame (o, x);
 				x.Dispose ();
+			}
+		}
+
+		[Test]
+		public void GetPeer_ReturnsRegisteredPeerConcurrently ()
+		{
+			using (var source = new JavaObject ())
+			using (var vm = new ConcurrentGetPeerValueManager (source.JniPeerMembers))
+			using (var start = new Barrier (2)) {
+				vm.OnSetRuntime (JniRuntime.CurrentRuntime);
+				vm.InitialPeekBarrier = start;
+
+				var first = Task.Run (() => vm.GetPeer (source.PeerReference));
+				var second = Task.Run (() => vm.GetPeer (source.PeerReference));
+				Task.WaitAll (first, second);
+
+				Assert.AreEqual (2, vm.CreatePeerCount);
+				Assert.AreSame (first.Result, second.Result);
+			}
+		}
+
+		class ConcurrentGetPeerValueManager : MyValueManager {
+
+			readonly JniPeerMembers peerMembers;
+			IJavaPeerable registeredPeer;
+			int peekPeerCount;
+			int createPeerCount;
+
+			public ConcurrentGetPeerValueManager (JniPeerMembers peerMembers)
+			{
+				this.peerMembers = peerMembers;
+			}
+
+			public Barrier InitialPeekBarrier { get; set; }
+
+			public int CreatePeerCount => createPeerCount;
+
+			public override IJavaPeerable PeekPeer (JniObjectReference reference)
+			{
+				var peer = Volatile.Read (ref registeredPeer);
+				if (Interlocked.Increment (ref peekPeerCount) <= 2 && InitialPeekBarrier != null) {
+					var barrier = InitialPeekBarrier;
+					if (!barrier.SignalAndWait (TimeSpan.FromSeconds (10))) {
+						throw new TimeoutException ("Timed out waiting for concurrent GetPeer() calls.");
+					}
+				}
+				return peer;
+			}
+
+			public override IJavaPeerable CreatePeer (
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions transfer,
+					[DynamicallyAccessedMembers (Constructors)]
+					Type targetType)
+			{
+				Interlocked.Increment (ref createPeerCount);
+				var peer = new TestPeer (reference, peerMembers);
+				Interlocked.CompareExchange (ref registeredPeer, peer, null);
+				return peer;
+			}
+
+			public override void DisposePeerUnlessReferenced (IJavaPeerable value)
+			{
+				value.Dispose ();
+			}
+		}
+
+		class TestPeer : IJavaPeerable {
+
+			JniObjectReference reference;
+			int identityHashCode;
+			JniManagedPeerStates state;
+
+			public TestPeer (JniObjectReference reference, JniPeerMembers peerMembers)
+			{
+				this.reference = reference;
+				JniPeerMembers = peerMembers;
+			}
+
+			public int JniIdentityHashCode => identityHashCode;
+
+			public JniObjectReference PeerReference => reference;
+
+			public JniPeerMembers JniPeerMembers { get; }
+
+			public JniManagedPeerStates JniManagedPeerState => state;
+
+			public void SetJniIdentityHashCode (int value)
+			{
+				identityHashCode = value;
+			}
+
+			public void SetPeerReference (JniObjectReference value)
+			{
+				reference = value;
+			}
+
+			public void SetJniManagedPeerState (JniManagedPeerStates value)
+			{
+				state = value;
+			}
+
+			public void UnregisterFromRuntime ()
+			{
+			}
+
+			public void DisposeUnlessReferenced ()
+			{
+			}
+
+			public void Disposed ()
+			{
+			}
+
+			public void Finalized ()
+			{
+			}
+
+			public void Dispose ()
+			{
 			}
 		}
 

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
@@ -45,7 +45,11 @@ namespace Java.InteropTests {
 				var second = Task.Run (() => vm.GetPeer (source.PeerReference));
 				Task.WaitAll (first, second);
 
-				Assert.AreEqual (1, vm.CreatePeerCount);
+				// Both callers miss the cache and create a peer -- creation is deliberately
+				// not serialized, because CreatePeer() runs activation constructors. Only one
+				// of them wins registration, and GetPeer() must hand that winner to both.
+				Assert.AreEqual (2, vm.CreatePeerCount);
+				Assert.AreSame (vm.RegisteredPeer, first.Result);
 				Assert.AreSame (first.Result, second.Result);
 			}
 		}
@@ -66,9 +70,13 @@ namespace Java.InteropTests {
 
 			public int CreatePeerCount => createPeerCount;
 
+			public IJavaPeerable RegisteredPeer => Volatile.Read (ref registeredPeer);
+
 			public override IJavaPeerable PeekPeer (JniObjectReference reference)
 			{
 				var peer = Volatile.Read (ref registeredPeer);
+				// Hold both callers at their *first* peek so both are guaranteed to miss
+				// before either one registers a peer.
 				if (Interlocked.Increment (ref peekPeerCount) <= 2 && InitialPeekBarrier != null) {
 					var barrier = InitialPeekBarrier;
 					if (!barrier.SignalAndWait (TimeSpan.FromSeconds (10))) {
@@ -85,7 +93,9 @@ namespace Java.InteropTests {
 					Type targetType)
 			{
 				Interlocked.Increment (ref createPeerCount);
-				var peer = new TestPeer (reference, peerMembers);
+				// Each peer owns its own reference, so discarding the loser cannot
+				// invalidate the winner or the source object.
+				var peer = new TestPeer (reference.NewGlobalRef (), peerMembers);
 				Interlocked.CompareExchange (ref registeredPeer, peer, null);
 				return peer;
 			}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -108,6 +108,7 @@ sealed class TypeMapAssemblyEmitter
 	MemberReferenceHandle _getActivationPeerRef;
 	MemberReferenceHandle _setActivationPeerReferenceRef;
 	MemberReferenceHandle _markActivationPeerReplaceableRef;
+	MemberReferenceHandle _markCreatedPeerReplaceableRef;
 	MemberReferenceHandle _waitForBridgeProcessingRef;
 	MemberReferenceHandle _androidEnvironmentUnhandledExceptionRef;
 	MemberReferenceHandle _ucoAttrCtorRef;
@@ -431,6 +432,11 @@ sealed class TypeMapAssemblyEmitter
 			sig => sig.MethodSignature ().Parameters (1,
 				rt => rt.Void (),
 				p => p.AddParameter ().Type ().IntPtr ()));
+
+		_markCreatedPeerReplaceableRef = _pe.AddMemberRef (_javaPeerProxyRef, "MarkCreatedPeerReplaceable",
+			sig => sig.MethodSignature ().Parameters (1,
+				rt => rt.Void (),
+				p => p.AddParameter ().Type ().Type (_iJavaPeerableRef, false)));
 
 		_waitForBridgeProcessingRef = _pe.AddMemberRef (_androidRuntimeInternalRef, "WaitForBridgeProcessing",
 			sig => sig.MethodSignature ().Parameters (0, rt => rt.Void (), p => { }));
@@ -800,25 +806,55 @@ sealed class TypeMapAssemblyEmitter
 		});
 	}
 
+	/// <summary>
+	/// Emits CreateInstance for XA-style activation (leaf type):
+	///   var obj = (TargetType)RuntimeHelpers.GetUninitializedObject(typeof(TargetType));
+	///   JavaPeerProxy.MarkCreatedPeerReplaceable(obj);
+	///   obj.Ctor(handle, ownership);
+	///   return obj;
+	/// </summary>
+	/// <remarks>
+	/// The peer is allocated uninitialized and marked replaceable before the activation
+	/// constructor runs, because that constructor is what registers the peer. See
+	/// <c>JavaPeerProxy.MarkCreatedPeerReplaceable()</c>. This mirrors
+	/// <c>TypeManager.CreateProxy()</c> in the non-trimmable typemap implementation.
+	/// </remarks>
 	void EmitCreateInstanceViaNewobj (EntityHandle typeRef)
 	{
 		var ctorRef = AddActivationCtorRef (typeRef);
 		EmitCreateInstanceBody (encoder => {
+			EmitUninitializedReplaceablePeer (encoder, typeRef);
+
+			encoder.OpCode (ILOpCode.Dup);
 			encoder.OpCode (ILOpCode.Ldarg_1);
 			encoder.OpCode (ILOpCode.Ldarg_2);
-			encoder.NewObject (ctorRef, parameterCount: 2);
+			encoder.Call (ctorRef, parameterCount: 2, isInstance: true);
+
 			encoder.Return (returnsValue: true);
 		});
+	}
+
+	/// <summary>
+	/// Emits, leaving the new instance on the stack:
+	///   var obj = (TargetType)RuntimeHelpers.GetUninitializedObject(typeof(TargetType));
+	///   JavaPeerProxy.MarkCreatedPeerReplaceable(obj);
+	/// </summary>
+	void EmitUninitializedReplaceablePeer (PEAssemblyBuilder.TrackedInstructionEncoder encoder, EntityHandle typeRef)
+	{
+		encoder.LoadToken (typeRef);
+		encoder.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
+		encoder.Call (_getUninitializedObjectRef, parameterCount: 1, returnsValue: true);
+		encoder.CastClass (typeRef);
+
+		encoder.OpCode (ILOpCode.Dup);
+		encoder.Call (_markCreatedPeerReplaceableRef, parameterCount: 1);
 	}
 
 	void EmitCreateInstanceInheritedCtor (EntityHandle targetTypeRef, ActivationCtorData activationCtor)
 	{
 		var baseActivationCtorRef = AddActivationCtorRef (_pe.ResolveTypeRef (activationCtor.DeclaringType));
 		EmitCreateInstanceBody (encoder => {
-			encoder.LoadToken (targetTypeRef);
-			encoder.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
-			encoder.Call (_getUninitializedObjectRef, parameterCount: 1, returnsValue: true);
-			encoder.CastClass (targetTypeRef);
+			EmitUninitializedReplaceablePeer (encoder, targetTypeRef);
 
 			encoder.OpCode (ILOpCode.Dup);
 			encoder.OpCode (ILOpCode.Ldarg_1);
@@ -831,16 +867,22 @@ sealed class TypeMapAssemblyEmitter
 
 	/// <summary>
 	/// Emits CreateInstance for JavaInterop-style activation (leaf type):
+	///   var result = (TargetType)RuntimeHelpers.GetUninitializedObject(typeof(TargetType));
+	///   JavaPeerProxy.MarkCreatedPeerReplaceable(result);
 	///   var jniRef = new JniObjectReference(handle);
-	///   var result = new TargetType(ref jniRef, JniObjectReferenceOptions.Copy);
+	///   result.Ctor(ref jniRef, JniObjectReferenceOptions.Copy);
 	///   JNIEnv.DeleteRef(handle, ownership);
 	///   return result;
 	/// </summary>
+	/// <remarks>
+	/// See <see cref="EmitCreateInstanceViaNewobj"/> for why the instance is allocated
+	/// uninitialized and marked replaceable before its activation constructor runs.
+	/// </remarks>
 	void EmitCreateInstanceViaJavaInteropNewobj (EntityHandle typeRef)
 	{
 		var ctorRef = AddJavaInteropActivationCtorRef (typeRef);
 		EmitCreateInstanceBodyWithLocals (
-			EncodeJniObjectReferenceAndObjectLocals,
+			EncodeJniObjectReferenceLocal,
 			encoder => {
 				// var jniRef = new JniObjectReference(handle, JniObjectReferenceType.Invalid);
 				encoder.LoadLocalAddress (0);
@@ -848,18 +890,20 @@ sealed class TypeMapAssemblyEmitter
 				encoder.LoadConstantI4 (0); // JniObjectReferenceType.Invalid
 				encoder.Call (_jniObjectReferenceCtorRef, parameterCount: 2, isInstance: true);
 
-				// var result = new TargetType(ref jniRef, JniObjectReferenceOptions.Copy);
+				EmitUninitializedReplaceablePeer (encoder, typeRef);
+
+				// result.Ctor(ref jniRef, JniObjectReferenceOptions.Copy);
+				// The result stays on the stack across JNIEnv.DeleteRef() below.
+				encoder.OpCode (ILOpCode.Dup);
 				encoder.LoadLocalAddress (0);
 				encoder.LoadConstantI4 (1); // JniObjectReferenceOptions.Copy
-				encoder.NewObject (ctorRef, parameterCount: 2);
-				encoder.StoreLocal (1); // save result
+				encoder.Call (ctorRef, parameterCount: 2, isInstance: true);
 
 				// JNIEnv.DeleteRef(handle, ownership);
 				encoder.OpCode (ILOpCode.Ldarg_1); // handle
 				encoder.OpCode (ILOpCode.Ldarg_2); // ownership
 				encoder.Call (_jniEnvDeleteRefRef, parameterCount: 2);
 
-				encoder.LoadLocal (1); // load result
 				encoder.Return (returnsValue: true);
 			});
 	}
@@ -879,10 +923,8 @@ sealed class TypeMapAssemblyEmitter
 			EncodeJniObjectReferenceLocal,
 			encoder => {
 				// var obj = (TargetType)RuntimeHelpers.GetUninitializedObject(typeof(TargetType));
-				encoder.LoadToken (targetTypeRef);
-				encoder.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
-				encoder.Call (_getUninitializedObjectRef, parameterCount: 1, returnsValue: true);
-				encoder.CastClass (targetTypeRef);
+				// JavaPeerProxy.MarkCreatedPeerReplaceable(obj);
+				EmitUninitializedReplaceablePeer (encoder, targetTypeRef);
 
 				// dup obj (one copy for the call, one for the return)
 				encoder.OpCode (ILOpCode.Dup);
@@ -914,18 +956,6 @@ sealed class TypeMapAssemblyEmitter
 		blob.WriteCompressedInteger (1); // 1 local variable
 		blob.WriteByte ((byte) SignatureTypeKind.ValueType);
 		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_jniObjectReferenceRef));
-	}
-
-	void EncodeJniObjectReferenceAndObjectLocals (BlobBuilder blob)
-	{
-		// LOCAL_SIG header (0x07), count = 2:
-		//   local 0: JniObjectReference (valuetype)
-		//   local 1: object (for storing the newobj result across the DeleteRef call)
-		blob.WriteByte ((byte) SignatureKind.LocalVariables);
-		blob.WriteCompressedInteger (2); // 2 local variables
-		blob.WriteByte ((byte) SignatureTypeKind.ValueType);
-		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_jniObjectReferenceRef));
-		blob.WriteByte ((byte) SignatureTypeCode.Object);
 	}
 
 	MemberReferenceHandle AddJavaInteropActivationCtorRef (EntityHandle declaringTypeRef)

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -110,6 +110,30 @@ namespace Java.Interop
 			peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
 		}
 
+		/// <summary>
+		/// Marks an implicitly created peer as replaceable, before its activation
+		/// constructor runs.
+		/// </summary>
+		/// <remarks>
+		/// Generated <see cref="CreateInstance"/> overrides call this on the
+		/// uninitialized instance before invoking the activation constructor, because the
+		/// constructor is what registers the peer and
+		/// <c>JniRuntime.JniValueManager.AddPeer()</c> arbitrates between an incoming and
+		/// an already registered peer using <see cref="JniManagedPeerStates.Replaceable"/>.
+		/// A peer that only becomes replaceable *after* it is registered would let a second
+		/// implicitly created peer evict it, so two threads wrapping the same Java instance
+		/// could each end up holding a different wrapper.
+		///
+		/// This mirrors <c>TypeManager.CreateProxy()</c>, which pre-marks the uninitialized
+		/// instance for the same reason.
+		/// </remarks>
+		public static void MarkCreatedPeerReplaceable (IJavaPeerable peer)
+		{
+			ArgumentNullException.ThrowIfNull (peer);
+
+			peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
+		}
+
 		static bool IsActivationPeer (IJavaPeerable peer)
 		{
 			var state = peer.JniManagedPeerState;

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
@@ -136,9 +136,9 @@ static class JavaMarshalRegisteredPeers
 						!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable)) {
 					peer.Dispose ();
 					peers [i] = new ReferenceTrackingHandle (value);
-				} else if ((!target.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable) ||
-							!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable)) &&
-						JniEnvironment.Runtime.ObjectReferenceManager.LogGlobalReferenceMessages) {
+				} else if (JniEnvironment.Runtime.ObjectReferenceManager.LogGlobalReferenceMessages &&
+						(!target.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable) ||
+							!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable))) {
 					WarnNotReplacing (key, value, target);
 				}
 				GC.KeepAlive (target);

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Android.Runtime;
 /// </remarks>
 static class JavaMarshalRegisteredPeers
 {
-	static readonly ConcurrentDictionary<int, List<ReferenceTrackingHandle>> RegisteredInstances = new ();
+	static readonly Dictionary<int, List<ReferenceTrackingHandle>> RegisteredInstances = new ();
 	static readonly ConcurrentQueue<IntPtr> CollectedContexts = new ();
 
 	static readonly object initializeLock = new ();
@@ -65,7 +65,9 @@ static class JavaMarshalRegisteredPeers
 				Debug.Assert (contextPtr != IntPtr.Zero, "CollectedContexts should not contain null pointers.");
 				HandleContext* context = (HandleContext*)contextPtr;
 
-				Remove (context);
+				lock (RegisteredInstances) {
+					Remove (context);
+				}
 
 				HandleContext.Free (ref context);
 			}
@@ -76,13 +78,15 @@ static class JavaMarshalRegisteredPeers
 				if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? peers))
 					return;
 
-				lock (peers) {
-					for (int i = peers.Count - 1; i >= 0; i--) {
-						if (peers [i].BelongsToContext (context)) {
-							peers.RemoveAt (i);
-						}
+				for (int i = peers.Count - 1; i >= 0; i--) {
+					var peer = peers [i];
+					if (peer.BelongsToContext (context)) {
+						peers.RemoveAt (i);
 					}
-					RemoveListIfEmpty (key, peers);
+				}
+
+				if (peers.Count == 0) {
+					RegisteredInstances.Remove (key);
 				}
 			}
 		}
@@ -102,48 +106,46 @@ static class JavaMarshalRegisteredPeers
 			JniObjectReference.Dispose (ref r, JniObjectReferenceOptions.CopyAndDispose);
 		}
 		int key = value.JniIdentityHashCode;
-		while (true) {
-			var peers = RegisteredInstances.GetOrAdd (key, static _ => []);
-			lock (peers) {
-				if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? current) ||
-						!ReferenceEquals (peers, current)) {
-					continue;
-				}
-
-				for (int i = peers.Count - 1; i >= 0; i--) {
-					ReferenceTrackingHandle peer = peers [i];
-					if (peer.Target is not IJavaPeerable target)
-						continue;
-					if (!JniEnvironment.Types.IsSameObject (target.PeerReference, value.PeerReference))
-						continue;
-					// JNIEnv.NewObject/JNIEnv.CreateInstance() compatibility.
-					// When two MCW's are created for one Java instance [0],
-					// we want the 2nd MCW to replace the 1st, as the 2nd is
-					// the one the dev created; the 1st is an implicit intermediary.
-					//
-					// Meanwhile, a new "replaceable" instance should *not* replace an
-					// existing "replaceable" instance; see dotnet/android#9862.
-					//
-					// [0]: If Java ctor invokes overridden virtual method, we'll
-					// transition into managed code w/o a registered instance, and
-					// thus will create an "intermediary" via
-					// (IntPtr, JniHandleOwnership) .ctor.
-					if (target.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable) &&
-							!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable)) {
-						peer.Dispose ();
-						peers [i] = new ReferenceTrackingHandle (value);
-					} else if ((!target.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable) ||
-								!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable)) &&
-							JniEnvironment.Runtime.ObjectReferenceManager.LogGlobalReferenceMessages) {
-						WarnNotReplacing (key, value, target);
-					}
-					GC.KeepAlive (target);
-					return;
-				}
-
-				peers.Add (new ReferenceTrackingHandle (value));
+		lock (RegisteredInstances) {
+			List<ReferenceTrackingHandle>? peers;
+			if (!RegisteredInstances.TryGetValue (key, out peers)) {
+				peers = [new ReferenceTrackingHandle (value)];
+				RegisteredInstances.Add (key, peers);
 				return;
 			}
+
+			for (int i = peers.Count - 1; i >= 0; i--) {
+				ReferenceTrackingHandle peer = peers [i];
+				if (peer.Target is not IJavaPeerable target)
+					continue;
+				if (!JniEnvironment.Types.IsSameObject (target.PeerReference, value.PeerReference))
+					continue;
+				// JNIEnv.NewObject/JNIEnv.CreateInstance() compatibility.
+				// When two MCW's are created for one Java instance [0],
+				// we want the 2nd MCW to replace the 1st, as the 2nd is
+				// the one the dev created; the 1st is an implicit intermediary.
+				//
+				// Meanwhile, a new "replaceable" instance should *not* replace an
+				// existing "replaceable" instance; see dotnet/android#9862.
+				//
+				// [0]: If Java ctor invokes overridden virtual method, we'll
+				// transition into managed code w/o a registered instance, and
+				// thus will create an "intermediary" via
+				// (IntPtr, JniHandleOwnership) .ctor.
+				if (target.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable) &&
+						!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable)) {
+					peer.Dispose ();
+					peers [i] = new ReferenceTrackingHandle (value);
+				} else if ((!target.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable) ||
+							!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable)) &&
+						JniEnvironment.Runtime.ObjectReferenceManager.LogGlobalReferenceMessages) {
+					WarnNotReplacing (key, value, target);
+				}
+				GC.KeepAlive (target);
+				return;
+			}
+
+			peers.Add (new ReferenceTrackingHandle (value));
 		}
 	}
 
@@ -170,10 +172,10 @@ static class JavaMarshalRegisteredPeers
 
 		int key = JniEnvironment.References.GetIdentityHashCode (reference);
 
-		if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? peers))
-			return null;
+		lock (RegisteredInstances) {
+			if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? peers))
+				return null;
 
-		lock (peers) {
 			for (int i = peers.Count - 1; i >= 0; i--) {
 				if (peers [i].Target is IJavaPeerable peer
 					&& JniEnvironment.Types.IsSameObject (reference, peer.PeerReference))
@@ -181,8 +183,11 @@ static class JavaMarshalRegisteredPeers
 					return peer;
 				}
 			}
-			return null;
+
+			if (peers.Count == 0)
+				RegisteredInstances.Remove (key);
 		}
+		return null;
 	}
 
 	public static void RemovePeer (IJavaPeerable value)
@@ -193,11 +198,11 @@ static class JavaMarshalRegisteredPeers
 		if (value == null)
 			throw new ArgumentNullException (nameof (value));
 
-		int key = value.JniIdentityHashCode;
-		if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? peers))
-			return;
+		lock (RegisteredInstances) {
+			int key = value.JniIdentityHashCode;
+			if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? peers))
+				return;
 
-		lock (peers) {
 			for (int i = peers.Count - 1; i >= 0; i--) {
 				ReferenceTrackingHandle peer = peers [i];
 				IJavaPeerable? target = peer.Target;
@@ -207,7 +212,8 @@ static class JavaMarshalRegisteredPeers
 				}
 				GC.KeepAlive (target);
 			}
-			RemoveListIfEmpty (key, peers);
+			if (peers.Count == 0)
+				RegisteredInstances.Remove (key);
 		}
 	}
 
@@ -251,24 +257,16 @@ static class JavaMarshalRegisteredPeers
 		// Remove any collected contexts before iterating over all the registered instances
 		CollectPeers ();
 
-		var peers = new List<JniSurfacedPeerInfo> (RegisteredInstances.Count);
-		foreach (var (identityHashCode, referenceTrackingHandles) in RegisteredInstances) {
-			lock (referenceTrackingHandles) {
+		lock (RegisteredInstances) {
+			var peers = new List<JniSurfacedPeerInfo> (RegisteredInstances.Count);
+			foreach (var (identityHashCode, referenceTrackingHandles) in RegisteredInstances) {
 				foreach (var peer in referenceTrackingHandles) {
 					if (peer.Target is IJavaPeerable target) {
 						peers.Add (new JniSurfacedPeerInfo (identityHashCode, new WeakReference<IJavaPeerable> (target)));
 					}
 				}
 			}
-		}
-		return peers;
-	}
-
-	static void RemoveListIfEmpty (int key, List<ReferenceTrackingHandle> peers)
-	{
-		if (peers.Count == 0) {
-			((ICollection<KeyValuePair<int, List<ReferenceTrackingHandle>>>) RegisteredInstances)
-				.Remove (new KeyValuePair<int, List<ReferenceTrackingHandle>> (key, peers));
+			return peers;
 		}
 	}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalRegisteredPeers.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Android.Runtime;
 /// </remarks>
 static class JavaMarshalRegisteredPeers
 {
-	static readonly Dictionary<int, List<ReferenceTrackingHandle>> RegisteredInstances = new ();
+	static readonly ConcurrentDictionary<int, List<ReferenceTrackingHandle>> RegisteredInstances = new ();
 	static readonly ConcurrentQueue<IntPtr> CollectedContexts = new ();
 
 	static readonly object initializeLock = new ();
@@ -65,9 +65,7 @@ static class JavaMarshalRegisteredPeers
 				Debug.Assert (contextPtr != IntPtr.Zero, "CollectedContexts should not contain null pointers.");
 				HandleContext* context = (HandleContext*)contextPtr;
 
-				lock (RegisteredInstances) {
-					Remove (context);
-				}
+				Remove (context);
 
 				HandleContext.Free (ref context);
 			}
@@ -78,15 +76,13 @@ static class JavaMarshalRegisteredPeers
 				if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? peers))
 					return;
 
-				for (int i = peers.Count - 1; i >= 0; i--) {
-					var peer = peers [i];
-					if (peer.BelongsToContext (context)) {
-						peers.RemoveAt (i);
+				lock (peers) {
+					for (int i = peers.Count - 1; i >= 0; i--) {
+						if (peers [i].BelongsToContext (context)) {
+							peers.RemoveAt (i);
+						}
 					}
-				}
-
-				if (peers.Count == 0) {
-					RegisteredInstances.Remove (key);
+					RemoveListIfEmpty (key, peers);
 				}
 			}
 		}
@@ -106,44 +102,48 @@ static class JavaMarshalRegisteredPeers
 			JniObjectReference.Dispose (ref r, JniObjectReferenceOptions.CopyAndDispose);
 		}
 		int key = value.JniIdentityHashCode;
-		lock (RegisteredInstances) {
-			List<ReferenceTrackingHandle>? peers;
-			if (!RegisteredInstances.TryGetValue (key, out peers)) {
-				peers = [new ReferenceTrackingHandle (value)];
-				RegisteredInstances.Add (key, peers);
-				return;
-			}
-
-			for (int i = peers.Count - 1; i >= 0; i--) {
-				ReferenceTrackingHandle peer = peers [i];
-				if (peer.Target is not IJavaPeerable target)
+		while (true) {
+			var peers = RegisteredInstances.GetOrAdd (key, static _ => []);
+			lock (peers) {
+				if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? current) ||
+						!ReferenceEquals (peers, current)) {
 					continue;
-				if (!JniEnvironment.Types.IsSameObject (target.PeerReference, value.PeerReference))
-					continue;
-				// JNIEnv.NewObject/JNIEnv.CreateInstance() compatibility.
-				// When two MCW's are created for one Java instance [0],
-				// we want the 2nd MCW to replace the 1st, as the 2nd is
-				// the one the dev created; the 1st is an implicit intermediary.
-				//
-				// Meanwhile, a new "replaceable" instance should *not* replace an
-				// existing "replaceable" instance; see dotnet/android#9862.
-				//
-				// [0]: If Java ctor invokes overridden virtual method, we'll
-				// transition into managed code w/o a registered instance, and
-				// thus will create an "intermediary" via
-				// (IntPtr, JniHandleOwnership) .ctor.
-				if (target.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable) &&
-						!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable)) {
-					peer.Dispose ();
-					peers [i] = new ReferenceTrackingHandle (value);
-				} else if (JniEnvironment.Runtime.ObjectReferenceManager.LogGlobalReferenceMessages) {
-					WarnNotReplacing (key, value, target);
 				}
-				GC.KeepAlive (target);
+
+				for (int i = peers.Count - 1; i >= 0; i--) {
+					ReferenceTrackingHandle peer = peers [i];
+					if (peer.Target is not IJavaPeerable target)
+						continue;
+					if (!JniEnvironment.Types.IsSameObject (target.PeerReference, value.PeerReference))
+						continue;
+					// JNIEnv.NewObject/JNIEnv.CreateInstance() compatibility.
+					// When two MCW's are created for one Java instance [0],
+					// we want the 2nd MCW to replace the 1st, as the 2nd is
+					// the one the dev created; the 1st is an implicit intermediary.
+					//
+					// Meanwhile, a new "replaceable" instance should *not* replace an
+					// existing "replaceable" instance; see dotnet/android#9862.
+					//
+					// [0]: If Java ctor invokes overridden virtual method, we'll
+					// transition into managed code w/o a registered instance, and
+					// thus will create an "intermediary" via
+					// (IntPtr, JniHandleOwnership) .ctor.
+					if (target.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable) &&
+							!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable)) {
+						peer.Dispose ();
+						peers [i] = new ReferenceTrackingHandle (value);
+					} else if ((!target.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable) ||
+								!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable)) &&
+							JniEnvironment.Runtime.ObjectReferenceManager.LogGlobalReferenceMessages) {
+						WarnNotReplacing (key, value, target);
+					}
+					GC.KeepAlive (target);
+					return;
+				}
+
+				peers.Add (new ReferenceTrackingHandle (value));
 				return;
 			}
-
-			peers.Add (new ReferenceTrackingHandle (value));
 		}
 	}
 
@@ -170,10 +170,10 @@ static class JavaMarshalRegisteredPeers
 
 		int key = JniEnvironment.References.GetIdentityHashCode (reference);
 
-		lock (RegisteredInstances) {
-			if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? peers))
-				return null;
+		if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? peers))
+			return null;
 
+		lock (peers) {
 			for (int i = peers.Count - 1; i >= 0; i--) {
 				if (peers [i].Target is IJavaPeerable peer
 					&& JniEnvironment.Types.IsSameObject (reference, peer.PeerReference))
@@ -181,11 +181,8 @@ static class JavaMarshalRegisteredPeers
 					return peer;
 				}
 			}
-
-			if (peers.Count == 0)
-				RegisteredInstances.Remove (key);
+			return null;
 		}
-		return null;
 	}
 
 	public static void RemovePeer (IJavaPeerable value)
@@ -196,11 +193,11 @@ static class JavaMarshalRegisteredPeers
 		if (value == null)
 			throw new ArgumentNullException (nameof (value));
 
-		lock (RegisteredInstances) {
-			int key = value.JniIdentityHashCode;
-			if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? peers))
-				return;
+		int key = value.JniIdentityHashCode;
+		if (!RegisteredInstances.TryGetValue (key, out List<ReferenceTrackingHandle>? peers))
+			return;
 
+		lock (peers) {
 			for (int i = peers.Count - 1; i >= 0; i--) {
 				ReferenceTrackingHandle peer = peers [i];
 				IJavaPeerable? target = peer.Target;
@@ -210,8 +207,7 @@ static class JavaMarshalRegisteredPeers
 				}
 				GC.KeepAlive (target);
 			}
-			if (peers.Count == 0)
-				RegisteredInstances.Remove (key);
+			RemoveListIfEmpty (key, peers);
 		}
 	}
 
@@ -255,16 +251,24 @@ static class JavaMarshalRegisteredPeers
 		// Remove any collected contexts before iterating over all the registered instances
 		CollectPeers ();
 
-		lock (RegisteredInstances) {
-			var peers = new List<JniSurfacedPeerInfo> (RegisteredInstances.Count);
-			foreach (var (identityHashCode, referenceTrackingHandles) in RegisteredInstances) {
+		var peers = new List<JniSurfacedPeerInfo> (RegisteredInstances.Count);
+		foreach (var (identityHashCode, referenceTrackingHandles) in RegisteredInstances) {
+			lock (referenceTrackingHandles) {
 				foreach (var peer in referenceTrackingHandles) {
 					if (peer.Target is IJavaPeerable target) {
 						peers.Add (new JniSurfacedPeerInfo (identityHashCode, new WeakReference<IJavaPeerable> (target)));
 					}
 				}
 			}
-			return peers;
+		}
+		return peers;
+	}
+
+	static void RemoveListIfEmpty (int key, List<ReferenceTrackingHandle> peers)
+	{
+		if (peers.Count == 0) {
+			((ICollection<KeyValuePair<int, List<ReferenceTrackingHandle>>>) RegisteredInstances)
+				.Remove (new KeyValuePair<int, List<ReferenceTrackingHandle>> (key, peers));
 		}
 	}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Android.Runtime;
 /// </summary>
 public class TrimmableTypeMap
 {
+	const JniHandleOwnership CreatedPeerOwnership = JniHandleOwnership.DoNotTransfer | JniHandleOwnership.DoNotRegister;
+
 	static readonly Lock s_initLock = new ();
 	static readonly JavaPeerProxy s_noPeerSentinel = new MissingJavaPeerProxy ();
 	static TrimmableTypeMap? s_instance;
@@ -348,21 +350,21 @@ public class TrimmableTypeMap
 
 		IJavaPeerable? peer;
 		if (ShouldActivateClosedGenericTarget (proxy, targetType)) {
-			peer = ActivateUsingReflection (targetType, handle, JniHandleOwnership.DoNotTransfer);
+			peer = ActivateUsingReflection (targetType, handle, CreatedPeerOwnership);
 		} else {
-			peer = proxy?.CreateInstance (handle, JniHandleOwnership.DoNotTransfer);
+			peer = proxy?.CreateInstance (handle, CreatedPeerOwnership);
 		}
 		if (peer is not null) {
-			MarkCreatedPeer (peer);
+			RegisterCreatedPeer (peer);
 		}
 		return peer;
 	}
 
 	internal IJavaPeerable? CreateInstanceWithoutReflectionFallback (IntPtr handle, Type? targetType = null)
 	{
-		var peer = GetProxyForJavaObject (handle, targetType)?.CreateInstance (handle, JniHandleOwnership.DoNotTransfer);
+		var peer = GetProxyForJavaObject (handle, targetType)?.CreateInstance (handle, CreatedPeerOwnership);
 		if (peer is not null) {
-			MarkCreatedPeer (peer);
+			RegisterCreatedPeer (peer);
 		}
 		return peer;
 	}
@@ -398,13 +400,14 @@ public class TrimmableTypeMap
 		return (IJavaPeerable) ctor.Invoke ([handle, transfer]);
 	}
 
-	static void MarkCreatedPeer (IJavaPeerable peer)
+	static void RegisterCreatedPeer (IJavaPeerable peer)
 	{
 		var peerState = peer.JniManagedPeerState | JniManagedPeerStates.Replaceable;
 		if (global::Java.Interop.Runtime.IsGCUserPeer (peer.PeerReference.Handle)) {
 			peerState |= JniManagedPeerStates.Activatable;
 		}
 		peer.SetJniManagedPeerState (peerState);
+		JniEnvironment.Runtime.ValueManager.AddPeer (peer);
 	}
 
 	/// <summary>

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Android.Runtime;
@@ -19,8 +20,6 @@ namespace Microsoft.Android.Runtime;
 /// </summary>
 public class TrimmableTypeMap
 {
-	const JniHandleOwnership CreatedPeerOwnership = JniHandleOwnership.DoNotTransfer | JniHandleOwnership.DoNotRegister;
-
 	static readonly Lock s_initLock = new ();
 	static readonly JavaPeerProxy s_noPeerSentinel = new MissingJavaPeerProxy ();
 	static TrimmableTypeMap? s_instance;
@@ -350,21 +349,21 @@ public class TrimmableTypeMap
 
 		IJavaPeerable? peer;
 		if (ShouldActivateClosedGenericTarget (proxy, targetType)) {
-			peer = ActivateUsingReflection (targetType, handle, CreatedPeerOwnership);
+			peer = ActivateUsingReflection (targetType, handle, JniHandleOwnership.DoNotTransfer);
 		} else {
-			peer = proxy?.CreateInstance (handle, CreatedPeerOwnership);
+			peer = proxy?.CreateInstance (handle, JniHandleOwnership.DoNotTransfer);
 		}
 		if (peer is not null) {
-			RegisterCreatedPeer (peer);
+			MarkCreatedPeer (peer);
 		}
 		return peer;
 	}
 
 	internal IJavaPeerable? CreateInstanceWithoutReflectionFallback (IntPtr handle, Type? targetType = null)
 	{
-		var peer = GetProxyForJavaObject (handle, targetType)?.CreateInstance (handle, CreatedPeerOwnership);
+		var peer = GetProxyForJavaObject (handle, targetType)?.CreateInstance (handle, JniHandleOwnership.DoNotTransfer);
 		if (peer is not null) {
-			RegisterCreatedPeer (peer);
+			MarkCreatedPeer (peer);
 		}
 		return peer;
 	}
@@ -397,17 +396,22 @@ public class TrimmableTypeMap
 			return null;
 		}
 
-		return (IJavaPeerable) ctor.Invoke ([handle, transfer]);
+		// Allocate and mark the peer before running the activation constructor, which is
+		// what registers it; see JavaPeerProxy.MarkCreatedPeerReplaceable(). Generated
+		// JavaPeerProxy.CreateInstance() overrides do the same thing.
+		var peer = (IJavaPeerable) RuntimeHelpers.GetUninitializedObject (closedType);
+		JavaPeerProxy.MarkCreatedPeerReplaceable (peer);
+		ctor.Invoke (peer, [handle, transfer]);
+		return peer;
 	}
 
-	static void RegisterCreatedPeer (IJavaPeerable peer)
+	static void MarkCreatedPeer (IJavaPeerable peer)
 	{
 		var peerState = peer.JniManagedPeerState | JniManagedPeerStates.Replaceable;
 		if (global::Java.Interop.Runtime.IsGCUserPeer (peer.PeerReference.Handle)) {
 			peerState |= JniManagedPeerStates.Activatable;
 		}
 		peer.SetJniManagedPeerState (peerState);
-		JniEnvironment.Runtime.ValueManager.AddPeer (peer);
 	}
 
 	/// <summary>

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapValueManager.cs
@@ -15,6 +15,9 @@ sealed partial class TrimmableTypeMapValueManager : JniRuntime.JniValueManager
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 	const JniObjectReferenceOptions DoNotRegisterTarget = JniObjectReferenceOptions.CopyAndDoNotRegister & ~JniObjectReferenceOptions.Copy;
 
+	[ThreadStatic]
+	static JniObjectReference createPeerReference;
+
 	public TrimmableTypeMapValueManager ()
 	{
 		JavaMarshalRegisteredPeers.InitializeIfNeeded ();
@@ -112,6 +115,10 @@ sealed partial class TrimmableTypeMapValueManager : JniRuntime.JniValueManager
 		}
 
 		if ((options & DoNotRegisterTarget) != DoNotRegisterTarget) {
+			if (createPeerReference.IsValid &&
+					JniEnvironment.Types.IsSameObject (peer.PeerReference, createPeerReference)) {
+				peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
+			}
 			AddPeer (peer);
 		}
 	}
@@ -130,8 +137,14 @@ sealed partial class TrimmableTypeMapValueManager : JniRuntime.JniValueManager
 
 		try {
 			var resolvedTargetType = ResolvePeerType (targetType);
-			return TrimmableTypeMap.Instance.CreateInstance (reference.Handle, resolvedTargetType)
-				?? NotFoundFallback (ref reference, targetType, resolvedTargetType);
+			var previousCreatePeerReference = createPeerReference;
+			createPeerReference = reference;
+			try {
+				return TrimmableTypeMap.Instance.CreateInstance (reference.Handle, resolvedTargetType)
+					?? NotFoundFallback (ref reference, targetType, resolvedTargetType);
+			} finally {
+				createPeerReference = previousCreatePeerReference;
+			}
 		} finally {
 			JniObjectReference.Dispose (ref reference, transfer);
 		}

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapValueManager.cs
@@ -15,9 +15,6 @@ sealed partial class TrimmableTypeMapValueManager : JniRuntime.JniValueManager
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 	const JniObjectReferenceOptions DoNotRegisterTarget = JniObjectReferenceOptions.CopyAndDoNotRegister & ~JniObjectReferenceOptions.Copy;
 
-	[ThreadStatic]
-	static JniObjectReference createPeerReference;
-
 	public TrimmableTypeMapValueManager ()
 	{
 		JavaMarshalRegisteredPeers.InitializeIfNeeded ();
@@ -115,10 +112,6 @@ sealed partial class TrimmableTypeMapValueManager : JniRuntime.JniValueManager
 		}
 
 		if ((options & DoNotRegisterTarget) != DoNotRegisterTarget) {
-			if (createPeerReference.IsValid &&
-					JniEnvironment.Types.IsSameObject (peer.PeerReference, createPeerReference)) {
-				peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
-			}
 			AddPeer (peer);
 		}
 	}
@@ -137,14 +130,8 @@ sealed partial class TrimmableTypeMapValueManager : JniRuntime.JniValueManager
 
 		try {
 			var resolvedTargetType = ResolvePeerType (targetType);
-			var previousCreatePeerReference = createPeerReference;
-			createPeerReference = reference;
-			try {
-				return TrimmableTypeMap.Instance.CreateInstance (reference.Handle, resolvedTargetType)
-					?? NotFoundFallback (ref reference, targetType, resolvedTargetType);
-			} finally {
-				createPeerReference = previousCreatePeerReference;
-			}
+			return TrimmableTypeMap.Instance.CreateInstance (reference.Handle, resolvedTargetType)
+				?? NotFoundFallback (ref reference, targetType, resolvedTargetType);
 		} finally {
 			JniObjectReference.Dispose (ref reference, transfer);
 		}

--- a/src/Mono.Android/PublicAPI/API-37/PublicAPI.Unshipped.txt
+++ b/src/Mono.Android/PublicAPI/API-37/PublicAPI.Unshipped.txt
@@ -4375,6 +4375,7 @@ static Android.Widget.PhotoPicker.PhotoPickerSelectionParams.Creator.get -> Andr
 static Android.Widget.PhotoPicker.PhotoPickerUiCustomizationParams.Creator.get -> Android.OS.IParcelableCreator!
 static Java.Interop.JavaPeerProxy.GetActivationPeer(nint jniSelf) -> Java.Interop.IJavaPeerable?
 static Java.Interop.JavaPeerProxy.MarkActivationPeerReplaceable(nint jniSelf) -> void
+static Java.Interop.JavaPeerProxy.MarkCreatedPeerReplaceable(Java.Interop.IJavaPeerable! peer) -> void
 static Java.Interop.JavaPeerProxy.SetActivationPeerReference(Java.Interop.IJavaPeerable! peer, nint jniSelf) -> void
 static Java.Interop.JavaPeerProxy.ShouldSkipActivation(nint jniSelf) -> bool
 static Java.Lang.Character.UnicodeBlock.CjkUnifiedIdeographsExtensionI.get -> Java.Lang.Character.UnicodeBlock?

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -426,6 +426,38 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void Generate_LeafCtor_CreateInstanceMarksPeerReplaceableBeforeActivation ()
+	{
+		var peers = ScanFixtures ();
+		// ClickableView has its own (IntPtr, JniHandleOwnership) ctor
+		var clickableView = peers.First (p => p.JavaName == "my/app/ClickableView");
+
+		using var stream = GenerateAssembly (new [] { clickableView }, "LeafCtorPreMarkTest");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		AssertCreateInstancePreMarksPeer (pe, reader, "MyApp_ClickableView_Proxy", "ClickableView");
+	}
+
+	[Fact]
+	public void Generate_LeafJavaInteropCtor_CreateInstanceMarksPeerReplaceableBeforeActivation ()
+	{
+		var peer = MakeAcwPeer ("test/JiLeafTarget", "Test.JiLeafTarget", "TestAsm") with {
+			ActivationCtor = new ActivationCtorInfo {
+				DeclaringTypeName = "Test.JiLeafTarget",
+				DeclaringAssemblyName = "TestAsm",
+				Style = ActivationCtorStyle.JavaInterop,
+			},
+		};
+
+		using var stream = GenerateAssembly (new [] { peer }, "LeafJiCtorPreMarkTest");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		AssertCreateInstancePreMarksPeer (pe, reader, "Test_JiLeafTarget_Proxy", "JiLeafTarget");
+	}
+
+	[Fact]
 	public void Generate_InheritedCtor_CreateInstanceDoesNotActivate ()
 	{
 		var peers = ScanFixtures ();
@@ -2699,6 +2731,61 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 
 	static void AssertCreateInstanceReturnsNull (PEReader pe, MetadataReader reader, string proxyTypeName)
 	{
+		var ilBytes = GetCreateInstanceIL (pe, reader, proxyTypeName);
+		Assert.Equal (new [] { (byte) ILOpCode.Ldnull, (byte) ILOpCode.Ret }, ilBytes);
+	}
+
+	/// <summary>
+	/// Asserts that CreateInstance allocates the peer uninitialized and marks it replaceable
+	/// *before* invoking the activation constructor, rather than using <c>newobj</c>.
+	/// The activation constructor is what registers the peer, and
+	/// <c>JniRuntime.JniValueManager.AddPeer()</c> arbitrates using
+	/// <c>JniManagedPeerStates.Replaceable</c>: a peer that only becomes replaceable after it
+	/// is registered can be evicted by a second implicitly created peer, so two threads
+	/// wrapping the same Java instance could each keep a different wrapper.
+	/// </summary>
+	static void AssertCreateInstancePreMarksPeer (
+			PEReader pe,
+			MetadataReader reader,
+			string proxyTypeName,
+			string targetTypeShortName)
+	{
+		var ilBytes = GetCreateInstanceIL (pe, reader, proxyTypeName);
+
+		Assert.True (
+			AllMemberRefHandles (reader)
+				.Where (h => reader.GetString (reader.GetMemberReference (h).Name) == "GetUninitializedObject")
+				.Any (h => ILContainsCallToken (ilBytes, MetadataTokens.GetToken (h))),
+			"CreateInstance should allocate the peer via RuntimeHelpers.GetUninitializedObject()");
+
+		Assert.True (
+			AllMemberRefHandles (reader)
+				.Where (h => reader.GetString (reader.GetMemberReference (h).Name) == "MarkCreatedPeerReplaceable")
+				.Any (h => ILContainsCallToken (ilBytes, MetadataTokens.GetToken (h))),
+			"CreateInstance should call JavaPeerProxy.MarkCreatedPeerReplaceable()");
+
+		var activationCtors = AllMemberRefHandles (reader)
+			.Where (h => {
+				var mref = reader.GetMemberReference (h);
+				if (reader.GetString (mref.Name) != ".ctor" || mref.Parent.Kind != HandleKind.TypeReference) {
+					return false;
+				}
+				var typeRef = reader.GetTypeReference ((TypeReferenceHandle) mref.Parent);
+				return reader.GetString (typeRef.Name) == targetTypeShortName;
+			})
+			.ToList ();
+		Assert.NotEmpty (activationCtors);
+
+		Assert.True (
+			activationCtors.Any (h => ILContainsCallToken (ilBytes, MetadataTokens.GetToken (h))),
+			$"CreateInstance should `call` the {targetTypeShortName} activation ctor on the pre-marked instance");
+		Assert.All (activationCtors, h => Assert.False (
+			ILContainsNewobjToken (ilBytes, MetadataTokens.GetToken (h)),
+			$"CreateInstance must not `newobj` {targetTypeShortName}: the peer would register before it is marked replaceable"));
+	}
+
+	static byte[] GetCreateInstanceIL (PEReader pe, MetadataReader reader, string proxyTypeName)
+	{
 		var proxyTypeHandle = reader.TypeDefinitions.First (h => {
 			var type = reader.GetTypeDefinition (h);
 			return reader.GetString (type.Namespace) == "_TypeMap.Proxies" &&
@@ -2712,7 +2799,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		Assert.NotNull (body);
 		var ilBytes = body.GetILBytes ();
 		Assert.NotNull (ilBytes);
-		Assert.Equal (new [] { (byte) ILOpCode.Ldnull, (byte) ILOpCode.Ret }, ilBytes!);
+		return ilBytes!;
 	}
 
 	static List<MemberReferenceHandle> AllMemberRefHandles (MetadataReader reader) =>


### PR DESCRIPTION
Fixes a startup race where two threads create two managed wrappers for the same Java instance and each keeps a different one.

`Application.Context` can permanently cache a non-canonical peer, which is why `Android.RuntimeTests.JnienvArrayMarshaling.GetObjectArray` flakes in the CoreCLR + trimmable typemap configuration: `Assert.AreSame (context, values [0])` compares the cached wrapper against the registered one.

## The race

Android runs instrumentation `onCreate()` before application `onCreate()`, so during startup:

- the main thread runs `App.onCreate()` → `Application.n_OnCreate()` → `GetObject<Application>(self)`
- the instrumentation thread runs `OnStart()` → reads `Application.Context`

Both miss `PeekPeer()` for the same Java `Application`, both create a peer, and both register. Two things then go wrong:

1. `GetPeer()` returned the peer *it* created rather than the one that won registration.
2. Implicitly created peers were marked `JniManagedPeerStates.Replaceable` only *after* the activation constructor had already registered them, so `AddPeer()` could not use `Replaceable` to keep the first one — the second peer, not yet marked, evicted the first.

## Changes

**Return the registered peer.** `JniRuntime.JniValueManager.GetPeer()` creates as before, then re-reads the registry and returns whichever peer won registration, disposing the loser. Registration was already the arbiter of peer identity; the only missing piece was handing that winner back to every caller.

Creation is deliberately *not* serialized. `CreatePeer()` runs activation constructors and Java class loading, so a lock held across it can invert against a Java monitor owned by another thread that is itself waiting to create a peer. It would also serialize every peer creation process-wide, in shared code used by all runtime configurations, while `GetValue()` and `JavaAs()` reach `CreatePeer()` without it.

**Mark implicitly created peers before activation.** Generated `JavaPeerProxy.CreateInstance()` overrides now allocate the peer with `RuntimeHelpers.GetUninitializedObject()`, mark it `Replaceable`, and then invoke the activation constructor, instead of using `newobj`. `TrimmableTypeMap`'s reflection fallback for closed generic targets does the same.

This mirrors `TypeManager.CreateProxy()` in the non-trimmable typemap implementation, which already establishes the invariant this way.

Both halves are required: pre-marking makes registration a stable "first implicit peer wins" arbiter, and canonicalization makes every caller receive that winner.

**Suppress a now-expected warning.** With pre-marking, two concurrently created implicit peers are both `Replaceable` when they meet in `AddPeer()`. That is the normal outcome, so it no longer logs `Warning: Not registering PeerReference=...`.

### Rejected alternative

An earlier revision passed `JniHandleOwnership.DoNotRegister` through `CreateInstance()` so registration could happen explicitly, after construction. That flag never reaches `ConstructPeerCore()` for two families of peers — `Java.Lang.Throwable.SetHandle()` hardcodes `JniObjectReferenceOptions.Copy`, and so do both generated Java.Interop-style activation paths — so the invariant silently did not hold for them. It also left peers unregistered while their constructors ran, where `JavaPeerProxy.ShouldSkipActivation()` and `GetActivationPeer()` would no longer find them.

## Validation

- `Java.Interop-Tests`: 680 passed, 6 skipped. `GetPeer_ReturnsRegisteredPeerConcurrently` uses a barrier to force both callers past the initial `PeekPeer()` miss, then asserts both created a peer and both received the registered winner.
- `Microsoft.Android.Sdk.TrimmableTypeMap.Tests`: 801 passed, including two new tests asserting the generated `CreateInstance` allocates uninitialized, calls `MarkCreatedPeerReplaceable()`, and `call`s the activation constructor rather than `newobj`-ing it — for both XA-style and Java.Interop-style leaf constructors.
- `Mono.Android.csproj` builds clean.

Still to do: an on-device run of `JnienvArrayMarshaling.GetObjectArray` in Release/CoreCLRTrimmable.

Closes #10973
