### PR TITLE
[Mono] Fix JLO lookup for packaged MAUI satellite assemblies

### DIFF
--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -934,6 +934,18 @@ stages:
         xaSourcePath: $(Build.SourcesDirectory)/android
         displayName: Build MAUI template - Release
 
+    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+      parameters:
+        project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
+        arguments: >-
+          -f $(DotNetTargetFramework)-android -c Release
+          -p:UseMonoRuntime=true
+          -p:_DisableCheckForUnsupportedMonoMobileRuntime=true
+          --configfile $(Build.SourcesDirectory)/maui/NuGet.config
+          -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Mono.binlog
+        xaSourcePath: $(Build.SourcesDirectory)/android
+        displayName: Build MAUI template - Mono
+
     - task: CopyFiles@2
       displayName: copy build logs
       condition: always()

--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -620,6 +620,18 @@ stages:
         xaSourcePath: $(Build.SourcesDirectory)/android
         displayName: Build MAUI template - Release
 
+    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+      parameters:
+        project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
+        arguments: >-
+          -f $(DotNetTargetFramework)-android -c Release
+          -p:UseMonoRuntime=true
+          -p:_DisableCheckForUnsupportedMonoMobileRuntime=true
+          --configfile $(Build.SourcesDirectory)/maui/NuGet.config
+          -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Mono.binlog
+        xaSourcePath: $(Build.SourcesDirectory)/android
+        displayName: Build MAUI template - Mono
+
     - template: /build-tools/automation/yaml-templates/run-maui-r2r-helix-matrix.yaml
       parameters:
         project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -236,6 +236,18 @@ extends:
             xaSourcePath: $(Build.SourcesDirectory)/android
             displayName: Build MAUI template - Release
 
+        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+          parameters:
+            project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
+            arguments: >-
+              -f $(DotNetTargetFramework)-android -c Release
+              -p:UseMonoRuntime=true
+              -p:_DisableCheckForUnsupportedMonoMobileRuntime=true
+              --configfile $(Build.SourcesDirectory)/maui/NuGet.config
+              -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Mono.binlog
+            xaSourcePath: $(Build.SourcesDirectory)/android
+            displayName: Build MAUI template - Mono
+
         - template: /build-tools/automation/yaml-templates/run-maui-r2r-helix-matrix.yaml@self
           parameters:
             project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2300,8 +2300,9 @@ public class ToolbarEx {
 			}
 		}
 
-		[Test]
-		public void BuildDoesNotModifyNuGetPackageCache ()
+		[TestCase (AndroidRuntime.CoreCLR)]
+		[TestCase (AndroidRuntime.MonoVM)]
+		public void BuildDoesNotModifyNuGetPackageCache (AndroidRuntime runtime)
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
@@ -2328,7 +2329,10 @@ public class ToolbarEx {
 					new Package { Id = "Humanizer.Core.es", Version = "2.14.1" },
 				},
 			};
-			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetRuntime (runtime);
+			if (runtime == AndroidRuntime.MonoVM) {
+				proj.SetProperty ("_DisableCheckForUnsupportedMonoMobileRuntime", "true");
+			}
 			proj.SetProperty ("AndroidTypeMapImplementation", "llvm-ir");
 			proj.SetProperty (KnownProperties.PublishTrimmed, true.ToString ());
 			proj.MainActivity = proj.DefaultMainActivity

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1515,6 +1515,7 @@ because xbuild doesn't support framework reference assemblies.
         Condition=" '$(_AndroidUseMarshalMethods)' != 'True' or !$([System.String]::Copy('%(ResolvedAssemblies.Filename)').ToLowerInvariant().EndsWith('.resources')) " />
     <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' != 'True' " Include="@(_AfterILLinkSourceFiles->'$(_AfterILLinkOutputDir)%(DestinationSubPath)')" />
     <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' == 'True' " Include="@(_AfterILLinkSourceFiles)" />
+    <_AndroidScanMarkerFiles Include="@(_AndroidAssembliesToPackageWithoutLinkNoShrink->'%(JavaObjectsXmlFile)')" />
   </ItemGroup>
   <AssemblyModifierPipeline
       ApplicationJavaClass="$(AndroidApplicationJavaClass)"
@@ -1531,12 +1532,14 @@ because xbuild doesn't support framework reference assemblies.
       SourceFiles="@(_AfterILLinkSourceFiles)"
       TargetName="$(TargetName)">
   </AssemblyModifierPipeline>
-  <Touch Files="@(_AndroidAssembliesToPackageWithoutLinkNoShrink->'%(JavaObjectsXmlFile)')" AlwaysCreate="true" />
+  <MakeDir Directories="@(_AndroidScanMarkerFiles->'%(RootDir)%(Directory)')" />
+  <Touch Files="@(_AndroidScanMarkerFiles)" AlwaysCreate="true" />
   <Touch Files="$(_AdditionalPostLinkerStepsFlag)" AlwaysCreate="true" />
   <ItemGroup>
-    <FileWrites Include="@(_AndroidAssembliesToPackageWithoutLinkNoShrink->'%(JavaObjectsXmlFile)')" />
+    <FileWrites Include="@(_AndroidScanMarkerFiles)" />
     <_AfterILLinkSourceFiles Remove="@(_AfterILLinkSourceFiles)" />
     <_AfterILLinkDestFiles Remove="@(_AfterILLinkDestFiles)" />
+    <_AndroidScanMarkerFiles Remove="@(_AndroidScanMarkerFiles)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(_AndroidUseMarshalMethods)' != 'True' ">
     <FileWrites Include="$(_AfterILLinkOutputDir)**" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1447,10 +1447,10 @@ because xbuild doesn't support framework reference assemblies.
           Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' != 'True' "
       >$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)</_AndroidLinkNoShrinkOutput>
       <JavaObjectsXmlFile
