### PR TITLE
[build] Copy NDK redistributables when creating runtime packs

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -263,7 +263,6 @@
     <_MonoRuntimeFlavorDirName>mono</_MonoRuntimeFlavorDirName>
     <_CLRRuntimeFlavorDirName>clr</_CLRRuntimeFlavorDirName>
     <_NativeAotRuntimeFlavorDirName>nativeaot</_NativeAotRuntimeFlavorDirName>
-    <_RuntimeRedistDirName>redist</_RuntimeRedistDirName>
   </PropertyGroup>
 
   <!-- Whenever there's a need to use a locally built CoreCLR, both .NET for Android and the

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -44,16 +44,12 @@ projects that use the Microsoft.Android.Runtimes framework in .NET 6+.
   </Target>
 
  <Target Name="_GetRuntimePackItems"
-      DependsOnTargets="_GetLicense;_GetDefaultPackageVersion"
+      DependsOnTargets="_GetLicense;_GetDefaultPackageVersion;_AndroidGetNdkRedistributables"
       BeforeTargets="GetFilesToPackage" >
     <PropertyGroup>
       <_RuntimeFlavorDirName Condition=" '$(AndroidRuntime)' == 'CoreCLR' ">$(_CLRRuntimeFlavorDirName)</_RuntimeFlavorDirName>
       <_RuntimeFlavorDirName Condition=" '$(AndroidRuntime)' == 'NativeAOT' ">$(_NativeAotRuntimeFlavorDirName)</_RuntimeFlavorDirName>
       <_RuntimeFlavorDirName Condition=" '$(AndroidRuntime)' == 'Mono' Or '$(AndroidRuntime)' == '' ">$(_MonoRuntimeFlavorDirName)</_RuntimeFlavorDirName>
-      <_ClangArch Condition=" '$(AndroidRID)' == 'android-arm64' ">aarch64</_ClangArch>
-      <_ClangArch Condition=" '$(AndroidRID)' == 'android-arm' ">arm</_ClangArch>
-      <_ClangArch Condition=" '$(AndroidRID)' == 'android-x64' ">x86_64</_ClangArch>
-      <_ClangArch Condition=" '$(AndroidRID)' == 'android-x86' ">i686</_ClangArch>
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(AndroidRuntime)' == 'CoreCLR' ">
@@ -91,23 +87,16 @@ projects that use the Microsoft.Android.Runtimes framework in .NET 6+.
       <NativeRuntimeAsset Condition=" Exists('$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libarchive-dso-stub.so') " Include="$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libarchive-dso-stub.so" />
     </ItemGroup>
 
-    <!-- System lib stubs from the common redist directory, needed by all runtimes -->
+    <!-- System lib stubs needed by all runtimes -->
     <ItemGroup>
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\libc.so" />
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\libdl.so" />
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\liblog.so" />
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\libm.so" />
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\libz.so" />
+      <NativeRuntimeAsset Include="@(_AndroidNdkRedistributable)"
+          Condition=" '%(_AndroidNdkRedistributable.AndroidRID)' == '$(AndroidRID)' And '%(_AndroidNdkRedistributable.Kind)' == 'System' " />
     </ItemGroup>
 
     <!-- Toolchain libraries shared by CoreCLR and NativeAOT (both do native linking) -->
     <ItemGroup Condition=" '$(AndroidRuntime)' == 'CoreCLR' Or '$(AndroidRuntime)' == 'NativeAOT' ">
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\crtbegin_so.o" />
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\crtend_so.o" />
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\libc++_static.a" />
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\libc++abi.a" />
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\libclang_rt.builtins-$(_ClangArch)-android.a" />
-      <NativeRuntimeAsset Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\$(AndroidRID)\libunwind.a" />
+      <NativeRuntimeAsset Include="@(_AndroidNdkRedistributable)"
+          Condition=" '%(_AndroidNdkRedistributable.AndroidRID)' == '$(AndroidRID)' And '%(_AndroidNdkRedistributable.Kind)' == 'Toolchain' " />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(AndroidRuntime)' == 'NativeAOT' ">

