### PR TITLE
[NativeAOT] Stop linking and shipping libc++ and libunwind

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -99,6 +99,12 @@ projects that use the Microsoft.Android.Runtimes framework in .NET 6+.
           Condition=" '%(_AndroidNdkRedistributable.AndroidRID)' == '$(AndroidRID)' And '%(_AndroidNdkRedistributable.Kind)' == 'Toolchain' " />
     </ItemGroup>
 
+    <!-- NativeAOT applications do not link libc++, so its archives are only shipped for CoreCLR. -->
+    <ItemGroup Condition=" '$(AndroidRuntime)' == 'CoreCLR' ">
+      <NativeRuntimeAsset Include="@(_AndroidNdkRedistributable)"
+          Condition=" '%(_AndroidNdkRedistributable.AndroidRID)' == '$(AndroidRID)' And '%(_AndroidNdkRedistributable.Kind)' == 'CplusPlus' " />
+    </ItemGroup>
+
     <ItemGroup Condition=" '$(AndroidRuntime)' == 'NativeAOT' ">
       <NativeRuntimeAsset Condition=" Exists('$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.debug-static-debug.a') " Include="$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.debug-static-debug.a" />
       <NativeRuntimeAsset Condition=" Exists('$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.release-static-release.a') " Include="$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.release-static-release.a" />

--- a/build-tools/scripts/Ndk.targets
+++ b/build-tools/scripts/Ndk.targets
@@ -28,10 +28,10 @@
       <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\libz.so')" Kind="System" />
       <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\crtbegin_so.o')" Kind="Toolchain" />
       <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\crtend_so.o')" Kind="Toolchain" />
-      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\libc++_static.a')" Kind="Toolchain" />
-      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\libc++abi.a')" Kind="Toolchain" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\libc++_static.a')" Kind="CplusPlus" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\libc++abi.a')" Kind="CplusPlus" />
       <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkClangLibLinux)\libclang_rt.builtins-%(ClangArch)-android.a')" Kind="Toolchain" />
-      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkClangLibLinux)\%(UnwindArchDir)\libunwind.a')" Kind="Toolchain" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkClangLibLinux)\%(UnwindArchDir)\libunwind.a')" Kind="CplusPlus" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -359,6 +359,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <FileWrites Include="$(_AndroidNativeAotSharedLibrary)" />
       <FileWrites Include="$(_AndroidNativeAotSharedLibrary)$(NativeSymbolExt)" Condition=" '$(AndroidIncludeDebugSymbols)' != 'true' " />
       <FileWrites Include="$(NativeIntermediateOutputPath)sections.ld" />
+      <FileWrites Include="$(NativeIntermediateOutputPath)libRuntime.WorkstationGC.arm-ehabi.a" Condition=" '$(RuntimeIdentifier)' == 'android-arm' " />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -129,13 +129,14 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
 
           Also, do NOT use `clang++` here because it will link the dynamic libc++ library into the
           application. If, for some reason, `clang++` has to be used, `<LinkerArgs>` need to be
-          added to pass `-nostdlib` to it.
+          added to pass `-nostdlib++` to it.
       -->
       <CppCompilerAndLinker>$(_NdkClangPrefix)$(_NDKApiLevel)-clang$(_NdkWrapperScriptExt)</CppCompilerAndLinker>
       <CppLinker>$(_NdkClangPrefix)$(_NDKApiLevel)-clang$(_NdkWrapperScriptExt)</CppLinker>
       <ObjCopyName>llvm-objcopy</ObjCopyName>
 
-      <!-- We must ensure this is `false`, as it would interfere with statically linking libc++ -->
+      <!-- We must ensure this is `false`, so that the compiler driver does not add libc++,
+           which NativeAOT applications do not link. -->
       <LinkStandardCPlusPlusLibrary>false</LinkStandardCPlusPlusLibrary>
     </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -164,15 +164,11 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
 
       <_NdkLibs Include="@(RuntimePackAsset->WithMetadataValue('Filename', 'libnaot-android.release-static-release'))" />
 
-      <!-- Include libc++ -->
-      <_NdkLibs Include="$(_NdkSysrootDir)libc++_static.a" />
-      <_NdkLibs Include="$(_NdkSysrootDir)libc++abi.a" />
-
       <LinkerArg Include="&quot;%(_NdkLibs.Identity)&quot;" />
 
