### PR TITLE
[ci] Govern dnceng internal pipeline

### DIFF
--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -664,6 +664,7 @@ extends:
         - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml@self
           parameters:
             installTestSlicer: true
+            remove_dotnet: true
             use1ESTemplate: true
 
         # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
@@ -773,6 +774,7 @@ extends:
             useAgentJdkPath: true
             installTestSlicer: true
             installApkDiff: false
+            remove_dotnet: true
             use1ESTemplate: true
 
         - task: DownloadPipelineArtifact@2

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -26,7 +26,6 @@ trigger:
 # Azure Repos PR validation is configured through branch policies, not YAML.
 pr: none
 
-# Repository resources - checkout MAUI to force multi-repo checkout behavior
 # NOTE: `endpoint` values below are GitHub service connections in the
 # dnceng/internal project. Confirm the connection name(s) available there.
 resources:
@@ -35,6 +34,11 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+  - repository: macios-devtools
+    type: github
+    name: dotnet/macios-devtools
+    endpoint: internal
+    ref: refs/heads/main
   - repository: maui
     type: github
     name: dotnet/maui
@@ -93,6 +97,7 @@ extends:
     sdl:
       sourceRepositoriesToScan:
         exclude:
+        - repository: macios-devtools
         - repository: maui
     stages:
     # macOS Build Stage
@@ -140,10 +145,11 @@ extends:
           path: s/android
           persistCredentials: false
 
-        # Checkout a second repo to force multi-repo checkout behavior
+        # This small repository is intentionally unused; its checkout keeps the
+        # primary repository at s/android under Azure's multi-repo layout.
         # https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
-        - checkout: maui
-          path: s/maui
+        - checkout: macios-devtools
+          path: s/macios-devtools
 
         - template: /build-tools/automation/yaml-templates/build-macos-steps.yaml@self
           parameters:
@@ -198,9 +204,10 @@ extends:
           path: s/android
           persistCredentials: false
 
-        # Checkout a second repo to force multi-repo checkout behavior
-        - checkout: maui
-          path: s/maui
+        # This small repository is intentionally unused; its checkout keeps the
+        # primary repository at s/android under Azure's multi-repo layout.
+        - checkout: macios-devtools
+          path: s/macios-devtools
 
         - script: |
             sudo apt-get update
@@ -354,8 +361,10 @@ extends:
               fetchTags: false
               path: s/android
 
-            - checkout: maui
-              path: s/maui
+            # This small repository is intentionally unused; its checkout keeps the
+            # primary repository at s/android under Azure's multi-repo layout.
+            - checkout: macios-devtools
+              path: s/macios-devtools
 
             - task: DownloadPipelineArtifact@2
               displayName: Download unsigned macOS and Windows packages

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -95,6 +95,11 @@ extends:
       name: $(NetCoreInternalPoolName)
       image: $(WindowsPoolImageNetCoreInternal)
       os: windows
+    sdl:
+      sourceRepositoriesToScan:
+        exclude:
+        - repository: android-tools
+        - repository: maui
     stages:
     # macOS Build Stage
     - stage: mac_build

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -31,6 +31,10 @@ pr: none
 # dnceng/internal project. Confirm the connection name(s) available there.
 resources:
   repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
   - repository: android-tools
     type: github
     name: dotnet/android-tools
@@ -83,873 +87,905 @@ variables:
 - name: SkipTestStages
   value: false
 
-# Internal builds don't (yet) use 1ES templates - just plain stages
-stages:
-# macOS Build Stage
-- stage: mac_build
-  displayName: Mac
-  jobs:
-  - job: mac_build_create_installers
-    displayName: macOS > Build
-    # dnceng/internal has no AcesShared pool, so use hosted macOS images
-    pool:
-      name: Azure Pipelines
-      vmImage: $(HostedMacImage)
-      os: macOS
-    timeoutInMinutes: 240
-    cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
-    steps:
-    - checkout: self
-      path: s/android
-      persistCredentials: false
-
-    # Checkout a second repo to force multi-repo checkout behavior
-    # https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
-    - checkout: android-tools
-      path: s/android-tools
-
-    - template: /build-tools/automation/yaml-templates/build-macos-steps.yaml
-      parameters:
-        xaSourcePath: $(System.DefaultWorkingDirectory)/android
-        installerArtifactName: $(InstallerArtifactName)
-        nugetArtifactName: $(NuGetArtifactName)
-        testAssembliesArtifactName: $(TestAssembliesArtifactName)
-        windowsToolchainPdbArtifactName: $(WindowsToolchainPdbArtifactName)
-        buildResultArtifactName: Build Results - macOS
-        use1ESTemplate: false
-
-# Windows Build Stage
-- stage: win_build_test
-  displayName: Windows
-  dependsOn: []
-  jobs:
-  - job: win_build_test
-    displayName: Windows > Build & Smoke Test
+# Govern production builds with the official 1ES Pipeline Template.
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
     pool:
       name: $(NetCoreInternalPoolName)
-      demands:
-      - ImageOverride -equals $(WindowsPoolImageNetCoreInternal)
-    timeoutInMinutes: 240
-    steps:
-    - checkout: self
-      persistCredentials: false
-
-    - template: /build-tools/automation/yaml-templates/build-windows-steps.yaml
-      parameters:
-        buildResultArtifactName: Build Results - Windows
-        use1ESTemplate: false
-
-# Linux Build Stage
-- stage: linux_build
-  displayName: Linux
-  dependsOn: []
-  jobs:
-  - job: linux_build_create_sdk_pack
-    displayName: Linux > Build
-    pool:
-      name: $(NetCoreInternalPoolName)
-      demands:
-      - ImageOverride -equals $(LinuxPoolImageNetCoreInternal)
-    timeoutInMinutes: 240
-    workspace:
-      clean: all
-    variables:
-      CXX: g++-10
-      CC: gcc-10
-    steps:
-    - checkout: self
-      path: s/android
-      persistCredentials: false
-
-    # Checkout a second repo to force multi-repo checkout behavior
-    - checkout: android-tools
-      path: s/android-tools
-
-    - script: |
-        sudo apt-get update
-        sudo apt-get install -y g++-10 gcc-10
-      displayName: install g++-10 and gcc-10
-
-    - template: /build-tools/automation/yaml-templates/build-linux-steps.yaml
-      parameters:
-        buildResultArtifactName: Build Results - Linux
-        xaSourcePath: $(System.DefaultWorkingDirectory)/android
-        nugetArtifactName: $(LinuxNuGetArtifactName)
-        use1ESTemplate: false
-
-# Package Tests Stage
-- ${{ if ne(variables.SkipTestStages, 'true') }}:
-  - template: /build-tools/automation/yaml-templates/stage-package-tests.yaml
-    parameters:
-      macTestAgentsUseCleanImages: true
-      use1ESTemplate: false
-
-# Linux Tests Stage
-- stage: linux_tests
-  displayName: Linux Tests
-  dependsOn:
-  - mac_build
-  - linux_build
-  condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
-  jobs:
-  - job: linux_tests_smoke_1
-    displayName: Linux > Tests > MSBuild 1
-    pool:
-      name: $(NetCoreInternalPoolName)
-      demands:
-      - ImageOverride -equals $(LinuxPoolImageNetCoreInternal)
-    timeoutInMinutes: 180
-    workspace:
-      clean: all
-    steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
-      parameters:
-        useAgentJdkPath: false
-        use1ESTemplate: false
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: $(TestAssembliesArtifactName)
-        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
-
-    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
-      parameters:
-        testRunTitle: Xamarin.Android.Build.Tests - Linux BuildTest
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
-        dotNetTestExtraArgs: --filter "Name = BuildTest"
-
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml
-      parameters:
-        configuration: $(XA.Build.Configuration)
-        artifactName: Test Results - MSBuild - Linux 1
-        use1ESTemplate: false
-
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
-
-  - job: linux_tests_smoke_2
-    displayName: Linux > Tests > MSBuild 2
-    pool:
-      name: $(NetCoreInternalPoolName)
-      demands:
-      - ImageOverride -equals $(LinuxPoolImageNetCoreInternal)
-    timeoutInMinutes: 180
-    workspace:
-      clean: all
-    steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
-      parameters:
-        useAgentJdkPath: false
-        use1ESTemplate: false
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: $(TestAssembliesArtifactName)
-        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
-
-    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
-      parameters:
-        testRunTitle: Xamarin.Android.Build.Tests - Linux PackagingTest
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
-        dotNetTestExtraArgs: --filter "Name = PackagingTest"
-
-    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
-      parameters:
-        testRunTitle: Xamarin.Android.Build.Tests - Linux XASdkTests
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
-        dotNetTestExtraArgs: --filter "Name = XASdkTests & Name != XamarinLegacySdk"
-
-    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
-      parameters:
-        testRunTitle: Xamarin.Android.Build.Tests - Linux AndroidDependenciesTests
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
-        dotNetTestExtraArgs: --filter "Name = AndroidDependenciesTests"
-
-    - task: ShellScript@2
-      displayName: Test dotnet-local.sh
-      inputs:
-        scriptPath: dotnet-local.sh
-        args: >-
-          build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
-          -p:AndroidSdkDirectory="$(HOME)/android-toolchain/sdk"
-          -bl:$(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/build-helloworld.binlog
-
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml
-      parameters:
-        configuration: $(XA.Build.Configuration)
-        artifactName: Test Results - MSBuild - Linux 2
-        includeBuildResults: true
-        use1ESTemplate: false
-
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
-
-# Signing and Visual Studio workload insertion artifacts
-- stage: dotnet_prepare_release
-  displayName: Prepare .NET Release
-  dependsOn:
-  - mac_build
-  - linux_build
-  condition: and(
-      succeeded(),
-      ne(variables['Build.Reason'], 'PullRequest'),
-      ne(variables['Build.Reason'], 'Schedule')
-    )
-  jobs:
-  - template: /eng/common/templates/jobs/jobs.yml@self
-    parameters:
-      runAsPublic: false
-      enableMicrobuild: true
-      microbuildUseESRP: ${{ and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ne(variables['Build.Reason'], 'PullRequest')) }}
+      image: $(WindowsPoolImageNetCoreInternal)
+      os: windows
+    stages:
+    # macOS Build Stage
+    - stage: mac_build
+      displayName: Mac
       jobs:
-      - job: prepare_release
-        displayName: Sign NuGets and workload MSIs
-        timeoutInMinutes: 240
+      - job: mac_build_create_installers
+        displayName: macOS > Build
+        # dnceng/internal has no AcesShared pool, so use hosted macOS images
         pool:
-          name: $(NetCoreInternalPoolName)
-          demands:
-          - ImageOverride -equals $(WindowsPoolImageNetCoreInternal)
+          name: Azure Pipelines
+          vmImage: $(HostedMacImage)
+          os: macOS
+        timeoutInMinutes: 240
+        cancelTimeoutInMinutes: 5
         workspace:
           clean: all
