### PR TITLE
[release/10.0.1xx] Complete Maven feed backport

### DIFF
--- a/eng/gradle/mirror-dependencies.ps1
+++ b/eng/gradle/mirror-dependencies.ps1
@@ -35,7 +35,8 @@
     Maven coordinates to mirror directly, for tests that do not use Gradle.
     Each value is group:artifact:version, which attempts the POM, JAR, AAR, and
     Gradle module metadata files. Append an exact filename as a fourth segment
-    when a test requests a nonstandard payload.
+    when a test requests a nonstandard payload. The command fails if no payload
+    can be mirrored for any requested coordinate.
 
 .PARAMETER GradleWrapper
     Optional path to the Gradle wrapper used by CI for this project, relative
@@ -126,7 +127,12 @@ function Invoke-Mirror($logPath) {
         ForEach-Object { $_.Matches } |
         ForEach-Object { $_.Groups[1].Value } |
         Sort-Object -Unique
-    if ($urls.Count -eq 0) { return 0 }
+    if ($urls.Count -eq 0) {
+        return [pscustomobject]@{
+            SuccessCount = 0
+            FailureCount = 0
+        }
+    }
     $token = Get-AzDevOpsToken
     $basicCredential = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$token"))
     $headers = @{ Authorization = "Basic $basicCredential" }
@@ -141,7 +147,10 @@ function Invoke-Mirror($logPath) {
         }
     }
     Write-Host "  -> mirrored OK=$ok, not-found=$fail (of $($urls.Count))" -ForegroundColor Cyan