-      <!-- This library conflicts with static libc++ -->
-      <NativeLibrary Remove="$(IlcSdkPath)libstdc++compat.a" />
-      <LinkerArg Remove="$(IlcSdkPath)libstdc++compat.a" />
+      <!-- libstdc++compat.a supplies the C++ allocation ABI (operator new/delete, std::nothrow)
+           that the NativeAOT runtime itself depends on.  It used to be removed here because it
+           conflicts with static libc++, which we no longer link. -->
 
       <!-- Every p/invoke using the `xa-internal-api` "library" will be called directly -->
       <DirectPInvoke Include="xa-internal-api" />
@@ -301,7 +297,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       </_NativeAotCrtEndFiles>
       <_NativeAotLibSearchPaths Include="$(_NativeAotRuntimePackNativeDir)" />
       <_NativeAotCompilerRtLibs Include="$(_NativeAotRuntimePackNativeDir)/libclang_rt.builtins-$(_NdkAbi)-android.a" />
-      <_NativeAotCompilerRtLibs Include="$(_NativeAotRuntimePackNativeDir)/libunwind.a" />
     </ItemGroup>
 
     <!-- CRT and toolchain items from NDK -->
@@ -315,7 +310,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <_NativeAotLibSearchPaths Include="$(_NdkApiSysrootDir)" />
       <_NativeAotLibSearchPaths Include="$(_NdkSysrootDir)" />
       <_NativeAotCompilerRtLibs Include="$(_NdkClangResourceDir)/**/libclang_rt.builtins-$(_NdkAbi)-android.a" />
-      <_NativeAotCompilerRtLibs Include="$(_NdkClangResourceDir)/**/$(_NdkAbi)/libunwind.a" />
     </ItemGroup>
 
     <!-- Common items (same regardless of linker source) -->
@@ -330,12 +324,10 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <_NativeAotSystemLibraries Include="m" />
       <_NativeAotSystemLibraries Include="c" />
     </ItemGroup>
-    <!-- When using workload linker, resolve libc++/libnaot from runtime pack dir.
+    <!-- When using workload linker, resolve libnaot from runtime pack dir.
          When using NDK, @(_NdkLibs) already has the right NDK sysroot paths. -->
     <ItemGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' == 'true' ">
       <_NativeAotLinkLibraries Include="@(RuntimePackAsset->WithMetadataValue('Filename', 'libnaot-android.release-static-release'))" />
-      <_NativeAotLinkLibraries Include="$(_NativeAotRuntimePackNativeDir)libc++_static.a" />
-      <_NativeAotLinkLibraries Include="$(_NativeAotRuntimePackNativeDir)libc++abi.a" />
     </ItemGroup>
     <ItemGroup Condition=" '$(_AndroidUseWorkloadNativeLinker)' != 'true' ">
       <_NativeAotLinkLibraries Include="@(_NdkLibs)" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkNativeAotSharedLibrary.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkNativeAotSharedLibrary.cs
