### PR TITLE
[tests] Use approved feed for analyzer references

### DIFF
--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Android.Sdk.Analysis.csproj" />
     <None Include="$(MSBuildThisFileDirectory)..\..\..\NuGet.config" Link="NuGet.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <Import Project="..\..\..\build-tools\scripts\NUnitReferences.projitems" />

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Android.Sdk.Analysis.csproj" />
     <None Include="$(MSBuildThisFileDirectory)..\..\..\NuGet.config" Link="NuGet.config">
-      <CopyToOutputDirectory>IfDifferent</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <Import Project="..\..\..\build-tools\scripts\NUnitReferences.projitems" />

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Android.Sdk.Analysis.csproj" />
     <None Include="$(MSBuildThisFileDirectory)..\..\..\NuGet.config" Link="NuGet.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>IfDifferent</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <Import Project="..\..\..\build-tools\scripts\NUnitReferences.projitems" />

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj
@@ -19,6 +19,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Android.Sdk.Analysis.csproj" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\..\NuGet.config" Link="NuGet.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="..\..\..\build-tools\scripts\NUnitReferences.projitems" />
   <ItemGroup>

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -16,6 +16,8 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
 		public List<DiagnosticAnalyzer> Analyzers => analyzers;
 		public Test ()
 		{
+			ReferenceAssemblies = CSharpVerifierHelper.DefaultReferenceAssemblies;
+
 			SolutionTransforms.Add ((solution, projectId) => {
 				var project = solution.GetProject (projectId);
 				var compilationOptions = project.CompilationOptions;

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpCodeFixVerifier`2+Test.cs
@@ -11,6 +11,8 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 	{
 		public Test ()
 		{
+			ReferenceAssemblies = CSharpVerifierHelper.DefaultReferenceAssemblies;
+
 			SolutionTransforms.Add ((solution, projectId) => {
 				var compilationOptions = solution.GetProject (projectId).CompilationOptions;
 				compilationOptions = compilationOptions.WithSpecificDiagnosticOptions (
@@ -22,4 +24,3 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 		}
 	}
 }
-

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -8,6 +8,8 @@ public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
 	{
 		public Test ()
 		{
+			ReferenceAssemblies = CSharpVerifierHelper.DefaultReferenceAssemblies;
+
 			SolutionTransforms.Add ((solution, projectId) => {
 				var compilationOptions = solution.GetProject (projectId).CompilationOptions;
 				compilationOptions = compilationOptions.WithSpecificDiagnosticOptions (

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpVerifierHelper.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpVerifierHelper.cs
@@ -1,10 +1,15 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
 using System;
 using System.Collections.Immutable;
+using System.IO;
 
 internal static class CSharpVerifierHelper
 {
+	internal static ReferenceAssemblies DefaultReferenceAssemblies { get; } =
+		ReferenceAssemblies.Default.WithNuGetConfigFilePath (Path.Combine (AppContext.BaseDirectory, "NuGet.config"));
+
 	/// <summary>
 	/// By default, the compiler reports diagnostics for nullable reference types at
 	/// <see cref="DiagnosticSeverity.Warning"/>, and the analyzer test framework defaults to only validating


### PR DESCRIPTION
----

Pull Request

Roslyn analyzer tests acquire `Microsoft.NETCore.App.Ref` at test runtime. The testing library ignored the repository `NuGet.config` and contacted public NuGet infrastructure, producing CFS network-isolation violations on `main`.

Copy the repository NuGet configuration beside the test assembly and configure the analyzer, code-fix, and refactoring verifier types to use it. Runtime reference package acquisition now uses the approved Azure Artifacts feeds already defined by the repository.

The reported `ci.dot.net` and `shavamanifest*.azureedge.net` destinations are aliases associated with the same Azure Front Door event as the `testhost.exe` NuGet request. `asmconfigfiles-prod.azure-api.net` is intentionally unchanged because it originates from the pipeline-injected Geneva `ConfigDownloader.exe` and requires infrastructure remediation outside this repository.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [x] Unit tests

Validation: `dotnet test src\Microsoft.Android.Sdk.Analysis\Tests\Microsoft.Android.Sdk.Analysis.Tests.csproj -c Release -p:RestoreConfigFile=NuGet.config` (16 passed, 1 skipped). A fresh temporary package cache confirmed `Microsoft.NETCore.App.Ref.3.1.0.nupkg` was acquired through the copied approved-feed configuration.