### PR TITLE
Finish removing CLR local-string dependencies

### DIFF
--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -12,7 +12,6 @@
 #include <shared/log_types.hh>
 #include "../runtime-base/cpu-arch.hh"
 #include <runtime-base/jni-wrappers.hh>
-#include <runtime-base/strings.hh>
 #include "util.hh"
 
 struct BundledProperty;

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -10,7 +10,6 @@
 #include <runtime-base/android-system.hh>
 #include <runtime-base/cpu-arch.hh>
 #include <runtime-base/dso-loader.hh>
-#include <runtime-base/strings.hh>
 #include <runtime-base/util.hh>
 
 using namespace microsoft::java_interop;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -4,7 +4,6 @@
 #include <sys/stat.h>
 
 #include <shared/log_types.hh>
-#include <runtime-base/strings.hh>
 #include <runtime-base/util.hh>
 
 using namespace xamarin::android;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -24,12 +24,10 @@ Util::create_directory (const char *pathname, mode_t mode)
 	size_t path_length = strlen (pathname);
 	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 	char stack_buffer [Constants::SENSIBLE_PATH_MAX];
-	char *heap_buffer = nullptr;
 	char *path = stack_buffer;
 	if (allocation_size > sizeof (stack_buffer)) {
-		heap_buffer = static_cast<char*> (std::malloc (allocation_size));
-		abort_unless (heap_buffer != nullptr, "Failed to allocate directory path");
-		path = heap_buffer;
+		path = static_cast<char*> (std::malloc (allocation_size));
+		abort_unless (path != nullptr, "Failed to allocate directory path");
 	}
 	memcpy (path, pathname, path_length + 1);
 
@@ -56,7 +54,9 @@ Util::create_directory (const char *pathname, mode_t mode)
 	}
 	int saved_errno = errno;
 	umask (oldumask);
-	std::free (heap_buffer);
+	if (path != stack_buffer) {
+		std::free (path);
+	}
 	errno = saved_errno;
 
 	return ret;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -21,7 +21,7 @@ Util::create_directory (const char *pathname, mode_t mode)
 	 	mode = Constants::DEFAULT_DIRECTORY_MODE;
 	}
 
-	size_t path_length = strlen (pathname);
+	size_t path_length = strnlen (pathname, Constants::SENSIBLE_PATH_MAX);
 	if (path_length >= Constants::SENSIBLE_PATH_MAX) {
 		errno = ENAMETOOLONG;
 		return -1;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -24,7 +24,13 @@ Util::create_directory (const char *pathname, mode_t mode)
 	size_t path_length = strlen (pathname);
 	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
 	char local_buffer [Constants::SENSIBLE_PATH_MAX];
-	char *path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
+	char *heap_buffer = nullptr;
+	char *path = local_buffer;
+	if (allocation_size > sizeof (local_buffer)) {
+		heap_buffer = static_cast<char*> (std::malloc (allocation_size));
+		abort_unless (heap_buffer != nullptr, "Failed to allocate directory path");
+		path = heap_buffer;
+	}
 	memcpy (path, pathname, path_length + 1);
 
 	mode_t oldumask = umask (022);
@@ -50,7 +56,7 @@ Util::create_directory (const char *pathname, mode_t mode)
 	}
 	int saved_errno = errno;
 	umask (oldumask);
-	Helpers::free_temporary_buffer (path, local_buffer);
+	Util::free_if_used (heap_buffer);
 	errno = saved_errno;
 
 	return ret;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -1,4 +1,5 @@
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
 
 #include <sys/stat.h>
@@ -21,13 +22,13 @@ Util::create_directory (const char *pathname, mode_t mode)
 	 	mode = Constants::DEFAULT_DIRECTORY_MODE;
 	}
 
-	size_t path_length = strnlen (pathname, Constants::SENSIBLE_PATH_MAX);
-	if (path_length >= Constants::SENSIBLE_PATH_MAX) {
-		errno = ENAMETOOLONG;
+	size_t path_length = strlen (pathname);
+	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
+	auto path = static_cast<char*> (std::malloc (allocation_size));
+	if (path == nullptr) {
+		errno = ENOMEM;
 		return -1;
 	}
-
-	char path[Constants::SENSIBLE_PATH_MAX];
 	memcpy (path, pathname, path_length + 1);
 
 	mode_t oldumask = umask (022);
@@ -51,7 +52,10 @@ Util::create_directory (const char *pathname, mode_t mode)
 	if (ret == 0) {
 		ret = ::mkdir (path, mode);
 	}
+	int saved_errno = errno;
 	umask (oldumask);
+	std::free (path);
+	errno = saved_errno;
 
 	return ret;
 }

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -21,28 +21,35 @@ Util::create_directory (const char *pathname, mode_t mode)
 	 	mode = Constants::DEFAULT_DIRECTORY_MODE;
 	}
 