--- a/build-tools/scripts/Ndk.projitems
+++ b/build-tools/scripts/Ndk.projitems
@@ -22,6 +22,9 @@
         Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi-v7a:')) ">
       <ApiLevel>$(AndroidNdkApiLevel_ArmV7a)</ApiLevel>
       <AndroidRID>android-arm</AndroidRID>
+      <ToolchainPrefix>arm-linux-androideabi</ToolchainPrefix>
+      <ClangArch>arm</ClangArch>
+      <UnwindArchDir>arm</UnwindArchDir>
       <SupportMonoVM>True</SupportMonoVM>
       <SupportCoreCLR>True</SupportCoreCLR>
       <SupportNativeAOT>True</SupportNativeAOT>
@@ -32,6 +35,9 @@
         Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':arm64-v8a:')) ">
       <ApiLevel>$(AndroidNdkApiLevel_ArmV8a)</ApiLevel>
       <AndroidRID>android-arm64</AndroidRID>
+      <ToolchainPrefix>aarch64-linux-android</ToolchainPrefix>
+      <ClangArch>aarch64</ClangArch>
+      <UnwindArchDir>aarch64</UnwindArchDir>
       <SupportMonoVM>True</SupportMonoVM>
       <SupportCoreCLR>True</SupportCoreCLR>
       <SupportNativeAOT>True</SupportNativeAOT>
@@ -42,6 +48,9 @@
         Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86:')) ">
       <ApiLevel>$(AndroidNdkApiLevel_X86)</ApiLevel>
       <AndroidRID>android-x86</AndroidRID>
+      <ToolchainPrefix>i686-linux-android</ToolchainPrefix>
+      <ClangArch>i686</ClangArch>
+      <UnwindArchDir>i386</UnwindArchDir>
       <SupportMonoVM>True</SupportMonoVM>
       <SupportCoreCLR>False</SupportCoreCLR>
       <SupportNativeAOT>False</SupportNativeAOT>
@@ -52,6 +61,9 @@
         Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86_64:')) ">
       <ApiLevel>$(AndroidNdkApiLevel_X86_64)</ApiLevel>
       <AndroidRID>android-x64</AndroidRID>
+      <ToolchainPrefix>x86_64-linux-android</ToolchainPrefix>
+      <ClangArch>x86_64</ClangArch>
+      <UnwindArchDir>x86_64</UnwindArchDir>
       <SupportMonoVM>True</SupportMonoVM>
       <SupportCoreCLR>True</SupportCoreCLR>
       <SupportNativeAOT>True</SupportNativeAOT>

--- a/build-tools/scripts/Ndk.targets
+++ b/build-tools/scripts/Ndk.targets
@@ -6,4 +6,32 @@
   <Import
       Project="$(ProjitemsFile)"
       Condition="Exists('$(ProjitemsFile)')"/>