-    return $urls.Count
+    return [pscustomobject]@{
+        SuccessCount = $ok
+        FailureCount = $fail
+    }
 }
 
 function Get-MavenArtifactUrls($artifacts) {
@@ -177,14 +186,25 @@ if ($PSCmdlet.ParameterSetName -eq 'MavenArtifact') {
     Write-Host "Mirroring Maven artifacts directly:"
     $MavenArtifact | ForEach-Object { Write-Host "  $_" }
     $log = Join-Path ([IO.Path]::GetTempPath()) 'maven-artifact-mirror.log'
+    $failedArtifacts = @()
     try {
-        Get-MavenArtifactUrls $MavenArtifact |
-            ForEach-Object { "Could not GET '$_'" } |
-            Set-Content $log
-        Invoke-Mirror $log | Out-Null
+        foreach ($artifact in $MavenArtifact) {
+            Get-MavenArtifactUrls $artifact |
+                ForEach-Object { "Could not GET '$_'" } |
+                Set-Content $log
+            $result = Invoke-Mirror $log
+            if ($result.SuccessCount -eq 0) {
+                $failedArtifacts += $artifact
+            }
+        }
     }
     finally {
         Remove-Item $log -ErrorAction SilentlyContinue
+    }
+    if ($failedArtifacts.Count -gt 0) {
+        Write-Host "`nNo payloads were mirrored for:" -ForegroundColor Red
+        $failedArtifacts | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+        exit 1
     }
     return
 }
@@ -208,8 +228,8 @@ try {
             Write-Host "`nBUILD SUCCESSFUL after $i iteration(s). The feed now has the packages CI needs." -ForegroundColor Green
             return
         }
-        $count = Invoke-Mirror $log
-        if ($count -eq 0) {
+        $result = Invoke-Mirror $log
+        if (($result.SuccessCount + $result.FailureCount) -eq 0) {
             Write-Host "`nGradle failed but no 401s to mirror — see $log" -ForegroundColor Red
             Get-Content $log -Tail 30
             exit 1

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaDependencyVerification.cs
@@ -272,7 +272,13 @@ class MSBuildLoggingPomResolver : IProjectResolver
 		try {
 			using (var file = File.OpenRead (filename)) {
 				var project = Project.Load (file);
-				var registered_artifact = Artifact.Parse (project.VersionedArtifactString);
+
+				// POMs may inherit GroupId/Version from a <parent> element, so fall back to
+				// the parent's values when the project itself doesn't declare them. (Without
+				// this, building an Artifact would fail validation with an empty coordinate.)
+				var groupId = project.GroupId.HasValue () ? project.GroupId : (project.Parent?.GroupId ?? "");
+				var version = project.Version.HasValue () ? project.Version : (project.Parent?.Version ?? "");
+				var registered_artifact = new Artifact (groupId, project.ArtifactId ?? "", version);
 
 				// Return the registered artifact, preferring any overrides specified in the task item
 				var final_artifact = new Artifact (

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/JavaDependencyVerificationTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/JavaDependencyVerificationTests.cs
@@ -79,6 +79,27 @@ public class JavaDependencyVerificationTests
 	}
 
 	[Test]
+	public void InheritedArtifactCoordinates ()
+	{
+		using var parent_pom = new PomBuilder ("com.google.auto.value", "auto-value-parent", "1.10.4").BuildTemporary ();
+		using var pom = new PomBuilder ("", "auto-value-annotations", "")
+			.WithParent ("com.google.auto.value", "auto-value-parent", "1.10.4")
+			.BuildTemporary ();
+
+		var engine = new MockBuildEngine (TestContext.Out, []);
+		var task = new JavaDependencyVerification {
+			BuildEngine = engine,
+			AndroidLibraries = [CreateAndroidLibraryTaskItem ("auto-value-annotations.jar", pom.FilePath)],
+			AdditionalManifests = [CreateAndroidAdditionManifestTaskItem (parent_pom.FilePath)],
+		};
+
+		var result = task.RunTask ();
+
+		Assert.True (result);
+		Assert.AreEqual (0, engine.Errors.Count);
+	}
+
+	[Test]
 	public void MissingSpecifiedDependency ()
 	{
 		using var pom = new PomBuilder ("com.google.android", "material", "1.0")


### PR DESCRIPTION
## Summary

- backport `1c4d41c09eec` so direct Maven mirroring fails when any requested coordinate produces no payloads
- update `external/Java.Interop` from `33992194b9373e9322244612c94ed9941b9bc2fd` to dotnet/java-interop#1498's single release backport commit `7c110bfad3ee0a87f303609426167722ccb4ba77`
- include the release-applicable Java.Interop Maven test and java-source-utils routing that could not be carried by the main-branch subtree patch
- seed the release JavaParser 3.18.0 dependency graph into `dotnet-public-maven` for anonymous CI resolution

## Backport mapping

| Main change | Release equivalent |
| --- | --- |
| `ce636392a229` / #11711, `3c62389651c2` / #12055, Android portions of `466da4a84dc2` / #12199, and `adffb38fd731` / #12368 | `659cd98e7fb9` / #12397 |
| `8df1e87799f1` / #12198, `7ace3137a4fa` / #12336, `c09c89aa1f2e` / #12338, `13727e665929` / #12335, and `d57b8c42f131` / #12367 | `352831edcba6` / #12396 |
| approved .NET tool feed portion of `fa00357649bb` / #11701 | `dc9a8524138e` / #12420 |
| `1c4d41c09eec` / #12412 | `24252012aaf6` in this PR |
| Java.Interop hardening plus release-applicable routing from `466da4a84dc2` | dotnet/java-interop#1498, pinned here at `7c110bfad3ee0a87f303609426167722ccb4ba77` |

The later Dependabot-only Google Maven exposure and unrelated Gradle/dependency version churn are intentionally excluded. The final Java.Interop pin supersedes the earlier hardening-only candidate without amending or force-pushing commits.

## Validation

- Java.Interop.Tools.Maven tests: 106 passed, 0 failed
- CI-mode `java-source-utils` `jar` build resolved through `dotnet-public-maven` and succeeded after the mirror helper seeded the full transitive graph
- `mirror-dependencies.ps1` parsed successfully with the PowerShell parser
- Java.Interop final SHA is exactly one commit on top of the release pin
- `git diff --check origin/release/10.0.1xx..HEAD`