### PR TITLE
docs: fix typos in mobile docs and MSBuild guide

### DIFF
--- a/Documentation/docs-mobile/binding-libs/customizing-bindings/troubleshooting-bindings.md
+++ b/Documentation/docs-mobile/binding-libs/customizing-bindings/troubleshooting-bindings.md
@@ -22,7 +22,7 @@ When binding an existing Android library, it is necessary to keep in mind the fo
   dependencies required by the Android library must be included in the
   .NET for Android project via a NuGet package or as an **AndroidLibrary**.
 
-- **The Android API level that the Android library is targetting**
+- **The Android API level that the Android library is targeting**
   &ndash; It is not possible to "downgrade" the Android API level;
   ensure that the .NET for Android binding project is targeting the same
   API level (or higher) as the Android library.

--- a/Documentation/docs-mobile/features/layout-code-behind/index.md
+++ b/Documentation/docs-mobile/features/layout-code-behind/index.md
@@ -545,7 +545,7 @@ taken when generating binding code for `<fragment>` elements in the layout files
 choose one `Fragment` implementation as the default one to be used if the `<fragment>` element does not
 have any specific type (managed or otherwise) specified. Binding code generator uses the
 [`$(AndroidFragmentType)`](../../building-apps/build-properties.md#androidfragmenttype)
-MSBuild property for that purpose. The property can be overriden by the user to specify a type different
+MSBuild property for that purpose. The property can be overridden by the user to specify a type different
 than the default one. The property is set to `Android.App.Fragment` by default, and is overridden by the
 AndroidX NuGet packages.
 

--- a/Documentation/docs-mobile/messages/java0000.md
+++ b/Documentation/docs-mobile/messages/java0000.md
@@ -29,7 +29,7 @@ run raised an error.
 ## Solution
 
 Look at the stack trace included in the error. This should provide
-some clues into why the error occured.
+some clues into why the error occurred.
 
 Consider submitting a [bug][bug] if you are getting this error under
 normal circumstances.

--- a/Documentation/guides/MSBuildBestPractices.md
+++ b/Documentation/guides/MSBuildBestPractices.md
@@ -384,7 +384,7 @@ Generally, the place to put intermediate files during a build is
 `obj\$(Configuration)\` and always has a trailing slash.
 
 MSBuild has a target, named `IncrementalClean`, that might be the bane
-of our existance...
+of our existence...
 
 First, I would read up on the [Clean target][clean] and understand how
 `Clean` really works within MSBuild. `Clean` in short, should delete


### PR DESCRIPTION
Four typo fixes:

- `Documentation/docs-mobile/binding-libs/customizing-bindings/troubleshooting-bindings.md:25` — `targetting` → `targeting`
- `Documentation/docs-mobile/features/layout-code-behind/index.md:548` — `overriden` → `overridden`
- `Documentation/docs-mobile/messages/java0000.md:32` — `occured` → `occurred`
- `Documentation/guides/MSBuildBestPractices.md:387` — `existance` → `existence`

Docs prose only.