+
+  <Target Name="_AndroidGetNdkRedistributables">
+    <PropertyGroup>
+      <_AndroidNdkToolchainOSTag Condition=" '$(HostOS)' == 'Linux'   ">linux-x86_64</_AndroidNdkToolchainOSTag>
+      <_AndroidNdkToolchainOSTag Condition=" '$(HostOS)' == 'Darwin'  ">darwin-x86_64</_AndroidNdkToolchainOSTag>
+      <_AndroidNdkToolchainOSTag Condition=" '$(HostOS)' == 'Windows' ">windows-x86_64</_AndroidNdkToolchainOSTag>
+      <_AndroidNdkToolchainRoot>$(AndroidNdkDirectory)\toolchains\llvm\prebuilt\$(_AndroidNdkToolchainOSTag)</_AndroidNdkToolchainRoot>
+      <_AndroidNdkSysrootLib>$(_AndroidNdkToolchainRoot)\sysroot\usr\lib</_AndroidNdkSysrootLib>
+      <!-- AndroidVersion.txt starts with the full LLVM version e.g. "19.0.1\n". -->
+      <_AndroidNdkVersionFileContent>$([System.IO.File]::ReadAllText('$(_AndroidNdkToolchainRoot)\AndroidVersion.txt'))</_AndroidNdkVersionFileContent>
+      <_AndroidNdkLlvmMajor>$(_AndroidNdkVersionFileContent.Substring(0, $(_AndroidNdkVersionFileContent.IndexOf('.'))))</_AndroidNdkLlvmMajor>
+      <_AndroidNdkClangLibLinux>$(_AndroidNdkToolchainRoot)\lib\clang\$(_AndroidNdkLlvmMajor)\lib\linux</_AndroidNdkClangLibLinux>
+    </PropertyGroup>
+    <ItemGroup>
+      <_AndroidNdkRedistributable Remove="@(_AndroidNdkRedistributable)" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\libc.so')" Kind="System" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\libdl.so')" Kind="System" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\liblog.so')" Kind="System" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\libm.so')" Kind="System" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\libz.so')" Kind="System" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\crtbegin_so.o')" Kind="Toolchain" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\crtend_so.o')" Kind="Toolchain" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\libc++_static.a')" Kind="Toolchain" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\libc++abi.a')" Kind="Toolchain" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkClangLibLinux)\libclang_rt.builtins-%(ClangArch)-android.a')" Kind="Toolchain" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkClangLibLinux)\%(UnwindArchDir)\libunwind.a')" Kind="Toolchain" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/androidsdk/androidsdk.targets
+++ b/src/androidsdk/androidsdk.targets
@@ -38,10 +38,6 @@
     <_InstallLatestPlatformOnly Condition=" '$(AndroidSdkPlatforms.ToLower())' == 'latest' ">true</_InstallLatestPlatformOnly>
     <_RequestedApiLevels>;$(AndroidSdkPlatforms.Replace(',', ';'));</_RequestedApiLevels>
 
-    <!-- NDK toolchain dir name inside `<NDK>/toolchains/llvm/prebuilt/`. -->
-    <_NdkToolchainOSTag Condition=" '$(HostOS)' == 'Linux'   ">linux-x86_64</_NdkToolchainOSTag>
-    <_NdkToolchainOSTag Condition=" '$(HostOS)' == 'Darwin'  ">darwin-x86_64</_NdkToolchainOSTag>
-    <_NdkToolchainOSTag Condition=" '$(HostOS)' == 'Windows' ">windows-x86_64</_NdkToolchainOSTag>
     <_NdkHostTag Condition=" '$(HostOS)' == 'Linux'   ">linux</_NdkHostTag>
     <_NdkHostTag Condition=" '$(HostOS)' == 'Darwin'  ">darwin</_NdkHostTag>
     <_NdkHostTag Condition=" '$(HostOS)' == 'Windows' ">windows</_NdkHostTag>
@@ -410,72 +406,8 @@
 
   <Target Name="_InstallAndroidSdkComponents"
       BeforeTargets="Build"
-      DependsOnTargets="_ExtractAndroidSdkPackages;_GenerateAndroidPackageXmls;_CopyNdkRedistributables"
+      DependsOnTargets="_ExtractAndroidSdkPackages;_GenerateAndroidPackageXmls"
   />
