### PR TITLE
[native] Construct DSO names and directory paths without local strings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -110,7 +110,8 @@ namespace Xamarin.Android.Build.Tests
 			};
 			using var stdOutput = new StringWriter ();
 			using var stdError = new StringWriter ();
-			using var cancellationTokenSource = new CancellationTokenSource (TimeSpan.FromSeconds (30));
+			int timeoutInSeconds = TestEnvironment.IsRunningOnCI ? 120 : 30;
+			using var cancellationTokenSource = new CancellationTokenSource (TimeSpan.FromSeconds (timeoutInSeconds));
 			int processId = -1;
 			int exitCode;
 			try {
@@ -123,7 +124,7 @@ namespace Xamarin.Android.Build.Tests
 				).GetAwaiter ().GetResult ();
 			} catch (OperationCanceledException) {
 				exitCode = -1;
-				stdError.WriteLine ($"apkdiff timed out after 30 seconds (PID {processId}).");
+				stdError.WriteLine ($"apkdiff timed out after {timeoutInSeconds} seconds (PID {processId}).");
 			}
 
 			var result = (code: exitCode, stdOutput: stdOutput.ToString ().Trim (), stdError: stdError.ToString ().Trim ());

--- a/src/native/clr/include/host/pinvoke-override-impl.hh
+++ b/src/native/clr/include/host/pinvoke-override-impl.hh
@@ -16,16 +16,14 @@ namespace xamarin::android {
 
 		// Handle p/invokes of the form [DllImport ("liblog")] or [DllImport ("log")]
 		if (!Util::path_has_directory_components (library_name)) {
-			size_t name_length = Util::get_dso_name_length (library_name, true);
-			size_t allocation_size = Helpers::add_with_overflow_check<size_t> (name_length, 1uz);
 			char local_buffer [Util::LocalPathBufferSize];
-			char *short_library_name = Helpers::get_temporary_buffer (local_buffer, allocation_size);
-			Util::format_dso_name (library_name, true, short_library_name, allocation_size);
+			char *heap_buffer;
+			const char *short_library_name = Util::format_dso_name (local_buffer, heap_buffer, library_name, true);
 
-			std::string_view short_library_name_view { short_library_name, name_length };
+			std::string_view short_library_name_view { short_library_name };
 			log_debug (LOG_ASSEMBLY, "Modified p/invoke library name to '{}'", short_library_name_view);
 			lib_handle = MonodroidDl::monodroid_dlopen (short_library_name_view, microsoft::java_interop::JAVA_INTEROP_LIB_LOAD_LOCALLY);
-			Helpers::free_temporary_buffer (short_library_name, local_buffer);
+			Util::free_if_used (heap_buffer);
 		}
 
 		if (lib_handle == nullptr) {

--- a/src/native/clr/include/host/pinvoke-override-impl.hh
+++ b/src/native/clr/include/host/pinvoke-override-impl.hh
@@ -18,7 +18,7 @@ namespace xamarin::android {
 		if (!Util::path_has_directory_components (library_name)) {
 			char stack_buffer [Util::LocalPathBufferSize];
 			char *heap_buffer;
-			const char *short_library_name = Util::format_dso_name (stack_buffer, heap_buffer, library_name, true);
+			const char *short_library_name = Util::format_dso_name (stack_buffer, sizeof (stack_buffer), heap_buffer, library_name, true);
 
 			std::string_view short_library_name_view { short_library_name };
 			log_debug (LOG_ASSEMBLY, "Modified p/invoke library name to '{}'", short_library_name_view);

--- a/src/native/clr/include/host/pinvoke-override-impl.hh
+++ b/src/native/clr/include/host/pinvoke-override-impl.hh
@@ -15,16 +15,9 @@ namespace xamarin::android {
 		void *lib_handle = nullptr;
 
 		// Handle p/invokes of the form [DllImport ("liblog")] or [DllImport ("log")]
-		// TODO: try modifying the name to contain both the `log` prefix and the `.so` suffix
 		dynamic_local_path_string short_library_name;
 		if (!Util::path_has_directory_components (library_name)) {
-			if (!library_name.starts_with (Constants::DSO_PREFIX)) {
-				short_library_name.append (Constants::DSO_PREFIX);
-			}
-			short_library_name.append (library_name);
-			if (!short_library_name.ends_with (Constants::dso_suffix)) {
-				short_library_name.append (Constants::dso_suffix);
-			}
+			Util::append_dso_name (short_library_name, library_name, true);
 
 			log_debug (LOG_ASSEMBLY, "Modified p/invoke library name to '{}'", short_library_name.get ());
 			lib_handle = MonodroidDl::monodroid_dlopen (short_library_name.get (), microsoft::java_interop::JAVA_INTEROP_LIB_LOAD_LOCALLY);

--- a/src/native/clr/include/host/pinvoke-override-impl.hh
+++ b/src/native/clr/include/host/pinvoke-override-impl.hh
@@ -16,14 +16,14 @@ namespace xamarin::android {
 
 		// Handle p/invokes of the form [DllImport ("liblog")] or [DllImport ("log")]
 		if (!Util::path_has_directory_components (library_name)) {
-			char local_buffer [Util::LocalPathBufferSize];
+			char stack_buffer [Util::LocalPathBufferSize];
 			char *heap_buffer;
-			const char *short_library_name = Util::format_dso_name (local_buffer, heap_buffer, library_name, true);
+			const char *short_library_name = Util::format_dso_name (stack_buffer, heap_buffer, library_name, true);
 
 			std::string_view short_library_name_view { short_library_name };
 			log_debug (LOG_ASSEMBLY, "Modified p/invoke library name to '{}'", short_library_name_view);
 			lib_handle = MonodroidDl::monodroid_dlopen (short_library_name_view, microsoft::java_interop::JAVA_INTEROP_LIB_LOAD_LOCALLY);
-			Util::free_if_used (heap_buffer);
+			std::free (heap_buffer);
 		}
 
 		if (lib_handle == nullptr) {

--- a/src/native/clr/include/host/pinvoke-override-impl.hh
+++ b/src/native/clr/include/host/pinvoke-override-impl.hh
@@ -15,12 +15,16 @@ namespace xamarin::android {
 		void *lib_handle = nullptr;
 
 		// Handle p/invokes of the form [DllImport ("liblog")] or [DllImport ("log")]
-		dynamic_local_path_string short_library_name;
+		char short_library_name[Constants::SENSIBLE_PATH_MAX];
 		if (!Util::path_has_directory_components (library_name)) {
-			Util::append_dso_name (short_library_name, library_name, true);
-
-			log_debug (LOG_ASSEMBLY, "Modified p/invoke library name to '{}'", short_library_name.get ());
-			lib_handle = MonodroidDl::monodroid_dlopen (short_library_name.get (), microsoft::java_interop::JAVA_INTEROP_LIB_LOAD_LOCALLY);
+			ssize_t name_length = Util::format_dso_name (library_name, true, short_library_name, sizeof (short_library_name));
+			if (name_length >= 0) {
+				std::string_view short_library_name_view { short_library_name, static_cast<size_t>(name_length) };
+				log_debug (LOG_ASSEMBLY, "Modified p/invoke library name to '{}'", short_library_name_view);
+				lib_handle = MonodroidDl::monodroid_dlopen (short_library_name_view, microsoft::java_interop::JAVA_INTEROP_LIB_LOAD_LOCALLY);
+			} else {
+				log_warn (LOG_ASSEMBLY, "Unable to construct short p/invoke library name for '{}': name is too long", library_name);
+			}
 		}
 
 		if (lib_handle == nullptr) {

--- a/src/native/clr/include/host/pinvoke-override-impl.hh
+++ b/src/native/clr/include/host/pinvoke-override-impl.hh
@@ -17,13 +17,14 @@ namespace xamarin::android {
 		// Handle p/invokes of the form [DllImport ("liblog")] or [DllImport ("log")]
 		if (!Util::path_has_directory_components (library_name)) {
 			char stack_buffer [Util::LocalPathBufferSize];
-			char *heap_buffer;
-			const char *short_library_name = Util::format_dso_name (stack_buffer, sizeof (stack_buffer), heap_buffer, library_name, true);
+			char *short_library_name = Util::format_dso_name (stack_buffer, sizeof (stack_buffer), library_name, true);
 
 			std::string_view short_library_name_view { short_library_name };
 			log_debug (LOG_ASSEMBLY, "Modified p/invoke library name to '{}'", short_library_name_view);
 			lib_handle = MonodroidDl::monodroid_dlopen (short_library_name_view, microsoft::java_interop::JAVA_INTEROP_LIB_LOAD_LOCALLY);
-			std::free (heap_buffer);
+			if (short_library_name != stack_buffer) {
+				std::free (short_library_name);
+			}
 		}
 
 		if (lib_handle == nullptr) {

--- a/src/native/clr/include/host/pinvoke-override-impl.hh
+++ b/src/native/clr/include/host/pinvoke-override-impl.hh
@@ -4,8 +4,6 @@
 #error The PINVOKE_OVERRIDE_INLINE macro must be defined before including this header file
 #endif
 
-#include <cstdlib>
-
 #include "pinvoke-override.hh"
 #include "../runtime-base/logger.hh"
 #include "../runtime-base/monodroid-dl.hh"
@@ -18,12 +16,16 @@ namespace xamarin::android {
 
 		// Handle p/invokes of the form [DllImport ("liblog")] or [DllImport ("log")]
 		if (!Util::path_has_directory_components (library_name)) {
-			size_t name_length;
-			char *short_library_name = Util::format_dso_name (library_name, true, name_length);
+			size_t name_length = Util::get_dso_name_length (library_name, true);
+			size_t allocation_size = Helpers::add_with_overflow_check<size_t> (name_length, 1uz);
+			char local_buffer [Util::LocalPathBufferSize];
+			char *short_library_name = Helpers::get_temporary_buffer (local_buffer, allocation_size);
+			Util::format_dso_name (library_name, true, short_library_name, allocation_size);
+
 			std::string_view short_library_name_view { short_library_name, name_length };
 			log_debug (LOG_ASSEMBLY, "Modified p/invoke library name to '{}'", short_library_name_view);
 			lib_handle = MonodroidDl::monodroid_dlopen (short_library_name_view, microsoft::java_interop::JAVA_INTEROP_LIB_LOAD_LOCALLY);
-			std::free (short_library_name);
+			Helpers::free_temporary_buffer (short_library_name, local_buffer);
 		}
 
 		if (lib_handle == nullptr) {

--- a/src/native/clr/include/host/pinvoke-override-impl.hh
+++ b/src/native/clr/include/host/pinvoke-override-impl.hh
@@ -4,6 +4,8 @@
 #error The PINVOKE_OVERRIDE_INLINE macro must be defined before including this header file
 #endif
 
+#include <cstdlib>
+
 #include "pinvoke-override.hh"
 #include "../runtime-base/logger.hh"
 #include "../runtime-base/monodroid-dl.hh"
@@ -15,16 +17,13 @@ namespace xamarin::android {
 		void *lib_handle = nullptr;
 
 		// Handle p/invokes of the form [DllImport ("liblog")] or [DllImport ("log")]
-		char short_library_name[Constants::SENSIBLE_PATH_MAX];
 		if (!Util::path_has_directory_components (library_name)) {
-			ssize_t name_length = Util::format_dso_name (library_name, true, short_library_name, sizeof (short_library_name));
-			if (name_length >= 0) {
-				std::string_view short_library_name_view { short_library_name, static_cast<size_t>(name_length) };
-				log_debug (LOG_ASSEMBLY, "Modified p/invoke library name to '{}'", short_library_name_view);
-				lib_handle = MonodroidDl::monodroid_dlopen (short_library_name_view, microsoft::java_interop::JAVA_INTEROP_LIB_LOAD_LOCALLY);
-			} else {
-				log_warn (LOG_ASSEMBLY, "Unable to construct short p/invoke library name for '{}': name is too long", library_name);
-			}
+			size_t name_length;
+			char *short_library_name = Util::format_dso_name (library_name, true, name_length);
+			std::string_view short_library_name_view { short_library_name, name_length };
+			log_debug (LOG_ASSEMBLY, "Modified p/invoke library name to '{}'", short_library_name_view);
+			lib_handle = MonodroidDl::monodroid_dlopen (short_library_name_view, microsoft::java_interop::JAVA_INTEROP_LIB_LOAD_LOCALLY);
+			std::free (short_library_name);
 		}
 
 		if (lib_handle == nullptr) {

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -147,7 +147,7 @@ namespace xamarin::android {
 		static auto load_dso_from_any_directories (std::string_view const& name, int dl_flags, bool is_jni) noexcept -> void*;
 
 	private:
-		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *path_buffer, size_t path_buffer_length) noexcept -> ssize_t;
+		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, size_t &path_length) noexcept -> char*;
 
 		template<class TContainer> // TODO: replace with a concept
 		static auto load_dso_from_specified_dirs (TContainer directories, std::string_view const& dso_name, int dl_flags, bool is_jni) noexcept -> void*;

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -12,7 +12,6 @@
 #include <shared/log_types.hh>
 #include "../runtime-base/cpu-arch.hh"
 #include <runtime-base/jni-wrappers.hh>
-#include <runtime-base/strings.hh>
 #include "util.hh"
 
 struct BundledProperty;

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -147,8 +147,24 @@ namespace xamarin::android {
 		static auto load_dso_from_any_directories (std::string_view const& name, int dl_flags, bool is_jni) noexcept -> void*;
 
 	private:
-		static auto get_full_dso_path_length (std::string const& base_dir, std::string_view const& dso_path) noexcept -> size_t;
-		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> size_t;
+		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> ssize_t;
+
+		template<size_t Size>
+		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char (&stack_buffer)[Size], char *&heap_buffer) noexcept -> const char*
+		{
+			heap_buffer = nullptr;
+			ssize_t result = get_full_dso_path (base_dir, dso_path, stack_buffer, Size);
+			if (result >= 0) {
+				return stack_buffer;
+			}
+
+			size_t required_capacity = static_cast<size_t>(-result);
+			heap_buffer = static_cast<char*> (std::malloc (required_capacity));
+			abort_unless (heap_buffer != nullptr, "Failed to allocate full DSO path");
+			result = get_full_dso_path (base_dir, dso_path, heap_buffer, required_capacity);
+			abort_unless (result >= 0, "Failed to format full DSO path using the required capacity");
+			return heap_buffer;
+		}
 
 		template<class TContainer> // TODO: replace with a concept
 		static auto load_dso_from_specified_dirs (TContainer directories, std::string_view const& dso_name, int dl_flags, bool is_jni) noexcept -> void*;

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -149,11 +149,10 @@ namespace xamarin::android {
 	private:
 		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> ssize_t;
 
-		template<size_t Size>
-		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char (&stack_buffer)[Size], char *&heap_buffer) noexcept -> const char*
+		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *stack_buffer, size_t stack_buffer_size, char *&heap_buffer) noexcept -> const char*
 		{
 			heap_buffer = nullptr;
-			ssize_t result = get_full_dso_path (base_dir, dso_path, stack_buffer, Size);
+			ssize_t result = get_full_dso_path (base_dir, dso_path, stack_buffer, stack_buffer_size);
 			if (result >= 0) {
 				return stack_buffer;
 			}

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -147,7 +147,8 @@ namespace xamarin::android {
 		static auto load_dso_from_any_directories (std::string_view const& name, int dl_flags, bool is_jni) noexcept -> void*;
 
 	private:
-		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, size_t &path_length) noexcept -> char*;
+		static auto get_full_dso_path_length (std::string const& base_dir, std::string_view const& dso_path) noexcept -> size_t;
+		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> size_t;
 
 		template<class TContainer> // TODO: replace with a concept
 		static auto load_dso_from_specified_dirs (TContainer directories, std::string_view const& dso_name, int dl_flags, bool is_jni) noexcept -> void*;

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -147,7 +147,7 @@ namespace xamarin::android {
 		static auto load_dso_from_any_directories (std::string_view const& name, int dl_flags, bool is_jni) noexcept -> void*;
 
 	private:
-		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, dynamic_local_string<SENSIBLE_PATH_MAX>& path) noexcept -> bool;
+		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *path_buffer, size_t path_buffer_length) noexcept -> ssize_t;
 
 		template<class TContainer> // TODO: replace with a concept
 		static auto load_dso_from_specified_dirs (TContainer directories, std::string_view const& dso_name, int dl_flags, bool is_jni) noexcept -> void*;

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -147,11 +147,11 @@ namespace xamarin::android {
 		static auto load_dso_from_any_directories (std::string_view const& name, int dl_flags, bool is_jni) noexcept -> void*;
 
 	private:
-		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> ssize_t;
+		static auto format_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> ssize_t;
 
 		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *stack_buffer, size_t stack_buffer_size) noexcept -> char*
 		{
-			ssize_t result = get_full_dso_path (base_dir, dso_path, stack_buffer, stack_buffer_size);
+			ssize_t result = format_full_dso_path (base_dir, dso_path, stack_buffer, stack_buffer_size);
 			if (result >= 0) {
 				return stack_buffer;
 			}
@@ -159,7 +159,7 @@ namespace xamarin::android {
 			size_t required_capacity = static_cast<size_t>(-result);
 			char *heap_buffer = static_cast<char*> (std::malloc (required_capacity));
 			abort_unless (heap_buffer != nullptr, "Failed to allocate full DSO path");
-			result = get_full_dso_path (base_dir, dso_path, heap_buffer, required_capacity);
+			result = format_full_dso_path (base_dir, dso_path, heap_buffer, required_capacity);
 			abort_unless (result >= 0, "Failed to format full DSO path using the required capacity");
 			return heap_buffer;
 		}

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -149,16 +149,15 @@ namespace xamarin::android {
 	private:
 		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> ssize_t;
 
-		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *stack_buffer, size_t stack_buffer_size, char *&heap_buffer) noexcept -> const char*
+		static auto get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *stack_buffer, size_t stack_buffer_size) noexcept -> char*
 		{
-			heap_buffer = nullptr;
 			ssize_t result = get_full_dso_path (base_dir, dso_path, stack_buffer, stack_buffer_size);
 			if (result >= 0) {
 				return stack_buffer;
 			}
 
 			size_t required_capacity = static_cast<size_t>(-result);
-			heap_buffer = static_cast<char*> (std::malloc (required_capacity));
+			char *heap_buffer = static_cast<char*> (std::malloc (required_capacity));
 			abort_unless (heap_buffer != nullptr, "Failed to allocate full DSO path");
 			result = get_full_dso_path (base_dir, dso_path, heap_buffer, required_capacity);
 			abort_unless (result >= 0, "Failed to format full DSO path using the required capacity");

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -386,24 +386,16 @@ namespace xamarin::android {
 			);
 		}
 
-		static auto format_dso_name (std::string_view const& name, bool add_lib_prefix, char *buffer, size_t buffer_length) noexcept -> ssize_t
+		static auto format_dso_name (std::string_view const& name, bool add_lib_prefix, size_t &name_length) noexcept -> char*
 		{
-			if (buffer == nullptr || buffer_length == 0) {
-				return -1;
-			}
-
-			buffer [0] = '\0';
 			std::string_view prefix = add_lib_prefix && !name.starts_with (Constants::DSO_PREFIX) ? Constants::DSO_PREFIX : std::string_view {};
 			std::string_view suffix = name.ends_with (Constants::dso_suffix) ? std::string_view {} : Constants::dso_suffix;
 
-			if (name.length () > std::numeric_limits<size_t>::max () - prefix.length () - suffix.length ()) {
-				return -1;
-			}
-
-			size_t name_length = prefix.length () + name.length () + suffix.length ();
-			if (name_length >= buffer_length || name_length > static_cast<size_t>(std::numeric_limits<ssize_t>::max ())) {
-				return -1;
-			}
+			name_length = Helpers::add_with_overflow_check<size_t> (prefix.length (), name.length ());
+			name_length = Helpers::add_with_overflow_check<size_t> (name_length, suffix.length ());
+			size_t allocation_size = Helpers::add_with_overflow_check<size_t> (name_length, 1uz);
+			auto buffer = static_cast<char*> (std::malloc (allocation_size));
+			abort_unless (buffer != nullptr, "Failed to allocate DSO name");
 
 			char *destination = buffer;
 			if (!prefix.empty ()) {
@@ -419,7 +411,7 @@ namespace xamarin::android {
 			}
 			buffer [name_length] = '\0';
 
-			return static_cast<ssize_t>(name_length);
+			return buffer;
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -386,17 +386,23 @@ namespace xamarin::android {
 			);
 		}
 
-		static auto format_dso_name (std::string_view const& name, bool add_lib_prefix, size_t &name_length) noexcept -> char*
+		static auto get_dso_name_length (std::string_view const& name, bool add_lib_prefix) noexcept -> size_t
 		{
 			std::string_view prefix = add_lib_prefix && !name.starts_with (Constants::DSO_PREFIX) ? Constants::DSO_PREFIX : std::string_view {};
 			std::string_view suffix = name.ends_with (Constants::dso_suffix) ? std::string_view {} : Constants::dso_suffix;
 
-			name_length = Helpers::add_with_overflow_check<size_t> (prefix.length (), name.length ());
+			size_t name_length = Helpers::add_with_overflow_check<size_t> (prefix.length (), name.length ());
 			name_length = Helpers::add_with_overflow_check<size_t> (name_length, suffix.length ());
-			size_t allocation_size = Helpers::add_with_overflow_check<size_t> (name_length, 1uz);
-			auto buffer = static_cast<char*> (std::malloc (allocation_size));
-			abort_unless (buffer != nullptr, "Failed to allocate DSO name");
+			return name_length;
+		}
 
+		static auto format_dso_name (std::string_view const& name, bool add_lib_prefix, char *buffer, size_t buffer_size) noexcept -> size_t
+		{
+			size_t name_length = get_dso_name_length (name, add_lib_prefix);
+			abort_unless (buffer != nullptr && buffer_size > name_length, "DSO name buffer is too small");
+
+			std::string_view prefix = add_lib_prefix && !name.starts_with (Constants::DSO_PREFIX) ? Constants::DSO_PREFIX : std::string_view {};
+			std::string_view suffix = name.ends_with (Constants::dso_suffix) ? std::string_view {} : Constants::dso_suffix;
 			char *destination = buffer;
 			if (!prefix.empty ()) {
 				memcpy (destination, prefix.data (), prefix.length ());
@@ -411,7 +417,7 @@ namespace xamarin::android {
 			}
 			buffer [name_length] = '\0';
 
-			return buffer;
+			return name_length;
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -396,10 +396,15 @@ namespace xamarin::android {
 			return name_length;
 		}
 
-		static auto format_dso_name (std::string_view const& name, bool add_lib_prefix, char *buffer, size_t buffer_size) noexcept -> size_t
+		// Returns the name length excluding NUL, or the negative required capacity including NUL.
+		static auto format_dso_name (std::string_view const& name, bool add_lib_prefix, char *buffer, size_t buffer_size) noexcept -> ssize_t
 		{
 			size_t name_length = get_dso_name_length (name, add_lib_prefix);
-			abort_unless (buffer != nullptr && buffer_size > name_length, "DSO name buffer is too small");
+			size_t required_capacity = Helpers::add_with_overflow_check<size_t> (name_length, 1uz);
+			abort_unless (required_capacity <= static_cast<size_t>(std::numeric_limits<ssize_t>::max ()), "DSO name is too long");
+			if (buffer == nullptr || buffer_size < required_capacity) {
+				return -static_cast<ssize_t>(required_capacity);
+			}
 
 			std::string_view prefix = add_lib_prefix && !name.starts_with (Constants::DSO_PREFIX) ? Constants::DSO_PREFIX : std::string_view {};
 			std::string_view suffix = name.ends_with (Constants::dso_suffix) ? std::string_view {} : Constants::dso_suffix;
@@ -417,7 +422,24 @@ namespace xamarin::android {
 			}
 			buffer [name_length] = '\0';
 
-			return name_length;
+			return static_cast<ssize_t>(name_length);
+		}
+
+		template<size_t Size>
+		static auto format_dso_name (char (&stack_buffer)[Size], char *&heap_buffer, std::string_view const& name, bool add_lib_prefix) noexcept -> const char*
+		{
+			heap_buffer = nullptr;
+			ssize_t result = format_dso_name (name, add_lib_prefix, stack_buffer, Size);
+			if (result >= 0) {
+				return stack_buffer;
+			}
+
+			size_t required_capacity = static_cast<size_t>(-result);
+			heap_buffer = static_cast<char*> (std::malloc (required_capacity));
+			abort_unless (heap_buffer != nullptr, "Failed to allocate DSO name");
+			result = format_dso_name (name, add_lib_prefix, heap_buffer, required_capacity);
+			abort_unless (result >= 0, "Failed to format DSO name using the required capacity");
+			return heap_buffer;
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -386,6 +386,19 @@ namespace xamarin::android {
 			);
 		}
 
+		template<size_t MaxStackSpace, detail::PathBuffer<MaxStackSpace> TBuffer>
+		static void append_dso_name (TBuffer& buf, std::string_view const& name, bool add_lib_prefix) noexcept
+		{
+			if (add_lib_prefix && !name.starts_with (Constants::DSO_PREFIX)) {
+				buf.append (Constants::DSO_PREFIX);
+			}
+
+			buf.append (name);
+			if (!name.ends_with (Constants::dso_suffix)) {
+				buf.append (Constants::dso_suffix);
+			}
+		}
+
 	private:
 		static inline int page_size = getpagesize ();
 	};

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -386,17 +386,40 @@ namespace xamarin::android {
 			);
 		}
 
-		template<size_t MaxStackSpace, detail::PathBuffer<MaxStackSpace> TBuffer>
-		static void append_dso_name (TBuffer& buf, std::string_view const& name, bool add_lib_prefix) noexcept
+		static auto format_dso_name (std::string_view const& name, bool add_lib_prefix, char *buffer, size_t buffer_length) noexcept -> ssize_t
 		{
-			if (add_lib_prefix && !name.starts_with (Constants::DSO_PREFIX)) {
-				buf.append (Constants::DSO_PREFIX);
+			if (buffer == nullptr || buffer_length == 0) {
+				return -1;
 			}
 
-			buf.append (name);
-			if (!name.ends_with (Constants::dso_suffix)) {
-				buf.append (Constants::dso_suffix);
+			buffer [0] = '\0';
+			std::string_view prefix = add_lib_prefix && !name.starts_with (Constants::DSO_PREFIX) ? Constants::DSO_PREFIX : std::string_view {};
+			std::string_view suffix = name.ends_with (Constants::dso_suffix) ? std::string_view {} : Constants::dso_suffix;
+
+			if (name.length () > std::numeric_limits<size_t>::max () - prefix.length () - suffix.length ()) {
+				return -1;
 			}
+
+			size_t name_length = prefix.length () + name.length () + suffix.length ();
+			if (name_length >= buffer_length || name_length > static_cast<size_t>(std::numeric_limits<ssize_t>::max ())) {
+				return -1;
+			}
+
+			char *destination = buffer;
+			if (!prefix.empty ()) {
+				memcpy (destination, prefix.data (), prefix.length ());
+				destination += prefix.length ();
+			}
+			if (!name.empty ()) {
+				memcpy (destination, name.data (), name.length ());
+				destination += name.length ();
+			}
+			if (!suffix.empty ()) {
+				memcpy (destination, suffix.data (), suffix.length ());
+			}
+			buffer [name_length] = '\0';
+
+			return static_cast<ssize_t>(name_length);
 		}
 
 	private:

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -425,16 +425,15 @@ namespace xamarin::android {
 			return static_cast<ssize_t>(name_length);
 		}
 
-		static auto format_dso_name (char *stack_buffer, size_t stack_buffer_size, char *&heap_buffer, std::string_view const& name, bool add_lib_prefix) noexcept -> const char*
+		static auto format_dso_name (char *stack_buffer, size_t stack_buffer_size, std::string_view const& name, bool add_lib_prefix) noexcept -> char*
 		{
-			heap_buffer = nullptr;
 			ssize_t result = format_dso_name (name, add_lib_prefix, stack_buffer, stack_buffer_size);
 			if (result >= 0) {
 				return stack_buffer;
 			}
 
 			size_t required_capacity = static_cast<size_t>(-result);
-			heap_buffer = static_cast<char*> (std::malloc (required_capacity));
+			char *heap_buffer = static_cast<char*> (std::malloc (required_capacity));
 			abort_unless (heap_buffer != nullptr, "Failed to allocate DSO name");
 			result = format_dso_name (name, add_lib_prefix, heap_buffer, required_capacity);
 			abort_unless (result >= 0, "Failed to format DSO name using the required capacity");

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -425,11 +425,10 @@ namespace xamarin::android {
 			return static_cast<ssize_t>(name_length);
 		}
 
-		template<size_t Size>
-		static auto format_dso_name (char (&stack_buffer)[Size], char *&heap_buffer, std::string_view const& name, bool add_lib_prefix) noexcept -> const char*
+		static auto format_dso_name (char *stack_buffer, size_t stack_buffer_size, char *&heap_buffer, std::string_view const& name, bool add_lib_prefix) noexcept -> const char*
 		{
 			heap_buffer = nullptr;
-			ssize_t result = format_dso_name (name, add_lib_prefix, stack_buffer, Size);
+			ssize_t result = format_dso_name (name, add_lib_prefix, stack_buffer, stack_buffer_size);
 			if (result >= 0) {
 				return stack_buffer;
 			}

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -326,27 +326,14 @@ auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_
 		return false;
 	}
 
-	dynamic_local_path_string lib_path { dso_path };
-	bool have_so_extension = lib_path.ends_with (Constants::dso_suffix);
-	if (base_dir.empty () || Util::is_path_rooted (dso_path)) {
-		// Absolute path or no base path, can't do much with it
-		path.assign (dso_path);
-		if (!have_so_extension) {
-			path.append (Constants::dso_suffix);
-		}
-
-		return true;
+	path.clear ();
+	bool is_rooted = Util::is_path_rooted (dso_path);
+	if (!base_dir.empty () && !is_rooted) {
+		path.append (base_dir).append (Constants::DIR_SEP);
 	}
 
-	path.assign (base_dir).append (Constants::DIR_SEP);
-
-	if (!Util::path_has_directory_components (dso_path) && !lib_path.starts_with (Constants::DSO_PREFIX)) {
-		path.append (Constants::DSO_PREFIX);
-	}
-	path.append (dso_path);
-	if (!have_so_extension) {
-		path.append (Constants::dso_suffix);
-	}
+	bool add_lib_prefix = !base_dir.empty () && !is_rooted && !Util::path_has_directory_components (dso_path);
+	Util::append_dso_name (path, dso_path, add_lib_prefix);
 
 	return true;
 }

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -357,12 +357,13 @@ auto AndroidSystem::load_dso_from_specified_dirs (TContainer directories, std::s
 
 	for (std::string const& dir : directories) {
 		char stack_buffer [Util::LocalPathBufferSize];
-		char *heap_buffer;
-		const char *full_path = get_full_dso_path (dir, dso_name, stack_buffer, sizeof (stack_buffer), heap_buffer);
+		char *full_path = get_full_dso_path (dir, dso_name, stack_buffer, sizeof (stack_buffer));
 
 		std::string_view full_path_view { full_path };
 		void *handle = DsoLoader::load (full_path_view, dl_flags, is_jni);
-		std::free (heap_buffer);
+		if (full_path != stack_buffer) {
+			std::free (full_path);
+		}
 		if (handle != nullptr) {
 			return handle;
 		}

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -320,42 +320,21 @@ AndroidSystem::lookup_system_property (const char *name, size_t &value_len) noex
 	);
 }
 
-auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *path_buffer, size_t path_buffer_length) noexcept -> ssize_t
+auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, size_t &path_length) noexcept -> char*
 {
-	if (path_buffer == nullptr || path_buffer_length == 0) {
-		return -1;
-	}
-
-	path_buffer [0] = '\0';
-	if (dso_path.empty ()) {
-		return -1;
-	}
-
-	size_t path_length = 0;
 	bool is_rooted = Util::is_path_rooted (dso_path);
-	if (!base_dir.empty () && !is_rooted) {
-		if (base_dir.length () >= path_buffer_length - 1) {
-			return -1;
-		}
-
-		memcpy (path_buffer, base_dir.data (), base_dir.length ());
-		path_buffer [base_dir.length ()] = Constants::DIR_SEP [0];
-		path_length = base_dir.length () + 1;
-	}
-
 	bool add_lib_prefix = !base_dir.empty () && !is_rooted && !Util::path_has_directory_components (dso_path);
-	ssize_t dso_name_length = Util::format_dso_name (
-		dso_path,
-		add_lib_prefix,
-		path_buffer + path_length,
-		path_buffer_length - path_length
-	);
-	if (dso_name_length < 0 || path_length > static_cast<size_t>(std::numeric_limits<ssize_t>::max ()) - static_cast<size_t>(dso_name_length)) {
-		path_buffer [0] = '\0';
-		return -1;
+	size_t dso_name_length;
+	auto dso_name = Util::format_dso_name (dso_path, add_lib_prefix, dso_name_length);
+
+	if (base_dir.empty () || is_rooted) {
+		path_length = dso_name_length;
+		return dso_name;
 	}
 
-	return static_cast<ssize_t>(path_length + static_cast<size_t>(dso_name_length));
+	auto full_path = Util::join_paths (base_dir, std::string_view { dso_name, dso_name_length }, path_length);
+	std::free (dso_name);
+	return full_path.release ();
 }
 
 template<class TContainer> [[gnu::always_inline]]
@@ -365,16 +344,12 @@ auto AndroidSystem::load_dso_from_specified_dirs (TContainer directories, std::s
 		return nullptr;
 	}
 
-	char full_path[Constants::SENSIBLE_PATH_MAX];
 	for (std::string const& dir : directories) {
-		ssize_t full_path_length = get_full_dso_path (dir, dso_name, full_path, sizeof (full_path));
-		if (full_path_length < 0) {
-			log_warn (LOG_ASSEMBLY, "Unable to construct DSO path for '{}' in '{}': path is too long", dso_name, dir);
-			continue;
-		}
-
-		std::string_view full_path_view { full_path, static_cast<size_t>(full_path_length) };
+		size_t full_path_length;
+		char *full_path = get_full_dso_path (dir, dso_name, full_path_length);
+		std::string_view full_path_view { full_path, full_path_length };
 		void *handle = DsoLoader::load (full_path_view, dl_flags, is_jni);
+		std::free (full_path);
 		if (handle != nullptr) {
 			return handle;
 		}

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -10,7 +10,6 @@
 #include <runtime-base/android-system.hh>
 #include <runtime-base/cpu-arch.hh>
 #include <runtime-base/dso-loader.hh>
-#include <runtime-base/strings.hh>
 #include <runtime-base/util.hh>
 
 using namespace microsoft::java_interop;

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -1,4 +1,3 @@
-#include <cstdlib>
 #include <limits>
 #include <string_view>
 
@@ -320,21 +319,36 @@ AndroidSystem::lookup_system_property (const char *name, size_t &value_len) noex
 	);
 }
 
-auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, size_t &path_length) noexcept -> char*
+auto AndroidSystem::get_full_dso_path_length (std::string const& base_dir, std::string_view const& dso_path) noexcept -> size_t
 {
 	bool is_rooted = Util::is_path_rooted (dso_path);
 	bool add_lib_prefix = !base_dir.empty () && !is_rooted && !Util::path_has_directory_components (dso_path);
-	size_t dso_name_length;
-	auto dso_name = Util::format_dso_name (dso_path, add_lib_prefix, dso_name_length);
-
+	size_t dso_name_length = Util::get_dso_name_length (dso_path, add_lib_prefix);
 	if (base_dir.empty () || is_rooted) {
-		path_length = dso_name_length;
-		return dso_name;
+		return dso_name_length;
 	}
 
-	char *full_path = Util::join_paths (base_dir, std::string_view { dso_name, dso_name_length }, path_length);
-	std::free (dso_name);
-	return full_path;
+	size_t path_length = Helpers::add_with_overflow_check<size_t> (base_dir.length (), dso_name_length);
+	path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+	return path_length;
+}
+
+auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> size_t
+{
+	size_t path_length = get_full_dso_path_length (base_dir, dso_path);
+	abort_unless (buffer != nullptr && buffer_size > path_length, "Full DSO path buffer is too small");
+
+	bool is_rooted = Util::is_path_rooted (dso_path);
+	bool add_lib_prefix = !base_dir.empty () && !is_rooted && !Util::path_has_directory_components (dso_path);
+	char *destination = buffer;
+	if (!base_dir.empty () && !is_rooted) {
+		memcpy (destination, base_dir.data (), base_dir.length ());
+		destination += base_dir.length ();
+		*destination++ = Constants::DIR_SEP [0];
+	}
+
+	Util::format_dso_name (dso_path, add_lib_prefix, destination, buffer_size - static_cast<size_t>(destination - buffer));
+	return path_length;
 }
 
 template<class TContainer> [[gnu::always_inline]]
@@ -345,11 +359,15 @@ auto AndroidSystem::load_dso_from_specified_dirs (TContainer directories, std::s
 	}
 
 	for (std::string const& dir : directories) {
-		size_t full_path_length;
-		char *full_path = get_full_dso_path (dir, dso_name, full_path_length);
+		size_t full_path_length = get_full_dso_path_length (dir, dso_name);
+		size_t allocation_size = Helpers::add_with_overflow_check<size_t> (full_path_length, 1uz);
+		char local_buffer [Util::LocalPathBufferSize];
+		char *full_path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
+		get_full_dso_path (dir, dso_name, full_path, allocation_size);
+
 		std::string_view full_path_view { full_path, full_path_length };
 		void *handle = DsoLoader::load (full_path_view, dl_flags, is_jni);
-		std::free (full_path);
+		Helpers::free_temporary_buffer (full_path, local_buffer);
 		if (handle != nullptr) {
 			return handle;
 		}

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -319,27 +319,23 @@ AndroidSystem::lookup_system_property (const char *name, size_t &value_len) noex
 	);
 }
 
-auto AndroidSystem::get_full_dso_path_length (std::string const& base_dir, std::string_view const& dso_path) noexcept -> size_t
+auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> ssize_t
 {
 	bool is_rooted = Util::is_path_rooted (dso_path);
 	bool add_lib_prefix = !base_dir.empty () && !is_rooted && !Util::path_has_directory_components (dso_path);
 	size_t dso_name_length = Util::get_dso_name_length (dso_path, add_lib_prefix);
-	if (base_dir.empty () || is_rooted) {
-		return dso_name_length;
+	size_t path_length = dso_name_length;
+	if (!base_dir.empty () && !is_rooted) {
+		path_length = Helpers::add_with_overflow_check<size_t> (base_dir.length (), dso_name_length);
+		path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 	}
 
-	size_t path_length = Helpers::add_with_overflow_check<size_t> (base_dir.length (), dso_name_length);
-	path_length = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
-	return path_length;
-}
+	size_t required_capacity = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+	abort_unless (required_capacity <= static_cast<size_t>(std::numeric_limits<ssize_t>::max ()), "Full DSO path is too long");
+	if (buffer == nullptr || buffer_size < required_capacity) {
+		return -static_cast<ssize_t>(required_capacity);
+	}
 
-auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> size_t
-{
-	size_t path_length = get_full_dso_path_length (base_dir, dso_path);
-	abort_unless (buffer != nullptr && buffer_size > path_length, "Full DSO path buffer is too small");
-
-	bool is_rooted = Util::is_path_rooted (dso_path);
-	bool add_lib_prefix = !base_dir.empty () && !is_rooted && !Util::path_has_directory_components (dso_path);
 	char *destination = buffer;
 	if (!base_dir.empty () && !is_rooted) {
 		memcpy (destination, base_dir.data (), base_dir.length ());
@@ -347,8 +343,9 @@ auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_
 		*destination++ = Constants::DIR_SEP [0];
 	}
 
-	Util::format_dso_name (dso_path, add_lib_prefix, destination, buffer_size - static_cast<size_t>(destination - buffer));
-	return path_length;
+	ssize_t result = Util::format_dso_name (dso_path, add_lib_prefix, destination, buffer_size - static_cast<size_t>(destination - buffer));
+	abort_unless (result >= 0, "Failed to format DSO name using the required capacity");
+	return static_cast<ssize_t>(path_length);
 }
 
 template<class TContainer> [[gnu::always_inline]]
@@ -359,15 +356,13 @@ auto AndroidSystem::load_dso_from_specified_dirs (TContainer directories, std::s
 	}
 
 	for (std::string const& dir : directories) {
-		size_t full_path_length = get_full_dso_path_length (dir, dso_name);
-		size_t allocation_size = Helpers::add_with_overflow_check<size_t> (full_path_length, 1uz);
 		char local_buffer [Util::LocalPathBufferSize];
-		char *full_path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
-		get_full_dso_path (dir, dso_name, full_path, allocation_size);
+		char *heap_buffer;
+		const char *full_path = get_full_dso_path (dir, dso_name, local_buffer, heap_buffer);
 
-		std::string_view full_path_view { full_path, full_path_length };
+		std::string_view full_path_view { full_path };
 		void *handle = DsoLoader::load (full_path_view, dl_flags, is_jni);
-		Helpers::free_temporary_buffer (full_path, local_buffer);
+		Util::free_if_used (heap_buffer);
 		if (handle != nullptr) {
 			return handle;
 		}

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -332,9 +332,9 @@ auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_
 		return dso_name;
 	}
 
-	auto full_path = Util::join_paths (base_dir, std::string_view { dso_name, dso_name_length }, path_length);
+	char *full_path = Util::join_paths (base_dir, std::string_view { dso_name, dso_name_length }, path_length);
 	std::free (dso_name);
-	return full_path.release ();
+	return full_path;
 }
 
 template<class TContainer> [[gnu::always_inline]]

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -358,7 +358,7 @@ auto AndroidSystem::load_dso_from_specified_dirs (TContainer directories, std::s
 	for (std::string const& dir : directories) {
 		char stack_buffer [Util::LocalPathBufferSize];
 		char *heap_buffer;
-		const char *full_path = get_full_dso_path (dir, dso_name, stack_buffer, heap_buffer);
+		const char *full_path = get_full_dso_path (dir, dso_name, stack_buffer, sizeof (stack_buffer), heap_buffer);
 
 		std::string_view full_path_view { full_path };
 		void *handle = DsoLoader::load (full_path_view, dl_flags, is_jni);

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -356,13 +356,13 @@ auto AndroidSystem::load_dso_from_specified_dirs (TContainer directories, std::s
 	}
 
 	for (std::string const& dir : directories) {
-		char local_buffer [Util::LocalPathBufferSize];
+		char stack_buffer [Util::LocalPathBufferSize];
 		char *heap_buffer;
-		const char *full_path = get_full_dso_path (dir, dso_name, local_buffer, heap_buffer);
+		const char *full_path = get_full_dso_path (dir, dso_name, stack_buffer, heap_buffer);
 
 		std::string_view full_path_view { full_path };
 		void *handle = DsoLoader::load (full_path_view, dl_flags, is_jni);
-		Util::free_if_used (heap_buffer);
+		std::free (heap_buffer);
 		if (handle != nullptr) {
 			return handle;
 		}

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -320,22 +320,42 @@ AndroidSystem::lookup_system_property (const char *name, size_t &value_len) noex
 	);
 }
 
-auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, dynamic_local_string<SENSIBLE_PATH_MAX>& path) noexcept -> bool
+auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *path_buffer, size_t path_buffer_length) noexcept -> ssize_t
 {
-	if (dso_path.empty ()) {
-		return false;
+	if (path_buffer == nullptr || path_buffer_length == 0) {
+		return -1;
 	}
 
-	path.clear ();
+	path_buffer [0] = '\0';
+	if (dso_path.empty ()) {
+		return -1;
+	}
+
+	size_t path_length = 0;
 	bool is_rooted = Util::is_path_rooted (dso_path);
 	if (!base_dir.empty () && !is_rooted) {
-		path.append (base_dir).append (Constants::DIR_SEP);
+		if (base_dir.length () >= path_buffer_length - 1) {
+			return -1;
+		}
+
+		memcpy (path_buffer, base_dir.data (), base_dir.length ());
+		path_buffer [base_dir.length ()] = Constants::DIR_SEP [0];
+		path_length = base_dir.length () + 1;
 	}
 
 	bool add_lib_prefix = !base_dir.empty () && !is_rooted && !Util::path_has_directory_components (dso_path);
-	Util::append_dso_name (path, dso_path, add_lib_prefix);
+	ssize_t dso_name_length = Util::format_dso_name (
+		dso_path,
+		add_lib_prefix,
+		path_buffer + path_length,
+		path_buffer_length - path_length
+	);
+	if (dso_name_length < 0 || path_length > static_cast<size_t>(std::numeric_limits<ssize_t>::max ()) - static_cast<size_t>(dso_name_length)) {
+		path_buffer [0] = '\0';
+		return -1;
+	}
 
-	return true;
+	return static_cast<ssize_t>(path_length + static_cast<size_t>(dso_name_length));
 }
 
 template<class TContainer> [[gnu::always_inline]]
@@ -345,13 +365,16 @@ auto AndroidSystem::load_dso_from_specified_dirs (TContainer directories, std::s
 		return nullptr;
 	}
 
-	dynamic_local_string<SENSIBLE_PATH_MAX> full_path;
+	char full_path[Constants::SENSIBLE_PATH_MAX];
 	for (std::string const& dir : directories) {
-		if (!get_full_dso_path (dir, dso_name, full_path)) {
+		ssize_t full_path_length = get_full_dso_path (dir, dso_name, full_path, sizeof (full_path));
+		if (full_path_length < 0) {
+			log_warn (LOG_ASSEMBLY, "Unable to construct DSO path for '{}' in '{}': path is too long", dso_name, dir);
 			continue;
 		}
 
-		void *handle = DsoLoader::load (full_path.get (), dl_flags, is_jni);
+		std::string_view full_path_view { full_path, static_cast<size_t>(full_path_length) };
+		void *handle = DsoLoader::load (full_path_view, dl_flags, is_jni);
 		if (handle != nullptr) {
 			return handle;
 		}

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -319,7 +319,7 @@ AndroidSystem::lookup_system_property (const char *name, size_t &value_len) noex
 	);
 }
 
-auto AndroidSystem::get_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> ssize_t
+auto AndroidSystem::format_full_dso_path (std::string const& base_dir, std::string_view const& dso_path, char *buffer, size_t buffer_size) noexcept -> ssize_t
 {
 	bool is_rooted = Util::is_path_rooted (dso_path);
 	bool add_lib_prefix = !base_dir.empty () && !is_rooted && !Util::path_has_directory_components (dso_path);

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -4,7 +4,6 @@
 #include <sys/stat.h>
 
 #include <shared/log_types.hh>
-#include <runtime-base/strings.hh>
 #include <runtime-base/util.hh>
 
 using namespace xamarin::android;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -24,12 +24,10 @@ Util::create_directory (const char *pathname, mode_t mode)
 	size_t path_length = strlen (pathname);
 	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 	char stack_buffer [Constants::SENSIBLE_PATH_MAX];
-	char *heap_buffer = nullptr;
 	char *path = stack_buffer;
 	if (allocation_size > sizeof (stack_buffer)) {
-		heap_buffer = static_cast<char*> (std::malloc (allocation_size));
-		abort_unless (heap_buffer != nullptr, "Failed to allocate directory path");
-		path = heap_buffer;
+		path = static_cast<char*> (std::malloc (allocation_size));
+		abort_unless (path != nullptr, "Failed to allocate directory path");
 	}
 	memcpy (path, pathname, path_length + 1);
 
@@ -56,7 +54,9 @@ Util::create_directory (const char *pathname, mode_t mode)
 	}
 	int saved_errno = errno;
 	umask (oldumask);
-	std::free (heap_buffer);
+	if (path != stack_buffer) {
+		std::free (path);
+	}
 	errno = saved_errno;
 
 	return ret;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -21,7 +21,7 @@ Util::create_directory (const char *pathname, mode_t mode)
 	 	mode = Constants::DEFAULT_DIRECTORY_MODE;
 	}
 
-	size_t path_length = strlen (pathname);
+	size_t path_length = strnlen (pathname, Constants::SENSIBLE_PATH_MAX);
 	if (path_length >= Constants::SENSIBLE_PATH_MAX) {
 		errno = ENAMETOOLONG;
 		return -1;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -24,7 +24,13 @@ Util::create_directory (const char *pathname, mode_t mode)
 	size_t path_length = strlen (pathname);
 	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 	char local_buffer [Constants::SENSIBLE_PATH_MAX];
-	char *path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
+	char *heap_buffer = nullptr;
+	char *path = local_buffer;
+	if (allocation_size > sizeof (local_buffer)) {
+		heap_buffer = static_cast<char*> (std::malloc (allocation_size));
+		abort_unless (heap_buffer != nullptr, "Failed to allocate directory path");
+		path = heap_buffer;
+	}
 	memcpy (path, pathname, path_length + 1);
 
 	mode_t oldumask = umask (022);
@@ -50,7 +56,7 @@ Util::create_directory (const char *pathname, mode_t mode)
 	}
 	int saved_errno = errno;
 	umask (oldumask);
-	Helpers::free_temporary_buffer (path, local_buffer);
+	Util::free_if_used (heap_buffer);
 	errno = saved_errno;
 
 	return ret;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -1,4 +1,5 @@
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
 
 #include <sys/stat.h>
@@ -21,13 +22,13 @@ Util::create_directory (const char *pathname, mode_t mode)
 	 	mode = Constants::DEFAULT_DIRECTORY_MODE;
 	}
 
-	size_t path_length = strnlen (pathname, Constants::SENSIBLE_PATH_MAX);
-	if (path_length >= Constants::SENSIBLE_PATH_MAX) {
-		errno = ENAMETOOLONG;
+	size_t path_length = strlen (pathname);
+	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+	auto path = static_cast<char*> (std::malloc (allocation_size));
+	if (path == nullptr) {
+		errno = ENOMEM;
 		return -1;
 	}
-
-	char path[Constants::SENSIBLE_PATH_MAX];
 	memcpy (path, pathname, path_length + 1);
 
 	mode_t oldumask = umask (022);
@@ -51,7 +52,10 @@ Util::create_directory (const char *pathname, mode_t mode)
 	if (ret == 0) {
 		ret = ::mkdir (path, mode);
 	}
+	int saved_errno = errno;
 	umask (oldumask);
+	std::free (path);
+	errno = saved_errno;
 
 	return ret;
 }

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -21,28 +21,35 @@ Util::create_directory (const char *pathname, mode_t mode)
 	 	mode = Constants::DEFAULT_DIRECTORY_MODE;
 	}
 
-	mode_t oldumask = umask (022);
-	dynamic_local_string<Constants::SENSIBLE_PATH_MAX> path { pathname };
-	int rv, ret = 0;
+	size_t path_length = strlen (pathname);
+	if (path_length >= Constants::SENSIBLE_PATH_MAX) {
+		errno = ENAMETOOLONG;
+		return -1;
+	}
 
-	for (char *d = path.get (); d != nullptr && *d != '\0'; d++) {
+	char path[Constants::SENSIBLE_PATH_MAX];
+	memcpy (path, pathname, path_length + 1);
+
+	mode_t oldumask = umask (022);
+	int ret = 0;
+
+	for (char *d = path; *d != '\0'; d++) {
 		if (*d != '/') {
 			continue;
 		}
 
 		*d = '\0';
-		if (*path.get () != '\0') {
-			rv = ::mkdir (path.get (), mode);
-			if (rv == -1 && errno != EEXIST) {
-				ret = -1;
-				break;
-			}
-		}
+		int rv = *path == '\0' ? 0 : ::mkdir (path, mode);
 		*d = '/';
+
+		if (rv == -1 && errno != EEXIST) {
+			ret = -1;
+			break;
+		}
 	}
 
 	if (ret == 0) {
-		ret = ::mkdir (pathname, mode);
+		ret = ::mkdir (path, mode);
 	}
 	umask (oldumask);
 

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -1,5 +1,4 @@
 #include <cerrno>
-#include <cstdlib>
 #include <cstring>
 
 #include <sys/stat.h>
@@ -24,11 +23,8 @@ Util::create_directory (const char *pathname, mode_t mode)
 
 	size_t path_length = strlen (pathname);
 	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
-	auto path = static_cast<char*> (std::malloc (allocation_size));
-	if (path == nullptr) {
-		errno = ENOMEM;
-		return -1;
-	}
+	char local_buffer [Constants::SENSIBLE_PATH_MAX];
+	char *path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
 	memcpy (path, pathname, path_length + 1);
 
 	mode_t oldumask = umask (022);
@@ -54,7 +50,7 @@ Util::create_directory (const char *pathname, mode_t mode)
 	}
 	int saved_errno = errno;
 	umask (oldumask);
-	std::free (path);
+	Helpers::free_temporary_buffer (path, local_buffer);
 	errno = saved_errno;
 
 	return ret;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -23,10 +23,10 @@ Util::create_directory (const char *pathname, mode_t mode)
 
 	size_t path_length = strlen (pathname);
 	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
-	char local_buffer [Constants::SENSIBLE_PATH_MAX];
+	char stack_buffer [Constants::SENSIBLE_PATH_MAX];
 	char *heap_buffer = nullptr;
-	char *path = local_buffer;
-	if (allocation_size > sizeof (local_buffer)) {
+	char *path = stack_buffer;
+	if (allocation_size > sizeof (stack_buffer)) {
 		heap_buffer = static_cast<char*> (std::malloc (allocation_size));
 		abort_unless (heap_buffer != nullptr, "Failed to allocate directory path");
 		path = heap_buffer;
@@ -56,7 +56,7 @@ Util::create_directory (const char *pathname, mode_t mode)
 	}
 	int saved_errno = errno;
 	umask (oldumask);
-	Util::free_if_used (heap_buffer);
+	std::free (heap_buffer);
 	errno = saved_errno;
 
 	return ret;


### PR DESCRIPTION
## Summary

Remove the CLR/NativeAOT local-string dependencies from DSO-name, path and directory construction, without introducing libc++ ownership or fixed-size limits. This removes the last `strings.hh` includes from the CLR/NativeAOT code.

Part of #12533. This PR is the combination of what were previously two stacked PRs — the DSO-name work and the directory-creation work — which sat directly on top of each other and modified the same files (`android-system.hh/cc`, `util.hh/cc`). They are reviewed together here.

## DSO names and paths

- centralize conditional `lib` prefix and `.so` suffix construction
- make DSO-name and full-path formatters return the negative required capacity including NUL
- retry through non-template helpers with explicit stack-buffer capacities
- return either the caller's stack buffer or exact-size `malloc()` storage, with no heap out-parameters
- free returned storage only when it differs from the caller-owned stack buffer
- preserve the original separator insertion and P/Invoke name-normalization behavior

## Directory creation

Preserves dynamically sized directory paths:

- calculate `strlen(pathname) + 1` once for mutable directory-path storage
- use the stack buffer when it fits and exact-size `malloc()` storage otherwise
- represent ownership through pointer identity and free the path only when it differs from the stack buffer
- temporarily terminate each component in place before calling `mkdir()`
- preserve filesystem `errno` across conditional heap cleanup
- remove the final CLR/NativeAOT `strings.hh` includes

Both halves use the same ownership convention — a returned pointer is freed only when it differs from the caller's stack buffer — which is the main reason they are easier to review as one change.

## Validation

- CoreCLR, MonoVM and NativeAOT all build clean
