### PR TITLE
[android-tools] Suppress Google SDK SHA-1 checksum alert

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
@@ -98,7 +98,12 @@ namespace Xamarin.Android.Tools
 
 		static HashAlgorithm CreateHashAlgorithm (ChecksumType checksumType) => checksumType switch {
 			ChecksumType.Sha256 => (HashAlgorithm) SHA256.Create (),
-			ChecksumType.Sha1 => SHA1.Create (),
+			// Google Android SDK repository manifests currently provide only SHA-1 checksums for
+			// command-line tools. This compatibility hash only compares an archive with that vendor
+			// field; it is not used for authentication, signing, passwords, or authorization.
+			// SHA-256 remains the default for other downloads. Review when Google offers a stronger
+			// manifest checksum.
+			ChecksumType.Sha1 => SHA1.Create (), // CodeQL [SM02196]
 			_ => throw new NotSupportedException ($"Unsupported checksum type: '{checksumType}'."),
 		};
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
@@ -98,11 +98,9 @@ namespace Xamarin.Android.Tools
 
 		static HashAlgorithm CreateHashAlgorithm (ChecksumType checksumType) => checksumType switch {
 			ChecksumType.Sha256 => (HashAlgorithm) SHA256.Create (),
-			// Google Android SDK repository manifests currently provide only SHA-1 checksums for
-			// command-line tools. This compatibility hash only compares an archive with that vendor
-			// field; it is not used for authentication, signing, passwords, or authorization.
-			// SHA-256 remains the default for other downloads. Review when Google offers a stronger
-			// manifest checksum.
+			// Google's manifest only provides SHA-1 for command-line tools. This vendor checksum is
+			// not used for authentication, signing, passwords, or authorization; SHA-256 remains the
+			// default. Review when Google provides a stronger checksum.
 			ChecksumType.Sha1 => SHA1.Create (), // CodeQL [SM02196]
 			_ => throw new NotSupportedException ($"Unsupported checksum type: '{checksumType}'."),
 		};

--- a/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
@@ -98,9 +98,8 @@ namespace Xamarin.Android.Tools
 
 		static HashAlgorithm CreateHashAlgorithm (ChecksumType checksumType) => checksumType switch {
 			ChecksumType.Sha256 => (HashAlgorithm) SHA256.Create (),
-			// Google's manifest only provides SHA-1 for command-line tools. This vendor checksum is
-			// not used for authentication, signing, passwords, or authorization; SHA-256 remains the
-			// default. Review when Google provides a stronger checksum.
+			// Google's manifest only provides SHA-1 checksums. This is not used for authentication,
+			// signing, passwords, or authorization. Review when Google provides a stronger checksum.
 			ChecksumType.Sha1 => SHA1.Create (), // CodeQL [SM02196]
 			_ => throw new NotSupportedException ($"Unsupported checksum type: '{checksumType}'."),
 		};

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/DownloadUtilsTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/DownloadUtilsTests.cs
@@ -110,6 +110,18 @@ namespace Xamarin.Android.Tools.Tests
 		}
 
 		[Test]
+		public void VerifyChecksum_GoogleManifestSha1MatchingHash_DoesNotThrow ()
+		{
+			var filePath = Path.Combine (tempDir, "test.bin");
+			File.WriteAllBytes (filePath, new byte [] { 0x48, 0x65, 0x6c, 0x6c, 0x6f }); // "Hello"
+
+			Assert.DoesNotThrow (() => DownloadUtils.VerifyChecksum (
+				filePath,
+				"f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0",
+				ChecksumType.Sha1));
+		}
+
+		[Test]
 		public void VerifyChecksum_MismatchedHash_Throws ()
 		{
 			var filePath = Path.Combine (tempDir, "test.bin");


### PR DESCRIPTION
----

Google's current [`repository2-3.xml`](https://dl.google.com/android/repository/repository2-3.xml) has 854 checksum nodes, all `type="sha1"`; the pinned `cmdline-tools;19.0` values match our feed. Google's [`repo-common-02.xsd`](https://android.googlesource.com/platform/tools/base/+/refs/heads/mirror-goog-studio-main/repository/src/main/resources/xsd/repo-common-02.xsd#257) defines one required checksum per archive and no parallel stronger field.

This adds a finding-specific `CodeQL [SM02196]` suppression to the single SHA-1 construction used to compare SDK archives with Google's manifest. It is not used for authentication, signing, passwords, or authorization; SHA-256 remains the default. Review this suppression when Google provides stronger checksums.

**Validation:** 55 focused `DownloadUtilsTests`/`SdkManagerTests` passed; `git diff --check` passed.