### PR TITLE
[Mono.Android] Suppress DSA client-certificate compatibility alert

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -1737,7 +1737,10 @@ namespace Xamarin.Android.Net
 				(key, algorithmName) = (rsa, "RSA");
 			} else if (clientCertificate.GetECDsaPrivateKey () is {} ec) {
 				(key, algorithmName) = (ec, "EC");
-			} else if (clientCertificate.GetDSAPrivateKey () is {} dsa) {
+			// DSA is retained only for existing customer/application-provided client certificates. Removing it would
+			// break supported client-certificate compatibility. RSA and ECDSA are selected first. This does not use DSA
+			// for Microsoft-controlled signing, certificate issuance, password storage, or new certificate generation.
+			} else if (clientCertificate.GetDSAPrivateKey () is {} dsa) { // CodeQL [SM03800]
 				(key, algorithmName) = (dsa, "DSA");
 			} else {
 				return null;

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -1737,9 +1737,8 @@ namespace Xamarin.Android.Net
 				(key, algorithmName) = (rsa, "RSA");
 			} else if (clientCertificate.GetECDsaPrivateKey () is {} ec) {
 				(key, algorithmName) = (ec, "EC");
-			// DSA is retained only for existing customer/application-provided client certificates. Removing it would
-			// break supported client-certificate compatibility. RSA and ECDSA are selected first. This does not use DSA
-			// for Microsoft-controlled signing, certificate issuance, password storage, or new certificate generation.
+			// Retain DSA only for customer-provided client certificates after preferring RSA and ECDSA.
+			// No Microsoft-controlled signing, issuance, key generation, or password storage; removal breaks compatibility.
 			} else if (clientCertificate.GetDSAPrivateKey () is {} dsa) { // CodeQL [SM03800]
 				(key, algorithmName) = (dsa, "DSA");
 			} else {


### PR DESCRIPTION
## Summary

Adds `CodeQL [SM03800]` only to the DSA client-certificate fallback in `AndroidMessageHandler.GetKeyEntry()`. DSA remains for customer-provided certificate compatibility after RSA and ECDSA are preferred. It is not used for Microsoft-controlled signing, issuance, key generation, or password storage; removing it would break compatibility. No behavior changes.

## Validation

- One scoped `SM03800` marker
- Comment-only executable diff
- `git diff --check`

No behavioral tests were needed for this comment-only suppression.