### PR TITLE
[release/11.0.1xx-rc1] Fix incremental APK archives and NuGet cache writes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildArchive.cs
@@ -158,15 +158,34 @@ public class BuildArchive : AndroidTask
 				// ItemSpec for these will be "<jarfile>#<entrypath>
 				// eg: "obj/myjar.jar#myfile.txt"
 				var jar_file_path = disk_path.Substring (0, disk_path.Length - (jar_entry_name.Length + 1));
+				var wasExistingOutputEntry = existingEntries.Remove (apk_path);
+				var hasApkEntry = apk.ContainsEntry (apk_path);
 
-				if (apk.ContainsEntry (apk_path)) {
+				if (hasApkEntry && !wasExistingOutputEntry) {
 					Log.LogDebugMessage ("Failed to add jar entry {0} from {1}: the same file already exists in the apk", jar_entry_name, Path.GetFileName (jar_file_path));
 					continue;
 				}
 
 				using (var stream = File.OpenRead (jar_file_path))
 				using (var jar = ZipArchive.Open (stream)) {
+					if (!jar.ContainsEntry (jar_entry_name)) {
+						Log.LogDebugMessage ("Failed to add jar entry {0} from {1}: entry not found in jar.", jar_entry_name, jar_file_path);
+						if (wasExistingOutputEntry)
+							existingEntries.Add (apk_path);
+						continue;
+					}
+
 					var jar_item = jar.ReadEntry (jar_entry_name);
+
+					if (hasApkEntry) {
+						// CRC is computed on uncompressed data — matching CRC means identical content regardless of compression settings.
+						if (apk.GetEntry (apk_path).CRC == jar_item.CRC) {
+							Log.LogDebugMessage ("Skipping {0} from {1} as it is up to date.", jar_entry_name, jar_file_path);
+							continue;
+						}
+
+						apk.DeleteEntry (apk_path);
+					}
 
 					byte [] data;
 					var d = MemoryStreamPool.Shared.Rent ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2301,6 +2301,79 @@ public class ToolbarEx {
 		}
 
 		[Test]
+		public void BuildDoesNotModifyNuGetPackageCache ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+				GlobalPackagesFolder = Path.Combine (Root, TestName, "packages"),
+				Imports = {
+					new Import (() => "EnableMarshalMethodsForPostLink.targets") {
+						TextContent = () =>
+"""
+<Project>
+	<!-- Exercise the in-place post-link path without enabling marshal methods for later CoreCLR targets. -->
+	<Target Name="_EnableMarshalMethodsForPostLink"
+		BeforeTargets="_RunAfterILLinkAdditionalSteps"
+		Condition=" '$(TestEnableMarshalMethodsForPostLink)' == 'true' ">
+		<PropertyGroup>
+			<_AndroidUseMarshalMethods>true</_AndroidUseMarshalMethods>
+		</PropertyGroup>
+	</Target>
+</Project>
+"""
+					},
+				},
+				PackageReferences = {
+					new Package { Id = "Humanizer.Core", Version = "2.14.1" },
+					new Package { Id = "Humanizer.Core.es", Version = "2.14.1" },
+				},
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("AndroidTypeMapImplementation", "llvm-ir");
+			proj.SetProperty (KnownProperties.PublishTrimmed, true.ToString ());
+			proj.MainActivity = proj.DefaultMainActivity
+				.Replace ("//${USINGS}", "using Humanizer;")
+				.Replace ("//${AFTER_ONCREATE}", "System.Console.WriteLine (System.DateTime.UtcNow.Humanize ());");
+
+			using var builder = CreateApkBuilder ();
+			var buildParameters = new [] { $"RestorePackagesPath={proj.GlobalPackagesFolder}" };
+			Assert.IsTrue (builder.Restore (proj, parameters: buildParameters), "Package restore should have succeeded.");
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false, parameters: buildParameters),
+				"Initial build should have succeeded.");
+
+			var satelliteAssemblies = Directory.GetFiles (proj.GlobalPackagesFolder, "*.resources.dll", SearchOption.AllDirectories);
+			Assert.IsNotEmpty (satelliteAssemblies, "The NuGet package should contain satellite assemblies.");
+
+			var originalWriteTimes = new Dictionary<string, DateTime> ();
+			foreach (string assembly in satelliteAssemblies) {
+				File.SetLastWriteTimeUtc (assembly, new DateTime (2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+				originalWriteTimes.Add (assembly, File.GetLastWriteTimeUtc (assembly));
+			}
+
+			var postLinkStamp = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "stamp", "_AdditionalPostLinkerSteps.stamp");
+			FileAssert.Exists (postLinkStamp);
+			File.Delete (postLinkStamp);
+
+			// A package cache is immutable: deny write sharing and verify timestamps remain unchanged.
+			var packageLocks = satelliteAssemblies
+				.Select (assembly => File.Open (assembly, FileMode.Open, FileAccess.Read, FileShare.Read))
+				.ToList ();
+			try {
+				var postLinkParameters = buildParameters.Append ("TestEnableMarshalMethodsForPostLink=true").ToArray ();
+				Assert.IsTrue (builder.RunTarget (proj, "_PrepareAssemblies", doNotCleanupOnUpdate: true, saveProject: false, parameters: postLinkParameters),
+					"Preparing assemblies should have succeeded.");
+				FileAssert.Exists (postLinkStamp);
+				foreach (string assembly in satelliteAssemblies) {
+					Assert.AreEqual (originalWriteTimes [assembly], File.GetLastWriteTimeUtc (assembly), $"Build should not modify '{assembly}'.");
+				}
+			} finally {
+				foreach (var packageLock in packageLocks) {
+					packageLock.Dispose ();
+				}
+			}
+		}
+
+		[Test]
 		[TestCase (true, AndroidRuntime.CoreCLR)]
 		[TestCase (false, AndroidRuntime.CoreCLR)]
 		// TODO: [TestCase (false, AndroidRuntime.NativeAOT)]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BuildArchiveTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BuildArchiveTests.cs