-
-  <!--
-    Copy NDK redistributable files (CRT, libc++, libunwind, libclang_rt.builtins)
-    for every supported ABI from the extracted NDK into the runtime redist directory.
-    MSBuild port of `Step_Android_SDK_NDK.CopyRedistributableFiles ()` in xaprepare.
-  -->
-  <ItemGroup>
-    <_NdkAbi Include="armeabi-v7a">
-      <ToolchainPrefix>arm-linux-androideabi</ToolchainPrefix>
-      <ClangArch>arm</ClangArch>
-      <UnwindArchDir>arm</UnwindArchDir>
-      <Rid>android-arm</Rid>
-    </_NdkAbi>
-    <_NdkAbi Include="arm64-v8a">
-      <ToolchainPrefix>aarch64-linux-android</ToolchainPrefix>
-      <ClangArch>aarch64</ClangArch>
-      <UnwindArchDir>aarch64</UnwindArchDir>
-      <Rid>android-arm64</Rid>
-    </_NdkAbi>
-    <_NdkAbi Include="x86">
-      <ToolchainPrefix>i686-linux-android</ToolchainPrefix>
-      <ClangArch>i686</ClangArch>
-      <UnwindArchDir>i386</UnwindArchDir>
-      <Rid>android-x86</Rid>
-    </_NdkAbi>
-    <_NdkAbi Include="x86_64">
-      <ToolchainPrefix>x86_64-linux-android</ToolchainPrefix>
-      <ClangArch>x86_64</ClangArch>
-      <UnwindArchDir>x86_64</UnwindArchDir>
-      <Rid>android-x64</Rid>
-    </_NdkAbi>
-    <_NdkCrtFile      Include="crtbegin_so.o;crtend_so.o;libc.so;libdl.so;liblog.so;libm.so;libz.so" />
-    <_NdkCppAbiFile   Include="libc++_static.a;libc++abi.a" />
-  </ItemGroup>
-
-  <Target Name="_CopyNdkRedistributables"
-      DependsOnTargets="_ExtractAndroidSdkPackages"
-      Inputs="$(AndroidNdkDirectory)\source.properties"
-      Outputs="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\%(_NdkAbi.Rid)\.ndk-redist-copied">
-    <PropertyGroup>
-      <_NdkToolchainRoot>$(AndroidNdkDirectory)\toolchains\llvm\prebuilt\$(_NdkToolchainOSTag)</_NdkToolchainRoot>
-      <_NdkSysrootLib>$(_NdkToolchainRoot)\sysroot\usr\lib</_NdkSysrootLib>
-      <!-- AndroidVersion.txt starts with the full LLVM version e.g. "19.0.1\n". -->
-      <_NdkVersionFileContent>$([System.IO.File]::ReadAllText('$(_NdkToolchainRoot)\AndroidVersion.txt'))</_NdkVersionFileContent>
-      <_NdkLlvmMajor>$(_NdkVersionFileContent.Substring(0, $(_NdkVersionFileContent.IndexOf('.'))))</_NdkLlvmMajor>
-      <_NdkClangLibLinux>$(_NdkToolchainRoot)\lib\clang\$(_NdkLlvmMajor)\lib\linux</_NdkClangLibLinux>
-      <!-- Per-ABI properties (batched via Outputs="...%(_NdkAbi.Rid)..."). -->
-      <_AbiPrefixDir>$(_NdkSysrootLib)\%(_NdkAbi.ToolchainPrefix)</_AbiPrefixDir>
-      <_AbiOutputDir>$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\%(_NdkAbi.Rid)</_AbiOutputDir>
-      <_AbiClangArch>%(_NdkAbi.ClangArch)</_AbiClangArch>
-      <_AbiUnwindArchDir>%(_NdkAbi.UnwindArchDir)</_AbiUnwindArchDir>
-    </PropertyGroup>
-    <ItemGroup>
-      <_NdkRedist Include="@(_NdkCrtFile    -> '$(_AbiPrefixDir)\$(AndroidMinimumDotNetApiLevel)\%(Identity)')" />
-      <_NdkRedist Include="@(_NdkCppAbiFile -> '$(_AbiPrefixDir)\%(Identity)')" />
-      <_NdkRedist Include="$(_NdkClangLibLinux)\libclang_rt.builtins-$(_AbiClangArch)-android.a" />
-      <_NdkRedist Include="$(_NdkClangLibLinux)\$(_AbiUnwindArchDir)\libunwind.a" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_NdkRedist)" DestinationFolder="$(_AbiOutputDir)" />
-    <Touch Files="$(_AbiOutputDir)\.ndk-redist-copied" AlwaysCreate="true" />
-    <ItemGroup>
-      <_NdkRedist Remove="@(_NdkRedist)" />
-    </ItemGroup>
-  </Target>
 
   <Target Name="_AcceptAndroidSdkLicenses"
       BeforeTargets="Build"

--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -344,7 +344,8 @@
           DependsOnTargets="Build">
   </Target>
 
