### PR TITLE
[ci] Bound logcat capture time

### DIFF
--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -82,15 +82,19 @@ steps:
   # earlier step failed or the job was canceled - in particular a failed -t:Install
   # (which now fails the lane fast) or a hung/timed-out test run. Losing logcat in
   # exactly those cases would defeat the diagnostics this template exists for; the
-  # capture is best-effort (continueOnError + '|| echo'). See dotnet/android#11830.
-- script: >
-    DEST="$(Build.StagingDirectory)/Test${{ parameters.configuration }}/${{ parameters.artifactFolder }}/" &&
-    mkdir -p "$DEST" &&
-    adb logcat -d > "$DEST/logcat-${{ parameters.testName }}.txt" ||
-    echo "logcat capture failed"
+  # capture is best-effort and time-bounded. See dotnet/android#11830.
+- script: |
+    DEST="$(Build.StagingDirectory)/Test${{ parameters.configuration }}/${{ parameters.artifactFolder }}/"
+    mkdir -p "$DEST"
+    if adb devices | awk 'NR > 1 && $2 == "device" { found=1 } END { exit !found }'; then
+      adb logcat -d > "$DEST/logcat-${{ parameters.testName }}.txt" || echo "logcat capture failed"
+    else
+      echo "logcat capture skipped: no connected device"
+    fi
   displayName: capture logcat ${{ parameters.testName }}
   condition: always()
   continueOnError: true
+  timeoutInMinutes: 1
 
 - task: PublishTestResults@2
   displayName: publish ${{ parameters.testName }} results

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -86,7 +86,12 @@ steps:
 - script: |
     DEST="$(Build.StagingDirectory)/Test${{ parameters.configuration }}/${{ parameters.artifactFolder }}/"
     mkdir -p "$DEST"
-    if adb devices | awk 'NR > 1 && $2 == "device" { found=1 } END { exit !found }'; then
+    ADB_DEVICES="$(adb devices 2>&1)"
+    ADB_STATUS=$?
+    echo "$ADB_DEVICES"
+    if [ "$ADB_STATUS" -ne 0 ]; then
+      echo "logcat capture failed: adb devices exited with code $ADB_STATUS"
+    elif echo "$ADB_DEVICES" | awk 'NR > 1 && $2 == "device" { found=1 } END { exit !found }'; then
       adb logcat -d > "$DEST/logcat-${{ parameters.testName }}.txt" || echo "logcat capture failed"
     else
       echo "logcat capture skipped: no connected device"


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

`adb logcat -d` waits indefinitely when an earlier pipeline step fails before an emulator is available. Because logcat capture runs under `always()`, this can block the remaining tasks until the entire job times out.

Skip capture when `adb devices` reports no connected device. Also apply a one-minute task timeout so a device disconnect between the check and capture cannot hang the job.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed - N/A
- [ ] Unit tests - N/A; YAML-only pipeline behavior change