@@ -15,6 +15,13 @@ namespace Xamarin.Android.Tasks;
 /// </summary>
 public class LinkNativeAotSharedLibrary : AndroidTask
 {
+	const string RuntimeWorkstationGcLibrary = "libRuntime.WorkstationGC.a";
+	static readonly string [] ArmEhabiPersonalitySymbols = [
+		"__aeabi_unwind_cpp_pr0",
+		"__aeabi_unwind_cpp_pr1",
+		"__aeabi_unwind_cpp_pr2",
+	];
+
 	public override string TaskPrefix => "LNAS";
 
 	[Required]
@@ -175,7 +182,11 @@ public class LinkNativeAotSharedLibrary : AndroidTask
 		linkItems.Add (CopyItemWithAbi (NativeObject, abi));
 
 		foreach (var lib in NativeLibraries) {
-			linkItems.Add (CopyItemWithAbi (lib, abi));
+			ITaskItem? library = MakeArmEhabiPersonalitySymbolsAvailable (lib, abi);
+			if (library == null) {
+				return false;
+			}
+			linkItems.Add (CopyItemWithAbi (library, abi));
 		}
 
 		if (SystemLibraries != null) {
@@ -216,6 +227,34 @@ public class LinkNativeAotSharedLibrary : AndroidTask
 		var output = CopyItemWithAbi (OutputSharedLibrary, abi);
 
 		return linker.Link (output, linkItems, startFiles, endFiles);
+	}
+
+	ITaskItem? MakeArmEhabiPersonalitySymbolsAvailable (ITaskItem library, string abi)
+	{
+		if (abi != "armeabi-v7a" || Path.GetFileName (library.ItemSpec) != RuntimeWorkstationGcLibrary) {
+			return library;
+		}
+
+		// NativeAOT's private libunwind already implements these, but localizes the symbols.
+		// Promote them instead of linking a second copy of libunwind.
+		Directory.CreateDirectory (IntermediateOutputPath);
+		string outputPath = Path.Combine (IntermediateOutputPath, "libRuntime.WorkstationGC.arm-ehabi.a");
+		string objcopy = Path.Combine (AndroidBinUtilsDirectory, MonoAndroidHelper.GetExecutablePath (AndroidBinUtilsDirectory, "llvm-objcopy"));
+		var args = new List<string> ();
+		foreach (string symbol in ArmEhabiPersonalitySymbols) {
+			args.Add ($"--globalize-symbol={symbol}");
+			args.Add ($"--weaken-symbol={symbol}");
+		}
+		args.Add (MonoAndroidHelper.QuoteFileNameArgument (library.ItemSpec));
+		args.Add (MonoAndroidHelper.QuoteFileNameArgument (outputPath));
+
+		if (MonoAndroidHelper.RunProcess ("Promote ARM EHABI personality symbols", objcopy, String.Join (" ", args), Log) != 0) {
+			return null;
+		}
+
+		var output = new TaskItem (library);
+		output.ItemSpec = outputPath;
+		return output;
 	}
 
 	/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
@@ -158,6 +158,32 @@ namespace Xamarin.Android.Build.Tests
 				Directory.Delete (outputDirectory, recursive: true);
 			}
 			Directory.CreateDirectory (outputDirectory);
