### PR TITLE
[NativeAOT] Add minimal C++ allocation shims

### DIFF
--- a/src/native/nativeaot/host/CMakeLists.txt
+++ b/src/native/nativeaot/host/CMakeLists.txt
@@ -27,6 +27,7 @@ set(XAMARIN_NAOT_ANDROID_STATIC_LIB "${XAMARIN_NAOT_ANDROID_LIB}-static")
 set(CLR_SOURCES_PATH "../../clr")
 
 set(XAMARIN_MONODROID_SOURCES
+  cxx-shims.cc
   host.cc
   host-environment.cc
   host-jni.cc

--- a/src/native/nativeaot/host/cxx-shims.cc
+++ b/src/native/nativeaot/host/cxx-shims.cc
@@ -3,20 +3,13 @@
 
 // NativeAOT compiles shared CoreCLR code that uses C++ allocation, but should not require libc++
 // only to provide these operators. Keep this list limited to symbols required by the host archive.
-namespace {
-	void *allocate_or_abort (std::size_t size) noexcept
-	{
-		void *memory = std::malloc (size == 0 ? 1 : size);
-		if (memory == nullptr) {
-			std::abort ();
-		}
-		return memory;
-	}
-}
-
 void *operator new[] (std::size_t size)
 {
-	return allocate_or_abort (size);
+	void *memory = std::malloc (size == 0 ? 1 : size);
+	if (memory == nullptr) {
+		std::abort ();
+	}
+	return memory;
 }
 
 void operator delete (void *memory) noexcept

--- a/src/native/nativeaot/host/cxx-shims.cc
+++ b/src/native/nativeaot/host/cxx-shims.cc
@@ -1,0 +1,30 @@
+#include <cstddef>
+#include <cstdlib>
+
+// NativeAOT compiles shared CoreCLR code that uses C++ allocation, but should not require libc++
+// only to provide these operators. Keep this list limited to symbols required by the host archive.
+namespace {
+	void *allocate_or_abort (std::size_t size) noexcept
+	{
+		void *memory = std::malloc (size == 0 ? 1 : size);
+		if (memory == nullptr) {
+			std::abort ();
+		}
+		return memory;
+	}
+}
+
+void *operator new[] (std::size_t size)
+{
+	return allocate_or_abort (size);
+}
+
+void operator delete (void *memory) noexcept
+{
+	std::free (memory);
+}
+
+void operator delete[] (void *memory) noexcept
+{
+	std::free (memory);
+}


### PR DESCRIPTION
## Summary

Provide the three C++ allocation operators currently required by the Android NativeAOT host without relying on libc++/libc++abi to define them.

Part of #12139. This is intentionally a small first step: NativeAOT and CoreCLR still compile shared native code that uses `new[]`/`delete[]`, while only NativeAOT is dropping its libc++ dependency today. Keeping the allocation boundary in a NativeAOT-only source avoids changing shared storage code or CoreCLR behavior.

## Changes

- add NativeAOT-local definitions for:
  - `operator new[](size_t)`;
  - `operator delete(void*)`;
  - `operator delete[](void*)`;
- allocate through `malloc`, with ordinary array allocation aborting on failure because the NativeAOT host is built without C++ exceptions;
- add the shim source only to the NativeAOT host CMake target.

The shim list matches the unresolved allocation symbols in every current arm, arm64, and x64 Debug/Release NativeAOT host archive. It deliberately does not add scalar `new`, sized delete, nothrow, exception, `__cxa_*`, RTTI, or unwind shims. These compatibility definitions can be removed later as shared NativeAOT/CoreCLR code stops requiring the C++ allocation ABI.

## Validation

- `dotnet build src/native/native-nativeaot.csproj -c Release --no-restore --nologo -p:BuildProjectReferences=false`
- confirmed all arm, arm64, and x64 Debug/Release NativeAOT static archives define the three required allocation operators;
- confirmed the allocation operators are not exported from the NativeAOT shared libraries.
