### PR TITLE
Bump to dotnet/lz4/net11.0@69f1e9a4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/dotnet/lz4
-    branch = release
+    branch = net11.0
 [submodule "external/robin-map"]
     path = external/robin-map
     url = https://github.com/xamarin/robin-map


### PR DESCRIPTION
## Summary

Update `external/lz4` from `ebb370ca83af193212df4dcbadcc5d87bc0de2f0` to `69f1e9a465ec8afade9de79c50d94016b49732bb`, the verified tip of `dotnet/lz4` branch `net11.0`.

The upstream range contains:

- [`3439079c`](https://github.com/dotnet/lz4/commit/3439079c): remove a dormant `SCORECARD_TOKEN` comment
- [`69f1e9a4`](https://github.com/dotnet/lz4/commit/69f1e9a4): replace weak test fingerprints with SHA-256

The `.gitmodules` branch metadata now tracks `net11.0`.

## Validation

- Verified `refs/heads/net11.0` resolves to `69f1e9a465ec8afade9de79c50d94016b49732bb`
- Verified the committed gitlink resolves to the same SHA
- `python -m py_compile external\lz4\tests\test-lz4-abi.py external\lz4\tests\test-lz4-speed.py external\lz4\tests\test-lz4-versions.py`
- `git diff --check`

The focused `xamarin.sync` native build could not run because this environment has no NMake/C/C++ compiler installed; configuration stopped before compilation.