### PR TITLE
[NativeAOT] Stop shipping libc++ archives in the runtime packs

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -99,6 +99,12 @@ projects that use the Microsoft.Android.Runtimes framework in .NET 6+.
           Condition=" '%(_AndroidNdkRedistributable.AndroidRID)' == '$(AndroidRID)' And '%(_AndroidNdkRedistributable.Kind)' == 'Toolchain' " />
     </ItemGroup>
 
+    <!-- NativeAOT applications do not link libc++, so its archives are only shipped for CoreCLR. -->
+    <ItemGroup Condition=" '$(AndroidRuntime)' == 'CoreCLR' ">
+      <NativeRuntimeAsset Include="@(_AndroidNdkRedistributable)"
+          Condition=" '%(_AndroidNdkRedistributable.AndroidRID)' == '$(AndroidRID)' And '%(_AndroidNdkRedistributable.Kind)' == 'CplusPlus' " />
+    </ItemGroup>
+
     <ItemGroup Condition=" '$(AndroidRuntime)' == 'NativeAOT' ">
       <NativeRuntimeAsset Condition=" Exists('$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.debug-static-debug.a') " Include="$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.debug-static-debug.a" />
       <NativeRuntimeAsset Condition=" Exists('$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.release-static-release.a') " Include="$(NativeRuntimeOutputRootDir)$(_RuntimeFlavorDirName)\$(AndroidRID)\libnaot-android.release-static-release.a" />

--- a/build-tools/scripts/Ndk.targets
+++ b/build-tools/scripts/Ndk.targets
@@ -28,10 +28,10 @@
       <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\libz.so')" Kind="System" />
       <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\crtbegin_so.o')" Kind="Toolchain" />
       <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\%(ApiLevel)\crtend_so.o')" Kind="Toolchain" />
-      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\libc++_static.a')" Kind="Toolchain" />
-      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\libc++abi.a')" Kind="Toolchain" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\libc++_static.a')" Kind="CplusPlus" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkSysrootLib)\%(ToolchainPrefix)\libc++abi.a')" Kind="CplusPlus" />
       <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkClangLibLinux)\libclang_rt.builtins-%(ClangArch)-android.a')" Kind="Toolchain" />
-      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkClangLibLinux)\%(UnwindArchDir)\libunwind.a')" Kind="Toolchain" />
+      <_AndroidNdkRedistributable Include="@(AndroidSupportedTargetJitAbi -> '$(_AndroidNdkClangLibLinux)\%(UnwindArchDir)\libunwind.a')" Kind="CplusPlus" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -372,6 +372,15 @@
                          RuntimePackName="$(_RuntimePackName)" />
     </ItemGroup>
 
+    <!-- NativeAOT applications do not link libc++, so its archives are only shipped for CoreCLR. -->
+    <ItemGroup Condition=" '$(CMakeRuntimeFlavor)' == 'CoreCLR' ">
+      <_RuntimePackFiles Include="@(_AndroidNdkRedistributable)"
+                         Condition=" '%(_AndroidNdkRedistributable.Kind)' == 'CplusPlus' "
+                         AndroidRID="%(_AndroidNdkRedistributable.AndroidRID)"
+                         AndroidRuntime="$(CMakeRuntimeFlavor)"
+                         RuntimePackName="$(_RuntimePackName)" />
+    </ItemGroup>
+
     <Copy
         SourceFiles="%(_RuntimePackFiles.Identity)"
         DestinationFolder="$(MicrosoftAndroidPacksRootDir)Microsoft.Android.Runtime.%(_RuntimePackFiles.RuntimePackName).$(AndroidApiLevel).%(_RuntimePackFiles.AndroidRID)\$(AndroidPackVersion)\runtimes\%(_RuntimePackFiles.AndroidRID)\native"


### PR DESCRIPTION
Contributes to #12139. Builds on #12523, which stopped linking libc++ into NativeAOT applications.

The NativeAOT runtime packs still ship `libc++_static.a`, `libc++abi.a` and `libunwind.a` even though nothing links them any more.

### Why this needs a new item kind

`_AndroidNdkRedistributable` (in `build-tools/scripts/Ndk.targets`) tagged NDK files with just two kinds:

* `System` — `libc.so`, `libdl.so`, `liblog.so`, `libm.so`, `libz.so` — shipped to every runtime.
* `Toolchain` — `crtbegin_so.o`, `crtend_so.o`, `libc++_static.a`, `libc++abi.a`, `libclang_rt.builtins-*.a`, `libunwind.a` — shipped to CoreCLR and NativeAOT, since both do native linking.

NativeAOT still needs `crtbegin_so.o`, `crtend_so.o` and `libclang_rt.builtins-*.a`, so the `Toolchain` group cannot just be dropped for NativeAOT.

This adds a third kind, `CplusPlus`, for the three C++ archives, and ships it only for CoreCLR. Both packaging sites are updated:

* `src/native/native.targets` — the local `bin/<Config>/lib/packs` layout.
* `build-tools/create-packs/Microsoft.Android.Runtime.proj` — the shipped NuGet packs.

### Size

Per ABI, removed from the NativeAOT runtime pack:

| Archive | Size |
| --- | ---: |
| `libc++_static.a` | 15,182,348 |
| `libc++abi.a` | 3,125,348 |
| `libunwind.a` | 91,152 |
| **Total** | **18,398,848** |

Across `android-arm`, `android-arm64` and `android-x64` that is roughly **55 MB** of pack content. This does not change application size — that was #12523 — but it shrinks what users restore.

### Testing

Deleted each pack directory and regenerated it via `_CopyToPackDirs`, rather than checking a pack that could still contain stale files.

NativeAOT (`android-arm64`) — the three archives are gone, and everything NativeAOT links is still present:

```
crtbegin_so.o  crtend_so.o  libc.so  libclang_rt.builtins-aarch64-android.a
libdl.so  liblog.so  libm.so  libz.so
libnaot-android.debug-static-debug.a  libnaot-android.debug.so
libnaot-android.release-static-release.a  libnaot-android.release.so
libxa-java-interop-release.a
```

CoreCLR (`android-arm64`) — all three are still shipped:

```
crtbegin_so.o  crtend_so.o  libarchive-dso-stub.so  libc.so
libc++_static.a  libc++abi.a  libclang_rt.builtins-aarch64-android.a
libdl.so  liblog.so  libm.so  libunwind.a  libz.so
```

Mono is unaffected — it only ever received the `System` kind.