+			Version apiLevel = XABuildConfig.AndroidLatestStableApiLevel;
+			string apiLevelName = apiLevel.Minor == 0 ? $"{apiLevel.Major}" : $"{apiLevel.Major}.{apiLevel.Minor}";
+			string installedRuntimePack = Path.Combine (
+				TestEnvironment.DotNetPreviewPacksDirectory,
+				$"Microsoft.Android.Runtime.NativeAOT.{apiLevelName}.android-arm64"
+			);
+			string runtimeAssembly = Directory.GetFiles (
+				installedRuntimePack,
+				"Microsoft.Android.Runtime.NativeAOT.dll",
+				SearchOption.AllDirectories
+			).Single ();
+			string installedReferencePack = Path.Combine (
+				TestEnvironment.DotNetPreviewPacksDirectory,
+				$"Microsoft.Android.Ref.{apiLevelName}"
+			);
+			string runtimeSymbols = Directory.GetFiles (
+				installedReferencePack,
+				"Microsoft.Android.Runtime.NativeAOT.pdb",
+				SearchOption.AllDirectories
+			).Single ();
+			string managedOutputRoot = Path.Combine (outputDirectory, "xbuild-frameworks", "Microsoft.Android");
+			string managedOutputDirectory = Path.Combine (managedOutputRoot, apiLevelName);
+			Directory.CreateDirectory (managedOutputDirectory);
+			File.Copy (runtimeAssembly, Path.Combine (managedOutputDirectory, Path.GetFileName (runtimeAssembly)));
+			File.Copy (runtimeSymbols, Path.Combine (managedOutputDirectory, Path.GetFileName (runtimeSymbols)));
+
 			string runtimePackProject = Path.Combine (XABuildPaths.TopDirectory, "build-tools", "create-packs", "Microsoft.Android.Runtime.proj");
 			var dotnet = new DotNetCLI (runtimePackProject) {
 				ProjectDirectory = outputDirectory,
@@ -167,8 +193,10 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (
 				dotnet.Pack (parameters: [
 					$"Configuration={XABuildPaths.Configuration}",
+					$"AndroidApiLevel={apiLevelName}",
 					$"AndroidRuntime={runtime}",
 					"AndroidRID=android-arm64",
+					$"_MonoAndroidNETOutputRoot={managedOutputRoot}{Path.DirectorySeparatorChar}",
 					$"BaseIntermediateOutputPath={Path.Combine (outputDirectory, "obj")}{Path.DirectorySeparatorChar}",
 					$"PackageOutputPath={outputDirectory}",
 				]),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
@@ -1,7 +1,10 @@
+using System;
 using System.IO;
+using System.Linq;
 
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
+using Xamarin.Android.Tools;
 using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
@@ -13,6 +16,18 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("Node-2")]
 	public class NativeAotBuildTests : BaseTest
 	{
+		static readonly string [] ArmEhabiPersonalitySymbols = [
+			"__aeabi_unwind_cpp_pr0",
+			"__aeabi_unwind_cpp_pr1",
+			"__aeabi_unwind_cpp_pr2",
+		];
+
+		static readonly string [] CPlusPlusArchiveNames = [
+			"libc++_static.a",
+			"libc++abi.a",
+			"libunwind.a",
+		];
+
 		[Test]
 		public void RestoreNativeAot_AndroidArmRuntimePack ()
 		{
@@ -115,13 +130,62 @@ namespace Xamarin.Android.Build.Tests
 		void AssertArmEhabiSymbolsPromoted (ProjectBuilder builder, XamarinAndroidApplicationProject proj)
 		{
 			string nativeDirectory = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "android-arm", "native");
-			FileAssert.Exists (Path.Combine (nativeDirectory, "libRuntime.WorkstationGC.arm-ehabi.a"));
+			string runtimeArchive = Path.Combine (nativeDirectory, "libRuntime.WorkstationGC.arm-ehabi.a");
+			FileAssert.Exists (runtimeArchive);
 
 			string [] linkerResponseFiles = Directory.GetFiles (nativeDirectory, "ld.*.rsp");
 			Assert.AreEqual (1, linkerResponseFiles.Length, "One native linker response file should be generated.");
 			string linkerResponse = File.ReadAllText (linkerResponseFiles [0]);
 			StringAssert.Contains ("libRuntime.WorkstationGC.arm-ehabi.a", linkerResponse);
 			StringAssert.DoesNotContain ("libunwind.a", linkerResponse);
+
+			NdkTools ndk = NdkTools.Create (AndroidNdkPath);
+			ndk.OSBinPath = TestEnvironment.OSBinDirectory;
+			string llvmNm = ndk.GetToolPath ("llvm-nm", AndroidTargetArch.Arm, 0);
+			var (exitCode, standardOutput, standardError) = RunProcessWithExitCode (llvmNm, $"--defined-only \"{runtimeArchive}\"");
+			Assert.AreEqual (0, exitCode, $"llvm-nm failed:{Environment.NewLine}{standardError}");
+			foreach (string symbol in ArmEhabiPersonalitySymbols) {
+				StringAssert.Contains ($" W {symbol}", standardOutput, $"{symbol} should be a weak global symbol.");
+			}
+		}
+
+		[TestCase (AndroidRuntime.NativeAOT, false)]
+		[TestCase (AndroidRuntime.CoreCLR, true)]
+		public void RuntimePackCPlusPlusArchives (AndroidRuntime runtime, bool shouldContain)
+		{
+			string outputDirectory = Path.Combine (Root, TestName);
+			if (Directory.Exists (outputDirectory)) {
+				Directory.Delete (outputDirectory, recursive: true);
+			}
+			Directory.CreateDirectory (outputDirectory);
+			string runtimePackProject = Path.Combine (XABuildPaths.TopDirectory, "build-tools", "create-packs", "Microsoft.Android.Runtime.proj");
+			var dotnet = new DotNetCLI (runtimePackProject) {
+				ProjectDirectory = outputDirectory,
+				BuildLogFile = Path.Combine (outputDirectory, "build.log"),
+				ProcessLogFile = Path.Combine (outputDirectory, "process.log"),
+			};
+			Assert.IsTrue (
+				dotnet.Pack (parameters: [
+					$"Configuration={XABuildPaths.Configuration}",
+					$"AndroidRuntime={runtime}",
+					"AndroidRID=android-arm64",
+					$"BaseIntermediateOutputPath={Path.Combine (outputDirectory, "obj")}{Path.DirectorySeparatorChar}",
+					$"PackageOutputPath={outputDirectory}",
+				]),
+				$"Packing the {runtime} runtime pack should succeed. See {dotnet.ProcessLogFile}."
+			);
+
+			string packagePath = Directory.GetFiles (outputDirectory, "*.nupkg")
+				.Single (path => !path.EndsWith (".symbols.nupkg", StringComparison.OrdinalIgnoreCase));
+			using var package = ZipHelper.OpenZip (packagePath);
+			foreach (string archiveName in CPlusPlusArchiveNames) {
+				string archivePath = $"runtimes/android-arm64/native/{archiveName}";
+				if (shouldContain) {
+					package.AssertContainsEntry (packagePath, archivePath);
+				} else {
+					package.AssertDoesNotContainEntry (packagePath, archivePath);
+				}
+			}
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
@@ -76,6 +76,23 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void BuildNativeAot_AndroidArm_WithoutNdk ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.NativeAOT);
+			proj.SetRuntimeIdentifiers (["armeabi-v7a"]);
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (
+				builder.Build (proj),
+				"android-arm build should succeed without NDK."
+			);
+			AssertArmEhabiSymbolsPromoted (builder, proj);
+		}
+
+		[Test]
 		public void BuildNativeAot_AndroidArm_WithNdkLinker ()
 		{
 			var proj = new XamarinAndroidApplicationProject {
@@ -92,6 +109,19 @@ namespace Xamarin.Android.Build.Tests
 				]),
 				"android-arm build should succeed with NDK linker."
 			);
