### PR TITLE
Avoid copying transitive task dependencies

### DIFF
--- a/src/Microsoft.Android.Build.Tasks/Microsoft.Android.Build.Tasks.csproj
+++ b/src/Microsoft.Android.Build.Tasks/Microsoft.Android.Build.Tasks.csproj
@@ -17,6 +17,13 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+    <!--
+      We share $(OutputPath) with Xamarin.Android.Build.Tasks.csproj. Letting NuGet copy this
+      project's transitive runtime assets there can overwrite the netstandard2.0 assemblies
+      Build.Tasks already deposited with incompatible framework-specific implementations.
+      Only our compiled assembly needs to land in the SDK pack tools folder.
+    -->
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <!-- Microsoft.Build.* references flow transitively from Microsoft.Android.Build.BaseTasks. -->


### PR DESCRIPTION
## Description

Port the shared-output fix from #12468 to `main` by disabling `CopyLocalLockFileAssemblies` for `Microsoft.Android.Build.Tasks`.

The project shares the SDK pack tools output with `Xamarin.Android.Build.Tasks`; preventing transitive runtime asset copies avoids replacing compatible shared assemblies with framework-specific implementations.

## Validation

Built `Microsoft.Android.Build.Tasks.csproj` into an isolated shared SDK tools output and confirmed:

- `System.IO.Hashing.dll` is not copied
- `Microsoft.Android.Build.BaseTasks.dll` remains copied
- `Microsoft.Android.Build.Tasks.dll` is produced