-  <Target Name="_CopyToPackDirs">
+  <Target Name="_CopyToPackDirs"
+          DependsOnTargets="_AndroidGetNdkRedistributables">
     <PropertyGroup>
       <_RuntimePackName Condition=" '$(CMakeRuntimeFlavor)' == 'MonoVM' ">Mono</_RuntimePackName>
       <_RuntimePackName Condition=" '$(CMakeRuntimeFlavor)' == 'CoreCLR' ">CoreCLR</_RuntimePackName>
@@ -356,19 +357,17 @@
                          AndroidRID="%(AndroidSupportedTargetJitAbi.AndroidRID)"
                          AndroidRuntime="$(CMakeRuntimeFlavor)"
                          RuntimePackName="$(_RuntimePackName)" />
-      <_RuntimePackFiles Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\%(AndroidSupportedTargetJitAbi.AndroidRID)\*.so"
-                         AndroidRID="%(AndroidSupportedTargetJitAbi.AndroidRID)"
+      <_RuntimePackFiles Include="@(_AndroidNdkRedistributable)"
+                         Condition=" '%(_AndroidNdkRedistributable.Kind)' == 'System' "
+                         AndroidRID="%(_AndroidNdkRedistributable.AndroidRID)"
                          AndroidRuntime="$(CMakeRuntimeFlavor)"
                          RuntimePackName="$(_RuntimePackName)" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(CMakeRuntimeFlavor)' == 'CoreCLR' Or '$(CMakeRuntimeFlavor)' == 'NativeAOT' ">
-      <_RuntimePackFiles Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\%(AndroidSupportedTargetJitAbi.AndroidRID)\*.o"
-                         AndroidRID="%(AndroidSupportedTargetJitAbi.AndroidRID)"
-                         AndroidRuntime="$(CMakeRuntimeFlavor)"
-                         RuntimePackName="$(_RuntimePackName)" />
-      <_RuntimePackFiles Include="$(NativeRuntimeOutputRootDir)$(_RuntimeRedistDirName)\%(AndroidSupportedTargetJitAbi.AndroidRID)\*.a"
-                         AndroidRID="%(AndroidSupportedTargetJitAbi.AndroidRID)"
+      <_RuntimePackFiles Include="@(_AndroidNdkRedistributable)"
+                         Condition=" '%(_AndroidNdkRedistributable.Kind)' == 'Toolchain' "
+                         AndroidRID="%(_AndroidNdkRedistributable.AndroidRID)"
                          AndroidRuntime="$(CMakeRuntimeFlavor)"
                          RuntimePackName="$(_RuntimePackName)" />
     </ItemGroup>


### PR DESCRIPTION
## Context

`make prepare` currently copies selected Android NDK files into `bin/<Configuration>/lib/runtimes/redist`, even though those files are only consumed when producing runtime packs. This creates an approximately 58 MB configuration- and checkout-local staging directory in every prepared worktree.

The NDK itself is already stored in the shared Android toolchain directory, so the intermediate copy is unnecessary.

## Changes

- Remove `_CopyNdkRedistributables` from Android SDK provisioning.
- Add the NDK toolchain metadata to `AndroidSupportedTargetJitAbi`.
- Expose the selected NDK files through a reusable `_AndroidGetNdkRedistributables` target.
- Copy those files directly from `$(AndroidNdkDirectory)` into local unpacked runtime packs.
- Use the same direct NDK inputs when creating runtime-pack NuGet packages.
- Remove the now-unused runtime redist staging property.

Mono runtime packs receive the five Android system-library stubs. CoreCLR and NativeAOT runtime packs additionally receive the CRT objects, libc++, compiler-rt, and libunwind, preserving the existing payload.

## Validation

- `make prepare` succeeds without creating `bin/Debug/lib/runtimes/redist`.
- `_AndroidGetNdkRedistributables` selects 44 existing files: 11 for each supported RID.
- `make all` succeeds.
- Local runtime packs contain 5 NDK assets for Mono and 11 for CoreCLR/NativeAOT.
- Representative `android-arm64` Mono and CoreCLR NuGet runtime packs build successfully and contain the expected files under `runtimes/android-arm64/native`.