@@ -1,0 +1,189 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+using Xamarin.Tools.Zip;
+
+namespace Xamarin.Android.Build.Tests;
+
+[TestFixture]
+public class BuildArchiveTests
+{
+	string? tempDirectory;
+
+	string TempDirectory => tempDirectory ?? throw new InvalidOperationException ("Setup has not run.");
+
+	[SetUp]
+	public void Setup ()
+	{
+		tempDirectory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+		Directory.CreateDirectory (tempDirectory);
+	}
+
+	[TearDown]
+	public void TearDown ()
+	{
+		if (!tempDirectory.IsNullOrEmpty () && Directory.Exists (tempDirectory))
+			Directory.Delete (tempDirectory, recursive: true);
+	}
+
+	[Test]
+	public void ConsecutiveUnchangedBuildsKeepJavaArchiveEntries ()
+	{
+		var apk = Path.Combine (TempDirectory, "app.apk");
+		var jar = Path.Combine (TempDirectory, "classes.jar");
+
+		CreateArchive (apk, ("AndroidManifest.xml", "manifest"), ("commonMain/default/manifest", "existing"), ("stale.txt", "stale"));
+		CreateArchive (jar, ("commonMain/default/manifest", "current"));
+
+		var item = new TaskItem ($"{jar}#commonMain/default/manifest");
+		item.SetMetadata ("ArchivePath", "commonMain/default/manifest");
+		item.SetMetadata ("JavaArchiveEntry", "commonMain/default/manifest");
+		string? previousSnapshot = null;
+
+		for (var build = 1; build <= 3; build++) {
+			var task = new BuildArchive {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				ApkOutputPath = apk,
+				FilesToAddToArchive = [item],
+			};
+
+			Assert.IsTrue (task.RunTask (), $"build {build} should have succeeded");
+
+			var snapshot = GetArchiveSnapshot (apk);
+			if (previousSnapshot is not null)
+				Assert.AreEqual (previousSnapshot, snapshot, $"build {build} should match the previous unchanged build");
+			previousSnapshot = snapshot;
+
+			using (var archive = ZipArchive.Open (apk, FileMode.Open)) {
+				archive.AssertEntryContents (apk, "commonMain/default/manifest", "current");
+				archive.AssertDoesNotContainEntry (apk, "stale.txt");
+			}
+		}
+	}
+
+	[Test]
+	public void ExistingJavaArchiveEntriesAreSkippedWhenUpToDate ()
+	{
+		var apk = Path.Combine (TempDirectory, "app.apk");
+		var jar = Path.Combine (TempDirectory, "classes.jar");
+
+		CreateArchive (apk, ("commonMain/default/manifest", "current"));
+		CreateArchive (jar, ("commonMain/default/manifest", "current"));
+
+		var item = new TaskItem ($"{jar}#commonMain/default/manifest");
+		item.SetMetadata ("ArchivePath", "commonMain/default/manifest");
+		item.SetMetadata ("JavaArchiveEntry", "commonMain/default/manifest");
+		var messages = new List<BuildMessageEventArgs> ();
+
+		var task = new BuildArchive {
+			BuildEngine = new MockBuildEngine (TestContext.Out, messages: messages),
+			ApkOutputPath = apk,
+			FilesToAddToArchive = [item],
+		};
+
+		Assert.IsTrue (task.RunTask (), "task should have succeeded");
+
+		Assert.That (messages, Has.Some.Property (nameof (BuildMessageEventArgs.Message)).EqualTo ($"Skipping commonMain/default/manifest from {jar} as it is up to date."));
+
+		using (var archive = ZipArchive.Open (apk, FileMode.Open)) {
+			archive.AssertEntryContents (apk, "commonMain/default/manifest", "current");
+		}
+	}
+
+	[Test]
+	public void DuplicateJavaArchiveEntriesKeepFirstCurrentBuildItem ()
+	{
+		var apk = Path.Combine (TempDirectory, "app.apk");
+		var firstJar = Path.Combine (TempDirectory, "first.jar");
+		var secondJar = Path.Combine (TempDirectory, "second.jar");
+
+		CreateArchive (apk, ("stale.txt", "stale"));
+		CreateArchive (firstJar, ("commonMain/default/manifest", "first"));
+		CreateArchive (secondJar, ("commonMain/default/manifest", "second"));
+
+		var firstItem = new TaskItem ($"{firstJar}#commonMain/default/manifest");
+		firstItem.SetMetadata ("ArchivePath", "commonMain/default/manifest");
+		firstItem.SetMetadata ("JavaArchiveEntry", "commonMain/default/manifest");
+		var secondItem = new TaskItem ($"{secondJar}#commonMain/default/manifest");
+		secondItem.SetMetadata ("ArchivePath", "commonMain/default/manifest");
+		secondItem.SetMetadata ("JavaArchiveEntry", "commonMain/default/manifest");
+		var messages = new List<BuildMessageEventArgs> ();
+
+		var task = new BuildArchive {
+			BuildEngine = new MockBuildEngine (TestContext.Out, messages: messages),
+			ApkOutputPath = apk,
+			FilesToAddToArchive = [firstItem, secondItem],
+		};
+
+		Assert.IsTrue (task.RunTask (), "task should have succeeded");
+
+		Assert.That (messages, Has.Some.Property (nameof (BuildMessageEventArgs.Message)).EqualTo ("Failed to add jar entry commonMain/default/manifest from second.jar: the same file already exists in the apk"));
+
+		using (var archive = ZipArchive.Open (apk, FileMode.Open)) {
+			archive.AssertEntryContents (apk, "commonMain/default/manifest", "first");
+			archive.AssertDoesNotContainEntry (apk, "stale.txt");
+		}
+	}
+
+	[Test]
+	public void MissingJarEntryIsSkippedAndExistingOutputEntryIsRemoved ()
+	{
+		var apk = Path.Combine (TempDirectory, "app.apk");
+		var jar = Path.Combine (TempDirectory, "classes.jar");
+
+		CreateArchive (apk, ("commonMain/default/manifest", "existing"));
+		CreateArchive (jar, ("other-entry.txt", "contents"));
+
+		var item = new TaskItem ($"{jar}#commonMain/default/manifest");
+		item.SetMetadata ("ArchivePath", "commonMain/default/manifest");
+		item.SetMetadata ("JavaArchiveEntry", "commonMain/default/manifest");
+		var messages = new List<BuildMessageEventArgs> ();
+
+		var task = new BuildArchive {
+			BuildEngine = new MockBuildEngine (TestContext.Out, messages: messages),
+			ApkOutputPath = apk,
+			FilesToAddToArchive = [item],
+		};
+
+		Assert.IsTrue (task.RunTask (), "task should have succeeded");
+
+		Assert.That (messages, Has.Some.Property (nameof (BuildMessageEventArgs.Message)).EqualTo ($"Failed to add jar entry commonMain/default/manifest from {jar}: entry not found in jar."));
+
+		// The entry should be removed. If the APK itself no longer exists, all entries were cleared (also satisfies the assertion).
+		if (File.Exists (apk)) {
+			using (var archive = ZipArchive.Open (apk, FileMode.Open)) {
+				archive.AssertDoesNotContainEntry (apk, "commonMain/default/manifest");
+			}
+		}
+	}
+
+	static void CreateArchive (string path, params (string name, string contents) [] entries)
+	{
+		using (var stream = File.Create (path))
+		using (var archive = ZipArchive.Create (stream)) {
+			foreach (var entry in entries) {
+				archive.AddEntry (entry.name, entry.contents, encoding: Encoding.UTF8);
+			}
+		}
+	}
+
+	static string GetArchiveSnapshot (string path)
+	{
+		using var archive = ZipArchive.Open (path, FileMode.Open);
+		return string.Join ("\n", archive
+			.OrderBy (entry => entry.FullName, StringComparer.Ordinal)
+			.Select (entry => {
+				using var stream = new MemoryStream ();
+				entry.Extract (stream);
+				return $"{entry.FullName}:{Convert.ToBase64String (stream.ToArray ())}";
+			}));
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1468,8 +1468,10 @@ because xbuild doesn't support framework reference assemblies.
     Outputs="$(_AdditionalPostLinkerStepsFlag)">
   <MakeDir Directories="$(_AfterILLinkOutputDir)" Condition=" '$(_AndroidUseMarshalMethods)' != 'True' " />
   <ItemGroup>
-    <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' != 'True' " Include="@(ResolvedAssemblies->'$(_AfterILLinkOutputDir)%(DestinationSubPath)')" />
-    <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' == 'True' " Include="@(ResolvedAssemblies)" />
+    <_AfterILLinkSourceFiles Include="@(ResolvedAssemblies)"
+        Condition=" '$(_AndroidUseMarshalMethods)' != 'True' or !$([System.String]::Copy('%(ResolvedAssemblies.Filename)').ToLowerInvariant().EndsWith('.resources')) " />
+    <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' != 'True' " Include="@(_AfterILLinkSourceFiles->'$(_AfterILLinkOutputDir)%(DestinationSubPath)')" />
+    <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' == 'True' " Include="@(_AfterILLinkSourceFiles)" />
   </ItemGroup>
   <AssemblyModifierPipeline
       ApplicationJavaClass="$(AndroidApplicationJavaClass)"
@@ -1483,11 +1485,12 @@ because xbuild doesn't support framework reference assemblies.
       ReadSymbols="$(_AndroidLinkAssembliesReadSymbols)"
       ResolvedAssemblies="@(_AllResolvedAssemblies)"
       ResolvedUserAssemblies="@(ResolvedUserAssemblies)"
-      SourceFiles="@(ResolvedAssemblies)"
+      SourceFiles="@(_AfterILLinkSourceFiles)"
       TargetName="$(TargetName)">
   </AssemblyModifierPipeline>
   <Touch Files="$(_AdditionalPostLinkerStepsFlag)" AlwaysCreate="true" />
   <ItemGroup>
+    <_AfterILLinkSourceFiles Remove="@(_AfterILLinkSourceFiles)" />
     <_AfterILLinkDestFiles Remove="@(_AfterILLinkDestFiles)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(_AndroidUseMarshalMethods)' != 'True' ">


### PR DESCRIPTION
## Summary

- Backports #11552 (`286b38c3109cd39b5512fcfd23530e7cbba7db6f`) so incremental `BuildArchive` updates retain unchanged JAR resources, replace updated entries, and remove stale entries correctly.
- Backports #12450 (`66d3f745f5b231e5c82b78ee9fcf105f883dd9bd`) so in-place post-link processing excludes satellite assemblies from the NuGet package cache, while preserving normal packaging and non-in-place behavior.

## RC1 justification

These are narrowly scoped customer-facing correctness and reliability fixes. They prevent stale or incorrect APK contents during incremental builds, prevent mutation of NuGet package-cache assemblies, and avoid concurrent-build XAAMP7024 failures caused by writes to shared cached satellite assemblies.

There are no public API changes and no dependency changes.

## Validation

- PASS: `BuildArchiveTests` — 4 passed, 0 failed.
- PASS: `Xamarin.Android.Build.Tests` and its product dependencies compiled successfully with the host .NET 11 SDK after building the existing bootstrap task prerequisites.
- PASS: `Xamarin.Android.Common.targets` XML validation.
- The `BuildDoesNotModifyNuGetPackageCache` integration test compiled and started, but could not execute its nested app build because this checkout does not contain the repo-local SDK at `bin\Debug\dotnet\dotnet`; CI should provide full-build coverage.

Upstream references: https://github.com/dotnet/android/pull/11552 and https://github.com/dotnet/android/pull/12450.