+			AssertArmEhabiSymbolsPromoted (builder, proj);
+		}
+
+		void AssertArmEhabiSymbolsPromoted (ProjectBuilder builder, XamarinAndroidApplicationProject proj)
+		{
+			string nativeDirectory = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "android-arm", "native");
+			FileAssert.Exists (Path.Combine (nativeDirectory, "libRuntime.WorkstationGC.arm-ehabi.a"));
+
+			string [] linkerResponseFiles = Directory.GetFiles (nativeDirectory, "ld.*.rsp");
+			Assert.AreEqual (1, linkerResponseFiles.Length, "One native linker response file should be generated.");
+			string linkerResponse = File.ReadAllText (linkerResponseFiles [0]);
+			StringAssert.Contains ("libRuntime.WorkstationGC.arm-ehabi.a", linkerResponse);
+			StringAssert.DoesNotContain ("libunwind.a", linkerResponse);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
@@ -169,20 +169,12 @@ namespace Xamarin.Android.Build.Tests
 				"Microsoft.Android.Runtime.NativeAOT.dll",
 				SearchOption.AllDirectories
 			).Single ();
-			string installedReferencePack = Path.Combine (
-				TestEnvironment.DotNetPreviewPacksDirectory,
-				$"Microsoft.Android.Ref.{apiLevelName}"
-			);
-			string runtimeSymbols = Directory.GetFiles (
-				installedReferencePack,
-				"Microsoft.Android.Runtime.NativeAOT.pdb",
-				SearchOption.AllDirectories
-			).Single ();
 			string managedOutputRoot = Path.Combine (outputDirectory, "xbuild-frameworks", "Microsoft.Android");
 			string managedOutputDirectory = Path.Combine (managedOutputRoot, apiLevelName);
 			Directory.CreateDirectory (managedOutputDirectory);
 			File.Copy (runtimeAssembly, Path.Combine (managedOutputDirectory, Path.GetFileName (runtimeAssembly)));
-			File.Copy (runtimeSymbols, Path.Combine (managedOutputDirectory, Path.GetFileName (runtimeSymbols)));
+			// The pack target requires a PDB, but its contents are unrelated to native asset composition.
+			File.Create (Path.Combine (managedOutputDirectory, "Microsoft.Android.Runtime.NativeAOT.pdb")).Dispose ();
 
 			string runtimePackProject = Path.Combine (XABuildPaths.TopDirectory, "build-tools", "create-packs", "Microsoft.Android.Runtime.proj");
 			var dotnet = new DotNetCLI (runtimePackProject) {
@@ -213,6 +205,56 @@ namespace Xamarin.Android.Build.Tests
 				} else {
 					package.AssertDoesNotContainEntry (packagePath, archivePath);
 				}
