### PR TITLE
[Native] Join paths without dynamic strings

### DIFF
--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -93,7 +93,7 @@ namespace xamarin::android {
 		static void create_xdg_directory (jstring_wrapper &home, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
 		{
 			std::array<char, SENSIBLE_PATH_MAX> dir_buffer;
-			if (Util::join_paths (dir_buffer.data (), dir_buffer.size (), home.get_string_view (), relative_path) == 0) {
+			if (Util::join_paths (dir_buffer.data (), dir_buffer.size (), home.get_string_view (), relative_path) < 0) {
 				log_warnf (LOG_DEFAULT, "Failed to create XDG directory: path is too long");
 				return;
 			}

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -9,7 +9,6 @@
 
 #include <runtime-base/jni-wrappers.hh>
 #include <runtime-base/logger.hh>
-#include <runtime-base/strings.hh>
 #include <runtime-base/util.hh>
 
 struct AppEnvironmentVariable;
@@ -91,7 +90,7 @@ namespace xamarin::android {
 		[[gnu::flatten, gnu::always_inline]]
 		static void create_xdg_directory (jstring_wrapper &home, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
 		{
-			char dir_buffer [SENSIBLE_PATH_MAX];
+			char dir_buffer [Constants::SENSIBLE_PATH_MAX];
 			if (Util::join_paths (dir_buffer, sizeof (dir_buffer), home.get_string_view (), relative_path) < 0) {
 				log_warnf (LOG_DEFAULT, "Failed to create XDG directory: path is too long");
 				return;

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -93,7 +93,7 @@ namespace xamarin::android {
 		{
 			std::string_view home_path = home.get_string_view ();
 			char stack_buffer [Util::LocalPathBufferSize];
-			ssize_t result = Util::join_paths (stack_buffer, sizeof (stack_buffer), home_path, relative_path);
+			ssize_t result = Util::format_joined_path (stack_buffer, sizeof (stack_buffer), home_path, relative_path);
 			abort_unless (result >= 0, "XDG directory path is too long");
 
 			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", stack_buffer);

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -92,9 +92,9 @@ namespace xamarin::android {
 		static void create_xdg_directory (jstring_wrapper &home, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
 		{
 			std::string_view home_path = home.get_string_view ();
-			char local_buffer [Util::LocalPathBufferSize];
+			char stack_buffer [Util::LocalPathBufferSize];
 			char *heap_buffer;
-			const char *dir_path = Util::join_paths (local_buffer, heap_buffer, home_path, relative_path);
+			const char *dir_path = Util::join_paths (stack_buffer, heap_buffer, home_path, relative_path);
 
 			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
 			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);
@@ -105,7 +105,7 @@ namespace xamarin::android {
 			if (!environment_variable_name.empty ()) {
 				set_variable (environment_variable_name.data (), dir_path);
 			}
-			Util::free_if_used (heap_buffer);
+			std::free (heap_buffer);
 		}
 
 		[[gnu::flatten, gnu::always_inline]]

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -91,7 +91,13 @@ namespace xamarin::android {
 		[[gnu::flatten, gnu::always_inline]]
 		static void create_xdg_directory (jstring_wrapper &home, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
 		{
-			char *dir_path = Util::join_paths (home.get_string_view (), relative_path);
+			std::string_view home_path = home.get_string_view ();
+			size_t dir_path_length = Util::get_joined_path_length (home_path, relative_path);
+			size_t allocation_size = Helpers::add_with_overflow_check<size_t> (dir_path_length, 1uz);
+			char local_buffer [Util::LocalPathBufferSize];
+			char *dir_path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
+			Util::join_paths (dir_path, allocation_size, home_path, relative_path);
+
 			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
 			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);
 			if (rv < 0 && errno != EEXIST) {
@@ -101,7 +107,7 @@ namespace xamarin::android {
 			if (!environment_variable_name.empty ()) {
 				set_variable (environment_variable_name.data (), dir_path);
 			}
-			std::free (dir_path);
+			Helpers::free_temporary_buffer (dir_path, local_buffer);
 		}
 
 		[[gnu::flatten, gnu::always_inline]]

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -2,6 +2,7 @@
 
 #include <jni.h>
 
+#include <array>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
@@ -89,34 +90,37 @@ namespace xamarin::android {
 
 	private:
 		[[gnu::flatten, gnu::always_inline]]
-		static void create_xdg_directory (jstring_wrapper &home, size_t home_len, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
+		static void create_xdg_directory (jstring_wrapper &home, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
 		{
-			static_local_string<SENSIBLE_PATH_MAX> dir (home_len + relative_path.length ());
-			Util::path_combine (dir, home.get_string_view (), relative_path);
+			std::array<char, SENSIBLE_PATH_MAX> dir_buffer;
+			auto dir = Util::join_paths (dir_buffer.data (), dir_buffer.size (), home.get_string_view (), relative_path);
+			if (!dir.has_value ()) {
+				log_warnf (LOG_DEFAULT, "Failed to create XDG directory: path is too long");
+				return;
+			}
 
-			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", optional_string (dir.get ()));
-			int rv = Util::create_directory (dir.get (), Constants::DEFAULT_DIRECTORY_MODE);
+			const char *dir_path = dir->data ();
+			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
+			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);
 			if (rv < 0 && errno != EEXIST) {
-				log_warnf (LOG_DEFAULT, "Failed to create XDG directory %s. %s", optional_string (dir.get ()), strerror (errno));
+				log_warnf (LOG_DEFAULT, "Failed to create XDG directory %s. %s", dir_path, strerror (errno));
 			}
 
 			if (!environment_variable_name.empty ()) {
-				set_variable (environment_variable_name.data (), dir.get ());
+				set_variable (environment_variable_name.data (), dir_path);
 			}
 		}
 
 		[[gnu::flatten, gnu::always_inline]]
 		static void create_xdg_directories_and_environment (jstring_wrapper &homeDir) noexcept
 		{
-			size_t home_len = strlen (homeDir.get_cstr ());
-
 			constexpr auto XDG_DATA_HOME = "XDG_DATA_HOME"sv;
 			constexpr auto HOME_PATH = ".local/share"sv;
-			create_xdg_directory (homeDir, home_len, HOME_PATH, XDG_DATA_HOME);
+			create_xdg_directory (homeDir, HOME_PATH, XDG_DATA_HOME);
 
 			constexpr auto XDG_CONFIG_HOME = "XDG_CONFIG_HOME"sv;
 			constexpr auto CONFIG_PATH = ".config"sv;
-			create_xdg_directory (homeDir, home_len, CONFIG_PATH, XDG_CONFIG_HOME);
+			create_xdg_directory (homeDir, CONFIG_PATH, XDG_CONFIG_HOME);
 		}
 
 	public:

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -93,13 +93,12 @@ namespace xamarin::android {
 		static void create_xdg_directory (jstring_wrapper &home, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
 		{
 			std::array<char, SENSIBLE_PATH_MAX> dir_buffer;
-			auto dir = Util::join_paths (dir_buffer.data (), dir_buffer.size (), home.get_string_view (), relative_path);
-			if (!dir.has_value ()) {
+			if (Util::join_paths (dir_buffer.data (), dir_buffer.size (), home.get_string_view (), relative_path) == 0) {
 				log_warnf (LOG_DEFAULT, "Failed to create XDG directory: path is too long");
 				return;
 			}
 
-			const char *dir_path = dir->data ();
+			const char *dir_path = dir_buffer.data ();
 			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
 			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);
 			if (rv < 0 && errno != EEXIST) {

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -93,19 +93,18 @@ namespace xamarin::android {
 		{
 			std::string_view home_path = home.get_string_view ();
 			char stack_buffer [Util::LocalPathBufferSize];
-			char *heap_buffer;
-			const char *dir_path = Util::join_paths (stack_buffer, sizeof (stack_buffer), heap_buffer, home_path, relative_path);
+			ssize_t result = Util::join_paths (stack_buffer, sizeof (stack_buffer), home_path, relative_path);
+			abort_unless (result >= 0, "XDG directory path is too long");
 
-			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
-			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);
+			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", stack_buffer);
+			int rv = Util::create_directory (stack_buffer, Constants::DEFAULT_DIRECTORY_MODE);
 			if (rv < 0 && errno != EEXIST) {
-				log_warnf (LOG_DEFAULT, "Failed to create XDG directory %s. %s", dir_path, strerror (errno));
+				log_warnf (LOG_DEFAULT, "Failed to create XDG directory %s. %s", stack_buffer, strerror (errno));
 			}
 
 			if (!environment_variable_name.empty ()) {
-				set_variable (environment_variable_name.data (), dir_path);
+				set_variable (environment_variable_name.data (), stack_buffer);
 			}
-			std::free (heap_buffer);
 		}
 
 		[[gnu::flatten, gnu::always_inline]]

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -4,6 +4,7 @@
 
 #include <cerrno>
 #include <cstdlib>
+#include <cstdlib>
 #include <cstring>
 #include <string_view>
 
@@ -90,8 +91,7 @@ namespace xamarin::android {
 		[[gnu::flatten, gnu::always_inline]]
 		static void create_xdg_directory (jstring_wrapper &home, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
 		{
-			auto dir_buffer = Util::join_paths (home.get_string_view (), relative_path);
-			const char *dir_path = dir_buffer.get ();
+			char *dir_path = Util::join_paths (home.get_string_view (), relative_path);
 			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
 			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);
 			if (rv < 0 && errno != EEXIST) {
@@ -101,6 +101,7 @@ namespace xamarin::android {
 			if (!environment_variable_name.empty ()) {
 				set_variable (environment_variable_name.data (), dir_path);
 			}
+			std::free (dir_path);
 		}
 
 		[[gnu::flatten, gnu::always_inline]]

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -2,7 +2,6 @@
 
 #include <jni.h>
 
-#include <array>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
@@ -92,13 +91,13 @@ namespace xamarin::android {
 		[[gnu::flatten, gnu::always_inline]]
 		static void create_xdg_directory (jstring_wrapper &home, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
 		{
-			std::array<char, SENSIBLE_PATH_MAX> dir_buffer;
-			if (Util::join_paths (dir_buffer.data (), dir_buffer.size (), home.get_string_view (), relative_path) < 0) {
+			char dir_buffer [SENSIBLE_PATH_MAX];
+			if (Util::join_paths (dir_buffer, sizeof (dir_buffer), home.get_string_view (), relative_path) < 0) {
 				log_warnf (LOG_DEFAULT, "Failed to create XDG directory: path is too long");
 				return;
 			}
 
-			const char *dir_path = dir_buffer.data ();
+			const char *dir_path = dir_buffer;
 			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
 			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);
 			if (rv < 0 && errno != EEXIST) {

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -94,7 +94,7 @@ namespace xamarin::android {
 			std::string_view home_path = home.get_string_view ();
 			char stack_buffer [Util::LocalPathBufferSize];
 			char *heap_buffer;
-			const char *dir_path = Util::join_paths (stack_buffer, heap_buffer, home_path, relative_path);
+			const char *dir_path = Util::join_paths (stack_buffer, sizeof (stack_buffer), heap_buffer, home_path, relative_path);
 
 			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
 			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -92,11 +92,10 @@ namespace xamarin::android {
 		static void create_xdg_directory (jstring_wrapper &home, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
 		{
 			std::string_view home_path = home.get_string_view ();
-			size_t dir_path_length = Util::get_joined_path_length (home_path, relative_path);
-			size_t allocation_size = Helpers::add_with_overflow_check<size_t> (dir_path_length, 1uz);
 			char local_buffer [Util::LocalPathBufferSize];
-			char *dir_path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
-			Util::join_paths (dir_path, allocation_size, home_path, relative_path);
+			char *heap_buffer;
+			Util::join_paths (local_buffer, heap_buffer, home_path, relative_path);
+			const char *dir_path = heap_buffer == nullptr ? local_buffer : heap_buffer;
 
 			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
 			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);
@@ -107,7 +106,7 @@ namespace xamarin::android {
 			if (!environment_variable_name.empty ()) {
 				set_variable (environment_variable_name.data (), dir_path);
 			}
-			Helpers::free_temporary_buffer (dir_path, local_buffer);
+			std::free (heap_buffer);
 		}
 
 		[[gnu::flatten, gnu::always_inline]]

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -90,13 +90,8 @@ namespace xamarin::android {
 		[[gnu::flatten, gnu::always_inline]]
 		static void create_xdg_directory (jstring_wrapper &home, std::string_view const& relative_path, std::string_view const& environment_variable_name) noexcept
 		{
-			char dir_buffer [Constants::SENSIBLE_PATH_MAX];
-			if (Util::join_paths (dir_buffer, sizeof (dir_buffer), home.get_string_view (), relative_path) < 0) {
-				log_warnf (LOG_DEFAULT, "Failed to create XDG directory: path is too long");
-				return;
-			}
-
-			const char *dir_path = dir_buffer;
+			auto dir_buffer = Util::join_paths (home.get_string_view (), relative_path);
+			const char *dir_path = dir_buffer.get ();
 			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
 			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);
 			if (rv < 0 && errno != EEXIST) {

--- a/src/native/clr/include/host/host-environment.hh
+++ b/src/native/clr/include/host/host-environment.hh
@@ -94,8 +94,7 @@ namespace xamarin::android {
 			std::string_view home_path = home.get_string_view ();
 			char local_buffer [Util::LocalPathBufferSize];
 			char *heap_buffer;
-			Util::join_paths (local_buffer, heap_buffer, home_path, relative_path);
-			const char *dir_path = heap_buffer == nullptr ? local_buffer : heap_buffer;
+			const char *dir_path = Util::join_paths (local_buffer, heap_buffer, home_path, relative_path);
 
 			log_debugf (LOG_DEFAULT, "Creating XDG directory: %s", dir_path);
 			int rv = Util::create_directory (dir_path, Constants::DEFAULT_DIRECTORY_MODE);
@@ -106,7 +105,7 @@ namespace xamarin::android {
 			if (!environment_variable_name.empty ()) {
 				set_variable (environment_variable_name.data (), dir_path);
 			}
-			std::free (heap_buffer);
+			Util::free_if_used (heap_buffer);
 		}
 
 		[[gnu::flatten, gnu::always_inline]]

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -148,7 +148,7 @@ namespace xamarin::android {
 #if defined(DEBUG)
 		static void add_system_property (const char *name, const char *value) noexcept;
 		static void setup_environment (const char *name, const char *value) noexcept;
-		static void setup_environment_from_override_file (dynamic_local_string<Constants::SENSIBLE_PATH_MAX> const& path) noexcept;
+		static void setup_environment_from_override_file (std::string_view path) noexcept;
 #endif
 
 		static void set_embedded_dso_mode_enabled (bool yesno) noexcept

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -148,7 +148,7 @@ namespace xamarin::android {
 #if defined(DEBUG)
 		static void add_system_property (const char *name, const char *value) noexcept;
 		static void setup_environment (const char *name, const char *value) noexcept;
-		static void setup_environment_from_override_file (std::string_view path) noexcept;
+		static void setup_environment_from_override_file (const char *path) noexcept;
 #endif
 
 		static void set_embedded_dso_mode_enabled (bool yesno) noexcept

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -6,7 +6,6 @@
 #include <unistd.h>
 
 #include <cerrno>
-#include <concepts>
 #include <cstdio>
 #include <cstring>
 #include <limits>
@@ -17,7 +16,6 @@
 #include <shared/helpers.hh>
 #include <runtime-base/jni-wrappers.hh>
 #include "logger.hh"
-#include <runtime-base/strings.hh>
 
 #if !defined(XA_HOST_NATIVEAOT)
 #include "archive-dso-stub-config.hh"
@@ -25,19 +23,6 @@
 
 namespace xamarin::android {
 	namespace detail {
-		template<typename T>
-		concept PathComponentString = requires {
-			std::same_as<std::remove_cvref_t<T>, char*> ||
-			std::same_as<std::remove_cvref_t<T>, std::string_view> ||
-			std::same_as<std::remove_cvref_t<T>, std::string>;
-		};
-
-		template<class T, size_t MaxBufferStorage>
-		concept PathBuffer = requires {
-			std::derived_from<std::remove_cvref<T>, dynamic_local_storage<MaxBufferStorage>> ||
-			std::derived_from<std::remove_cvref<T>, static_local_storage<MaxBufferStorage>>;
-		};
-
 		struct mmap_info
 		{
 			void   *area;
@@ -119,16 +104,6 @@ namespace xamarin::android {
 			}
 
 			return file_exists_no_null_check (file);
-		}
-
-		template<size_t MaxStackSize>
-		static auto file_exists (dynamic_local_string<MaxStackSize> const& file) noexcept -> bool
-		{
-			if (file.empty ()) {
-				return false;
-			}
-
-			return file_exists_no_null_check (file.get ());
 		}
 
 		static auto file_exists (int dirfd, std::string_view const& file) noexcept -> bool
@@ -367,42 +342,6 @@ namespace xamarin::android {
 
 			return static_cast<ssize_t>(path_length);
 		}
-
-	private:
-		// TODO: needs some work to accept mixed params of different accepted types
-		template<size_t MaxStackSpace, detail::PathBuffer<MaxStackSpace> TBuffer, detail::PathComponentString ...TPart>
-		static void path_combine_common (TBuffer& buf, TPart&&... parts) noexcept
-		{
-			buf.clear ();
-
-			for (auto const& part : {parts...}) {
-				if (!buf.empty ()) {
-					buf.append ("/"sv);
-				}
-
-				if constexpr (std::same_as<std::remove_cvref_t<decltype(part)>, char*>) {
-					if (part != nullptr) {
-						buf.append_c (part);
-					}
-				} else {
-					buf.append (part);
-				}
-			}
-		}
-
-	public:
-		template<size_t MaxStackSpace, detail::PathComponentString ...TParts>
-		static void path_combine (dynamic_local_string<MaxStackSpace>& buf, TParts&&... parts) noexcept
-		{
-			path_combine_common<MaxStackSpace> (buf, std::forward<TParts>(parts)...);
-		}
-
-		template<size_t MaxStackSpace, detail::PathComponentString ...TParts>
-		static void path_combine (static_local_string<MaxStackSpace>& buf, TParts&&... parts) noexcept
-		{
-			path_combine_common<MaxStackSpace> (buf, std::forward<TParts>(parts)...);
-		}
-
 	private:
 		static inline int page_size = getpagesize ();
 	};

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -6,7 +6,6 @@
 #include <unistd.h>
 
 #include <cerrno>
-#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <limits>
@@ -39,6 +38,8 @@ namespace xamarin::android {
 		};
 
 	public:
+		static constexpr size_t LocalPathBufferSize = Constants::SENSIBLE_PATH_MAX;
+
 		static int create_directory (const char *pathname, mode_t mode);
 
 		static auto create_directory (std::string_view const& dir, mode_t mode) noexcept -> int
@@ -308,19 +309,26 @@ namespace xamarin::android {
 			return !path.empty () && path.contains ('/');
 		}
 
-		static auto join_paths (std::string_view first, std::string_view second, size_t &path_length) noexcept -> char*
+		static auto get_joined_path_length (std::string_view first, std::string_view second) noexcept -> size_t
 		{
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
 			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
 			size_t second_offset = remove_duplicate_separator ? 1uz : 0uz;
-			path_length = Helpers::add_with_overflow_check<size_t> (first.length (), second.length () - second_offset);
+			size_t path_length = Helpers::add_with_overflow_check<size_t> (first.length (), second.length () - second_offset);
 			if (add_separator) {
 				path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 			}
+			return path_length;
+		}
 
-			size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
-			auto buffer = static_cast<char*> (std::malloc (allocation_size));
-			abort_unless (buffer != nullptr, "Failed to allocate joined path");
+		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> size_t
+		{
+			size_t path_length = get_joined_path_length (first, second);
+			abort_unless (buffer != nullptr && buffer_size > path_length, "Joined path buffer is too small");
+
+			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
+			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
+			size_t second_offset = remove_duplicate_separator ? 1uz : 0uz;
 			char *destination = buffer;
 			if (!first.empty ()) {
 				memcpy (destination, first.data (), first.length ());
@@ -335,13 +343,7 @@ namespace xamarin::android {
 			}
 			buffer [path_length] = '\0';
 
-			return buffer;
-		}
-
-		static auto join_paths (std::string_view first, std::string_view second) noexcept -> char*
-		{
-			size_t path_length;
-			return join_paths (first, second, path_length);
+			return path_length;
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -332,10 +332,11 @@ namespace xamarin::android {
 			return !path.empty () && path.contains ('/');
 		}
 
-		template<size_t Size>
-		static auto join_paths (std::array<char, Size>& buffer, std::string_view first, std::string_view second) noexcept -> std::optional<std::string_view>
+		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> std::optional<std::string_view>
 		{
-			static_assert (Size > 0);
+			if (buffer == nullptr || buffer_size == 0) {
+				return std::nullopt;
+			}
 
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
 			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
@@ -345,11 +346,11 @@ namespace xamarin::android {
 				path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 			}
 
-			if (path_length >= Size) {
+			if (path_length >= buffer_size) {
 				return std::nullopt;
 			}
 
-			char *destination = buffer.data ();
+			char *destination = buffer;
 			if (!first.empty ()) {
 				memcpy (destination, first.data (), first.length ());
 				destination += first.length ();
@@ -363,7 +364,7 @@ namespace xamarin::android {
 			}
 			buffer [path_length] = '\0';
 
-			return std::string_view { buffer.data (), path_length };
+			return std::string_view { buffer, path_length };
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstring>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <string_view>
 
@@ -307,26 +308,19 @@ namespace xamarin::android {
 			return !path.empty () && path.contains ('/');
 		}
 
-		// Returns the path length excluding the terminating NUL, or -1 on failure.
-		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> ssize_t
+		static auto join_paths (std::string_view first, std::string_view second, size_t &path_length) noexcept -> std::unique_ptr<char[]>
 		{
-			if (buffer == nullptr || buffer_size == 0) {
-				return -1;
-			}
-
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
 			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
 			size_t second_offset = remove_duplicate_separator ? 1uz : 0uz;
-			size_t path_length = Helpers::add_with_overflow_check<size_t> (first.length (), second.length () - second_offset);
+			path_length = Helpers::add_with_overflow_check<size_t> (first.length (), second.length () - second_offset);
 			if (add_separator) {
 				path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 			}
 
-			if (path_length >= buffer_size || path_length > static_cast<size_t>(std::numeric_limits<ssize_t>::max ())) {
-				return -1;
-			}
-
-			char *destination = buffer;
+			size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+			auto buffer = std::make_unique<char[]> (allocation_size);
+			char *destination = buffer.get ();
 			if (!first.empty ()) {
 				memcpy (destination, first.data (), first.length ());
 				destination += first.length ();
@@ -340,8 +334,15 @@ namespace xamarin::android {
 			}
 			buffer [path_length] = '\0';
 
-			return static_cast<ssize_t>(path_length);
+			return buffer;
 		}
+
+		static auto join_paths (std::string_view first, std::string_view second) noexcept -> std::unique_ptr<char[]>
+		{
+			size_t path_length;
+			return join_paths (first, second, path_length);
+		}
+
 	private:
 		static inline int page_size = getpagesize ();
 	};

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -332,10 +332,11 @@ namespace xamarin::android {
 			return !path.empty () && path.contains ('/');
 		}
 
-		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> std::optional<std::string_view>
+		// Returns the number of bytes written, including the terminating NUL, or 0 on failure.
+		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> size_t
 		{
 			if (buffer == nullptr || buffer_size == 0) {
-				return std::nullopt;
+				return 0;
 			}
 
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
@@ -347,7 +348,7 @@ namespace xamarin::android {
 			}
 
 			if (path_length >= buffer_size) {
-				return std::nullopt;
+				return 0;
 			}
 
 			char *destination = buffer;
@@ -364,7 +365,7 @@ namespace xamarin::android {
 			}
 			buffer [path_length] = '\0';
 
-			return std::string_view { buffer, path_length };
+			return path_length + 1uz;
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -311,7 +311,7 @@ namespace xamarin::android {
 		}
 
 		// Returns the path length excluding NUL, or the negative required capacity including NUL.
-		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> ssize_t
+		static auto format_joined_path (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> ssize_t
 		{
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
 			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
@@ -346,7 +346,7 @@ namespace xamarin::android {
 
 		static auto join_paths (char *stack_buffer, size_t stack_buffer_size, std::string_view first, std::string_view second) noexcept -> char*
 		{
-			ssize_t result = join_paths (stack_buffer, stack_buffer_size, first, second);
+			ssize_t result = format_joined_path (stack_buffer, stack_buffer_size, first, second);
 			if (result >= 0) {
 				return stack_buffer;
 			}
@@ -354,7 +354,7 @@ namespace xamarin::android {
 			size_t required_capacity = static_cast<size_t>(-result);
 			char *heap_buffer = static_cast<char*> (std::malloc (required_capacity));
 			abort_unless (heap_buffer != nullptr, "Failed to allocate joined path");
-			result = join_paths (heap_buffer, required_capacity, first, second);
+			result = format_joined_path (heap_buffer, required_capacity, first, second);
 			abort_unless (result >= 0, "Failed to join path using the required capacity");
 			return heap_buffer;
 		}

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -10,6 +10,7 @@
 #include <concepts>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <optional>
 #include <string_view>
 
@@ -332,11 +333,11 @@ namespace xamarin::android {
 			return !path.empty () && path.contains ('/');
 		}
 
-		// Returns the number of bytes written, including the terminating NUL, or 0 on failure.
-		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> size_t
+		// Returns the path length excluding the terminating NUL, or -1 on failure.
+		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> ssize_t
 		{
 			if (buffer == nullptr || buffer_size == 0) {
-				return 0;
+				return -1;
 			}
 
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
@@ -347,8 +348,8 @@ namespace xamarin::android {
 				path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 			}
 
-			if (path_length >= buffer_size) {
-				return 0;
+			if (path_length >= buffer_size || path_length > static_cast<size_t>(std::numeric_limits<ssize_t>::max ())) {
+				return -1;
 			}
 
 			char *destination = buffer;
@@ -365,7 +366,7 @@ namespace xamarin::android {
 			}
 			buffer [path_length] = '\0';
 
-			return path_length + 1uz;
+			return static_cast<ssize_t>(path_length);
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -5,9 +5,11 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <array>
 #include <cerrno>
 #include <concepts>
 #include <cstdio>
+#include <cstring>
 #include <optional>
 #include <string_view>
 
@@ -328,6 +330,40 @@ namespace xamarin::android {
 		static auto path_has_directory_components (std::string_view const& path) noexcept -> bool
 		{
 			return !path.empty () && path.contains ('/');
+		}
+
+		template<size_t Size>
+		static auto join_paths (std::array<char, Size>& buffer, std::string_view first, std::string_view second) noexcept -> std::optional<std::string_view>
+		{
+			static_assert (Size > 0);
+
+			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
+			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
+			size_t second_offset = remove_duplicate_separator ? 1uz : 0uz;
+			size_t path_length = Helpers::add_with_overflow_check<size_t> (first.length (), second.length () - second_offset);
+			if (add_separator) {
+				path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+			}
+
+			if (path_length >= Size) {
+				return std::nullopt;
+			}
+
+			char *destination = buffer.data ();
+			if (!first.empty ()) {
+				memcpy (destination, first.data (), first.length ());
+				destination += first.length ();
+			}
+			if (add_separator) {
+				*destination++ = '/';
+			}
+			size_t second_length = second.length () - second_offset;
+			if (second_length > 0) {
+				memcpy (destination, second.data () + second_offset, second_length);
+			}
+			buffer [path_length] = '\0';
+
+			return std::string_view { buffer.data (), path_length };
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -5,7 +5,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <array>
 #include <cerrno>
 #include <concepts>
 #include <cstdio>
@@ -48,7 +47,7 @@ namespace xamarin::android {
 
 	class Util
 	{
-		static constexpr inline std::array<char, 16> hex_map {
+		static constexpr inline char hex_map [16] {
 			'0', '1', '2', '3', '4', '5', '6', '7',
 			'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
 		};

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -344,16 +344,15 @@ namespace xamarin::android {
 			return static_cast<ssize_t>(path_length);
 		}
 
-		static auto join_paths (char *stack_buffer, size_t stack_buffer_size, char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> const char*
+		static auto join_paths (char *stack_buffer, size_t stack_buffer_size, std::string_view first, std::string_view second) noexcept -> char*
 		{
-			heap_buffer = nullptr;
 			ssize_t result = join_paths (stack_buffer, stack_buffer_size, first, second);
 			if (result >= 0) {
 				return stack_buffer;
 			}
 
 			size_t required_capacity = static_cast<size_t>(-result);
-			heap_buffer = static_cast<char*> (std::malloc (required_capacity));
+			char *heap_buffer = static_cast<char*> (std::malloc (required_capacity));
 			abort_unless (heap_buffer != nullptr, "Failed to allocate joined path");
 			result = join_paths (heap_buffer, required_capacity, first, second);
 			abort_unless (result >= 0, "Failed to join path using the required capacity");

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <limits>
@@ -309,7 +310,8 @@ namespace xamarin::android {
 			return !path.empty () && path.contains ('/');
 		}
 
-		static auto get_joined_path_length (std::string_view first, std::string_view second) noexcept -> size_t
+		// Returns the path length excluding NUL, or the negative required capacity including NUL.
+		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> ssize_t
 		{
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
 			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
@@ -318,17 +320,13 @@ namespace xamarin::android {
 			if (add_separator) {
 				path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 			}
-			return path_length;
-		}
 
-		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> size_t
-		{
-			size_t path_length = get_joined_path_length (first, second);
-			abort_unless (buffer != nullptr && buffer_size > path_length, "Joined path buffer is too small");
+			size_t required_capacity = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+			abort_unless (required_capacity <= static_cast<size_t>(std::numeric_limits<ssize_t>::max ()), "Joined path is too long");
+			if (buffer == nullptr || buffer_size < required_capacity) {
+				return -static_cast<ssize_t>(required_capacity);
+			}
 
-			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
-			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
-			size_t second_offset = remove_duplicate_separator ? 1uz : 0uz;
 			char *destination = buffer;
 			if (!first.empty ()) {
 				memcpy (destination, first.data (), first.length ());
@@ -343,7 +341,24 @@ namespace xamarin::android {
 			}
 			buffer [path_length] = '\0';
 
-			return path_length;
+			return static_cast<ssize_t>(path_length);
+		}
+
+		template<size_t Size>
+		static auto join_paths (char (&stack_buffer)[Size], char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> ssize_t
+		{
+			heap_buffer = nullptr;
+			ssize_t result = join_paths (stack_buffer, Size, first, second);
+			if (result >= 0) {
+				return result;
+			}
+
+			size_t required_capacity = static_cast<size_t>(-result);
+			heap_buffer = static_cast<char*> (std::malloc (required_capacity));
+			abort_unless (heap_buffer != nullptr, "Failed to allocate joined path");
+			result = join_paths (heap_buffer, required_capacity, first, second);
+			abort_unless (result >= 0, "Failed to join path using the required capacity");
+			return result;
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -344,11 +344,10 @@ namespace xamarin::android {
 			return static_cast<ssize_t>(path_length);
 		}
 
-		template<size_t Size>
-		static auto join_paths (char (&stack_buffer)[Size], char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> const char*
+		static auto join_paths (char *stack_buffer, size_t stack_buffer_size, char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> const char*
 		{
 			heap_buffer = nullptr;
-			ssize_t result = join_paths (stack_buffer, Size, first, second);
+			ssize_t result = join_paths (stack_buffer, stack_buffer_size, first, second);
 			if (result >= 0) {
 				return stack_buffer;
 			}

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -345,12 +345,12 @@ namespace xamarin::android {
 		}
 
 		template<size_t Size>
-		static auto join_paths (char (&stack_buffer)[Size], char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> ssize_t
+		static auto join_paths (char (&stack_buffer)[Size], char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> const char*
 		{
 			heap_buffer = nullptr;
 			ssize_t result = join_paths (stack_buffer, Size, first, second);
 			if (result >= 0) {
-				return result;
+				return stack_buffer;
 			}
 
 			size_t required_capacity = static_cast<size_t>(-result);
@@ -358,7 +358,12 @@ namespace xamarin::android {
 			abort_unless (heap_buffer != nullptr, "Failed to allocate joined path");
 			result = join_paths (heap_buffer, required_capacity, first, second);
 			abort_unless (result >= 0, "Failed to join path using the required capacity");
-			return result;
+			return heap_buffer;
+		}
+
+		static void free_if_used (void *heap_buffer) noexcept
+		{
+			std::free (heap_buffer);
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -6,10 +6,10 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <limits>
-#include <memory>
 #include <optional>
 #include <string_view>
 
@@ -308,7 +308,7 @@ namespace xamarin::android {
 			return !path.empty () && path.contains ('/');
 		}
 
-		static auto join_paths (std::string_view first, std::string_view second, size_t &path_length) noexcept -> std::unique_ptr<char[]>
+		static auto join_paths (std::string_view first, std::string_view second, size_t &path_length) noexcept -> char*
 		{
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
 			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
@@ -319,8 +319,9 @@ namespace xamarin::android {
 			}
 
 			size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
-			auto buffer = std::make_unique<char[]> (allocation_size);
-			char *destination = buffer.get ();
+			auto buffer = static_cast<char*> (std::malloc (allocation_size));
+			abort_unless (buffer != nullptr, "Failed to allocate joined path");
+			char *destination = buffer;
 			if (!first.empty ()) {
 				memcpy (destination, first.data (), first.length ());
 				destination += first.length ();
@@ -337,7 +338,7 @@ namespace xamarin::android {
 			return buffer;
 		}
 
-		static auto join_paths (std::string_view first, std::string_view second) noexcept -> std::unique_ptr<char[]>
+		static auto join_paths (std::string_view first, std::string_view second) noexcept -> char*
 		{
 			size_t path_length;
 			return join_paths (first, second, path_length);

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -361,11 +361,6 @@ namespace xamarin::android {
 			return heap_buffer;
 		}
 
-		static void free_if_used (void *heap_buffer) noexcept
-		{
-			std::free (heap_buffer);
-		}
-
 	private:
 		static inline int page_size = getpagesize ();
 	};

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include <limits>
 #include <string_view>
 
@@ -257,14 +258,15 @@ AndroidSystem::setup_environment () noexcept
 #if defined(DEBUG)
 	log_debug (LOG_DEFAULT, "Loading environment from the override directory."sv);
 
-	auto env_override_file_buffer = Util::join_paths (
+	char *env_override_file = Util::join_paths (
 		primary_override_dir,
 		Constants::OVERRIDE_ENVIRONMENT_FILE_NAME
 	);
-	if (Util::file_exists (env_override_file_buffer.get ())) {
-		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file_buffer.get ());
-		setup_environment_from_override_file (env_override_file_buffer.get ());
+	if (Util::file_exists (env_override_file)) {
+		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file);
+		setup_environment_from_override_file (env_override_file);
 	}
+	std::free (env_override_file);
 #endif // def DEBUG
 }
 
@@ -272,12 +274,11 @@ void
 AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcept
 {
 	// appDirs[Constants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
-	auto libmonodroid_path_buffer = Util::join_paths (
+	char *libmonodroid_path = Util::join_paths (
 		appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view (),
 		"libmonodroid.so"sv
 	);
 
-	const char *libmonodroid_path = libmonodroid_path_buffer.get ();
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path);
 	if (!Util::file_exists (libmonodroid_path)) {
 		log_debug (LOG_ASSEMBLY, "{} not found, assuming application/android:extractNativeLibs == false", libmonodroid_path);
@@ -287,6 +288,7 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 		set_embedded_dso_mode_enabled (false);
 		native_libraries_dir.assign (appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
 	}
+	std::free (libmonodroid_path);
 }
 
 auto

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -258,15 +258,17 @@ AndroidSystem::setup_environment () noexcept
 #if defined(DEBUG)
 	log_debug (LOG_DEFAULT, "Loading environment from the override directory."sv);
 
-	char *env_override_file = Util::join_paths (
-		primary_override_dir,
-		Constants::OVERRIDE_ENVIRONMENT_FILE_NAME
-	);
+	size_t env_override_file_length = Util::get_joined_path_length (primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
+	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (env_override_file_length, 1uz);
+	char local_buffer [Util::LocalPathBufferSize];
+	char *env_override_file = Helpers::get_temporary_buffer (local_buffer, allocation_size);
+	Util::join_paths (env_override_file, allocation_size, primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
+
 	if (Util::file_exists (env_override_file)) {
 		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file);
 		setup_environment_from_override_file (env_override_file);
 	}
-	std::free (env_override_file);
+	Helpers::free_temporary_buffer (env_override_file, local_buffer);
 #endif // def DEBUG
 }
 
@@ -274,10 +276,12 @@ void
 AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcept
 {
 	// appDirs[Constants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
-	char *libmonodroid_path = Util::join_paths (
-		appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view (),
-		"libmonodroid.so"sv
-	);
+	std::string_view app_data_dir = appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view ();
+	size_t path_length = Util::get_joined_path_length (app_data_dir, "libmonodroid.so"sv);
+	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+	char local_buffer [Util::LocalPathBufferSize];
+	char *libmonodroid_path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
+	Util::join_paths (libmonodroid_path, allocation_size, app_data_dir, "libmonodroid.so"sv);
 
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path);
 	if (!Util::file_exists (libmonodroid_path)) {
@@ -288,7 +292,7 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 		set_embedded_dso_mode_enabled (false);
 		native_libraries_dir.assign (appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
 	}
-	std::free (libmonodroid_path);
+	Helpers::free_temporary_buffer (libmonodroid_path, local_buffer);
 }
 
 auto

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -259,14 +259,15 @@ AndroidSystem::setup_environment () noexcept
 	log_debug (LOG_DEFAULT, "Loading environment from the override directory."sv);
 
 	char stack_buffer [Util::LocalPathBufferSize];
-	char *heap_buffer;
-	const char *env_override_file = Util::join_paths (stack_buffer, sizeof (stack_buffer), heap_buffer, primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
+	char *env_override_file = Util::join_paths (stack_buffer, sizeof (stack_buffer), primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
 
 	if (Util::file_exists (env_override_file)) {
 		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file);
 		setup_environment_from_override_file (env_override_file);
 	}
-	std::free (heap_buffer);
+	if (env_override_file != stack_buffer) {
+		std::free (env_override_file);
+	}
 #endif // def DEBUG
 }
 
@@ -276,8 +277,7 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 	// appDirs[Constants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
 	std::string_view app_data_dir = appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view ();
 	char stack_buffer [Util::LocalPathBufferSize];
-	char *heap_buffer;
-	const char *libmonodroid_path = Util::join_paths (stack_buffer, sizeof (stack_buffer), heap_buffer, app_data_dir, "libmonodroid.so"sv);
+	char *libmonodroid_path = Util::join_paths (stack_buffer, sizeof (stack_buffer), app_data_dir, "libmonodroid.so"sv);
 
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path);
 	if (!Util::file_exists (libmonodroid_path)) {
@@ -288,7 +288,9 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 		set_embedded_dso_mode_enabled (false);
 		native_libraries_dir.assign (appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
 	}
-	std::free (heap_buffer);
+	if (libmonodroid_path != stack_buffer) {
+		std::free (libmonodroid_path);
+	}
 }
 
 auto

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -1,3 +1,4 @@
+#include <array>
 #include <limits>
 #include <string_view>
 
@@ -58,19 +59,19 @@ AndroidSystem::setup_environment (const char *name, const char *value) noexcept
 }
 
 void
-AndroidSystem::setup_environment_from_override_file (dynamic_local_string<Constants::SENSIBLE_PATH_MAX> const& path) noexcept
+AndroidSystem::setup_environment_from_override_file (std::string_view path) noexcept
 {
 	using read_count_type = size_t;
 
 	struct stat sbuf;
-	if (::stat (path.get (), &sbuf) < 0) {
-		log_warn (LOG_DEFAULT, "Failed to stat the environment override file {}: {}", path.get (), strerror (errno));
+	if (::stat (path.data (), &sbuf) < 0) {
+		log_warn (LOG_DEFAULT, "Failed to stat the environment override file {}: {}", path, strerror (errno));
 		return;
 	}
 
-	int fd = open (path.get (), O_RDONLY);
+	int fd = open (path.data (), O_RDONLY);
 	if (fd < 0) {
-		log_warn (LOG_DEFAULT, "Failed to open the environment override file {}: {}", path.get (), strerror (errno));
+		log_warn (LOG_DEFAULT, "Failed to open the environment override file {}: {}", path, strerror (errno));
 		return;
 	}
 
@@ -88,7 +89,7 @@ AndroidSystem::setup_environment_from_override_file (dynamic_local_string<Consta
 	} while (r < 0 && errno == EINTR);
 
 	if (nread == 0) {
-		log_warn (LOG_DEFAULT, "Failed to read the environment override file {}: {}", path.get (), strerror (errno));
+		log_warn (LOG_DEFAULT, "Failed to read the environment override file {}: {}", path, strerror (errno));
 		return;
 	}
 
@@ -109,26 +110,26 @@ AndroidSystem::setup_environment_from_override_file (dynamic_local_string<Consta
 	// # Variable value, terminated with NUL and padded to [value width] with NUL characters
 	// value\0
 	if (nread < Constants::OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE) {
-		log_warn (LOG_DEFAULT, "Invalid format of the environment override file {}: malformatted header", path.get ());
+		log_warn (LOG_DEFAULT, "Invalid format of the environment override file {}: malformatted header", path);
 		return;
 	}
 
 	char *endptr;
 	unsigned long name_width = strtoul (buf.get (), &endptr, 16);
 	if ((name_width == std::numeric_limits<unsigned long>::max () && errno == ERANGE) || (buf[0] != '\0' && *endptr != '\0')) {
-		log_warn (LOG_DEFAULT, "Malformed header of the environment override file {}: name width has invalid format", path.get ());
+		log_warn (LOG_DEFAULT, "Malformed header of the environment override file {}: name width has invalid format", path);
 		return;
 	}
 
 	unsigned long value_width = strtoul (buf.get () + 11, &endptr, 16);
 	if ((value_width == std::numeric_limits<unsigned long>::max () && errno == ERANGE) || (buf[0] != '\0' && *endptr != '\0')) {
-		log_warn (LOG_DEFAULT, "Malformed header of the environment override file {}: value width has invalid format", path.get ());
+		log_warn (LOG_DEFAULT, "Malformed header of the environment override file {}: value width has invalid format", path);
 		return;
 	}
 
 	uint64_t data_width = name_width + value_width;
 	if (data_width > file_size - Constants::OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE || (file_size - Constants::OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE) % data_width != 0) {
-		log_warn (LOG_DEFAULT, "Malformed environment override file {}: invalid data size", path.get ());
+		log_warn (LOG_DEFAULT, "Malformed environment override file {}: invalid data size", path);
 		return;
 	}
 
@@ -136,11 +137,11 @@ AndroidSystem::setup_environment_from_override_file (dynamic_local_string<Consta
 	char *name = buf.get () + Constants::OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE;
 	while (data_size > 0 && data_size >= data_width) {
 		if (*name == '\0') {
-			log_warn (LOG_DEFAULT, "Malformed environment override file {}: name at offset {} is empty", path.get (), name - buf.get ());
+			log_warn (LOG_DEFAULT, "Malformed environment override file {}: name at offset {} is empty", path, name - buf.get ());
 			return;
 		}
 
-		log_debug (LOG_DEFAULT, "Setting environment variable from the override file {}: '{}' = '{}'", path.get (), name, name + name_width);
+		log_debug (LOG_DEFAULT, "Setting environment variable from the override file {}: '{}' = '{}'", path, name, name + name_width);
 		setup_environment (name, name + name_width);
 		name += data_width;
 		data_size -= data_width;
@@ -257,12 +258,18 @@ AndroidSystem::setup_environment () noexcept
 #if defined(DEBUG)
 	log_debug (LOG_DEFAULT, "Loading environment from the override directory."sv);
 
-	dynamic_local_string<Constants::SENSIBLE_PATH_MAX> env_override_file;
-	Util::path_combine (env_override_file, std::string_view {primary_override_dir}, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
-	log_debug (LOG_DEFAULT, "{}", env_override_file.get ());
-	if (Util::file_exists (env_override_file)) {
-		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file.get ());
-		setup_environment_from_override_file (env_override_file);
+	std::array<char, Constants::SENSIBLE_PATH_MAX> env_override_file_buffer;
+	auto env_override_file = Util::join_paths (
+		env_override_file_buffer.data (),
+		env_override_file_buffer.size (),
+		primary_override_dir,
+		Constants::OVERRIDE_ENVIRONMENT_FILE_NAME
+	);
+	if (!env_override_file.has_value ()) {
+		log_warn (LOG_DEFAULT, "Environment override file path is too long");
+	} else if (Util::file_exists (*env_override_file)) {
+		log_debug (LOG_DEFAULT, "Loading {}"sv, *env_override_file);
+		setup_environment_from_override_file (*env_override_file);
 	}
 #endif // def DEBUG
 }
@@ -271,12 +278,22 @@ void
 AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcept
 {
 	// appDirs[Constants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
-	dynamic_local_string<Constants::SENSIBLE_PATH_MAX> libmonodroid_path;
-	Util::path_combine (libmonodroid_path, appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view (), "libmonodroid.so"sv);
+	std::array<char, Constants::SENSIBLE_PATH_MAX> libmonodroid_path_buffer;
+	auto libmonodroid_path = Util::join_paths (
+		libmonodroid_path_buffer.data (),
+		libmonodroid_path_buffer.size (),
+		appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view (),
+		"libmonodroid.so"sv
+	);
+	if (!libmonodroid_path.has_value ()) {
+		log_warn (LOG_ASSEMBLY, "libmonodroid path is too long, assuming application/android:extractNativeLibs == false");
+		set_embedded_dso_mode_enabled (true);
+		return;
+	}
 
-	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path.get ());
-	if (!Util::file_exists (libmonodroid_path)) {
-		log_debug (LOG_ASSEMBLY, "{} not found, assuming application/android:extractNativeLibs == false", libmonodroid_path.get ());
+	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", *libmonodroid_path);
+	if (!Util::file_exists (*libmonodroid_path)) {
+		log_debug (LOG_ASSEMBLY, "{} not found, assuming application/android:extractNativeLibs == false", *libmonodroid_path);
 		set_embedded_dso_mode_enabled (true);
 	} else {
 		log_debug (LOG_ASSEMBLY, "Native libs extracted to {}, assuming application/android:extractNativeLibs == true", appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -258,17 +258,16 @@ AndroidSystem::setup_environment () noexcept
 #if defined(DEBUG)
 	log_debug (LOG_DEFAULT, "Loading environment from the override directory."sv);
 
-	size_t env_override_file_length = Util::get_joined_path_length (primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
-	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (env_override_file_length, 1uz);
 	char local_buffer [Util::LocalPathBufferSize];
-	char *env_override_file = Helpers::get_temporary_buffer (local_buffer, allocation_size);
-	Util::join_paths (env_override_file, allocation_size, primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
+	char *heap_buffer;
+	Util::join_paths (local_buffer, heap_buffer, primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
+	const char *env_override_file = heap_buffer == nullptr ? local_buffer : heap_buffer;
 
 	if (Util::file_exists (env_override_file)) {
 		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file);
 		setup_environment_from_override_file (env_override_file);
 	}
-	Helpers::free_temporary_buffer (env_override_file, local_buffer);
+	std::free (heap_buffer);
 #endif // def DEBUG
 }
 
@@ -277,11 +276,10 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 {
 	// appDirs[Constants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
 	std::string_view app_data_dir = appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view ();
-	size_t path_length = Util::get_joined_path_length (app_data_dir, "libmonodroid.so"sv);
-	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 	char local_buffer [Util::LocalPathBufferSize];
-	char *libmonodroid_path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
-	Util::join_paths (libmonodroid_path, allocation_size, app_data_dir, "libmonodroid.so"sv);
+	char *heap_buffer;
+	Util::join_paths (local_buffer, heap_buffer, app_data_dir, "libmonodroid.so"sv);
+	const char *libmonodroid_path = heap_buffer == nullptr ? local_buffer : heap_buffer;
 
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path);
 	if (!Util::file_exists (libmonodroid_path)) {
@@ -292,7 +290,7 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 		set_embedded_dso_mode_enabled (false);
 		native_libraries_dir.assign (appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
 	}
-	Helpers::free_temporary_buffer (libmonodroid_path, local_buffer);
+	std::free (heap_buffer);
 }
 
 auto

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -260,14 +260,13 @@ AndroidSystem::setup_environment () noexcept
 
 	char local_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	Util::join_paths (local_buffer, heap_buffer, primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
-	const char *env_override_file = heap_buffer == nullptr ? local_buffer : heap_buffer;
+	const char *env_override_file = Util::join_paths (local_buffer, heap_buffer, primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
 
 	if (Util::file_exists (env_override_file)) {
 		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file);
 		setup_environment_from_override_file (env_override_file);
 	}
-	std::free (heap_buffer);
+	Util::free_if_used (heap_buffer);
 #endif // def DEBUG
 }
 
@@ -278,8 +277,7 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 	std::string_view app_data_dir = appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view ();
 	char local_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	Util::join_paths (local_buffer, heap_buffer, app_data_dir, "libmonodroid.so"sv);
-	const char *libmonodroid_path = heap_buffer == nullptr ? local_buffer : heap_buffer;
+	const char *libmonodroid_path = Util::join_paths (local_buffer, heap_buffer, app_data_dir, "libmonodroid.so"sv);
 
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path);
 	if (!Util::file_exists (libmonodroid_path)) {
@@ -290,7 +288,7 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 		set_embedded_dso_mode_enabled (false);
 		native_libraries_dir.assign (appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
 	}
-	std::free (heap_buffer);
+	Util::free_if_used (heap_buffer);
 }
 
 auto

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -260,7 +260,7 @@ AndroidSystem::setup_environment () noexcept
 
 	char stack_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	const char *env_override_file = Util::join_paths (stack_buffer, heap_buffer, primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
+	const char *env_override_file = Util::join_paths (stack_buffer, sizeof (stack_buffer), heap_buffer, primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
 
 	if (Util::file_exists (env_override_file)) {
 		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file);
@@ -277,7 +277,7 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 	std::string_view app_data_dir = appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view ();
 	char stack_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	const char *libmonodroid_path = Util::join_paths (stack_buffer, heap_buffer, app_data_dir, "libmonodroid.so"sv);
+	const char *libmonodroid_path = Util::join_paths (stack_buffer, sizeof (stack_buffer), heap_buffer, app_data_dir, "libmonodroid.so"sv);
 
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path);
 	if (!Util::file_exists (libmonodroid_path)) {

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -258,15 +258,15 @@ AndroidSystem::setup_environment () noexcept
 #if defined(DEBUG)
 	log_debug (LOG_DEFAULT, "Loading environment from the override directory."sv);
 
-	char local_buffer [Util::LocalPathBufferSize];
+	char stack_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	const char *env_override_file = Util::join_paths (local_buffer, heap_buffer, primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
+	const char *env_override_file = Util::join_paths (stack_buffer, heap_buffer, primary_override_dir, Constants::OVERRIDE_ENVIRONMENT_FILE_NAME);
 
 	if (Util::file_exists (env_override_file)) {
 		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file);
 		setup_environment_from_override_file (env_override_file);
 	}
-	Util::free_if_used (heap_buffer);
+	std::free (heap_buffer);
 #endif // def DEBUG
 }
 
@@ -275,9 +275,9 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 {
 	// appDirs[Constants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
 	std::string_view app_data_dir = appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view ();
-	char local_buffer [Util::LocalPathBufferSize];
+	char stack_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	const char *libmonodroid_path = Util::join_paths (local_buffer, heap_buffer, app_data_dir, "libmonodroid.so"sv);
+	const char *libmonodroid_path = Util::join_paths (stack_buffer, heap_buffer, app_data_dir, "libmonodroid.so"sv);
 
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path);
 	if (!Util::file_exists (libmonodroid_path)) {
@@ -288,7 +288,7 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 		set_embedded_dso_mode_enabled (false);
 		native_libraries_dir.assign (appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
 	}
-	Util::free_if_used (heap_buffer);
+	std::free (heap_buffer);
 }
 
 auto

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -1,4 +1,3 @@
-#include <array>
 #include <limits>
 #include <string_view>
 
@@ -258,18 +257,18 @@ AndroidSystem::setup_environment () noexcept
 #if defined(DEBUG)
 	log_debug (LOG_DEFAULT, "Loading environment from the override directory."sv);
 
-	std::array<char, Constants::SENSIBLE_PATH_MAX> env_override_file_buffer;
+	char env_override_file_buffer [Constants::SENSIBLE_PATH_MAX];
 	ssize_t env_override_file_length = Util::join_paths (
-		env_override_file_buffer.data (),
-		env_override_file_buffer.size (),
+		env_override_file_buffer,
+		sizeof (env_override_file_buffer),
 		primary_override_dir,
 		Constants::OVERRIDE_ENVIRONMENT_FILE_NAME
 	);
 	if (env_override_file_length < 0) {
 		log_warn (LOG_DEFAULT, "Environment override file path is too long");
-	} else if (Util::file_exists (env_override_file_buffer.data ())) {
-		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file_buffer.data ());
-		setup_environment_from_override_file (env_override_file_buffer.data ());
+	} else if (Util::file_exists (env_override_file_buffer)) {
+		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file_buffer);
+		setup_environment_from_override_file (env_override_file_buffer);
 	}
 #endif // def DEBUG
 }
@@ -278,10 +277,10 @@ void
 AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcept
 {
 	// appDirs[Constants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
-	std::array<char, Constants::SENSIBLE_PATH_MAX> libmonodroid_path_buffer;
+	char libmonodroid_path_buffer [Constants::SENSIBLE_PATH_MAX];
 	ssize_t libmonodroid_path_length = Util::join_paths (
-		libmonodroid_path_buffer.data (),
-		libmonodroid_path_buffer.size (),
+		libmonodroid_path_buffer,
+		sizeof (libmonodroid_path_buffer),
 		appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view (),
 		"libmonodroid.so"sv
 	);
@@ -291,7 +290,7 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 		return;
 	}
 
-	const char *libmonodroid_path = libmonodroid_path_buffer.data ();
+	const char *libmonodroid_path = libmonodroid_path_buffer;
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path);
 	if (!Util::file_exists (libmonodroid_path)) {
 		log_debug (LOG_ASSEMBLY, "{} not found, assuming application/android:extractNativeLibs == false", libmonodroid_path);

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -257,18 +257,13 @@ AndroidSystem::setup_environment () noexcept
 #if defined(DEBUG)
 	log_debug (LOG_DEFAULT, "Loading environment from the override directory."sv);
 
-	char env_override_file_buffer [Constants::SENSIBLE_PATH_MAX];
-	ssize_t env_override_file_length = Util::join_paths (
-		env_override_file_buffer,
-		sizeof (env_override_file_buffer),
+	auto env_override_file_buffer = Util::join_paths (
 		primary_override_dir,
 		Constants::OVERRIDE_ENVIRONMENT_FILE_NAME
 	);
-	if (env_override_file_length < 0) {
-		log_warn (LOG_DEFAULT, "Environment override file path is too long");
-	} else if (Util::file_exists (env_override_file_buffer)) {
-		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file_buffer);
-		setup_environment_from_override_file (env_override_file_buffer);
+	if (Util::file_exists (env_override_file_buffer.get ())) {
+		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file_buffer.get ());
+		setup_environment_from_override_file (env_override_file_buffer.get ());
 	}
 #endif // def DEBUG
 }
@@ -277,20 +272,12 @@ void
 AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcept
 {
 	// appDirs[Constants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
-	char libmonodroid_path_buffer [Constants::SENSIBLE_PATH_MAX];
-	ssize_t libmonodroid_path_length = Util::join_paths (
-		libmonodroid_path_buffer,
-		sizeof (libmonodroid_path_buffer),
+	auto libmonodroid_path_buffer = Util::join_paths (
 		appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view (),
 		"libmonodroid.so"sv
 	);
-	if (libmonodroid_path_length < 0) {
-		log_warn (LOG_ASSEMBLY, "libmonodroid path is too long, assuming application/android:extractNativeLibs == false");
-		set_embedded_dso_mode_enabled (true);
-		return;
-	}
 
-	const char *libmonodroid_path = libmonodroid_path_buffer;
+	const char *libmonodroid_path = libmonodroid_path_buffer.get ();
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path);
 	if (!Util::file_exists (libmonodroid_path)) {
 		log_debug (LOG_ASSEMBLY, "{} not found, assuming application/android:extractNativeLibs == false", libmonodroid_path);

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -259,13 +259,13 @@ AndroidSystem::setup_environment () noexcept
 	log_debug (LOG_DEFAULT, "Loading environment from the override directory."sv);
 
 	std::array<char, Constants::SENSIBLE_PATH_MAX> env_override_file_buffer;
-	size_t env_override_file_length = Util::join_paths (
+	ssize_t env_override_file_length = Util::join_paths (
 		env_override_file_buffer.data (),
 		env_override_file_buffer.size (),
 		primary_override_dir,
 		Constants::OVERRIDE_ENVIRONMENT_FILE_NAME
 	);
-	if (env_override_file_length == 0) {
+	if (env_override_file_length < 0) {
 		log_warn (LOG_DEFAULT, "Environment override file path is too long");
 	} else if (Util::file_exists (env_override_file_buffer.data ())) {
 		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file_buffer.data ());
@@ -279,13 +279,13 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 {
 	// appDirs[Constants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
 	std::array<char, Constants::SENSIBLE_PATH_MAX> libmonodroid_path_buffer;
-	size_t libmonodroid_path_length = Util::join_paths (
+	ssize_t libmonodroid_path_length = Util::join_paths (
 		libmonodroid_path_buffer.data (),
 		libmonodroid_path_buffer.size (),
 		appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view (),
 		"libmonodroid.so"sv
 	);
-	if (libmonodroid_path_length == 0) {
+	if (libmonodroid_path_length < 0) {
 		log_warn (LOG_ASSEMBLY, "libmonodroid path is too long, assuming application/android:extractNativeLibs == false");
 		set_embedded_dso_mode_enabled (true);
 		return;

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -59,17 +59,17 @@ AndroidSystem::setup_environment (const char *name, const char *value) noexcept
 }
 
 void
-AndroidSystem::setup_environment_from_override_file (std::string_view path) noexcept
+AndroidSystem::setup_environment_from_override_file (const char *path) noexcept
 {
 	using read_count_type = size_t;
 
 	struct stat sbuf;
-	if (::stat (path.data (), &sbuf) < 0) {
+	if (::stat (path, &sbuf) < 0) {
 		log_warn (LOG_DEFAULT, "Failed to stat the environment override file {}: {}", path, strerror (errno));
 		return;
 	}
 
-	int fd = open (path.data (), O_RDONLY);
+	int fd = open (path, O_RDONLY);
 	if (fd < 0) {
 		log_warn (LOG_DEFAULT, "Failed to open the environment override file {}: {}", path, strerror (errno));
 		return;
@@ -259,17 +259,17 @@ AndroidSystem::setup_environment () noexcept
 	log_debug (LOG_DEFAULT, "Loading environment from the override directory."sv);
 
 	std::array<char, Constants::SENSIBLE_PATH_MAX> env_override_file_buffer;
-	auto env_override_file = Util::join_paths (
+	size_t env_override_file_length = Util::join_paths (
 		env_override_file_buffer.data (),
 		env_override_file_buffer.size (),
 		primary_override_dir,
 		Constants::OVERRIDE_ENVIRONMENT_FILE_NAME
 	);
-	if (!env_override_file.has_value ()) {
+	if (env_override_file_length == 0) {
 		log_warn (LOG_DEFAULT, "Environment override file path is too long");
-	} else if (Util::file_exists (*env_override_file)) {
-		log_debug (LOG_DEFAULT, "Loading {}"sv, *env_override_file);
-		setup_environment_from_override_file (*env_override_file);
+	} else if (Util::file_exists (env_override_file_buffer.data ())) {
+		log_debug (LOG_DEFAULT, "Loading {}"sv, env_override_file_buffer.data ());
+		setup_environment_from_override_file (env_override_file_buffer.data ());
 	}
 #endif // def DEBUG
 }
@@ -279,21 +279,22 @@ AndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcep
 {
 	// appDirs[Constants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
 	std::array<char, Constants::SENSIBLE_PATH_MAX> libmonodroid_path_buffer;
-	auto libmonodroid_path = Util::join_paths (
+	size_t libmonodroid_path_length = Util::join_paths (
 		libmonodroid_path_buffer.data (),
 		libmonodroid_path_buffer.size (),
 		appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_string_view (),
 		"libmonodroid.so"sv
 	);
-	if (!libmonodroid_path.has_value ()) {
+	if (libmonodroid_path_length == 0) {
 		log_warn (LOG_ASSEMBLY, "libmonodroid path is too long, assuming application/android:extractNativeLibs == false");
 		set_embedded_dso_mode_enabled (true);
 		return;
 	}
 
-	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", *libmonodroid_path);
-	if (!Util::file_exists (*libmonodroid_path)) {
-		log_debug (LOG_ASSEMBLY, "{} not found, assuming application/android:extractNativeLibs == false", *libmonodroid_path);
+	const char *libmonodroid_path = libmonodroid_path_buffer.data ();
+	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to {}", libmonodroid_path);
+	if (!Util::file_exists (libmonodroid_path)) {
+		log_debug (LOG_ASSEMBLY, "{} not found, assuming application/android:extractNativeLibs == false", libmonodroid_path);
 		set_embedded_dso_mode_enabled (true);
 	} else {
 		log_debug (LOG_ASSEMBLY, "Native libs extracted to {}, assuming application/android:extractNativeLibs == true", appDirs[Constants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -79,13 +79,13 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 
 	Util::create_public_directory (override_dir);
 	std::array<char, Constants::SENSIBLE_PATH_MAX> path_buffer;
-	auto path = Util::join_paths (path_buffer.data (), path_buffer.size (), override_dir, fallback_filename);
-	if (!path.has_value ()) {
+	size_t path_length = Util::join_paths (path_buffer.data (), path_buffer.size (), override_dir, fallback_filename);
+	if (path_length == 0) {
 		log_warnf (category, "Unable to open fallback log file: path is too long");
 		return nullptr;
 	}
 
-	std::string_view path_view = *path;
+	std::string_view path_view { path_buffer.data (), path_length - 1uz };
 	return log_and_return (open_file (path_view), path_view);
 }
 

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -77,11 +77,15 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 	}
 
 	Util::create_public_directory (override_dir);
-	size_t path_length;
-	char *path_buffer = Util::join_paths (override_dir, fallback_filename, path_length);
+	size_t path_length = Util::get_joined_path_length (override_dir, fallback_filename);
+	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+	char local_buffer [Util::LocalPathBufferSize];
+	char *path_buffer = Helpers::get_temporary_buffer (local_buffer, allocation_size);
+	Util::join_paths (path_buffer, allocation_size, override_dir, fallback_filename);
+
 	std::string_view path_view { path_buffer, path_length };
 	FILE *ret = log_and_return (open_file (path_view), path_view);
-	std::free (path_buffer);
+	Helpers::free_temporary_buffer (path_buffer, local_buffer);
 	return ret;
 }
 

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -1,4 +1,3 @@
-#include <array>
 #include <cerrno>
 #include <cstdarg>
 #include <cstdlib>
@@ -78,14 +77,14 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 	}
 
 	Util::create_public_directory (override_dir);
-	std::array<char, Constants::SENSIBLE_PATH_MAX> path_buffer;
-	ssize_t path_length = Util::join_paths (path_buffer.data (), path_buffer.size (), override_dir, fallback_filename);
+	char path_buffer [Constants::SENSIBLE_PATH_MAX];
+	ssize_t path_length = Util::join_paths (path_buffer, sizeof (path_buffer), override_dir, fallback_filename);
 	if (path_length < 0) {
 		log_warnf (category, "Unable to open fallback log file: path is too long");
 		return nullptr;
 	}
 
-	std::string_view path_view { path_buffer.data (), static_cast<size_t>(path_length) };
+	std::string_view path_view { path_buffer, static_cast<size_t>(path_length) };
 	return log_and_return (open_file (path_view), path_view);
 }
 

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -79,12 +79,11 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 	Util::create_public_directory (override_dir);
 	char local_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	ssize_t path_length = Util::join_paths (local_buffer, heap_buffer, override_dir, fallback_filename);
-	const char *path_buffer = heap_buffer == nullptr ? local_buffer : heap_buffer;
+	const char *path_buffer = Util::join_paths (local_buffer, heap_buffer, override_dir, fallback_filename);
 
-	std::string_view path_view { path_buffer, static_cast<size_t>(path_length) };
+	std::string_view path_view { path_buffer };
 	ret = log_and_return (open_file (path_view), path_view);
-	std::free (heap_buffer);
+	Util::free_if_used (heap_buffer);
 	return ret;
 }
 

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -79,7 +79,7 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 	Util::create_public_directory (override_dir);
 	char stack_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	const char *path_buffer = Util::join_paths (stack_buffer, heap_buffer, override_dir, fallback_filename);
+	const char *path_buffer = Util::join_paths (stack_buffer, sizeof (stack_buffer), heap_buffer, override_dir, fallback_filename);
 
 	std::string_view path_view { path_buffer };
 	ret = log_and_return (open_file (path_view), path_view);

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -84,7 +84,7 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 	Util::join_paths (path_buffer, allocation_size, override_dir, fallback_filename);
 
 	std::string_view path_view { path_buffer, path_length };
-	FILE *ret = log_and_return (open_file (path_view), path_view);
+	ret = log_and_return (open_file (path_view), path_view);
 	Helpers::free_temporary_buffer (path_buffer, local_buffer);
 	return ret;
 }

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -77,13 +77,13 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 	}
 	Util::create_public_directory (override_dir);
 	Util::create_public_directory (override_dir);
-	char local_buffer [Util::LocalPathBufferSize];
+	char stack_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	const char *path_buffer = Util::join_paths (local_buffer, heap_buffer, override_dir, fallback_filename);
+	const char *path_buffer = Util::join_paths (stack_buffer, heap_buffer, override_dir, fallback_filename);
 
 	std::string_view path_view { path_buffer };
 	ret = log_and_return (open_file (path_view), path_view);
-	Util::free_if_used (heap_buffer);
+	std::free (heap_buffer);
 	return ret;
 }
 

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -77,14 +77,9 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 	}
 
 	Util::create_public_directory (override_dir);
-	char path_buffer [Constants::SENSIBLE_PATH_MAX];
-	ssize_t path_length = Util::join_paths (path_buffer, sizeof (path_buffer), override_dir, fallback_filename);
-	if (path_length < 0) {
-		log_warnf (category, "Unable to open fallback log file: path is too long");
-		return nullptr;
-	}
-
-	std::string_view path_view { path_buffer, static_cast<size_t>(path_length) };
+	size_t path_length;
+	auto path_buffer = Util::join_paths (override_dir, fallback_filename, path_length);
+	std::string_view path_view { path_buffer.get (), path_length };
 	return log_and_return (open_file (path_view), path_view);
 }
 

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -78,9 +78,11 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 
 	Util::create_public_directory (override_dir);
 	size_t path_length;
-	auto path_buffer = Util::join_paths (override_dir, fallback_filename, path_length);
-	std::string_view path_view { path_buffer.get (), path_length };
-	return log_and_return (open_file (path_view), path_view);
+	char *path_buffer = Util::join_paths (override_dir, fallback_filename, path_length);
+	std::string_view path_view { path_buffer, path_length };
+	FILE *ret = log_and_return (open_file (path_view), path_view);
+	std::free (path_buffer);
+	return ret;
 }
 
 void

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -78,13 +78,15 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 	}
 
 	Util::create_public_directory (override_dir);
-	dynamic_local_string<Constants::SENSIBLE_PATH_MAX> p;
-	p.append (override_dir)
-		.append ("/")
-		.append (fallback_filename);
+	std::array<char, Constants::SENSIBLE_PATH_MAX> path_buffer;
+	auto path = Util::join_paths (path_buffer, override_dir, fallback_filename);
+	if (!path.has_value ()) {
+		log_warnf (category, "Unable to open fallback log file: path is too long");
+		return nullptr;
+	}
 
-	std::string_view path = p.as_string_view ();
-	return log_and_return (open_file (path), path);
+	std::string_view path_view = *path;
+	return log_and_return (open_file (path_view), path_view);
 }
 
 void

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -79,7 +79,7 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 
 	Util::create_public_directory (override_dir);
 	std::array<char, Constants::SENSIBLE_PATH_MAX> path_buffer;
-	auto path = Util::join_paths (path_buffer, override_dir, fallback_filename);
+	auto path = Util::join_paths (path_buffer.data (), path_buffer.size (), override_dir, fallback_filename);
 	if (!path.has_value ()) {
 		log_warnf (category, "Unable to open fallback log file: path is too long");
 		return nullptr;

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -76,7 +76,6 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 		return log_and_return (ret, custom_path);
 	}
 	Util::create_public_directory (override_dir);
-	Util::create_public_directory (override_dir);
 	char stack_buffer [Util::LocalPathBufferSize];
 	char *path_buffer = Util::join_paths (stack_buffer, sizeof (stack_buffer), override_dir, fallback_filename);
 

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -79,13 +79,13 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 
 	Util::create_public_directory (override_dir);
 	std::array<char, Constants::SENSIBLE_PATH_MAX> path_buffer;
-	size_t path_length = Util::join_paths (path_buffer.data (), path_buffer.size (), override_dir, fallback_filename);
-	if (path_length == 0) {
+	ssize_t path_length = Util::join_paths (path_buffer.data (), path_buffer.size (), override_dir, fallback_filename);
+	if (path_length < 0) {
 		log_warnf (category, "Unable to open fallback log file: path is too long");
 		return nullptr;
 	}
 
-	std::string_view path_view { path_buffer.data (), path_length - 1uz };
+	std::string_view path_view { path_buffer.data (), static_cast<size_t>(path_length) };
 	return log_and_return (open_file (path_view), path_view);
 }
 

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -78,12 +78,13 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 	Util::create_public_directory (override_dir);
 	Util::create_public_directory (override_dir);
 	char stack_buffer [Util::LocalPathBufferSize];
-	char *heap_buffer;
-	const char *path_buffer = Util::join_paths (stack_buffer, sizeof (stack_buffer), heap_buffer, override_dir, fallback_filename);
+	char *path_buffer = Util::join_paths (stack_buffer, sizeof (stack_buffer), override_dir, fallback_filename);
 
 	std::string_view path_view { path_buffer };
 	ret = log_and_return (open_file (path_view), path_view);
-	std::free (heap_buffer);
+	if (path_buffer != stack_buffer) {
+		std::free (path_buffer);
+	}
 	return ret;
 }
 

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -75,17 +75,16 @@ auto Logger::open_file (LogCategories category, std::string_view const& custom_p
 	if (ret != nullptr) {
 		return log_and_return (ret, custom_path);
 	}
-
 	Util::create_public_directory (override_dir);
-	size_t path_length = Util::get_joined_path_length (override_dir, fallback_filename);
-	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+	Util::create_public_directory (override_dir);
 	char local_buffer [Util::LocalPathBufferSize];
-	char *path_buffer = Helpers::get_temporary_buffer (local_buffer, allocation_size);
-	Util::join_paths (path_buffer, allocation_size, override_dir, fallback_filename);
+	char *heap_buffer;
+	ssize_t path_length = Util::join_paths (local_buffer, heap_buffer, override_dir, fallback_filename);
+	const char *path_buffer = heap_buffer == nullptr ? local_buffer : heap_buffer;
 
-	std::string_view path_view { path_buffer, path_length };
+	std::string_view path_view { path_buffer, static_cast<size_t>(path_length) };
 	ret = log_and_return (open_file (path_view), path_view);
-	Helpers::free_temporary_buffer (path_buffer, local_buffer);
+	std::free (heap_buffer);
 	return ret;
 }
 

--- a/src/native/common/include/shared/helpers.hh
+++ b/src/native/common/include/shared/helpers.hh
@@ -19,28 +19,6 @@ namespace xamarin::android
 	class [[gnu::visibility("hidden")]] Helpers
 	{
 	public:
-		template<size_t Size>
-		static auto get_temporary_buffer (char (&local_buffer)[Size], size_t required_size) noexcept -> char*
-		{
-			if (required_size <= Size) {
-				return local_buffer;
-			}
-
-			auto buffer = static_cast<char*> (std::malloc (required_size));
-			if (buffer == nullptr) {
-				abort_application ("Failed to allocate temporary buffer");
-			}
-			return buffer;
-		}
-
-		template<size_t Size>
-		static void free_temporary_buffer (char *buffer, char (&local_buffer)[Size]) noexcept
-		{
-			if (buffer != local_buffer) {
-				std::free (buffer);
-			}
-		}
-
 		template<typename Ret, typename P1, typename P2>
 		[[gnu::always_inline]]
 		static auto add_with_overflow_check (P1 a, P2 b, std::source_location sloc = std::source_location::current ()) noexcept -> Ret

--- a/src/native/common/include/shared/helpers.hh
+++ b/src/native/common/include/shared/helpers.hh
@@ -19,6 +19,28 @@ namespace xamarin::android
 	class [[gnu::visibility("hidden")]] Helpers
 	{
 	public:
+		template<size_t Size>
+		static auto get_temporary_buffer (char (&local_buffer)[Size], size_t required_size) noexcept -> char*
+		{
+			if (required_size <= Size) {
+				return local_buffer;
+			}
+
+			auto buffer = static_cast<char*> (std::malloc (required_size));
+			if (buffer == nullptr) {
+				abort_application ("Failed to allocate temporary buffer");
+			}
+			return buffer;
+		}
+
+		template<size_t Size>
+		static void free_temporary_buffer (char *buffer, char (&local_buffer)[Size]) noexcept
+		{
+			if (buffer != local_buffer) {
+				std::free (buffer);
+			}
+		}
+
 		template<typename Ret, typename P1, typename P2>
 		[[gnu::always_inline]]
 		static auto add_with_overflow_check (P1 a, P2 b, std::source_location sloc = std::source_location::current ()) noexcept -> Ret

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <cstdlib>
 
 #include <runtime-base/android-system.hh>
 #include <runtime-base/strings.hh>
@@ -194,17 +195,19 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	// Note that to access the file for a release app, the app must be made debuggable
 	// and `run-as` must be used.
 	std::string_view file_name = output_file_name == nullptr ? default_timing_file_name : *output_file_name;
-	auto timing_log_path_buffer = Util::join_paths (getenv ("TMPDIR"), file_name);
-	const char *timing_log_path = timing_log_path_buffer.get ();
+	char *timing_log_path = Util::join_paths (getenv ("TMPDIR"), file_name);
 
 	FILE *timing_log = Util::monodroid_fopen (timing_log_path, "w");
 	if (timing_log == nullptr) {
 		log_error (LOG_TIMING, "[2/2] Unable to create the performance measurements file '{}'"sv, timing_log_path);
+		std::free (timing_log_path);
 		return;
 	}
 
 	if (!Util::set_world_accessible (fileno (timing_log))) {
 		log_warn (LOG_TIMING, "[2/2] Failed to make performance measurements file '{}' world-readable"sv, timing_log_path);
+		fclose (timing_log);
+		std::free (timing_log_path);
 		return;
 	}
 
@@ -220,6 +223,7 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	dump (entries, true /* indent */, line_writer);
 	fflush (timing_log);
 	fclose (timing_log);
+	std::free (timing_log_path);
 }
 
 void FastTiming::dump () noexcept

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -198,20 +198,19 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	std::string_view temporary_directory = getenv ("TMPDIR");
 	char local_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	Util::join_paths (local_buffer, heap_buffer, temporary_directory, file_name);
-	const char *timing_log_path = heap_buffer == nullptr ? local_buffer : heap_buffer;
+	const char *timing_log_path = Util::join_paths (local_buffer, heap_buffer, temporary_directory, file_name);
 
 	FILE *timing_log = Util::monodroid_fopen (timing_log_path, "w");
 	if (timing_log == nullptr) {
 		log_error (LOG_TIMING, "[2/2] Unable to create the performance measurements file '{}'"sv, timing_log_path);
-		std::free (heap_buffer);
+		Util::free_if_used (heap_buffer);
 		return;
 	}
 
 	if (!Util::set_world_accessible (fileno (timing_log))) {
 		log_warn (LOG_TIMING, "[2/2] Failed to make performance measurements file '{}' world-readable"sv, timing_log_path);
 		fclose (timing_log);
-		std::free (heap_buffer);
+		Util::free_if_used (heap_buffer);
 		return;
 	}
 
@@ -227,7 +226,7 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	dump (entries, true /* indent */, line_writer);
 	fflush (timing_log);
 	fclose (timing_log);
-	std::free (heap_buffer);
+	Util::free_if_used (heap_buffer);
 }
 
 void FastTiming::dump () noexcept

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -190,27 +190,29 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 		return;
 	}
 
-	dynamic_local_path_string timing_log_path;
+	char timing_log_path [SENSIBLE_PATH_MAX];
 
 	// We can count on the envvar being there, since we set it ourselves at startup
 	// Note that to access the file for a release app, the app must be made debuggable
 	// and `run-as` must be used.
-	timing_log_path.assign_c (getenv("TMPDIR"));
-	timing_log_path.append ("/"sv);
-	timing_log_path.append (output_file_name == nullptr ? default_timing_file_name : *output_file_name);
+	std::string_view file_name = output_file_name == nullptr ? default_timing_file_name : *output_file_name;
+	if (Util::join_paths (timing_log_path, sizeof (timing_log_path), getenv ("TMPDIR"), file_name) < 0) {
+		log_error (LOG_TIMING, "[2/2] Unable to create the performance measurements file: path is too long");
+		return;
+	}
 
-	FILE *timing_log = Util::monodroid_fopen (timing_log_path.get (), "w");
+	FILE *timing_log = Util::monodroid_fopen (timing_log_path, "w");
 	if (timing_log == nullptr) {
-		log_error (LOG_TIMING, "[2/2] Unable to create the performance measurements file '{}'"sv, timing_log_path.get ());
+		log_error (LOG_TIMING, "[2/2] Unable to create the performance measurements file '{}'"sv, timing_log_path);
 		return;
 	}
 
 	if (!Util::set_world_accessible (fileno (timing_log))) {
-		log_warn (LOG_TIMING, "[2/2] Failed to make performance measurements file '{}' world-readable"sv, timing_log_path.get ());
+		log_warn (LOG_TIMING, "[2/2] Failed to make performance measurements file '{}' world-readable"sv, timing_log_path);
 		return;
 	}
 
-	log_info (LOG_TIMING, "[2/2] Performance measurement results logged to file: {}"sv, timing_log_path.get ());
+	log_info (LOG_TIMING, "[2/2] Performance measurement results logged to file: {}"sv, timing_log_path);
 
 	auto line_writer = [=](std::string_view const& msg) {
 		if (!msg.empty ()) {

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -195,19 +195,24 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	// Note that to access the file for a release app, the app must be made debuggable
 	// and `run-as` must be used.
 	std::string_view file_name = output_file_name == nullptr ? default_timing_file_name : *output_file_name;
-	char *timing_log_path = Util::join_paths (getenv ("TMPDIR"), file_name);
+	std::string_view temporary_directory = getenv ("TMPDIR");
+	size_t timing_log_path_length = Util::get_joined_path_length (temporary_directory, file_name);
+	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (timing_log_path_length, 1uz);
+	char local_buffer [Util::LocalPathBufferSize];
+	char *timing_log_path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
+	Util::join_paths (timing_log_path, allocation_size, temporary_directory, file_name);
 
 	FILE *timing_log = Util::monodroid_fopen (timing_log_path, "w");
 	if (timing_log == nullptr) {
 		log_error (LOG_TIMING, "[2/2] Unable to create the performance measurements file '{}'"sv, timing_log_path);
-		std::free (timing_log_path);
+		Helpers::free_temporary_buffer (timing_log_path, local_buffer);
 		return;
 	}
 
 	if (!Util::set_world_accessible (fileno (timing_log))) {
 		log_warn (LOG_TIMING, "[2/2] Failed to make performance measurements file '{}' world-readable"sv, timing_log_path);
 		fclose (timing_log);
-		std::free (timing_log_path);
+		Helpers::free_temporary_buffer (timing_log_path, local_buffer);
 		return;
 	}
 
@@ -223,7 +228,7 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	dump (entries, true /* indent */, line_writer);
 	fflush (timing_log);
 	fclose (timing_log);
-	std::free (timing_log_path);
+	Helpers::free_temporary_buffer (timing_log_path, local_buffer);
 }
 
 void FastTiming::dump () noexcept

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -196,21 +196,21 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	// and `run-as` must be used.
 	std::string_view file_name = output_file_name == nullptr ? default_timing_file_name : *output_file_name;
 	std::string_view temporary_directory = getenv ("TMPDIR");
-	char local_buffer [Util::LocalPathBufferSize];
+	char stack_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	const char *timing_log_path = Util::join_paths (local_buffer, heap_buffer, temporary_directory, file_name);
+	const char *timing_log_path = Util::join_paths (stack_buffer, heap_buffer, temporary_directory, file_name);
 
 	FILE *timing_log = Util::monodroid_fopen (timing_log_path, "w");
 	if (timing_log == nullptr) {
 		log_error (LOG_TIMING, "[2/2] Unable to create the performance measurements file '{}'"sv, timing_log_path);
-		Util::free_if_used (heap_buffer);
+		std::free (heap_buffer);
 		return;
 	}
 
 	if (!Util::set_world_accessible (fileno (timing_log))) {
 		log_warn (LOG_TIMING, "[2/2] Failed to make performance measurements file '{}' world-readable"sv, timing_log_path);
 		fclose (timing_log);
-		Util::free_if_used (heap_buffer);
+		std::free (heap_buffer);
 		return;
 	}
 
@@ -226,7 +226,7 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	dump (entries, true /* indent */, line_writer);
 	fflush (timing_log);
 	fclose (timing_log);
-	Util::free_if_used (heap_buffer);
+	std::free (heap_buffer);
 }
 
 void FastTiming::dump () noexcept

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -196,23 +196,22 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	// and `run-as` must be used.
 	std::string_view file_name = output_file_name == nullptr ? default_timing_file_name : *output_file_name;
 	std::string_view temporary_directory = getenv ("TMPDIR");
-	size_t timing_log_path_length = Util::get_joined_path_length (temporary_directory, file_name);
-	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (timing_log_path_length, 1uz);
 	char local_buffer [Util::LocalPathBufferSize];
-	char *timing_log_path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
-	Util::join_paths (timing_log_path, allocation_size, temporary_directory, file_name);
+	char *heap_buffer;
+	Util::join_paths (local_buffer, heap_buffer, temporary_directory, file_name);
+	const char *timing_log_path = heap_buffer == nullptr ? local_buffer : heap_buffer;
 
 	FILE *timing_log = Util::monodroid_fopen (timing_log_path, "w");
 	if (timing_log == nullptr) {
 		log_error (LOG_TIMING, "[2/2] Unable to create the performance measurements file '{}'"sv, timing_log_path);
-		Helpers::free_temporary_buffer (timing_log_path, local_buffer);
+		std::free (heap_buffer);
 		return;
 	}
 
 	if (!Util::set_world_accessible (fileno (timing_log))) {
 		log_warn (LOG_TIMING, "[2/2] Failed to make performance measurements file '{}' world-readable"sv, timing_log_path);
 		fclose (timing_log);
-		Helpers::free_temporary_buffer (timing_log_path, local_buffer);
+		std::free (heap_buffer);
 		return;
 	}
 
@@ -228,7 +227,7 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	dump (entries, true /* indent */, line_writer);
 	fflush (timing_log);
 	fclose (timing_log);
-	Helpers::free_temporary_buffer (timing_log_path, local_buffer);
+	std::free (heap_buffer);
 }
 
 void FastTiming::dump () noexcept

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -198,7 +198,7 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	std::string_view temporary_directory = getenv ("TMPDIR");
 	char stack_buffer [Util::LocalPathBufferSize];
 	char *heap_buffer;
-	const char *timing_log_path = Util::join_paths (stack_buffer, heap_buffer, temporary_directory, file_name);
+	const char *timing_log_path = Util::join_paths (stack_buffer, sizeof (stack_buffer), heap_buffer, temporary_directory, file_name);
 
 	FILE *timing_log = Util::monodroid_fopen (timing_log_path, "w");
 	if (timing_log == nullptr) {

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -190,16 +190,12 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 		return;
 	}
 
-	char timing_log_path [SENSIBLE_PATH_MAX];
-
 	// We can count on the envvar being there, since we set it ourselves at startup
 	// Note that to access the file for a release app, the app must be made debuggable
 	// and `run-as` must be used.
 	std::string_view file_name = output_file_name == nullptr ? default_timing_file_name : *output_file_name;
-	if (Util::join_paths (timing_log_path, sizeof (timing_log_path), getenv ("TMPDIR"), file_name) < 0) {
-		log_error (LOG_TIMING, "[2/2] Unable to create the performance measurements file: path is too long");
-		return;
-	}
+	auto timing_log_path_buffer = Util::join_paths (getenv ("TMPDIR"), file_name);
+	const char *timing_log_path = timing_log_path_buffer.get ();
 
 	FILE *timing_log = Util::monodroid_fopen (timing_log_path, "w");
 	if (timing_log == nullptr) {

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -197,20 +197,23 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	std::string_view file_name = output_file_name == nullptr ? default_timing_file_name : *output_file_name;
 	std::string_view temporary_directory = getenv ("TMPDIR");
 	char stack_buffer [Util::LocalPathBufferSize];
-	char *heap_buffer;
-	const char *timing_log_path = Util::join_paths (stack_buffer, sizeof (stack_buffer), heap_buffer, temporary_directory, file_name);
+	char *timing_log_path = Util::join_paths (stack_buffer, sizeof (stack_buffer), temporary_directory, file_name);
 
 	FILE *timing_log = Util::monodroid_fopen (timing_log_path, "w");
 	if (timing_log == nullptr) {
 		log_error (LOG_TIMING, "[2/2] Unable to create the performance measurements file '{}'"sv, timing_log_path);
-		std::free (heap_buffer);
+		if (timing_log_path != stack_buffer) {
+			std::free (timing_log_path);
+		}
 		return;
 	}
 
 	if (!Util::set_world_accessible (fileno (timing_log))) {
 		log_warn (LOG_TIMING, "[2/2] Failed to make performance measurements file '{}' world-readable"sv, timing_log_path);
 		fclose (timing_log);
-		std::free (heap_buffer);
+		if (timing_log_path != stack_buffer) {
+			std::free (timing_log_path);
+		}
 		return;
 	}
 
@@ -226,7 +229,9 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 	dump (entries, true /* indent */, line_writer);
 	fflush (timing_log);
 	fclose (timing_log);
-	std::free (heap_buffer);
+	if (timing_log_path != stack_buffer) {
+		std::free (timing_log_path);
+	}
 }
 
 void FastTiming::dump () noexcept

--- a/src/native/mono/runtime-base/util.hh
+++ b/src/native/mono/runtime-base/util.hh
@@ -112,7 +112,7 @@ namespace xamarin::android
 		}
 
 		// Returns the path length excluding NUL, or the negative required capacity including NUL.
-		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> ssize_t
+		static auto format_joined_path (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> ssize_t
 		{
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
 			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
@@ -147,7 +147,7 @@ namespace xamarin::android
 
 		static auto join_paths (char *stack_buffer, size_t stack_buffer_size, std::string_view first, std::string_view second) noexcept -> char*
 		{
-			ssize_t result = join_paths (stack_buffer, stack_buffer_size, first, second);
+			ssize_t result = format_joined_path (stack_buffer, stack_buffer_size, first, second);
 			if (result >= 0) {
 				return stack_buffer;
 			}
@@ -155,7 +155,7 @@ namespace xamarin::android
 			size_t required_capacity = static_cast<size_t>(-result);
 			char *heap_buffer = static_cast<char*> (std::malloc (required_capacity));
 			abort_unless (heap_buffer != nullptr, "Failed to allocate joined path");
-			result = join_paths (heap_buffer, required_capacity, first, second);
+			result = format_joined_path (heap_buffer, required_capacity, first, second);
 			abort_unless (result >= 0, "Failed to join path using the required capacity");
 			return heap_buffer;
 		}

--- a/src/native/mono/runtime-base/util.hh
+++ b/src/native/mono/runtime-base/util.hh
@@ -162,11 +162,6 @@ namespace xamarin::android
 			return heap_buffer;
 		}
 
-		static void free_if_used (void *heap_buffer) noexcept
-		{
-			std::free (heap_buffer);
-		}
-
 		// Make sure that `buf` has enough space! This is by design, the methods are supposed to be fast.
 		template<size_t MaxStackSpace, typename TBuffer>
 		static void path_combine (TBuffer& buf, const char* path1, const char* path2) noexcept

--- a/src/native/mono/runtime-base/util.hh
+++ b/src/native/mono/runtime-base/util.hh
@@ -146,12 +146,12 @@ namespace xamarin::android
 		}
 
 		template<size_t Size>
-		static auto join_paths (char (&stack_buffer)[Size], char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> ssize_t
+		static auto join_paths (char (&stack_buffer)[Size], char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> const char*
 		{
 			heap_buffer = nullptr;
 			ssize_t result = join_paths (stack_buffer, Size, first, second);
 			if (result >= 0) {
-				return result;
+				return stack_buffer;
 			}
 
 			size_t required_capacity = static_cast<size_t>(-result);
@@ -159,7 +159,12 @@ namespace xamarin::android
 			abort_unless (heap_buffer != nullptr, "Failed to allocate joined path");
 			result = join_paths (heap_buffer, required_capacity, first, second);
 			abort_unless (result >= 0, "Failed to join path using the required capacity");
-			return result;
+			return heap_buffer;
+		}
+
+		static void free_if_used (void *heap_buffer) noexcept
+		{
+			std::free (heap_buffer);
 		}
 
 		// Make sure that `buf` has enough space! This is by design, the methods are supposed to be fast.

--- a/src/native/mono/runtime-base/util.hh
+++ b/src/native/mono/runtime-base/util.hh
@@ -24,6 +24,7 @@ static inline constexpr int FALSE = 0;
 #include <cstring>
 #include <ctime>
 #include <fcntl.h>
+#include <limits>
 #include <optional>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -42,6 +43,7 @@ static inline constexpr int FALSE = 0;
 #include <mono/utils/mono-publib.h>
 
 #include <runtime-base/jni-wrappers.hh>
+#include <shared/helpers.hh>
 #include "java-interop-util.h"
 #include "logger.hh"
 #include <runtime-base/strings.hh>
@@ -105,6 +107,42 @@ namespace xamarin::android
 			}
 
 			return fd;
+		}
+
+		// Returns the path length excluding the terminating NUL, or -1 on failure.
+		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> ssize_t
+		{
+			if (buffer == nullptr || buffer_size == 0) {
+				return -1;
+			}
+
+			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
+			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
+			size_t second_offset = remove_duplicate_separator ? 1uz : 0uz;
+			size_t path_length = Helpers::add_with_overflow_check<size_t> (first.length (), second.length () - second_offset);
+			if (add_separator) {
+				path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+			}
+
+			if (path_length >= buffer_size || path_length > static_cast<size_t>(std::numeric_limits<ssize_t>::max ())) {
+				return -1;
+			}
+
+			char *destination = buffer;
+			if (!first.empty ()) {
+				memcpy (destination, first.data (), first.length ());
+				destination += first.length ();
+			}
+			if (add_separator) {
+				*destination++ = '/';
+			}
+			size_t second_length = second.length () - second_offset;
+			if (second_length > 0) {
+				memcpy (destination, second.data () + second_offset, second_length);
+			}
+			buffer [path_length] = '\0';
+
+			return static_cast<ssize_t>(path_length);
 		}
 
 		// Make sure that `buf` has enough space! This is by design, the methods are supposed to be fast.

--- a/src/native/mono/runtime-base/util.hh
+++ b/src/native/mono/runtime-base/util.hh
@@ -54,6 +54,8 @@ namespace xamarin::android
 	class Util
 	{
 	public:
+		static constexpr size_t LocalPathBufferSize = SENSIBLE_PATH_MAX;
+
 		static void initialize () noexcept;
 
 		static int monodroid_getpagesize () noexcept
@@ -109,13 +111,8 @@ namespace xamarin::android
 			return fd;
 		}
 
-		// Returns the path length excluding the terminating NUL, or -1 on failure.
-		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> ssize_t
+		static auto get_joined_path_length (std::string_view first, std::string_view second) noexcept -> size_t
 		{
-			if (buffer == nullptr || buffer_size == 0) {
-				return -1;
-			}
-
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
 			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
 			size_t second_offset = remove_duplicate_separator ? 1uz : 0uz;
@@ -123,11 +120,17 @@ namespace xamarin::android
 			if (add_separator) {
 				path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 			}
+			return path_length;
+		}
 
-			if (path_length >= buffer_size || path_length > static_cast<size_t>(std::numeric_limits<ssize_t>::max ())) {
-				return -1;
-			}
+		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> size_t
+		{
+			size_t path_length = get_joined_path_length (first, second);
+			abort_unless (buffer != nullptr && buffer_size > path_length, "Joined path buffer is too small");
 
+			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
+			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
+			size_t second_offset = remove_duplicate_separator ? 1uz : 0uz;
 			char *destination = buffer;
 			if (!first.empty ()) {
 				memcpy (destination, first.data (), first.length ());
@@ -142,7 +145,7 @@ namespace xamarin::android
 			}
 			buffer [path_length] = '\0';
 
-			return static_cast<ssize_t>(path_length);
+			return path_length;
 		}
 
 		// Make sure that `buf` has enough space! This is by design, the methods are supposed to be fast.

--- a/src/native/mono/runtime-base/util.hh
+++ b/src/native/mono/runtime-base/util.hh
@@ -145,16 +145,15 @@ namespace xamarin::android
 			return static_cast<ssize_t>(path_length);
 		}
 
-		static auto join_paths (char *stack_buffer, size_t stack_buffer_size, char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> const char*
+		static auto join_paths (char *stack_buffer, size_t stack_buffer_size, std::string_view first, std::string_view second) noexcept -> char*
 		{
-			heap_buffer = nullptr;
 			ssize_t result = join_paths (stack_buffer, stack_buffer_size, first, second);
 			if (result >= 0) {
 				return stack_buffer;
 			}
 
 			size_t required_capacity = static_cast<size_t>(-result);
-			heap_buffer = static_cast<char*> (std::malloc (required_capacity));
+			char *heap_buffer = static_cast<char*> (std::malloc (required_capacity));
 			abort_unless (heap_buffer != nullptr, "Failed to allocate joined path");
 			result = join_paths (heap_buffer, required_capacity, first, second);
 			abort_unless (result >= 0, "Failed to join path using the required capacity");

--- a/src/native/mono/runtime-base/util.hh
+++ b/src/native/mono/runtime-base/util.hh
@@ -111,7 +111,8 @@ namespace xamarin::android
 			return fd;
 		}
 
-		static auto get_joined_path_length (std::string_view first, std::string_view second) noexcept -> size_t
+		// Returns the path length excluding NUL, or the negative required capacity including NUL.
+		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> ssize_t
 		{
 			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
 			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
@@ -120,17 +121,13 @@ namespace xamarin::android
 			if (add_separator) {
 				path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 			}
-			return path_length;
-		}
 
-		static auto join_paths (char *buffer, size_t buffer_size, std::string_view first, std::string_view second) noexcept -> size_t
-		{
-			size_t path_length = get_joined_path_length (first, second);
-			abort_unless (buffer != nullptr && buffer_size > path_length, "Joined path buffer is too small");
+			size_t required_capacity = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+			abort_unless (required_capacity <= static_cast<size_t>(std::numeric_limits<ssize_t>::max ()), "Joined path is too long");
+			if (buffer == nullptr || buffer_size < required_capacity) {
+				return -static_cast<ssize_t>(required_capacity);
+			}
 
-			bool remove_duplicate_separator = first.ends_with ('/') && second.starts_with ('/');
-			bool add_separator = !first.empty () && !second.empty () && !first.ends_with ('/') && !second.starts_with ('/');
-			size_t second_offset = remove_duplicate_separator ? 1uz : 0uz;
 			char *destination = buffer;
 			if (!first.empty ()) {
 				memcpy (destination, first.data (), first.length ());
@@ -145,7 +142,24 @@ namespace xamarin::android
 			}
 			buffer [path_length] = '\0';
 
-			return path_length;
+			return static_cast<ssize_t>(path_length);
+		}
+
+		template<size_t Size>
+		static auto join_paths (char (&stack_buffer)[Size], char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> ssize_t
+		{
+			heap_buffer = nullptr;
+			ssize_t result = join_paths (stack_buffer, Size, first, second);
+			if (result >= 0) {
+				return result;
+			}
+
+			size_t required_capacity = static_cast<size_t>(-result);
+			heap_buffer = static_cast<char*> (std::malloc (required_capacity));
+			abort_unless (heap_buffer != nullptr, "Failed to allocate joined path");
+			result = join_paths (heap_buffer, required_capacity, first, second);
+			abort_unless (result >= 0, "Failed to join path using the required capacity");
+			return result;
 		}
 
 		// Make sure that `buf` has enough space! This is by design, the methods are supposed to be fast.

--- a/src/native/mono/runtime-base/util.hh
+++ b/src/native/mono/runtime-base/util.hh
@@ -145,11 +145,10 @@ namespace xamarin::android
 			return static_cast<ssize_t>(path_length);
 		}
 
-		template<size_t Size>
-		static auto join_paths (char (&stack_buffer)[Size], char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> const char*
+		static auto join_paths (char *stack_buffer, size_t stack_buffer_size, char *&heap_buffer, std::string_view first, std::string_view second) noexcept -> const char*
 		{
 			heap_buffer = nullptr;
-			ssize_t result = join_paths (stack_buffer, Size, first, second);
+			ssize_t result = join_paths (stack_buffer, stack_buffer_size, first, second);
 			if (result >= 0) {
 				return stack_buffer;
 			}


### PR DESCRIPTION
## Summary

Replace shared CoreCLR/NativeAOT path-building local strings with C buffers while preserving the original distinction between static and dynamic storage.

## Changes

- add `format_joined_path()` as the low-level formatter, returning the written length or the negative required capacity including NUL
- add non-template `join_paths()` with an explicit stack-buffer capacity, returning either the caller's stack buffer or exact-size `malloc()` storage
- free returned storage only when it differs from the caller-owned stack buffer; no heap out-parameter or cleanup helper is needed
- keep the former `static_local_string` XDG path stack-only and fail explicitly if its fixed storage is insufficient
- preserve dynamic growth for fallback log paths, environment overrides, `libmonodroid.so` detection, and timing output paths
- remove obsolete CLR local-string path helpers and `strings.hh` dependencies
- avoid creating the fallback logging directory twice

## Validation

- Local native builds intentionally skipped; relying on CI validation
- No focused `join_paths()` test was added because the repository has no host-native C++ unit-test target and the private runtime helper is not directly callable from device tests
