### PR TITLE
Run public CI for all PRs

### DIFF
--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -17,9 +17,7 @@ schedules:
 pr:
   branches:
     include:
-    - main
-    - release/*
-    - feature/*
+    - '*'
 
 parameters:
 - name: macTestAgentsUseCleanImages   # Test agents we do not need to clean up when finished because they are not reused


### PR DESCRIPTION
----

Public CI currently runs only for PRs targeting `main`, `release/*`, or `feature/*`, so stacked PRs targeting other branches are not validated. Match every PR target branch so each entry in a stacked PR chain runs the public pipeline.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed: N/A
- [x] Unit tests: N/A (Azure Pipelines trigger configuration only)