+			}
+		}
+
+		[Test]
+		public void CopyNativeAotRuntimePackRemovesStaleCPlusPlusArchives ()
+		{
+			string outputDirectory = Path.Combine (Root, TestName);
+			if (Directory.Exists (outputDirectory)) {
+				Directory.Delete (outputDirectory, recursive: true);
+			}
+			Directory.CreateDirectory (outputDirectory);
+
+			Version apiLevel = XABuildConfig.AndroidLatestStableApiLevel;
+			string apiLevelName = apiLevel.Minor == 0 ? $"{apiLevel.Major}" : $"{apiLevel.Major}.{apiLevel.Minor}";
+			string packVersion = "1.0.0-test";
+			string packsRoot = Path.Combine (outputDirectory, "packs");
+			string nativeDirectory = Path.Combine (
+				packsRoot,
+				$"Microsoft.Android.Runtime.NativeAOT.{apiLevelName}.android-arm64",
+				packVersion,
+				"runtimes",
+				"android-arm64",
+				"native"
+			);
+			Directory.CreateDirectory (nativeDirectory);
+			foreach (string archiveName in CPlusPlusArchiveNames) {
+				File.Create (Path.Combine (nativeDirectory, archiveName)).Dispose ();
+			}
+
+			string nativeProject = Path.Combine (XABuildPaths.TopDirectory, "src", "native", "native-nativeaot.csproj");
+			var dotnet = new DotNetCLI (nativeProject) {
+				ProjectDirectory = outputDirectory,
+				BuildLogFile = Path.Combine (outputDirectory, "build.log"),
+				ProcessLogFile = Path.Combine (outputDirectory, "process.log"),
+			};
+			Assert.IsTrue (
+				dotnet.Build (
+					target: "_CopyToPackDirs",
+					parameters: [
+						$"Configuration={XABuildPaths.Configuration}",
+						$"AndroidApiLevel={apiLevelName}",
+						$"AndroidPackVersion={packVersion}",
+						$"MicrosoftAndroidPacksRootDir={packsRoot}{Path.DirectorySeparatorChar}",
+					]
+				),
+				$"Copying the NativeAOT runtime pack should succeed. See {dotnet.ProcessLogFile}."
+			);
+
+			foreach (string archiveName in CPlusPlusArchiveNames) {
+				FileAssert.DoesNotExist (Path.Combine (nativeDirectory, archiveName));
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
@@ -137,7 +137,9 @@ namespace Xamarin.Android.Build.Tests
 			Assert.AreEqual (1, linkerResponseFiles.Length, "One native linker response file should be generated.");
 			string linkerResponse = File.ReadAllText (linkerResponseFiles [0]);
 			StringAssert.Contains ("libRuntime.WorkstationGC.arm-ehabi.a", linkerResponse);
-			StringAssert.DoesNotContain ("libunwind.a", linkerResponse);
+			foreach (string archiveName in CPlusPlusArchiveNames) {
+				StringAssert.DoesNotContain (archiveName, linkerResponse);
+			}
 
 			NdkTools ndk = NdkTools.Create (AndroidNdkPath);
 			ndk.OSBinPath = TestEnvironment.OSBinDirectory;

--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -372,6 +372,15 @@
                          RuntimePackName="$(_RuntimePackName)" />
     </ItemGroup>
 
+    <!-- NativeAOT applications do not link libc++, so its archives are only shipped for CoreCLR. -->
+    <ItemGroup Condition=" '$(CMakeRuntimeFlavor)' == 'CoreCLR' ">
+      <_RuntimePackFiles Include="@(_AndroidNdkRedistributable)"
+                         Condition=" '%(_AndroidNdkRedistributable.Kind)' == 'CplusPlus' "
+                         AndroidRID="%(_AndroidNdkRedistributable.AndroidRID)"
+                         AndroidRuntime="$(CMakeRuntimeFlavor)"
+                         RuntimePackName="$(_RuntimePackName)" />
+    </ItemGroup>
+
     <Copy
         SourceFiles="%(_RuntimePackFiles.Identity)"
         DestinationFolder="$(MicrosoftAndroidPacksRootDir)Microsoft.Android.Runtime.%(_RuntimePackFiles.RuntimePackName).$(AndroidApiLevel).%(_RuntimePackFiles.AndroidRID)\$(AndroidPackVersion)\runtimes\%(_RuntimePackFiles.AndroidRID)\native"

--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -381,6 +381,15 @@
                          RuntimePackName="$(_RuntimePackName)" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(CMakeRuntimeFlavor)' == 'NativeAOT' ">
+      <_NativeAotObsoleteRuntimePackFile Include="@(_AndroidNdkRedistributable)"
+                                         Condition=" '%(_AndroidNdkRedistributable.Kind)' == 'CplusPlus' ">
+        <DestinationFile>$(MicrosoftAndroidPacksRootDir)Microsoft.Android.Runtime.$(_RuntimePackName).$(AndroidApiLevel).%(_AndroidNdkRedistributable.AndroidRID)\$(AndroidPackVersion)\runtimes\%(_AndroidNdkRedistributable.AndroidRID)\native\%(_AndroidNdkRedistributable.Filename)%(_AndroidNdkRedistributable.Extension)</DestinationFile>
+      </_NativeAotObsoleteRuntimePackFile>
+    </ItemGroup>
+
+    <Delete Files="@(_NativeAotObsoleteRuntimePackFile->'%(DestinationFile)')" />
+
     <Copy
         SourceFiles="%(_RuntimePackFiles.Identity)"
         DestinationFolder="$(MicrosoftAndroidPacksRootDir)Microsoft.Android.Runtime.%(_RuntimePackFiles.RuntimePackName).$(AndroidApiLevel).%(_RuntimePackFiles.AndroidRID)\$(AndroidPackVersion)\runtimes\%(_RuntimePackFiles.AndroidRID)\native"


### PR DESCRIPTION
Closes #12139
Closes #12146

Removes `libc++_static.a`, `libc++abi.a` and `libunwind.a` from the NativeAOT link. This is the payoff for the local-string removal work in the rest of this stack: with `strings.hh`, `dynamic_local_string` and `static_local_string` gone, nothing in `libnaot-android` uses libc++ any more.

For 32-bit ARM, ILC output still references the EHABI personality routines `__aeabi_unwind_cpp_pr0` and `__aeabi_unwind_cpp_pr1`. The NativeAOT runtime already contains their implementations in `libRuntime.WorkstationGC.a`, but dotnet/runtime localizes those symbols. `LinkNativeAotSharedLibrary` now makes an intermediate copy of that archive and promotes `pr0`, `pr1` and `pr2` to weak globals with `llvm-objcopy`. This adds no shim implementation and avoids linking or shipping a second copy of libunwind.

### Who was actually using the C++ runtime?

Linking with libc++ removed leaves exactly six undefined symbols. Only one of them came from our code:

| Symbol | Referenced from |
| --- | --- |
| `operator new[](size_t)` | `android-system-shared.cc` — **ours** |
| `operator delete(void*)` | `gcenv.ee.cpp`, `UnixNativeCodeManager.cpp` |
| `operator delete[](void*)` | `gcenv.ee.cpp`, `interoplibinterface_java.cpp` |
| `operator new(size_t, nothrow_t const&)` | `gcenv.ee.cpp`, `TypeManager.cpp` |
| `operator new[](size_t, nothrow_t const&)` | `gcenv.ee.cpp`, `RhConfig.cpp` |
| `std::nothrow` | `gcenv.ee.cpp`, `UnixNativeCodeManager.cpp` |

The five runtime-owned ones belong to the NativeAOT runtime from dotnet/runtime, and the ILC SDK already ships definitions for all of them in `libstdc++compat.a`. Our targets were unconditionally *removing* that archive with the comment *"This library conflicts with static libc++"* — which is only true while libc++ is linked. With libc++ gone there is no conflict, so we simply stop removing it.

The one symbol that was ours came from a dead code path in `monodroid__system_property_get`, which is now removed earlier in the stack by #12517 (the PR that makes that path unreachable in the first place).

The result is **no shim implementation** in this repo and a link with zero undefined symbols.

### 32-bit ARM EHABI

`android-arm` uses ARM EHABI unwind tables. The generated NativeAOT object references `__aeabi_unwind_cpp_pr0` and `__aeabi_unwind_cpp_pr1`; removing the NDK `libunwind.a` initially exposed these as XA3007 linker failures on both macOS and Windows CI.

`libRuntime.WorkstationGC.a` already carries the same `pr0`, `pr1` and `pr2` implementations in `Runtime.PrivateLibunwind.o`, together with the private unwinder they call. They are local symbols, so the application object cannot resolve them directly. Before linking an `armeabi-v7a` application, the build task creates `libRuntime.WorkstationGC.arm-ehabi.a` in the intermediate directory and promotes only those three symbols to weak globals. Weak binding preserves compatibility with applications that provide their own strong EHABI personalities, while the app export script keeps them local to the final DSO.

No extra unwind code is linked: this reuses the object that the NativeAOT runtime already extracts.

### Size impact

Default MAUI app (`dotnet new maui`), `net11.0-android`, `android-arm64`, Release, `PublishAot=true`. Both sides built clean from the same tree.

| | before | after | delta |
| --- | ---: | ---: | ---: |
| `.so` | 25,229,320 | 25,029,728 | **−199,592** (−0.79%) |
| `.so` deflated in APK | 9,829,143 | 9,761,291 | **−67,852** (−0.69%) |
| APK | 14,903,624 | 14,833,992 | **−69,632** (−0.47%) |

### Commits

1. **Stop linking libc++ and libunwind** — the targets change.
2. **Update stale libc++ linker comments.**
3. **Stop shipping libc++ archives in the runtime packs** — see below.
4. **Reuse private ARM unwind personalities** — promote the runtime's existing EHABI symbols instead of restoring `libunwind.a`.

### Notes

* This PR depends on #12509: before it, the GC bridge used a `std::unordered_map`, which drags in `__next_prime` and `__libcpp_verbose_abort` from libc++ internals. The rest of this stack is already rebased on top of it, so nothing further is needed.
* This only affects **NativeAOT**. The Mono and CoreCLR runtimes still link libc++, and `NativeRuntimeComponents.cs` (the unified-runtime archive list) is deliberately untouched.
* ARM64 and x64 do not need the NDK unwind archive. On 32-bit ARM, the application resolves EHABI personalities from the NativeAOT runtime's existing private unwinder after symbol promotion.

### Testing

Built, installed and launched a default MAUI app on an API 36 arm64 emulator. Cold start with no crashes.

`llvm-nm --undefined-only` on the resulting `libnaot-android.release-static-release.a` reports no `operator new`/`operator delete`, `__cxa_*`, `_Unwind_*` or `__libcpp_*` references. The only remaining `std::` symbols are `string_view` appearing in mangled names, which is header-only and carries no runtime dependency.

The 32-bit ARM path is covered locally in both linker configurations:

* `BuildNativeAot_AndroidArm_WithoutNdk` — workload linker.
* `BuildNativeAot_AndroidArm_WithNdkLinker` — NDK linker.

Both tests build successfully and assert that the linker response uses `libRuntime.WorkstationGC.arm-ehabi.a` and does not contain `libunwind.a`.

---

## Also: stop shipping the archives in the runtime packs

Previously a separate PR stacked directly on this one; folded in here because "stop linking it" and "stop shipping it" are the same change to the reader, and reviewing them apart means reading the same targets twice.

The NativeAOT runtime packs still shipped `libc++_static.a`, `libc++abi.a` and `libunwind.a` even though, after the change above, nothing links them any more.

### Why this needs a new item kind

`_AndroidNdkRedistributable` (in `build-tools/scripts/Ndk.targets`) tagged NDK files with just two kinds:

* `System` — `libc.so`, `libdl.so`, `liblog.so`, `libm.so`, `libz.so` — shipped to every runtime.
* `Toolchain` — `crtbegin_so.o`, `crtend_so.o`, `libc++_static.a`, `libc++abi.a`, `libclang_rt.builtins-*.a`, `libunwind.a` — shipped to CoreCLR and NativeAOT, since both do native linking.

NativeAOT still needs `crtbegin_so.o`, `crtend_so.o` and `libclang_rt.builtins-*.a`, so the `Toolchain` group cannot just be dropped for NativeAOT.

This adds a third kind, `CplusPlus`, for the three C++ archives, and ships it only for CoreCLR. Both packaging sites are updated:

* `src/native/native.targets` — the local `bin/<Config>/lib/packs` layout.
* `build-tools/create-packs/Microsoft.Android.Runtime.proj` — the shipped NuGet packs.

### Size

Per ABI, removed from the NativeAOT runtime pack:

| Archive | Size |
| --- | ---: |
| `libc++_static.a` | 15,182,348 |
| `libc++abi.a` | 3,125,348 |
| `libunwind.a` | 91,152 |
| **Total** | **18,398,848** |

Across `android-arm`, `android-arm64` and `android-x64` that is roughly **55 MB** of pack content. This does not change application size — that is the linker change above — but it shrinks what users restore.

### Testing

Deleted each pack directory and regenerated it via `_CopyToPackDirs`, rather than checking a pack that could still contain stale files.

NativeAOT (`android-arm64`) — the three archives are gone, and everything NativeAOT links is still present:

```
crtbegin_so.o  crtend_so.o  libc.so  libclang_rt.builtins-aarch64-android.a
libdl.so  liblog.so  libm.so  libz.so
libnaot-android.debug-static-debug.a  libnaot-android.debug.so
libnaot-android.release-static-release.a  libnaot-android.release.so
libxa-java-interop-release.a
```

CoreCLR (`android-arm64`) — all three are still shipped:

```
crtbegin_so.o  crtend_so.o  libarchive-dso-stub.so  libc.so
libc++_static.a  libc++abi.a  libclang_rt.builtins-aarch64-android.a
libdl.so  liblog.so  libm.so  libunwind.a  libz.so
```

Mono is unaffected — it only ever received the `System` kind.