-          Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' == 'True' "
+          Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' == 'True' Or ('$(PublishTrimmed)' == 'true' And $([System.String]::Copy('%(ResolvedAssemblies.Filename)').ToLowerInvariant().EndsWith('.resources'))) "
       >$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubDirectory)%(Filename).scan.empty</JavaObjectsXmlFile>
       <TypeMapObjectsXmlFile
-          Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' == 'True' "
+          Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' == 'True' Or ('$(PublishTrimmed)' == 'true' And $([System.String]::Copy('%(ResolvedAssemblies.Filename)').ToLowerInvariant().EndsWith('.resources'))) "
       >$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubDirectory)%(Filename).scan.empty</TypeMapObjectsXmlFile>
     </ResolvedAssemblies>
     <_AndroidAssembliesToLinkNoShrink
@@ -1515,7 +1515,7 @@ because xbuild doesn't support framework reference assemblies.
         Condition=" '$(_AndroidUseMarshalMethods)' != 'True' or !$([System.String]::Copy('%(ResolvedAssemblies.Filename)').ToLowerInvariant().EndsWith('.resources')) " />
     <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' != 'True' " Include="@(_AfterILLinkSourceFiles->'$(_AfterILLinkOutputDir)%(DestinationSubPath)')" />
     <_AfterILLinkDestFiles Condition=" '$(_AndroidUseMarshalMethods)' == 'True' " Include="@(_AfterILLinkSourceFiles)" />
-    <_AndroidScanMarkerFiles Include="@(_AndroidAssembliesToPackageWithoutLinkNoShrink->'%(JavaObjectsXmlFile)')" />
+    <_AndroidScanMarkerFiles Include="@(ResolvedAssemblies->'%(JavaObjectsXmlFile)')" Condition=" '%(ResolvedAssemblies.JavaObjectsXmlFile)' != '' " />
   </ItemGroup>
   <AssemblyModifierPipeline
       ApplicationJavaClass="$(AndroidApplicationJavaClass)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1447,10 +1447,10 @@ because xbuild doesn't support framework reference assemblies.
           Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' != 'True' "
       >$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)</_AndroidLinkNoShrinkOutput>
       <JavaObjectsXmlFile
-          Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' == 'True' Or ('$(PublishTrimmed)' == 'true' And $([System.String]::Copy('%(ResolvedAssemblies.Filename)').ToLowerInvariant().EndsWith('.resources'))) "
+          Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' == 'True' Or ('$(PublishTrimmed)' == 'true' And '$(AndroidTypeMapImplementation)' != 'trimmable' And $([System.String]::Copy('%(ResolvedAssemblies.Filename)').ToLowerInvariant().EndsWith('.resources'))) "
       >$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubDirectory)%(Filename).scan.empty</JavaObjectsXmlFile>
       <TypeMapObjectsXmlFile
-          Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' == 'True' Or ('$(PublishTrimmed)' == 'true' And $([System.String]::Copy('%(ResolvedAssemblies.Filename)').ToLowerInvariant().EndsWith('.resources'))) "
+          Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' == 'True' Or ('$(PublishTrimmed)' == 'true' And '$(AndroidTypeMapImplementation)' != 'trimmable' And $([System.String]::Copy('%(ResolvedAssemblies.Filename)').ToLowerInvariant().EndsWith('.resources'))) "
       >$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubDirectory)%(Filename).scan.empty</TypeMapObjectsXmlFile>
     </ResolvedAssemblies>
     <_AndroidAssembliesToLinkNoShrink

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1446,6 +1446,12 @@ because xbuild doesn't support framework reference assemblies.
       <_AndroidLinkNoShrinkOutput
           Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' != 'True' "
       >$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)</_AndroidLinkNoShrinkOutput>
+      <JavaObjectsXmlFile
+          Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' == 'True' "
+      >$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubDirectory)%(Filename).scan.empty</JavaObjectsXmlFile>
+      <TypeMapObjectsXmlFile
+          Condition=" '%(ResolvedAssemblies.AndroidSkipAssemblyModification)' == 'True' "
+      >$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubDirectory)%(Filename).scan.empty</TypeMapObjectsXmlFile>
     </ResolvedAssemblies>
     <_AndroidAssembliesToLinkNoShrink
         Include="@(ResolvedAssemblies)"
@@ -1525,8 +1531,10 @@ because xbuild doesn't support framework reference assemblies.
       SourceFiles="@(_AfterILLinkSourceFiles)"
       TargetName="$(TargetName)">
   </AssemblyModifierPipeline>
+  <Touch Files="@(_AndroidAssembliesToPackageWithoutLinkNoShrink->'%(JavaObjectsXmlFile)')" AlwaysCreate="true" />
   <Touch Files="$(_AdditionalPostLinkerStepsFlag)" AlwaysCreate="true" />
   <ItemGroup>
+    <FileWrites Include="@(_AndroidAssembliesToPackageWithoutLinkNoShrink->'%(JavaObjectsXmlFile)')" />
     <_AfterILLinkSourceFiles Remove="@(_AfterILLinkSourceFiles)" />
     <_AfterILLinkDestFiles Remove="@(_AfterILLinkDestFiles)" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add a Release MAUI template build using Mono to cover the packaging path
- preserve empty JLO and typemap scan-marker metadata for unchanged assemblies after trimming
- cover Mono Release builds with NuGet satellite assemblies

## Validation
The new MAUI Mono CI build reproduces the expected missing `Microsoft.Maui.Controls.resources.jlo.xml` failure from the package cache before this fix.

Fixes #12487.