-	mode_t oldumask = umask (022);
-	dynamic_local_string<Constants::SENSIBLE_PATH_MAX> path { pathname };
-	int rv, ret = 0;
+	size_t path_length = strlen (pathname);
+	if (path_length >= Constants::SENSIBLE_PATH_MAX) {
+		errno = ENAMETOOLONG;
+		return -1;
+	}
 
-	for (char *d = path.get (); d != nullptr && *d != '\0'; d++) {
+	char path[Constants::SENSIBLE_PATH_MAX];
+	memcpy (path, pathname, path_length + 1);
+
+	mode_t oldumask = umask (022);
+	int ret = 0;
+
+	for (char *d = path; *d != '\0'; d++) {
 		if (*d != '/') {
 			continue;
 		}
 
 		*d = '\0';
-		if (*path.get () != '\0') {
-			rv = ::mkdir (path.get (), mode);
-			if (rv == -1 && errno != EEXIST) {
-				ret = -1;
-				break;
-			}
-		}
+		int rv = *path == '\0' ? 0 : ::mkdir (path, mode);
 		*d = '/';
+
+		if (rv == -1 && errno != EEXIST) {
+			ret = -1;
+			break;
+		}
 	}
 
 	if (ret == 0) {
-		ret = ::mkdir (pathname, mode);
+		ret = ::mkdir (path, mode);
 	}
 	umask (oldumask);
 

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -1,5 +1,4 @@
 #include <cerrno>
-#include <cstdlib>
 #include <cstring>
 
 #include <sys/stat.h>
@@ -24,11 +23,8 @@ Util::create_directory (const char *pathname, mode_t mode)
 
 	size_t path_length = strlen (pathname);
 	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
-	auto path = static_cast<char*> (std::malloc (allocation_size));
-	if (path == nullptr) {
-		errno = ENOMEM;
-		return -1;
-	}
+	char local_buffer [Constants::SENSIBLE_PATH_MAX];
+	char *path = Helpers::get_temporary_buffer (local_buffer, allocation_size);
 	memcpy (path, pathname, path_length + 1);
 
 	mode_t oldumask = umask (022);
@@ -54,7 +50,7 @@ Util::create_directory (const char *pathname, mode_t mode)
 	}
 	int saved_errno = errno;
 	umask (oldumask);
-	std::free (path);
+	Helpers::free_temporary_buffer (path, local_buffer);
 	errno = saved_errno;
 
 	return ret;

--- a/src/native/clr/runtime-base/util.cc
+++ b/src/native/clr/runtime-base/util.cc
@@ -23,10 +23,10 @@ Util::create_directory (const char *pathname, mode_t mode)
 
 	size_t path_length = strlen (pathname);
 	size_t allocation_size = Helpers::add_with_overflow_check<size_t> (path_length, 1uz);
-	char local_buffer [Constants::SENSIBLE_PATH_MAX];
+	char stack_buffer [Constants::SENSIBLE_PATH_MAX];
 	char *heap_buffer = nullptr;
-	char *path = local_buffer;
-	if (allocation_size > sizeof (local_buffer)) {
+	char *path = stack_buffer;
+	if (allocation_size > sizeof (stack_buffer)) {
 		heap_buffer = static_cast<char*> (std::malloc (allocation_size));
 		abort_unless (heap_buffer != nullptr, "Failed to allocate directory path");
 		path = heap_buffer;
@@ -56,7 +56,7 @@ Util::create_directory (const char *pathname, mode_t mode)
 	}
 	int saved_errno = errno;
 	umask (oldumask);
-	Util::free_if_used (heap_buffer);
+	std::free (heap_buffer);
 	errno = saved_errno;
 
 	return ret;


### PR DESCRIPTION
## Summary

Finish removing CLR/NativeAOT local-string dependencies while preserving dynamically sized directory paths.

## Changes

- calculate `strlen(pathname) + 1` once for mutable directory-path storage
- use the sensible stack buffer when it fits and exact-size `malloc()` storage otherwise
- represent ownership through pointer identity and free the path only when it differs from the stack buffer
- temporarily terminate each component in place before calling `mkdir()`
- preserve filesystem `errno` across conditional heap cleanup
- remove the final CLR/NativeAOT `strings.hh` includes

This is the top PR in stack #12519. Together, the stack removes all CLR/NativeAOT uses of the local-string hierarchy and their `strings.hh` dependencies.

## Validation

- Local native builds intentionally skipped; relying on CI validation
