### PR TITLE
[tests] Drop duplicate NativeAOT trimmable test lane

### DIFF
--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -181,15 +181,6 @@ stages:
     - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
-        testName: Mono.Android.NET_Tests-NativeAOTTrimmable
-        project: tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
-        extraBuildArgs: -p:TestsFlavor=NativeAOTTrimmable -p:PublishAot=true -p:AndroidTypeMapImplementation=trimmable
-        artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
-        artifactFolder: $(DotNetTargetFramework)-NativeAOTTrimmable
-
-    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
-      parameters:
-        configuration: $(XA.Build.Configuration)
         testName: Xamarin.Android.JcwGen_Tests
         project: tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Xamarin.Android.JcwGen_Tests-Signed.apk


### PR DESCRIPTION
## Summary

- remove the additional `Mono.Android.NET_Tests-NativeAOTTrimmable` device-test lane
- keep the existing `Mono.Android.NET_Tests-NativeAOT` lane as the single NativeAOT configuration

`PublishAot=true` already defaults `AndroidTypeMapImplementation` to `trimmable`, so both lanes build and run the same test configuration. `TestsFlavor` only changes output naming and does not select a different test set.

Follow-up to #12113. Once #12113 merges, this PR can be retargeted to `main` without changing its one-file diff.