+        templateContext:
+          outputParentDirectory: $(System.DefaultWorkingDirectory)/android/bin
+          outputs:
+          - output: pipelineArtifact
+            displayName: upload nupkgs
+            artifactName: $(NuGetArtifactName)
+            targetPath: $(System.DefaultWorkingDirectory)/android/bin/Build$(XA.Build.Configuration)/nuget-unsigned
+          - output: pipelineArtifact
+            displayName: upload symbols nupkgs
+            artifactName: $(NuGetArtifactName)-symbols
+            targetPath: $(System.DefaultWorkingDirectory)/android/bin/Build$(XA.Build.Configuration)/nuget-unsigned-symbols
+          - output: pipelineArtifact
+            displayName: upload Windows toolchain pdb files
+            artifactName: $(WindowsToolchainPdbArtifactName)
+            targetPath: $(System.DefaultWorkingDirectory)/android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb
+          - output: pipelineArtifact
+            displayName: upload test assemblies
+            artifactName: $(TestAssembliesArtifactName)
+            targetPath: $(System.DefaultWorkingDirectory)/android/bin/Test$(XA.Build.Configuration)
+            sbomEnabled: false
+          - output: pipelineArtifact
+            displayName: upload build tools inventory
+            artifactName: AndroidBuildToolsInventory
+            targetPath: $(System.DefaultWorkingDirectory)/android/bin/Build$(XA.Build.Configuration)/buildtoolsinventory.csv
+            sbomEnabled: false
         steps:
         - checkout: self
-          clean: true
-          fetchDepth: 1
-          fetchTags: false
           path: s/android
+          persistCredentials: false
 
+        # Checkout a second repo to force multi-repo checkout behavior
+        # https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
         - checkout: android-tools
           path: s/android-tools
 
-        - task: DownloadPipelineArtifact@2
-          displayName: Download unsigned macOS and Windows packages
-          inputs:
-            artifactName: $(NuGetArtifactName)
-            downloadPath: $(Build.StagingDirectory)\unsigned\mac-win
+        - template: /build-tools/automation/yaml-templates/build-macos-steps.yaml
+          parameters:
+            xaSourcePath: $(System.DefaultWorkingDirectory)/android
+            installerArtifactName: $(InstallerArtifactName)
+            nugetArtifactName: $(NuGetArtifactName)
+            testAssembliesArtifactName: $(TestAssembliesArtifactName)
+            windowsToolchainPdbArtifactName: $(WindowsToolchainPdbArtifactName)
+            buildResultArtifactName: Build Results - macOS
+            use1ESTemplate: true
+
+    # Windows Build Stage
+    - stage: win_build_test
+      displayName: Windows
+      dependsOn: []
+      jobs:
+      - job: win_build_test
+        displayName: Windows > Build & Smoke Test
+        pool:
+          name: $(NetCoreInternalPoolName)
+          image: $(WindowsPoolImageNetCoreInternal)
+          os: windows
+        timeoutInMinutes: 240
+        steps:
+        - checkout: self
+          persistCredentials: false
+
+        - template: /build-tools/automation/yaml-templates/build-windows-steps.yaml
+          parameters:
+            buildResultArtifactName: Build Results - Windows
+            use1ESTemplate: true
+
+    # Linux Build Stage
+    - stage: linux_build
+      displayName: Linux
+      dependsOn: []
+      jobs:
+      - job: linux_build_create_sdk_pack
+        displayName: Linux > Build
+        pool:
+          name: $(NetCoreInternalPoolName)
+          image: $(LinuxPoolImageNetCoreInternal)
+          os: linux
+        timeoutInMinutes: 240
+        workspace:
+          clean: all
+        variables:
+          CXX: g++-10
+          CC: gcc-10
+        steps:
+        - checkout: self
+          path: s/android
+          persistCredentials: false
+
+        # Checkout a second repo to force multi-repo checkout behavior
+        - checkout: android-tools
+          path: s/android-tools
+
+        - script: |
+            sudo apt-get update
+            sudo apt-get install -y g++-10 gcc-10
+          displayName: install g++-10 and gcc-10
+
+        - template: /build-tools/automation/yaml-templates/build-linux-steps.yaml
+          parameters:
+            buildResultArtifactName: Build Results - Linux
+            xaSourcePath: $(System.DefaultWorkingDirectory)/android
+            nugetArtifactName: $(LinuxNuGetArtifactName)
+            use1ESTemplate: true
+
+    # Package Tests Stage
+    - ${{ if ne(variables.SkipTestStages, 'true') }}:
+      - template: /build-tools/automation/yaml-templates/stage-package-tests.yaml
+        parameters:
+          macTestAgentsUseCleanImages: true
+          usePublicSetupTemplate: true
+          use1ESTemplate: true
+
+    # Linux Tests Stage
+    - stage: linux_tests
+      displayName: Linux Tests
+      dependsOn:
+      - mac_build
+      - linux_build
+      condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
+      jobs:
+      - job: linux_tests_smoke_1
+        displayName: Linux > Tests > MSBuild 1
+        pool:
+          name: $(NetCoreInternalPoolName)
+          image: $(LinuxPoolImageNetCoreInternal)
+          os: linux
+        timeoutInMinutes: 180
+        workspace:
+          clean: all
+        steps:
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+          parameters:
+            useAgentJdkPath: false
+            use1ESTemplate: true
 
         - task: DownloadPipelineArtifact@2
-          displayName: Download unsigned Linux packages
           inputs:
-            artifactName: $(LinuxNuGetArtifactName)
-            downloadPath: $(Build.StagingDirectory)\unsigned\linux
+            artifactName: $(TestAssembliesArtifactName)
+            downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-        - task: UseDotNet@2
-          displayName: Install .NET 8 SDK for SwixBuild
+        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
+          parameters:
+            testRunTitle: Xamarin.Android.Build.Tests - Linux BuildTest
+            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
+            dotNetTestExtraArgs: --filter "Name = BuildTest"
+
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+          parameters:
+            configuration: $(XA.Build.Configuration)
+            artifactName: Test Results - MSBuild - Linux 1
+            use1ESTemplate: true
+
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+
+      - job: linux_tests_smoke_2
+        displayName: Linux > Tests > MSBuild 2
+        pool:
+          name: $(NetCoreInternalPoolName)
+          image: $(LinuxPoolImageNetCoreInternal)
+          os: linux
+        timeoutInMinutes: 180
+        workspace:
+          clean: all
+        steps:
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+          parameters:
+            useAgentJdkPath: false
+            use1ESTemplate: true
+
+        - task: DownloadPipelineArtifact@2
           inputs:
-            version: 8.0.x
+            artifactName: $(TestAssembliesArtifactName)
+            downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-        - task: UseDotNet@2
-          displayName: Install .NET SDK for Arcade signing
+        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
+          parameters:
+            testRunTitle: Xamarin.Android.Build.Tests - Linux PackagingTest
+            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
+            dotNetTestExtraArgs: --filter "Name = PackagingTest"
+
+        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
+          parameters:
+            testRunTitle: Xamarin.Android.Build.Tests - Linux XASdkTests
+            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
+            dotNetTestExtraArgs: --filter "Name = XASdkTests & Name != XamarinLegacySdk"
+
+        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
+          parameters:
+            testRunTitle: Xamarin.Android.Build.Tests - Linux AndroidDependenciesTests
+            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
+            dotNetTestExtraArgs: --filter "Name = AndroidDependenciesTests"
+
+        - task: ShellScript@2
+          displayName: Test dotnet-local.sh
           inputs:
-            version: $(DotNetSdkVersion).x
-            includePreviewVersions: true
+            scriptPath: dotnet-local.sh
+            args: >-
+              build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
+              -p:AndroidSdkDirectory="$(HOME)/android-toolchain/sdk"
+              -bl:$(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/build-helloworld.binlog
 
-        - pwsh: |
-            $unsigned = "$(Build.StagingDirectory)\unsigned"
-            $artifacts = "$(Build.SourcesDirectory)\android\artifacts"
-            $shipping = Join-Path $artifacts "packages\Release\Shipping"
-            $logs = Join-Path $artifacts "log\Release"
-            $signingLogs = "$(Build.StagingDirectory)\signing-logs"
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+          parameters:
+            configuration: $(XA.Build.Configuration)
+            artifactName: Test Results - MSBuild - Linux 2
+            includeBuildResults: true
+            use1ESTemplate: true
 
-            Remove-Item $artifacts -Recurse -Force -ErrorAction Ignore
-            New-Item $shipping -ItemType Directory -Force | Out-Null
-            New-Item $logs -ItemType Directory -Force | Out-Null
-            New-Item $signingLogs -ItemType Directory -Force | Out-Null
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
 
-            $packages = @(Get-ChildItem $unsigned -Filter "*.nupkg" -File -Recurse)
-            if ($packages.Count -eq 0) {
-              throw "The build did not publish any NuGet packages."
-            }
-            Copy-Item $packages.FullName $shipping
+    # Signing and Visual Studio workload insertion artifacts
+    - stage: dotnet_prepare_release
+      displayName: Prepare .NET Release
+      dependsOn:
+      - mac_build
+      - linux_build
+      condition: and(
+          succeeded(),
+          ne(variables['Build.Reason'], 'PullRequest'),
+          ne(variables['Build.Reason'], 'Schedule')
+        )
+      jobs:
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          runAsPublic: false
+          enableMicrobuild: true
+          microbuildUseESRP: ${{ and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ne(variables['Build.Reason'], 'PullRequest')) }}
+          jobs:
+          - job: prepare_release
+            displayName: Sign NuGets and workload MSIs
+            timeoutInMinutes: 240
+            pool:
+              name: $(NetCoreInternalPoolName)
+              image: $(WindowsPoolImageNetCoreInternal)
+              os: windows
+            workspace:
+              clean: all
+            steps:
+            - checkout: self
+              clean: true
+              fetchDepth: 1
+              fetchTags: false
+              path: s/android
 
-            $workloadProps = Get-ChildItem $unsigned -Filter "vs-workload.props" -File -Recurse | Select-Object -First 1
-            if (-not $workloadProps) {
-              throw "The build did not publish vs-workload.props."
-            }
-            Copy-Item $workloadProps.FullName $shipping
+            - checkout: android-tools
+              path: s/android-tools
 
-            $signList = Get-ChildItem $unsigned -Filter "SignList.xml" -File -Recurse | Select-Object -First 1
-            if (-not $signList) {
-              throw "The build did not publish SignList.xml."
-            }
+            - task: DownloadPipelineArtifact@2
+              displayName: Download unsigned macOS and Windows packages
+              inputs:
+                artifactName: $(NuGetArtifactName)
+                downloadPath: $(Build.StagingDirectory)\unsigned\mac-win
 
