### PR TITLE
Remove duplicate CoreCLR runtime test lane

### DIFF
--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -140,15 +140,6 @@ stages:
 
     - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
 
-    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
-      parameters:
-        configuration: $(XA.Build.Configuration)
-        testName: Mono.Android.NET_Tests-CoreCLR
-        project: tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
-        extraBuildArgs: -p:TestsFlavor=CoreCLR -p:UseMonoRuntime=false
-        artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
-        artifactFolder: $(DotNetTargetFramework)-CoreCLR
-
     # Smoke coverage that the test app still builds and runs under Mono.
     - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:


### PR DESCRIPTION
## Summary

Remove the explicit `Mono.Android.NET_Tests-CoreCLR` package-test lane because the default Release configuration already uses CoreCLR.

## Verification

Compared both published test runs in public CI build [1565020](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1565020):

| Run | Total | Passed | Skipped | Failed |
| --- | ---: | ---: | ---: | ---: |
| `Mono.Android.NET_Tests-Release` | 350 | 293 | 57 | 0 |
| `Mono.Android.NET_Tests-CoreCLR` | 350 | 293 | 57 | 0 |

The complete `(outcome, test name)` multisets were identical: all 350 test names and outcomes matched. The default runtime selection falls through to CoreCLR when `UseMonoRuntime` is unset, making the explicit `UseMonoRuntime=false` lane redundant.