-            [xml] $arcadeSignList = Get-Content $signList.FullName
-            $packageEntries = foreach ($package in $packages) {
-              $archive = [IO.Compression.ZipFile]::OpenRead($package.FullName)
-              try {
-                foreach ($entry in $archive.Entries) {
-                  [pscustomobject]@{
-                    FullName = $entry.FullName.Replace("\", "/")
-                    Name = $entry.Name
+            - task: DownloadPipelineArtifact@2
+              displayName: Download unsigned Linux packages
+              inputs:
+                artifactName: $(LinuxNuGetArtifactName)
+                downloadPath: $(Build.StagingDirectory)\unsigned\linux
+
+            - task: UseDotNet@2
+              displayName: Install .NET 8 SDK for SwixBuild
+              inputs:
+                version: 8.0.x
+
+            - task: UseDotNet@2
+              displayName: Install .NET SDK for Arcade signing
+              inputs:
+                version: $(DotNetSdkVersion).x
+                includePreviewVersions: true
+
+            - pwsh: |
+                $unsigned = "$(Build.StagingDirectory)\unsigned"
+                $artifacts = "$(Build.SourcesDirectory)\android\artifacts"
+                $shipping = Join-Path $artifacts "packages\Release\Shipping"
+                $logs = Join-Path $artifacts "log\Release"
+                $signingLogs = "$(Build.StagingDirectory)\signing-logs"
+
+                Remove-Item $artifacts -Recurse -Force -ErrorAction Ignore
+                New-Item $shipping -ItemType Directory -Force | Out-Null
+                New-Item $logs -ItemType Directory -Force | Out-Null
+                New-Item $signingLogs -ItemType Directory -Force | Out-Null
+
+                $packages = @(Get-ChildItem $unsigned -Filter "*.nupkg" -File -Recurse)
+                if ($packages.Count -eq 0) {
+                  throw "The build did not publish any NuGet packages."
+                }
+                Copy-Item $packages.FullName $shipping
+
+                $workloadProps = Get-ChildItem $unsigned -Filter "vs-workload.props" -File -Recurse | Select-Object -First 1
+                if (-not $workloadProps) {
+                  throw "The build did not publish vs-workload.props."
+                }
+                Copy-Item $workloadProps.FullName $shipping
+
+                $signList = Get-ChildItem $unsigned -Filter "SignList.xml" -File -Recurse | Select-Object -First 1
+                if (-not $signList) {
+                  throw "The build did not publish SignList.xml."
+                }
+
+                [xml] $arcadeSignList = Get-Content $signList.FullName
+                $packageEntries = foreach ($package in $packages) {
+                  $archive = [IO.Compression.ZipFile]::OpenRead($package.FullName)
+                  try {
+                    foreach ($entry in $archive.Entries) {
+                      [pscustomobject]@{
+                        FullName = $entry.FullName.Replace("\", "/")
+                        Name = $entry.Name
+                      }
+                    }
+                  } finally {
+                    $archive.Dispose()
                   }
                 }
-              } finally {
-                $archive.Dispose()
-              }
-            }
 
-            foreach ($item in @($arcadeSignList.SelectNodes("/Project/ItemGroup/*[@Include]"))) {
-              $include = $item.GetAttribute("Include").Replace("\", "/")
-              if ($include.Contains("*") -or $include.Contains("?")) {
-                $matchedEntries = if ($include.Contains("/")) {
-                  @($packageEntries | Where-Object { $_.FullName -like $include -or $_.FullName -like "*/$include" })
-                } else {
-                  @($packageEntries | Where-Object { $_.Name -like $include })
+                foreach ($item in @($arcadeSignList.SelectNodes("/Project/ItemGroup/*[@Include]"))) {
+                  $include = $item.GetAttribute("Include").Replace("\", "/")
+                  if ($include.Contains("*") -or $include.Contains("?")) {
+                    $matchedEntries = if ($include.Contains("/")) {
+                      @($packageEntries | Where-Object { $_.FullName -like $include -or $_.FullName -like "*/$include" })
+                    } else {
+                      @($packageEntries | Where-Object { $_.Name -like $include })
+                    }
+                    $names = @($matchedEntries.Name | Where-Object { $_ } | Sort-Object -Unique)
+                    if ($names.Count -eq 0) {
+                      throw "Signing pattern '$include' did not match any package entries."
+                    }
+                    foreach ($name in $names) {
+                      $expandedItem = $item.Clone()
+                      $escapedName = $name.Replace("%", "%25").Replace(";", "%3B")
+                      $expandedItem.SetAttribute("Include", $escapedName)
+                      [void] $item.ParentNode.InsertBefore($expandedItem, $item)
+                    }
+                    [void] $item.ParentNode.RemoveChild($item)
+                  } else {
+                    if ($item.LocalName -eq "MacDeveloperSign" -or $item.LocalName -eq "MacDeveloperSignHarden") {
+                      $include = [IO.Path]::GetFileName($include)
+                    }
+                    $include = $include.Replace("%", "%25").Replace(";", "%3B")
+                    $item.SetAttribute("Include", $include)
+                  }
                 }
-                $names = @($matchedEntries.Name | Where-Object { $_ } | Sort-Object -Unique)
-                if ($names.Count -eq 0) {
-                  throw "Signing pattern '$include' did not match any package entries."
+
+                $skipNames = @($arcadeSignList.SelectNodes("/Project/ItemGroup/Skip") | ForEach-Object Include)
+                foreach ($item in @($arcadeSignList.SelectNodes("/Project/ItemGroup/MacDeveloperSign | /Project/ItemGroup/MacDeveloperSignHarden"))) {
+                  if ($item.GetAttribute("Include") -in $skipNames) {
+                    [void] $item.ParentNode.RemoveChild($item)
+                  }
                 }
-                foreach ($name in $names) {
-                  $expandedItem = $item.Clone()
-                  $escapedName = $name.Replace("%", "%25").Replace(";", "%3B")
-                  $expandedItem.SetAttribute("Include", $escapedName)
-                  [void] $item.ParentNode.InsertBefore($expandedItem, $item)
+
+                $certificatesByName = @{}
+                foreach ($item in $arcadeSignList.SelectNodes("/Project/ItemGroup/ThirdParty | /Project/ItemGroup/ThirdPartyScript | /Project/ItemGroup/MacDeveloperSign | /Project/ItemGroup/MacDeveloperSignHarden")) {
+                  $name = $item.GetAttribute("Include")
+                  $certificateGroup = $item.LocalName
+                  if ($certificatesByName.ContainsKey($name) -and $certificatesByName[$name] -ne $certificateGroup) {
+                    throw "Signing entry '$name' is assigned to both '$($certificatesByName[$name])' and '$certificateGroup'."
+                  }
+                  $certificatesByName[$name] = $certificateGroup
                 }
-                [void] $item.ParentNode.RemoveChild($item)
-              } else {
-                if ($item.LocalName -eq "MacDeveloperSign" -or $item.LocalName -eq "MacDeveloperSignHarden") {
-                  $include = [IO.Path]::GetFileName($include)
+
+                $arcadeSignListPath = "$(Build.StagingDirectory)\ArcadeSignList.xml"
+                $arcadeSignList.Save($arcadeSignListPath)
+                Write-Host "##vso[task.setvariable variable=AndroidSignList]$arcadeSignListPath"
+
+                $signVerify = Get-ChildItem $unsigned -Filter "SignVerifyIgnore.txt" -File -Recurse | Select-Object -First 1
+                if (-not $signVerify) {
+                  throw "The build did not publish SignVerifyIgnore.txt."
                 }
-                $include = $include.Replace("%", "%25").Replace(";", "%3B")
-                $item.SetAttribute("Include", $include)
-              }
-            }
+                Copy-Item $signVerify.FullName "$(Build.StagingDirectory)\SignVerifyIgnore.txt"
 
-            $skipNames = @($arcadeSignList.SelectNodes("/Project/ItemGroup/Skip") | ForEach-Object Include)
-            foreach ($item in @($arcadeSignList.SelectNodes("/Project/ItemGroup/MacDeveloperSign | /Project/ItemGroup/MacDeveloperSignHarden"))) {
-              if ($item.GetAttribute("Include") -in $skipNames) {
-                [void] $item.ParentNode.RemoveChild($item)
-              }
-            }
+                $inputNames = $packages.Name | Sort-Object -Unique
+                $inputNames | ConvertTo-Json | Set-Content "$(Build.StagingDirectory)\unsigned-package-names.json"
 
-            $certificatesByName = @{}
-            foreach ($item in $arcadeSignList.SelectNodes("/Project/ItemGroup/ThirdParty | /Project/ItemGroup/ThirdPartyScript | /Project/ItemGroup/MacDeveloperSign | /Project/ItemGroup/MacDeveloperSignHarden")) {
-              $name = $item.GetAttribute("Include")
-              $certificateGroup = $item.LocalName
-              if ($certificatesByName.ContainsKey($name) -and $certificatesByName[$name] -ne $certificateGroup) {
-                throw "Signing entry '$name' is assigned to both '$($certificatesByName[$name])' and '$certificateGroup'."
-              }
-              $certificatesByName[$name] = $certificateGroup
-            }
+                $shortHash = "$(Build.SourceVersion)".Substring(0, 7)
+                Write-Host "##vso[task.setvariable variable=BUILD_SOURCEVERSIONSHORT]$shortHash"
+              displayName: Normalize unsigned artifacts for Arcade
 
-            $arcadeSignListPath = "$(Build.StagingDirectory)\ArcadeSignList.xml"
-            $arcadeSignList.Save($arcadeSignListPath)
-            Write-Host "##vso[task.setvariable variable=AndroidSignList]$arcadeSignListPath"
+            - pwsh: |
+                $adapter = "$(Agent.TempDirectory)\android-arcade"
+                Remove-Item $adapter -Recurse -Force -ErrorAction Ignore
+                Copy-Item "$(Build.SourcesDirectory)\android\build-tools\automation\dnceng\arcade" $adapter -Recurse
+                Copy-Item "$(Build.SourcesDirectory)\android\eng\common" "$adapter\eng\common" -Recurse
 
-            $signVerify = Get-ChildItem $unsigned -Filter "SignVerifyIgnore.txt" -File -Recurse | Select-Object -First 1
-            if (-not $signVerify) {
-              throw "The build did not publish SignVerifyIgnore.txt."
-            }
-            Copy-Item $signVerify.FullName "$(Build.StagingDirectory)\SignVerifyIgnore.txt"
+                $globalJson = Get-Content "$(Build.SourcesDirectory)\android\global.json" -Raw | ConvertFrom-Json -AsHashtable
+                $globalJson["tools"] = [ordered]@{
+                  dotnet = (& dotnet --version)
+                }
+                $globalJson | ConvertTo-Json -Depth 5 | Set-Content "$adapter\global.json"
 
-            $inputNames = $packages.Name | Sort-Object -Unique
-            $inputNames | ConvertTo-Json | Set-Content "$(Build.StagingDirectory)\unsigned-package-names.json"
+                Write-Host "##vso[task.setvariable variable=ArcadeAdapterRoot]$adapter"
+              displayName: Prepare isolated Arcade adapter
 
-            $shortHash = "$(Build.SourceVersion)".Substring(0, 7)
-            Write-Host "##vso[task.setvariable variable=BUILD_SOURCEVERSIONSHORT]$shortHash"
-          displayName: Normalize unsigned artifacts for Arcade
+            - pwsh: |
+                $properties = @(
+                  "/p:RepositoryEngineeringDir=$(ArcadeAdapterRoot)\eng\",
+                  "/p:AndroidRepoRoot=$(Build.SourcesDirectory)\android",
+                  "/p:AndroidSignList=$(AndroidSignList)",
+                  "/p:ArtifactsDir=$(Build.SourcesDirectory)\android\artifacts\",
+                  "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
+                  "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
+                  "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
+                  "/p:OfficialBuildId=$(_BuildOfficialId)",
+                  "/p:DotNetSignType=$(_SignType)",
+                  "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
+                  "/p:RepositoryName=dotnet/android"
+                )
 
-        - pwsh: |
-            $adapter = "$(Agent.TempDirectory)\android-arcade"
-            Remove-Item $adapter -Recurse -Force -ErrorAction Ignore
-            Copy-Item "$(Build.SourcesDirectory)\android\build-tools\automation\dnceng\arcade" $adapter -Recurse
-            Copy-Item "$(Build.SourcesDirectory)\android\eng\common" "$adapter\eng\common" -Recurse
+                & "$(ArcadeAdapterRoot)\eng\common\build.ps1" `
+                  -configuration Release `
+                  -msbuildEngine dotnet `
+                  -projects "$(ArcadeAdapterRoot)\Workloads.proj" `
+                  -restore `
+                  -sign `
+                  -ci `
+                  -warnAsError:$false `
+                  -binaryLogName "$(Build.StagingDirectory)\signing-logs\sign-nugets.binlog" `
+                  @properties
+              displayName: Sign prebuilt NuGet packages with Arcade
+              env:
+                BUILD_REPOSITORY_NAME: dotnet/android
+                BUILD_REPOSITORY_URI: https://github.com/dotnet/android
+                NUGET_CONFIG: $(Build.SourcesDirectory)\android\NuGet.config
+                NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
+                SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-            $globalJson = Get-Content "$(Build.SourcesDirectory)\android\global.json" -Raw | ConvertFrom-Json -AsHashtable
-            $globalJson["tools"] = [ordered]@{
-              dotnet = (& dotnet --version)
-            }
-            $globalJson | ConvertTo-Json -Depth 5 | Set-Content "$adapter\global.json"
+            - pwsh: |
+                $properties = @(
+                  "/p:RepositoryEngineeringDir=$(ArcadeAdapterRoot)\eng\",
+                  "/p:AndroidRepoRoot=$(Build.SourcesDirectory)\android",
+                  "/p:AndroidSignList=$(AndroidSignList)",
+                  "/p:ArtifactsDir=$(Build.SourcesDirectory)\android\artifacts\",
+                  "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
+                  "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
+                  "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
+                  "/p:OfficialBuildId=$(_BuildOfficialId)",
+                  "/p:DotNetSignType=$(_SignType)",
+                  "/p:SignWorkloadMsis=true",
+                  "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
+                  "/p:RepositoryName=dotnet/android"
+                )
 
-            Write-Host "##vso[task.setvariable variable=ArcadeAdapterRoot]$adapter"
-          displayName: Prepare isolated Arcade adapter
+                & "$(ArcadeAdapterRoot)\eng\common\build.ps1" `
+                  -configuration Release `
+                  -msbuildEngine dotnet `
+                  -projects "$(ArcadeAdapterRoot)\Workloads.proj" `
+                  -build `
+                  -sign `
+                  -ci `
+                  -warnAsError:$false `
+                  -binaryLogName "$(Build.StagingDirectory)\signing-logs\workload-msis.binlog" `
+                  @properties
+              displayName: Build and sign workload MSIs with Arcade
+              env:
+                BUILD_REPOSITORY_NAME: dotnet/android
+                BUILD_REPOSITORY_URI: https://github.com/dotnet/android
+                NUGET_CONFIG: $(Build.SourcesDirectory)\android\NuGet.config
+                NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
+                SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-        - pwsh: |
-            $properties = @(
-              "/p:RepositoryEngineeringDir=$(ArcadeAdapterRoot)\eng\",
-              "/p:AndroidRepoRoot=$(Build.SourcesDirectory)\android",
-              "/p:AndroidSignList=$(AndroidSignList)",
-              "/p:ArtifactsDir=$(Build.SourcesDirectory)\android\artifacts\",
-              "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
-              "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
-              "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
-              "/p:OfficialBuildId=$(_BuildOfficialId)",
-              "/p:DotNetSignType=$(_SignType)",
-              "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
-              "/p:RepositoryName=dotnet/android"
-            )
+            - pwsh: |
+                $properties = @(
+                  "/p:RepositoryEngineeringDir=$(ArcadeAdapterRoot)\eng\",
+                  "/p:AndroidRepoRoot=$(Build.SourcesDirectory)\android",
+                  "/p:AndroidSignList=$(AndroidSignList)",
+                  "/p:ArtifactsDir=$(Build.SourcesDirectory)\android\artifacts\",
+                  "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
+                  "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
+                  "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
+                  "/p:OfficialBuildId=$(_BuildOfficialId)",
+                  "/p:DotNetSignType=$(_SignType)",
+                  "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
+                  "/p:RepositoryName=dotnet/android"
+                )
 
-            & "$(ArcadeAdapterRoot)\eng\common\build.ps1" `
-              -configuration Release `
-              -msbuildEngine dotnet `
-              -projects "$(ArcadeAdapterRoot)\Workloads.proj" `
-              -restore `
-              -sign `
-              -ci `
-              -warnAsError:$false `
-              -binaryLogName "$(Build.StagingDirectory)\signing-logs\sign-nugets.binlog" `
-              @properties
-          displayName: Sign prebuilt NuGet packages with Arcade
-          env:
-            BUILD_REPOSITORY_NAME: dotnet/android
-            BUILD_REPOSITORY_URI: https://github.com/dotnet/android
-            NUGET_CONFIG: $(Build.SourcesDirectory)\android\NuGet.config
-            NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                & "$(ArcadeAdapterRoot)\eng\common\build.ps1" `
+                  -configuration Release `
+                  -msbuildEngine dotnet `
+                  -projects "$(ArcadeAdapterRoot)\Workloads.proj" `
+                  -sign `
+                  -ci `
+                  -warnAsError:$false `
+                  -binaryLogName "$(Build.StagingDirectory)\signing-logs\sign-msi-nugets.binlog" `
+                  @properties
+              displayName: Sign workload MSI NuGet packages with Arcade
+              env:
+                BUILD_REPOSITORY_NAME: dotnet/android
+                BUILD_REPOSITORY_URI: https://github.com/dotnet/android
+                NUGET_CONFIG: $(Build.SourcesDirectory)\android\NuGet.config
+                NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
+                SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-        - pwsh: |
-            $properties = @(
-              "/p:RepositoryEngineeringDir=$(ArcadeAdapterRoot)\eng\",
-              "/p:AndroidRepoRoot=$(Build.SourcesDirectory)\android",
-              "/p:AndroidSignList=$(AndroidSignList)",
-              "/p:ArtifactsDir=$(Build.SourcesDirectory)\android\artifacts\",
-              "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
-              "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
-              "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
-              "/p:OfficialBuildId=$(_BuildOfficialId)",
-              "/p:DotNetSignType=$(_SignType)",
-              "/p:SignWorkloadMsis=true",
-              "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
-              "/p:RepositoryName=dotnet/android"
-            )
+            - pwsh: |
+                $shipping = "$(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping"
+                $inputNames = @(Get-Content "$(Build.StagingDirectory)\unsigned-package-names.json" -Raw | ConvertFrom-Json)
+                foreach ($name in $inputNames) {
+                  if (-not (Test-Path (Join-Path $shipping $name) -PathType Leaf)) {
+                    throw "Signed output is missing '$name'."
+                  }
+                }
 
-            & "$(ArcadeAdapterRoot)\eng\common\build.ps1" `
-              -configuration Release `
-              -msbuildEngine dotnet `
-              -projects "$(ArcadeAdapterRoot)\Workloads.proj" `
-              -build `
-              -sign `
-              -ci `
-              -warnAsError:$false `
-              -binaryLogName "$(Build.StagingDirectory)\signing-logs\workload-msis.binlog" `
-              @properties
-          displayName: Build and sign workload MSIs with Arcade
-          env:
-            BUILD_REPOSITORY_NAME: dotnet/android
-            BUILD_REPOSITORY_URI: https://github.com/dotnet/android
-            NUGET_CONFIG: $(Build.SourcesDirectory)\android\NuGet.config
-            NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                $msiPackages = @(Get-ChildItem $shipping -Filter "*.nupkg" -File |
+                  Where-Object { $_.Name -notin $inputNames })
+                if ($msiPackages.Count -eq 0) {
+                  throw "The workload build did not generate any MSI NuGet packages."
+                }
 
-        - pwsh: |
-            $properties = @(
-              "/p:RepositoryEngineeringDir=$(ArcadeAdapterRoot)\eng\",
-              "/p:AndroidRepoRoot=$(Build.SourcesDirectory)\android",
-              "/p:AndroidSignList=$(AndroidSignList)",
-              "/p:ArtifactsDir=$(Build.SourcesDirectory)\android\artifacts\",
-              "/p:NuGetPackageRoot=$(Build.SourcesDirectory)\android\.packages\",
-              "/p:RestorePackagesPath=$(Build.SourcesDirectory)\android\.packages\",
-              "/p:RestoreConfigFile=$(Build.SourcesDirectory)\android\NuGet.config",
-              "/p:OfficialBuildId=$(_BuildOfficialId)",
-              "/p:DotNetSignType=$(_SignType)",
-              "/p:MicroBuildOverridePluginDirectory=$(Agent.TempDirectory)\MicroBuild\Plugins",
-              "/p:RepositoryName=dotnet/android"
-            )
+                $msiDirectory = "$(Build.StagingDirectory)\msi-nupkgs"
+                New-Item $msiDirectory -ItemType Directory -Force | Out-Null
+                Copy-Item $msiPackages.FullName $msiDirectory
+              displayName: Validate signed package outputs
 
-            & "$(ArcadeAdapterRoot)\eng\common\build.ps1" `
-              -configuration Release `
-              -msbuildEngine dotnet `
-              -projects "$(ArcadeAdapterRoot)\Workloads.proj" `
-              -sign `
-              -ci `
-              -warnAsError:$false `
-              -binaryLogName "$(Build.StagingDirectory)\signing-logs\sign-msi-nugets.binlog" `
-              @properties
-          displayName: Sign workload MSI NuGet packages with Arcade
-          env:
-            BUILD_REPOSITORY_NAME: dotnet/android
-            BUILD_REPOSITORY_URI: https://github.com/dotnet/android
-            NUGET_CONFIG: $(Build.SourcesDirectory)\android\NuGet.config
-            NUGET_PACKAGES: $(Build.SourcesDirectory)\android\.packages
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            - task: MicroBuildCodesignVerify@3
+              displayName: Verify signed workload artifacts
+              inputs:
+                TargetFolders: |
+                  $(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping\manifests
+                  $(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping\manifests-packs
+                  $(Build.StagingDirectory)\msi-nupkgs
+                ExcludeSNVerify: true
+                ApprovalListPathForCerts: $(Build.StagingDirectory)\SignVerifyIgnore.txt
 
-        - pwsh: |
-            $shipping = "$(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping"
-            $inputNames = @(Get-Content "$(Build.StagingDirectory)\unsigned-package-names.json" -Raw | ConvertFrom-Json)
-            foreach ($name in $inputNames) {
-              if (-not (Test-Path (Join-Path $shipping $name) -PathType Leaf)) {
-                throw "Signed output is missing '$name'."
-              }
-            }
+            - task: 1ES.PublishPipelineArtifact@1
+              displayName: Publish signed NuGet packages
+              inputs:
+                artifactName: nuget-signed
+                targetPath: $(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping
 
-            $msiPackages = @(Get-ChildItem $shipping -Filter "*.nupkg" -File |
-              Where-Object { $_.Name -notin $inputNames })
-            if ($msiPackages.Count -eq 0) {
-              throw "The workload build did not generate any MSI NuGet packages."
-            }
+            - task: 1ES.PublishPipelineArtifact@1
+              displayName: Publish signing logs
+              condition: always()
+              inputs:
+                artifactName: signing-logs-$(System.StageAttempt)-$(System.JobAttempt)
+                targetPath: $(Build.StagingDirectory)\signing-logs
 
-            $msiDirectory = "$(Build.StagingDirectory)\msi-nupkgs"
-            New-Item $msiDirectory -ItemType Directory -Force | Out-Null
-            Copy-Item $msiPackages.FullName $msiDirectory
-          displayName: Validate signed package outputs
+    # MSBuild Tests Stage
+    - stage: msbuild_dotnet
+      displayName: MSBuild Tests
+      dependsOn: mac_build
+      condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
+      jobs:
+      - job: mac_msbuild_tests
+        strategy:
+          parallel: 10
+        displayName: macOS > Tests > MSBuild
+        # dnceng/internal has no AcesShared pool, so use hosted macOS images
+        pool:
+          name: Azure Pipelines
+          vmImage: $(HostedMacImage)
+          os: macOS
+        timeoutInMinutes: 240
+        cancelTimeoutInMinutes: 5
+        steps:
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+          parameters:
+            installTestSlicer: true
+            use1ESTemplate: true
 
-        - task: MicroBuildCodesignVerify@3
-          displayName: Verify signed workload artifacts
+        # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
+        # Gradle distribution and Maven dependencies on first use.
+        - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+          parameters:
+            xaSourcePath: $(System.DefaultWorkingDirectory)
+
+        - task: DownloadPipelineArtifact@2
           inputs:
-            TargetFolders: |
-              $(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping\manifests
-              $(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping\manifests-packs
-              $(Build.StagingDirectory)\msi-nupkgs
-            ExcludeSNVerify: true
-            ApprovalListPathForCerts: $(Build.StagingDirectory)\SignVerifyIgnore.txt
+            artifactName: $(TestAssembliesArtifactName)
+            downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-        - task: PublishPipelineArtifact@1
-          displayName: Publish signed NuGet packages
+        - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+          parameters:
+            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
+            testFilter: ''
+            testRunTitle: Xamarin.Android.Build.Tests - macOS
+            retryFailedTests: false
+            xaSourcePath: $(System.DefaultWorkingDirectory)
+
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+          parameters:
+            artifactName: Test Results - MSBuild - macOS-$(System.JobPositionInPhase)
+            xaSourcePath: $(System.DefaultWorkingDirectory)
+            use1ESTemplate: true
+
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+          parameters:
+            condition: true
+
+      - job: win_msbuild_tests
+        strategy:
+          parallel: 8
+        displayName: Windows > Tests > MSBuild
+        pool:
+          name: $(NetCoreInternalPoolName)
+          image: $(WindowsPoolImageNetCoreInternal)
+          os: windows
+        timeoutInMinutes: 240
+        cancelTimeoutInMinutes: 5
+        steps:
+        - script: netsh int ipv4 set global sourceroutingbehavior=drop
+
+        - template: /build-tools/automation/yaml-templates/kill-processes.yaml
+
+        - template: /build-tools/automation/yaml-templates/clean.yaml
+
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+          parameters:
+            useAgentJdkPath: false
+            installTestSlicer: true
+            use1ESTemplate: true
+
+        # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
+        # Gradle distribution and Maven dependencies on first use.
+        - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+          parameters:
+            xaSourcePath: $(System.DefaultWorkingDirectory)
+
+        - task: DownloadPipelineArtifact@2
           inputs:
-            artifactName: nuget-signed
-            targetPath: $(Build.SourcesDirectory)\android\artifacts\packages\Release\Shipping
+            artifactName: $(TestAssembliesArtifactName)
+            downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-        - task: PublishPipelineArtifact@1
-          displayName: Publish signing logs
+        - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+          parameters:
+            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
+            testFilter: ''
+            testRunTitle: Xamarin.Android.Build.Tests - Windows
+            retryFailedTests: false
+            xaSourcePath: $(System.DefaultWorkingDirectory)
+
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+          parameters:
+            artifactName: Test Results - MSBuild - Windows-$(System.JobPositionInPhase)
+            xaSourcePath: $(System.DefaultWorkingDirectory)
+            use1ESTemplate: true
+
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+          parameters:
+            condition: true
+
+    # MSBuild Emulator Tests Stage
+    - stage: msbuilddevice_tests
+      displayName: MSBuild Emulator Tests
+      dependsOn: mac_build
+      condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
+      jobs:
+      - job: mac_dotnetdevice_tests
+        strategy:
+          parallel: 12
+        displayName: "macOS > Tests > MSBuild+Emulator"
+        # Emulator jobs need the hosted image that can boot Android emulators
+        pool:
+          name: Azure Pipelines
+          vmImage: $(HostedMacImageWithEmulator)
+          os: macOS
+        timeoutInMinutes: 180
+        cancelTimeoutInMinutes: 5
+        workspace:
+          clean: all
+        steps:
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+          parameters:
+            jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
+            useAgentJdkPath: true
+            installTestSlicer: true
+            installApkDiff: false
+            use1ESTemplate: true
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: $(TestAssembliesArtifactName)
+            downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
+
+        # Currently needed for samples/NativeAOT
+        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+          parameters:
+            project: Xamarin.Android.slnx
+            arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) --no-restore
+            displayName: prepare java.interop $(XA.Build.Configuration)
+            continueOnError: false
+
+        - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
+
+        - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+          parameters:
+            testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
+            testFilter: $(ExcludedNightlyNUnitCategories)
+            testRunTitle: MSBuildDeviceIntegration On Device - macOS
+
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+          parameters:
+            artifactName: Test Results - MSBuild With Emulator - macOS-$(System.JobPositionInPhase)
+            xaSourcePath: $(System.DefaultWorkingDirectory)
+            use1ESTemplate: true
+
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+          parameters:
+            condition: true
+
+    # Java.Interop Tests Stage
+    - template: /build-tools/automation/yaml-templates/stage-java-interop-tests.yaml@self
+      parameters:
+        windowsPool:
+          name: $(NetCoreInternalPoolName)
+          image: $(WindowsPoolImageNetCoreInternal)
+          os: windows
+        macPool:
+          name: Azure Pipelines
+          vmImage: $(HostedMacImage)
+          os: macOS
+
+    # MAUI Tests Stage
+    - stage: maui_tests
+      displayName: MAUI Tests
+      dependsOn: mac_build
+      condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
+      jobs:
+      - job: maui_tests_integration
+        displayName: MAUI Integration
+        pool:
+          name: $(NetCoreInternalPoolName)
+          image: 1es-windows-2022
+          os: windows
+        timeoutInMinutes: 180
+        workspace:
+          clean: all
+        variables:
+          BuildVersion: $(Build.BuildId)
+          # Ignore MAUI's public API analyzer errors (RS0016) - dotnet/android does not care about those
+          PublicApiType: Generate
+        steps:
+        - checkout: self
+          clean: true
+          submodules: recursive
+          path: s/android
+          persistCredentials: false
+
+        - checkout: maui
+          clean: true
+          submodules: recursive
+          path: s/maui
+          persistCredentials: true
+
+        # Restore ~/.gradle/caches between runs so MAUI's Gradle resolution
+        # for android-gradle-plugin/sdklib/ddmlib is not gated on the
+        # Maven feed every build.
+        - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+          parameters:
+            xaSourcePath: $(Build.SourcesDirectory)/android
+
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-steps.yaml
+          parameters:
+            xaSourcePath: $(Build.SourcesDirectory)/android
+            androidSdkPlatforms: $(DefaultTestSdkPlatforms)
+            dotnetVersion: $(DotNetSdkVersion)
+            dotnetQuality: $(DotNetSdkQuality)
+            jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
+            useAgentJdkPath: true
+            use1ESTemplate: true
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: $(NuGetArtifactName)
+            downloadPath: $(Build.StagingDirectory)/android-packs
+
+        - pwsh: |
+            $searchPath = Join-Path $(Build.StagingDirectory) android-packs
+            $wlmanPack = Get-ChildItem $searchPath -Filter *Android*Manifest*.nupkg | Select-Object -First 1
+            $dest = Join-Path $searchPath "tmp-wlman" "$($wlmanPack.BaseName)"
+            Expand-Archive -LiteralPath $wlmanPack -DestinationPath $dest
+            $wlmanJsonPath = Join-Path $dest "data" "WorkloadManifest.json"
+            $json = Get-Content $wlmanJsonPath | ConvertFrom-Json -AsHashtable
+            Write-Host "Setting variable ANDROID_PACK_VERSION = $($json["version"])"
+            Write-Host "##vso[task.setvariable variable=ANDROID_PACK_VERSION;]$($json["version"])"
+          displayName: Set ANDROID_PACK_VERSION
+
+        - pwsh: >-
+            $(Build.SourcesDirectory)/maui/eng/scripts/update-version-props.ps1
+            -xmlFileName "$(Build.SourcesDirectory)/maui/eng/Versions.props"
+            -androidVersion $(ANDROID_PACK_VERSION)
+          displayName: Update MAUI's Android dependency
+
+        - task: DotNetCoreCLI@2
+          displayName: Update Android SDK band in Workloads.csproj
+          inputs:
+            projects: $(Build.SourcesDirectory)/android/Xamarin.Android.slnx
+            arguments: -t:UpdateMauiWorkloadsProj -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/update-maui-workloadsproj.binlog
+
+        - pwsh: ./build.ps1 --target=dotnet --configuration="$(XA.Build.Configuration)" --nugetsource="$(Build.StagingDirectory)\android-packs" --verbosity=diagnostic
+          displayName: Install .NET
+          retryCountOnTaskFailure: 3
+          workingDirectory: $(Build.SourcesDirectory)/maui
+
+        - task: NodeTool@0
+          displayName: Install Node.js
+          # MAUI's TypeScript build steps for the BlazorWebView project shell out
+          # to node.exe; install it explicitly.
+          inputs:
+            versionSpec: '20.x'
+
+        - pwsh: |
+            # Match Configuration.props: prefer ANDROID_SDK_ROOT if set+exists,
+            # else $(HOME)\android-toolchain\sdk, else $env:USERPROFILE fallback.
+            $candidates = @()
+            if ($env:ANDROID_SDK_ROOT) { $candidates += $env:ANDROID_SDK_ROOT }
+            if ($env:ANDROID_HOME)     { $candidates += $env:ANDROID_HOME }
+            if ($env:HOME)             { $candidates += "$env:HOME\android-toolchain\sdk" }
+            if ($env:USERPROFILE)      { $candidates += "$env:USERPROFILE\android-toolchain\sdk" }
+            $sdk = $candidates | Where-Object { $_ -and (Test-Path (Join-Path $_ 'platforms')) } | Select-Object -First 1
+            if (-not $sdk) {
+              Write-Error "Could not find an Android SDK install with a 'platforms' subdir. Tried:`n$($candidates -join "`n")"
+              exit 1
+            }
+            Write-Host "Setting ANDROID_HOME / ANDROID_SDK_ROOT to '$sdk'"
+            Get-ChildItem (Join-Path $sdk 'platforms') | ForEach-Object { Write-Host "  platforms\$($_.Name)" }
+            Write-Host "##vso[task.setvariable variable=ANDROID_HOME]$sdk"
+            Write-Host "##vso[task.setvariable variable=ANDROID_SDK_ROOT]$sdk"
+          displayName: Point ANDROID_HOME at xa-prepare SDK
+
+        - pwsh: ./build.ps1 --target=dotnet-pack --configuration="$(XA.Build.Configuration)" --nugetsource="$(Build.StagingDirectory)\android-packs" --verbosity=diagnostic
+          displayName: Pack .NET Maui
+          workingDirectory: $(Build.SourcesDirectory)/maui
+
+        - task: DotNetCoreCLI@2
+          displayName: Install MAUI workload packs
+          retryCountOnTaskFailure: 3
+          inputs:
+            projects: $(Build.SourcesDirectory)/android/Xamarin.Android.slnx
+            arguments: -t:InstallMaui -p:MauiUseLocalPacks=true -p:MauiWorkloadToInstall=maui -p:MauiManifestDiagnosticsPath=$(Build.StagingDirectory)/logs/maui-manifest -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/install-maui.binlog
+
+        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+          parameters:
+            command: new
+            arguments: maui -o $(Build.StagingDirectory)/MauiTestProj --no-restore
+            xaSourcePath: $(Build.SourcesDirectory)/android
+            displayName: Create MAUI template
+            continueOnError: false
+
+        - template: /build-tools/automation/yaml-templates/set-maui-target-framework-android.yaml
+          parameters:
+            project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
+
+        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+          parameters:
+            project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
+            arguments: >-
+              -f $(DotNetTargetFramework)-android -c Debug
+              --configfile $(Build.SourcesDirectory)/maui/NuGet.config
+              -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Debug.binlog
+            xaSourcePath: $(Build.SourcesDirectory)/android
+            displayName: Build MAUI template - Debug
+
+        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+          parameters:
+            project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
+            arguments: >-
+              -f $(DotNetTargetFramework)-android -c Release
+              --configfile $(Build.SourcesDirectory)/maui/NuGet.config
+              -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Release.binlog
+            xaSourcePath: $(Build.SourcesDirectory)/android
+            displayName: Build MAUI template - Release
+
+        - task: CopyFiles@2
+          displayName: copy build logs
           condition: always()
           inputs:
-            artifactName: signing-logs-$(System.StageAttempt)-$(System.JobAttempt)
-            targetPath: $(Build.StagingDirectory)\signing-logs
+            Contents: |
+              $(Build.SourcesDirectory)/android/bin/*$(XA.Build.Configuration)/*.*log
+              $(Build.SourcesDirectory)/maui/artifacts/logs/**
+            TargetFolder: $(Build.StagingDirectory)/logs
+            flattenFolders: true
 
-# MSBuild Tests Stage
-- stage: msbuild_dotnet
-  displayName: MSBuild Tests
-  dependsOn: mac_build
-  condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
-  jobs:
-  - job: mac_msbuild_tests
-    strategy:
-      parallel: 10
-    displayName: macOS > Tests > MSBuild
-    # dnceng/internal has no AcesShared pool, so use hosted macOS images
-    pool:
-      name: Azure Pipelines
-      vmImage: $(HostedMacImage)
-      os: macOS
-    timeoutInMinutes: 240
-    cancelTimeoutInMinutes: 5
-    steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
-      parameters:
-        installTestSlicer: true
-        use1ESTemplate: false
+        - template: /build-tools/automation/yaml-templates/publish-artifact.yaml
+          parameters:
+            displayName: upload build and test results
+            artifactName: Test Results - MAUI Integration
+            targetPath: $(Build.StagingDirectory)/logs
+            condition: or(ne(variables['Agent.JobStatus'], 'Succeeded'), eq(variables['XA.PublishAllLogs'], 'true'))
+            use1ESTemplate: true
 
-    # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
-    # Gradle distribution and Maven dependencies on first use.
-    - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
-      parameters:
-        xaSourcePath: $(System.DefaultWorkingDirectory)
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: $(TestAssembliesArtifactName)
-        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
-
-    - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
-      parameters:
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
-        testFilter: ''
-        testRunTitle: Xamarin.Android.Build.Tests - macOS
-        retryFailedTests: false
-        xaSourcePath: $(System.DefaultWorkingDirectory)
-
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml
-      parameters:
-        artifactName: Test Results - MSBuild - macOS-$(System.JobPositionInPhase)
-        xaSourcePath: $(System.DefaultWorkingDirectory)
-        use1ESTemplate: false
-
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
-      parameters:
-        condition: true
-
-  - job: win_msbuild_tests
-    strategy:
-      parallel: 8
-    displayName: Windows > Tests > MSBuild
-    pool:
-      name: $(NetCoreInternalPoolName)
-      demands:
-      - ImageOverride -equals $(WindowsPoolImageNetCoreInternal)
-    timeoutInMinutes: 240
-    cancelTimeoutInMinutes: 5
-    steps:
-    - script: netsh int ipv4 set global sourceroutingbehavior=drop
-
-    - template: /build-tools/automation/yaml-templates/kill-processes.yaml
-
-    - template: /build-tools/automation/yaml-templates/clean.yaml
-
-    - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
-      parameters:
-        useAgentJdkPath: false
-        installTestSlicer: true
-        use1ESTemplate: false
-
-    # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
-    # Gradle distribution and Maven dependencies on first use.
-    - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
-      parameters:
-        xaSourcePath: $(System.DefaultWorkingDirectory)
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: $(TestAssembliesArtifactName)
-        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
-
-    - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
-      parameters:
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
-        testFilter: ''
-        testRunTitle: Xamarin.Android.Build.Tests - Windows
-        retryFailedTests: false
-        xaSourcePath: $(System.DefaultWorkingDirectory)
-
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml
-      parameters:
-        artifactName: Test Results - MSBuild - Windows-$(System.JobPositionInPhase)
-        xaSourcePath: $(System.DefaultWorkingDirectory)
-        use1ESTemplate: false
-
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
-      parameters:
-        condition: true
-
-# MSBuild Emulator Tests Stage
-- stage: msbuilddevice_tests
-  displayName: MSBuild Emulator Tests
-  dependsOn: mac_build
-  condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
-  jobs:
-  - job: mac_dotnetdevice_tests
-    strategy:
-      parallel: 12
-    displayName: "macOS > Tests > MSBuild+Emulator"
-    # Emulator jobs need the hosted image that can boot Android emulators
-    pool:
-      name: Azure Pipelines
-      vmImage: $(HostedMacImageWithEmulator)
-      os: macOS
-    timeoutInMinutes: 180
-    cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
-    steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
-      parameters:
-        jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
-        useAgentJdkPath: true
-        installTestSlicer: true
-        installApkDiff: false
-        use1ESTemplate: false
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: $(TestAssembliesArtifactName)
-        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
-
-    # Currently needed for samples/NativeAOT
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
-      parameters:
-        project: Xamarin.Android.slnx
-        arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) --no-restore
-        displayName: prepare java.interop $(XA.Build.Configuration)
-        continueOnError: false
-
-    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
-
-    - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
-      parameters:
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-        testFilter: $(ExcludedNightlyNUnitCategories)
-        testRunTitle: MSBuildDeviceIntegration On Device - macOS
-
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml
-      parameters:
-        artifactName: Test Results - MSBuild With Emulator - macOS-$(System.JobPositionInPhase)
-        xaSourcePath: $(System.DefaultWorkingDirectory)
-        use1ESTemplate: false
-
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
-      parameters:
-        condition: true
-
-# Java.Interop Tests Stage
-- template: /build-tools/automation/yaml-templates/stage-java-interop-tests.yaml@self
-  parameters:
-    windowsPool:
-      name: $(NetCoreInternalPoolName)
-      demands:
-      - ImageOverride -equals $(WindowsPoolImageNetCoreInternal)
-    macPool:
-      name: Azure Pipelines
-      vmImage: $(HostedMacImage)
-      os: macOS
-
-# MAUI Tests Stage
-- stage: maui_tests
-  displayName: MAUI Tests
-  dependsOn: mac_build
-  condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
-  jobs:
-  - job: maui_tests_integration
-    displayName: MAUI Integration
-    pool:
-      name: $(NetCoreInternalPoolName)
-      demands:
-      - ImageOverride -equals 1es-windows-2022
-      os: windows
-    timeoutInMinutes: 180
-    workspace:
-      clean: all
-    variables:
-      BuildVersion: $(Build.BuildId)
-      # Ignore MAUI's public API analyzer errors (RS0016) - dotnet/android does not care about those
-      PublicApiType: Generate
-    steps:
-    - checkout: self
-      clean: true
-      submodules: recursive
-      path: s/android
-      persistCredentials: false
-
-    - checkout: maui
-      clean: true
-      submodules: recursive
-      path: s/maui
-      persistCredentials: true
-
-    # Restore ~/.gradle/caches between runs so MAUI's Gradle resolution
-    # for android-gradle-plugin/sdklib/ddmlib is not gated on the
-    # Maven feed every build.
-    - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
-      parameters:
-        xaSourcePath: $(Build.SourcesDirectory)/android
-
-    - template: /build-tools/automation/yaml-templates/setup-test-environment-steps.yaml
-      parameters:
-        xaSourcePath: $(Build.SourcesDirectory)/android
-        androidSdkPlatforms: $(DefaultTestSdkPlatforms)
-        dotnetVersion: $(DotNetSdkVersion)
-        dotnetQuality: $(DotNetSdkQuality)
-        jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
-        useAgentJdkPath: true
-        use1ESTemplate: false
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: $(NuGetArtifactName)
-        downloadPath: $(Build.StagingDirectory)/android-packs
-
-    - pwsh: |
-        $searchPath = Join-Path $(Build.StagingDirectory) android-packs
-        $wlmanPack = Get-ChildItem $searchPath -Filter *Android*Manifest*.nupkg | Select-Object -First 1
-        $dest = Join-Path $searchPath "tmp-wlman" "$($wlmanPack.BaseName)"
-        Expand-Archive -LiteralPath $wlmanPack -DestinationPath $dest
-        $wlmanJsonPath = Join-Path $dest "data" "WorkloadManifest.json"
-        $json = Get-Content $wlmanJsonPath | ConvertFrom-Json -AsHashtable
-        Write-Host "Setting variable ANDROID_PACK_VERSION = $($json["version"])"
-        Write-Host "##vso[task.setvariable variable=ANDROID_PACK_VERSION;]$($json["version"])"
-      displayName: Set ANDROID_PACK_VERSION
-
-    - pwsh: >-
-        $(Build.SourcesDirectory)/maui/eng/scripts/update-version-props.ps1
-        -xmlFileName "$(Build.SourcesDirectory)/maui/eng/Versions.props"
-        -androidVersion $(ANDROID_PACK_VERSION)
-      displayName: Update MAUI's Android dependency
-
-    - task: DotNetCoreCLI@2
-      displayName: Update Android SDK band in Workloads.csproj
-      inputs:
-        projects: $(Build.SourcesDirectory)/android/Xamarin.Android.slnx
-        arguments: -t:UpdateMauiWorkloadsProj -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/update-maui-workloadsproj.binlog
-
-    - pwsh: ./build.ps1 --target=dotnet --configuration="$(XA.Build.Configuration)" --nugetsource="$(Build.StagingDirectory)\android-packs" --verbosity=diagnostic
-      displayName: Install .NET
-      retryCountOnTaskFailure: 3
-      workingDirectory: $(Build.SourcesDirectory)/maui
-
-    - task: NodeTool@0
-      displayName: Install Node.js
-      # MAUI's TypeScript build steps for the BlazorWebView project shell out
-      # to node.exe; install it explicitly.
-      inputs:
-        versionSpec: '20.x'
-
-    - pwsh: |
-        # Match Configuration.props: prefer ANDROID_SDK_ROOT if set+exists,
-        # else $(HOME)\android-toolchain\sdk, else $env:USERPROFILE fallback.
-        $candidates = @()
-        if ($env:ANDROID_SDK_ROOT) { $candidates += $env:ANDROID_SDK_ROOT }
-        if ($env:ANDROID_HOME)     { $candidates += $env:ANDROID_HOME }
-        if ($env:HOME)             { $candidates += "$env:HOME\android-toolchain\sdk" }
-        if ($env:USERPROFILE)      { $candidates += "$env:USERPROFILE\android-toolchain\sdk" }
-        $sdk = $candidates | Where-Object { $_ -and (Test-Path (Join-Path $_ 'platforms')) } | Select-Object -First 1
-        if (-not $sdk) {
-          Write-Error "Could not find an Android SDK install with a 'platforms' subdir. Tried:`n$($candidates -join "`n")"
-          exit 1
-        }
-        Write-Host "Setting ANDROID_HOME / ANDROID_SDK_ROOT to '$sdk'"
-        Get-ChildItem (Join-Path $sdk 'platforms') | ForEach-Object { Write-Host "  platforms\$($_.Name)" }
-        Write-Host "##vso[task.setvariable variable=ANDROID_HOME]$sdk"
-        Write-Host "##vso[task.setvariable variable=ANDROID_SDK_ROOT]$sdk"
-      displayName: Point ANDROID_HOME at xa-prepare SDK
-
-    - pwsh: ./build.ps1 --target=dotnet-pack --configuration="$(XA.Build.Configuration)" --nugetsource="$(Build.StagingDirectory)\android-packs" --verbosity=diagnostic
-      displayName: Pack .NET Maui
-      workingDirectory: $(Build.SourcesDirectory)/maui
-
-    - task: DotNetCoreCLI@2
-      displayName: Install MAUI workload packs
-      retryCountOnTaskFailure: 3
-      inputs:
-        projects: $(Build.SourcesDirectory)/android/Xamarin.Android.slnx
-        arguments: -t:InstallMaui -p:MauiUseLocalPacks=true -p:MauiWorkloadToInstall=maui -p:MauiManifestDiagnosticsPath=$(Build.StagingDirectory)/logs/maui-manifest -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/install-maui.binlog
-
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
-      parameters:
-        command: new
-        arguments: maui -o $(Build.StagingDirectory)/MauiTestProj --no-restore
-        xaSourcePath: $(Build.SourcesDirectory)/android
-        displayName: Create MAUI template
-        continueOnError: false
-
-    - template: /build-tools/automation/yaml-templates/set-maui-target-framework-android.yaml
-      parameters:
-        project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
-
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
-      parameters:
-        project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
-        arguments: >-
-          -f $(DotNetTargetFramework)-android -c Debug
-          --configfile $(Build.SourcesDirectory)/maui/NuGet.config
-          -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Debug.binlog
-        xaSourcePath: $(Build.SourcesDirectory)/android
-        displayName: Build MAUI template - Debug
-
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
-      parameters:
-        project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
-        arguments: >-
-          -f $(DotNetTargetFramework)-android -c Release
-          --configfile $(Build.SourcesDirectory)/maui/NuGet.config
-          -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Release.binlog
-        xaSourcePath: $(Build.SourcesDirectory)/android
-        displayName: Build MAUI template - Release
-
-    - task: CopyFiles@2
-      displayName: copy build logs
-      condition: always()
-      inputs:
-        Contents: |
-          $(Build.SourcesDirectory)/android/bin/*$(XA.Build.Configuration)/*.*log
-          $(Build.SourcesDirectory)/maui/artifacts/logs/**
-        TargetFolder: $(Build.StagingDirectory)/logs
-        flattenFolders: true
-
-    - template: /build-tools/automation/yaml-templates/publish-artifact.yaml
-      parameters:
-        displayName: upload build and test results
-        artifactName: Test Results - MAUI Integration
-        targetPath: $(Build.StagingDirectory)/logs
-        condition: or(ne(variables['Agent.JobStatus'], 'Succeeded'), eq(variables['XA.PublishAllLogs'], 'true'))
-        use1ESTemplate: false
-
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -146,7 +146,7 @@ extends:
         - checkout: android-tools
           path: s/android-tools
 
-        - template: /build-tools/automation/yaml-templates/build-macos-steps.yaml
+        - template: /build-tools/automation/yaml-templates/build-macos-steps.yaml@self
           parameters:
             xaSourcePath: $(System.DefaultWorkingDirectory)/android
             installerArtifactName: $(InstallerArtifactName)
@@ -172,7 +172,7 @@ extends:
         - checkout: self
           persistCredentials: false
 
-        - template: /build-tools/automation/yaml-templates/build-windows-steps.yaml
+        - template: /build-tools/automation/yaml-templates/build-windows-steps.yaml@self
           parameters:
             buildResultArtifactName: Build Results - Windows
             use1ESTemplate: true
@@ -208,7 +208,7 @@ extends:
             sudo apt-get install -y g++-10 gcc-10
           displayName: install g++-10 and gcc-10
 
-        - template: /build-tools/automation/yaml-templates/build-linux-steps.yaml
+        - template: /build-tools/automation/yaml-templates/build-linux-steps.yaml@self
           parameters:
             buildResultArtifactName: Build Results - Linux
             xaSourcePath: $(System.DefaultWorkingDirectory)/android
@@ -217,7 +217,7 @@ extends:
 
     # Package Tests Stage
     - ${{ if ne(variables.SkipTestStages, 'true') }}:
-      - template: /build-tools/automation/yaml-templates/stage-package-tests.yaml
+      - template: /build-tools/automation/yaml-templates/stage-package-tests.yaml@self
         parameters:
           macTestAgentsUseCleanImages: true
           usePublicSetupTemplate: true
@@ -241,7 +241,7 @@ extends:
         workspace:
           clean: all
         steps:
-        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml@self
           parameters:
             useAgentJdkPath: false
             use1ESTemplate: true
@@ -251,19 +251,19 @@ extends:
             artifactName: $(TestAssembliesArtifactName)
             downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
+        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
           parameters:
             testRunTitle: Xamarin.Android.Build.Tests - Linux BuildTest
             testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
             dotNetTestExtraArgs: --filter "Name = BuildTest"
 
-        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
           parameters:
             configuration: $(XA.Build.Configuration)
             artifactName: Test Results - MSBuild - Linux 1
             use1ESTemplate: true
 
-        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
 
       - job: linux_tests_smoke_2
         displayName: Linux > Tests > MSBuild 2
@@ -275,7 +275,7 @@ extends:
         workspace:
           clean: all
         steps:
-        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml@self
           parameters:
             useAgentJdkPath: false
             use1ESTemplate: true
@@ -285,19 +285,19 @@ extends:
             artifactName: $(TestAssembliesArtifactName)
             downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
+        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
           parameters:
             testRunTitle: Xamarin.Android.Build.Tests - Linux PackagingTest
             testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
             dotNetTestExtraArgs: --filter "Name = PackagingTest"
 
-        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
+        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
           parameters:
             testRunTitle: Xamarin.Android.Build.Tests - Linux XASdkTests
             testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
             dotNetTestExtraArgs: --filter "Name = XASdkTests & Name != XamarinLegacySdk"
 
-        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
+        - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
           parameters:
             testRunTitle: Xamarin.Android.Build.Tests - Linux AndroidDependenciesTests
             testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
@@ -312,14 +312,14 @@ extends:
               -p:AndroidSdkDirectory="$(HOME)/android-toolchain/sdk"
               -bl:$(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/build-helloworld.binlog
 
-        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
           parameters:
             configuration: $(XA.Build.Configuration)
             artifactName: Test Results - MSBuild - Linux 2
             includeBuildResults: true
             use1ESTemplate: true
 
-        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
 
     # Signing and Visual Studio workload insertion artifacts
     - stage: dotnet_prepare_release
@@ -662,14 +662,14 @@ extends:
         timeoutInMinutes: 240
         cancelTimeoutInMinutes: 5
         steps:
-        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml@self
           parameters:
             installTestSlicer: true
             use1ESTemplate: true
 
         # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
         # Gradle distribution and Maven dependencies on first use.
-        - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+        - template: /build-tools/automation/yaml-templates/cache-gradle.yaml@self
           parameters:
             xaSourcePath: $(System.DefaultWorkingDirectory)
 
@@ -678,7 +678,7 @@ extends:
             artifactName: $(TestAssembliesArtifactName)
             downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-        - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+        - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml@self
           parameters:
             testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
             testFilter: ''
@@ -686,13 +686,13 @@ extends:
             retryFailedTests: false
             xaSourcePath: $(System.DefaultWorkingDirectory)
 
-        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
           parameters:
             artifactName: Test Results - MSBuild - macOS-$(System.JobPositionInPhase)
             xaSourcePath: $(System.DefaultWorkingDirectory)
             use1ESTemplate: true
 
-        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
           parameters:
             condition: true
 
@@ -709,11 +709,11 @@ extends:
         steps:
         - script: netsh int ipv4 set global sourceroutingbehavior=drop
 
-        - template: /build-tools/automation/yaml-templates/kill-processes.yaml
+        - template: /build-tools/automation/yaml-templates/kill-processes.yaml@self
 
-        - template: /build-tools/automation/yaml-templates/clean.yaml
+        - template: /build-tools/automation/yaml-templates/clean.yaml@self
 
-        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml@self
           parameters:
             useAgentJdkPath: false
             installTestSlicer: true
@@ -721,7 +721,7 @@ extends:
 
         # AndroidGradleProjectTests run the Gradle wrapper, which downloads the
         # Gradle distribution and Maven dependencies on first use.
-        - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+        - template: /build-tools/automation/yaml-templates/cache-gradle.yaml@self
           parameters:
             xaSourcePath: $(System.DefaultWorkingDirectory)
 
@@ -730,7 +730,7 @@ extends:
             artifactName: $(TestAssembliesArtifactName)
             downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-        - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+        - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml@self
           parameters:
             testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
             testFilter: ''
@@ -738,13 +738,13 @@ extends:
             retryFailedTests: false
             xaSourcePath: $(System.DefaultWorkingDirectory)
 
-        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
           parameters:
             artifactName: Test Results - MSBuild - Windows-$(System.JobPositionInPhase)
             xaSourcePath: $(System.DefaultWorkingDirectory)
             use1ESTemplate: true
 
-        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
           parameters:
             condition: true
 
@@ -768,7 +768,7 @@ extends:
         workspace:
           clean: all
         steps:
-        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml@self
           parameters:
             jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
             useAgentJdkPath: true
@@ -782,28 +782,28 @@ extends:
             downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
         # Currently needed for samples/NativeAOT
-        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
           parameters:
             project: Xamarin.Android.slnx
             arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) --no-restore
             displayName: prepare java.interop $(XA.Build.Configuration)
             continueOnError: false
 
-        - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
+        - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml@self
 
-        - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+        - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml@self
           parameters:
             testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
             testFilter: $(ExcludedNightlyNUnitCategories)
             testRunTitle: MSBuildDeviceIntegration On Device - macOS
 
-        - template: /build-tools/automation/yaml-templates/upload-results.yaml
+        - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
           parameters:
             artifactName: Test Results - MSBuild With Emulator - macOS-$(System.JobPositionInPhase)
             xaSourcePath: $(System.DefaultWorkingDirectory)
             use1ESTemplate: true
 
-        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
           parameters:
             condition: true
 
@@ -854,11 +854,11 @@ extends:
         # Restore ~/.gradle/caches between runs so MAUI's Gradle resolution
         # for android-gradle-plugin/sdklib/ddmlib is not gated on the
         # Maven feed every build.
-        - template: /build-tools/automation/yaml-templates/cache-gradle.yaml
+        - template: /build-tools/automation/yaml-templates/cache-gradle.yaml@self
           parameters:
             xaSourcePath: $(Build.SourcesDirectory)/android
 
-        - template: /build-tools/automation/yaml-templates/setup-test-environment-steps.yaml
+        - template: /build-tools/automation/yaml-templates/setup-test-environment-steps.yaml@self
           parameters:
             xaSourcePath: $(Build.SourcesDirectory)/android
             androidSdkPlatforms: $(DefaultTestSdkPlatforms)
@@ -938,7 +938,7 @@ extends:
             projects: $(Build.SourcesDirectory)/android/Xamarin.Android.slnx
             arguments: -t:InstallMaui -p:MauiUseLocalPacks=true -p:MauiWorkloadToInstall=maui -p:MauiManifestDiagnosticsPath=$(Build.StagingDirectory)/logs/maui-manifest -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/install-maui.binlog
 
-        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
           parameters:
             command: new
             arguments: maui -o $(Build.StagingDirectory)/MauiTestProj --no-restore
@@ -946,11 +946,11 @@ extends:
             displayName: Create MAUI template
             continueOnError: false
 
-        - template: /build-tools/automation/yaml-templates/set-maui-target-framework-android.yaml
+        - template: /build-tools/automation/yaml-templates/set-maui-target-framework-android.yaml@self
           parameters:
             project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
 
-        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
           parameters:
             project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
             arguments: >-
@@ -960,7 +960,7 @@ extends:
             xaSourcePath: $(Build.SourcesDirectory)/android
             displayName: Build MAUI template - Debug
 
-        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+        - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
           parameters:
             project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
             arguments: >-
@@ -980,7 +980,7 @@ extends:
             TargetFolder: $(Build.StagingDirectory)/logs
             flattenFolders: true
 
-        - template: /build-tools/automation/yaml-templates/publish-artifact.yaml
+        - template: /build-tools/automation/yaml-templates/publish-artifact.yaml@self
           parameters:
             displayName: upload build and test results
             artifactName: Test Results - MAUI Integration
@@ -988,4 +988,4 @@ extends:
             condition: or(ne(variables['Agent.JobStatus'], 'Succeeded'), eq(variables['XA.PublishAllLogs'], 'true'))
             use1ESTemplate: true
 
-        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
+        - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -26,6 +26,7 @@ trigger:
 # Azure Repos PR validation is configured through branch policies, not YAML.
 pr: none
 
+# Repository resources - checkout macios-devtools to force multi-repo checkout behavior
 # NOTE: `endpoint` values below are GitHub service connections in the
 # dnceng/internal project. Confirm the connection name(s) available there.
 resources:

--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -26,7 +26,7 @@ trigger:
 # Azure Repos PR validation is configured through branch policies, not YAML.
 pr: none
 
-# Repository resources - checkout android-tools to force multi-repo checkout behavior
+# Repository resources - checkout MAUI to force multi-repo checkout behavior
 # NOTE: `endpoint` values below are GitHub service connections in the
 # dnceng/internal project. Confirm the connection name(s) available there.
 resources:
@@ -35,11 +35,6 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
-  - repository: android-tools
-    type: github
-    name: dotnet/android-tools
-    endpoint: internal
-    ref: refs/heads/main
   - repository: maui
     type: github
     name: dotnet/maui
@@ -98,7 +93,6 @@ extends:
     sdl:
       sourceRepositoriesToScan:
         exclude:
-        - repository: android-tools
         - repository: maui
     stages:
     # macOS Build Stage
@@ -148,8 +142,8 @@ extends:
 
         # Checkout a second repo to force multi-repo checkout behavior
         # https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
-        - checkout: android-tools
-          path: s/android-tools
+        - checkout: maui
+          path: s/maui
 
         - template: /build-tools/automation/yaml-templates/build-macos-steps.yaml@self
           parameters:
@@ -205,8 +199,8 @@ extends:
           persistCredentials: false
 
         # Checkout a second repo to force multi-repo checkout behavior
-        - checkout: android-tools
-          path: s/android-tools
+        - checkout: maui
+          path: s/maui
 
         - script: |
             sudo apt-get update
@@ -360,8 +354,8 @@ extends:
               fetchTags: false
               path: s/android
 
-            - checkout: android-tools
-              path: s/android-tools
+            - checkout: maui
+              path: s/maui
 
             - task: DownloadPipelineArtifact@2
               displayName: Download unsigned macOS and Windows packages

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -15,10 +15,10 @@ resources:
     type: git
     name: DevDiv/Xamarin.yaml-templates
     ref: refs/heads/main
-  - repository: maui
+  - repository: macios-devtools
     type: github
-    name: dotnet/maui
-    ref: net11.0
+    name: dotnet/macios-devtools
+    ref: refs/heads/main
     endpoint: xamarin
 
 parameters:

--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -33,6 +33,11 @@ parameters:
 # Repository resources
 resources:
   repositories:
+  - repository: macios-devtools
+    type: github
+    name: dotnet/macios-devtools
+    endpoint: public
+    ref: refs/heads/main
   - repository: maui
     type: github
     name: dotnet/maui
@@ -81,10 +86,11 @@ stages:
       submodules: recursive
       persistCredentials: false
 
-    # Checkout a second repo to force multi-repo checkout behavior
+    # This small repository is intentionally unused; its checkout keeps the
+    # primary repository at s/android under Azure's multi-repo layout.
     # https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
-    - checkout: maui
-      path: s/maui
+    - checkout: macios-devtools
+      path: s/macios-devtools
 
     - template: /build-tools/automation/yaml-templates/build-macos-steps.yaml
       parameters:
@@ -141,9 +147,10 @@ stages:
       submodules: recursive
       persistCredentials: false
 
-    # Checkout a second repo to force multi-repo checkout behavior
-    - checkout: maui
-      path: s/maui
+    # This small repository is intentionally unused; its checkout keeps the
+    # primary repository at s/android under Azure's multi-repo layout.
+    - checkout: macios-devtools
+      path: s/macios-devtools
 
     - script: |
         sudo apt-get update

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -21,6 +21,11 @@ resources:
     type: git
     name: DevDiv/Xamarin.yaml-templates
     ref: refs/heads/main
+  - repository: macios-devtools
+    type: github
+    name: dotnet/macios-devtools
+    ref: refs/heads/main
+    endpoint: xamarin
   - repository: maui
     type: github
     name: dotnet/maui
@@ -75,6 +80,7 @@ extends:
       sourceRepositoriesToScan:
         exclude:
         - repository: yaml-templates
+        - repository: macios-devtools
         - repository: maui
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -40,9 +40,10 @@ stages:
         resource: ${{ parameters.repositoryAlias }}
         commit: ${{ parameters.checkoutCommit }}
 
-    # Always checkout a second resource to ensure we are using multi-repo checkout behavior
+    # This small repository is intentionally unused; its checkout keeps the
+    # primary repository at s/android under Azure's multi-repo layout.
     #  https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
-    - checkout: maui
+    - checkout: macios-devtools
 
     - template: /build-tools/automation/yaml-templates/build-linux-steps.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -73,9 +73,10 @@ stages:
         resource: ${{ parameters.repositoryAlias }}
         commit: ${{ parameters.checkoutCommit }}
 
-    # Always checkout a second resource to ensure we are using multi-repo checkout behavior
+    # This small repository is intentionally unused; its checkout keeps the
+    # primary repository at s/android under Azure's multi-repo layout.
     #  https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
-    - checkout: maui
+    - checkout: macios-devtools
 
     - task: CodeQL3000Init@0
       displayName: CodeQL 3000 Init

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -22,9 +22,10 @@ steps:
   inputs:
     forceReinstallCredentialProvider: true
 
-# Always checkout a second resource to ensure we are using multi-repo checkout behavior
+# This small repository is intentionally unused; its checkout keeps the
+# primary repository at s/android under Azure's multi-repo layout.
 #  https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
-- checkout: maui
+- checkout: macios-devtools
 
 - task: CodeQL3000Init@0
   displayName: CodeQL 3000 Init

--- a/build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment-public.yaml
@@ -35,4 +35,4 @@ steps:
     installTestSlicer: ${{ parameters.installTestSlicer }}
     installApkDiff: ${{ parameters.installApkDiff }}
     androidSdkPlatforms: ${{ parameters.androidSdkPlatforms }}
-    use1ESTemplate: false
+    use1ESTemplate: ${{ parameters.use1ESTemplate }}

--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -2,6 +2,7 @@
 
 parameters:
   macTestAgentsUseCleanImages: 
+  usePublicSetupTemplate: false
   use1ESTemplate: true
 
 stages:
@@ -21,9 +22,14 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
-      parameters:
-        use1ESTemplate: ${{ parameters.use1ESTemplate }}
+    - ${{ if eq(parameters.usePublicSetupTemplate, true) }}:
+      - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+        parameters:
+          use1ESTemplate: ${{ parameters.use1ESTemplate }}
+    - ${{ else }}:
+      - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
+        parameters:
+          use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
     - task: DownloadPipelineArtifact@2
       inputs:
@@ -108,9 +114,14 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
-      parameters:
-        use1ESTemplate: ${{ parameters.use1ESTemplate }}
+    - ${{ if eq(parameters.usePublicSetupTemplate, true) }}:
+      - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+        parameters:
+          use1ESTemplate: ${{ parameters.use1ESTemplate }}
+    - ${{ else }}:
+      - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
+        parameters:
+          use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -25,6 +25,8 @@ stages:
     - ${{ if eq(parameters.usePublicSetupTemplate, true) }}:
       - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
         parameters:
+          jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
+          useAgentJdkPath: true
           use1ESTemplate: ${{ parameters.use1ESTemplate }}
     - ${{ else }}:
       - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -117,6 +119,8 @@ stages:
     - ${{ if eq(parameters.usePublicSetupTemplate, true) }}:
       - template: /build-tools/automation/yaml-templates/setup-test-environment-public.yaml
         parameters:
+          jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
+          useAgentJdkPath: true
           use1ESTemplate: ${{ parameters.use1ESTemplate }}
     - ${{ else }}:
       - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml


### PR DESCRIPTION
## Summary

- Migrate `dotnet-android-internal` to the official 1ES governed pipeline template while preserving its triggers, stage graph, pool images, signing flow, artifact names, and package-test JDK selection.
- Resolve repository-local templates explicitly from `@self` and classify auxiliary repositories for SDL scanning.
- Use the lightweight `dotnet/macios-devtools` repository wherever a second checkout exists only to keep the primary repository at `s/android`. This covers the internal, public, official/shared, and nightly pipelines; comments document why the checkout is required. Real MAUI integration jobs continue to check out `dotnet/maui`.
- Remove preinstalled .NET SDKs and runtimes from hosted macOS test agents before setup to prevent low-disk warnings without weakening the existing warning gate.

## Validation

- Azure DevOps template previews succeeded for the internal, public, official, PR, and nightly pipeline definitions.
- [Internal validation build 3060061](https://dev.azure.com/dnceng/internal/_build/results?buildId=3060061) ran commit `c33b84759`: 38 jobs passed and all hosted macOS jobs completed with zero low-disk warnings.
- The five failed jobs contain the same existing CheckLint test failures reproduced by the non-governed `main` build; no migration, checkout-shim, or disk-cleanup regression was found.