### PR TITLE
[build] Deduplicate Android tooling defaults

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -146,7 +146,7 @@
     <XAAndroidSourcesHash37_1>F63736E27B0D283298116DA8BCE2C024DE28C7E4081044B30716FCB6E0FA13F1</XAAndroidSourcesHash37_1>
     <XAAndroidSdkLicenseHash>24333f8a63b6825ea9c5514f83c2829b004d1fee</XAAndroidSdkLicenseHash>
     <!-- Android NDK: per-host zips. Use a private property name; the public
-         $(AndroidNdkVersion) is set to the pkg revision in Common.props.in. -->
+         $(AndroidNdkVersion) is set in Xamarin.Installer.Common.props. -->
     <_XAAndroidNdkRelease>28c</_XAAndroidNdkRelease>
     <_XAAndroidNdkPkgRevision>28.2.13676358</_XAAndroidNdkPkgRevision>
     <XAAndroidNdkHashMacOS>0D4599E8BBF1A1668A0D51A541729B2246360F350018A2081D0B302DBB594F2A</XAAndroidNdkHashMacOS>

--- a/Documentation/workflow/HowToAddNewApiLevel.md
+++ b/Documentation/workflow/HowToAddNewApiLevel.md
@@ -655,20 +655,19 @@ Android P introduced no documented XML artifact.
 
 ### Update Android Tooling Versions
 
-[`Xamarin.Android.Common.props.in`](../../src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in)
-contains multiple MSBuild properties which provide default versions for various Android SDK packages.
-These properties in turn come from properties defined within
+[`Xamarin.Installer.Common.props`](../../src/Xamarin.Installer.Build.Tasks/Xamarin.Installer.Common.props)
+contains MSBuild properties which provide the shipped default versions for various Android SDK packages.
+The bootstrap versions used to build and test the repository are defined separately in
 [`Configuration.props`](../../Configuration.props).
 
   * `$(AndroidSdkBuildToolsVersion)`: Android SDK `build-tools` version.
-    Defaults to `$(XABuildToolsFolder)` within `Configuration.props`.
   * `$(AndroidSdkPlatformToolsVersion)`:  Android SDK `platform-tools` version
-    Defaults to `$(XAPlatformToolsVersion)` within `Configuration.props`.
 
 The major version should generally match the new API level. For Android P this will be 28.x.x . If a version which exactly matches the API Level is not available then the latest version should be used.
 
-A separate PR should be created which bumps the values within `Configuration.props`
-to ensure that all unit tests pass.
+A separate PR should be created which coordinates the shipped defaults in
+`Xamarin.Installer.Common.props` with the bootstrap values in `Configuration.props`
+and ensures that all unit tests pass.
 
 ## Bindings Finalization
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -39,6 +39,7 @@ namespace Xamarin.Android.Build.Tests
 
 			var oldSdkPath = Environment.GetEnvironmentVariable ("TEST_ANDROID_SDK_PATH");
 			var oldJdkPath = Environment.GetEnvironmentVariable ("TEST_ANDROID_JDK_PATH");
+			var outdatedCommandLineToolsRevision = new Version (19, 0);
 			try {
 				string sdkPath = Path.Combine (Root, "temp", TestName, "android-sdk");
 				string jdkPath = Path.Combine (Root, "temp", TestName, "android-jdk");
@@ -84,6 +85,12 @@ namespace Xamarin.Android.Build.Tests
 							Directory.CreateDirectory (path);
 						}
 
+						if (manifestType == "Xamarin") {
+							var commandLineToolsPath = Path.Combine (sdkPath, "cmdline-tools", "latest");
+							Directory.CreateDirectory (commandLineToolsPath);
+							File.WriteAllText (Path.Combine (commandLineToolsPath, "source.properties"), $"Pkg.Revision={outdatedCommandLineToolsRevision}");
+						}
+
 						if (b.Build (proj, parameters: buildArgs.ToArray ())) {
 							installSucceeded = true;
 							break;
@@ -94,6 +101,16 @@ namespace Xamarin.Android.Build.Tests
 							Thread.Sleep (TimeSpan.FromSeconds (10));
 					}
 					Assert.IsTrue (installSucceeded, $"InstallAndroidDependencies should have succeeded within {maxInstallAttempts} attempts.");
+
+					if (manifestType == "Xamarin") {
+						var sourceProperties = Path.Combine (sdkPath, "cmdline-tools", "latest", "source.properties");
+						var revisionProperty = File.ReadLines (sourceProperties)
+							.First (line => line.StartsWith ("Pkg.Revision", StringComparison.Ordinal));
+						int separator = revisionProperty.IndexOf ('=');
+						Assert.GreaterOrEqual (separator, 0, "The command-line tools revision property should contain a value.");
+						var installedRevision = Version.Parse (revisionProperty.Substring (separator + 1).Trim ());
+						Assert.Greater (installedRevision.CompareTo (outdatedCommandLineToolsRevision), 0, "The outdated command-line tools installation should have been updated.");
+					}
 
 					// When dependencies can not be resolved/installed a warning will be present in build output:
 					//    Dependency `platform-tools` should have been installed but could not be resolved.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -140,21 +140,14 @@
         Replacements="@JAVA_INTEROP_COMMIT@=in-tree;@SQLITE_COMMIT@=$(_BuildInfo_SqliteCommit);@XAMARIN_ANDROID_TOOLS_COMMIT@=in-tree;">
     </ReplaceFileContents>
     <ItemGroup>
-      <_XACommonPropsReplacement Include="@COMMAND_LINE_TOOLS_VERSION@=$(CommandLineToolsFolder)" />
       <_XACommonPropsReplacement Include="@BUNDLETOOL_VERSION@=$(XABundleToolVersion)" />
-      <_XACommonPropsReplacement Include="@JAVA_SDK_VERSION@=$(JavaSdkVersion)" />
       <_XACommonPropsReplacement Include="@MIN_SUPPORTED_JDK_VERSION@=$(MinimumSupportedJavaSdkVersion)" />
-      <!-- <_XACommonPropsReplacement Include="@NDK_PKG_REVISION@=$(AndroidNdkPkgRevision)" /> -->
-      <_XACommonPropsReplacement Include="@NDK_PKG_REVISION@=26.3.11579264" />
       <_XACommonPropsReplacement Include="@NDK_ARM64_V8A_API@=$(AndroidNdkApiLevel_ArmV8a)" />
       <_XACommonPropsReplacement Include="@NDK_ARMEABI_V7_API@=$(AndroidNdkApiLevel_ArmV7a)" />
       <_XACommonPropsReplacement Include="@NDK_X86_64_API@=$(AndroidNdkApiLevel_X86_64)" />
       <_XACommonPropsReplacement Include="@NDK_X86_API@=$(AndroidNdkApiLevel_X86)" />
       <_XACommonPropsReplacement Include="@PACKAGE_VERSION_BUILD@=$(XAVersionCommitCount)" />
       <_XACommonPropsReplacement Include="@PACKAGE_VERSION@=$(ProductVersion)" />
-      <_XACommonPropsReplacement Include="@SDK_BUILD_TOOLS_VERSION@=$(XABuildToolsFolder)" />
-      <_XACommonPropsReplacement Include="@SDK_PLATFORM_TOOLS_VERSION@=$(XAPlatformToolsVersion)" />
-      <_XACommonPropsReplacement Include="@SDK_PLATFORM_VERSION@=android-$(AndroidLatestStablePlatformId)" />
     </ItemGroup>
     <ReplaceFileContents
         SourceFile="Xamarin.Android.Common.props.in"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -1,13 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<AndroidSdkBuildToolsVersion Condition=" '$(AndroidSdkBuildToolsVersion)' == '' ">@SDK_BUILD_TOOLS_VERSION@</AndroidSdkBuildToolsVersion>
-		<AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">@SDK_PLATFORM_TOOLS_VERSION@</AndroidSdkPlatformToolsVersion>
-		<AndroidSdkPlatformVersion Condition=" '$(AndroidSdkPlatformVersion)' == '' ">@SDK_PLATFORM_VERSION@</AndroidSdkPlatformVersion>
-
-		<AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">@COMMAND_LINE_TOOLS_VERSION@</AndroidCommandLineToolsVersion>
-		<AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
-		<AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">@NDK_PKG_REVISION@</AndroidNdkVersion>
-		<JavaSdkVersion Condition="'$(JavaSdkVersion)' == ''">@JAVA_SDK_VERSION@</JavaSdkVersion>
 		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">@MIN_SUPPORTED_JDK_VERSION@</MinimumSupportedJavaVersion>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -114,8 +114,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 *******************************************
 -->
 
-<Import Project="$(MSBuildThisFileDirectory)Xamarin.Installer.Common.props"
-	Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Installer.Common.props') And '$(DesignTimeBuild)' != 'true'"/>
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Installer.Common.props" />
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.props"
 	Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Android.Common.props')" />

--- a/src/Xamarin.Installer.AndroidSDK/Feeds/AndroidManifestFeed_d18.0.xml
+++ b/src/Xamarin.Installer.AndroidSDK/Feeds/AndroidManifestFeed_d18.0.xml
@@ -167,7 +167,29 @@
 			<url host-os="windows" host-bits="0" size="6304111" checksum-type="sha1" checksum="2d7599f59b54f02c4ecd33d656091a3c1e55ad9c">https://dl.google.com/android/repository/platform-tools_r33.0.2-windows.zip</url>
 		</urls>
 	</platform-tools>
-	<cmdline-tools revision="19.0" path="cmdline-tools;19.0" filesystem-path="cmdline-tools/latest" manifest-url="https://dl.google.com/android/repository/repository2-3.xml" description="Android SDK Command-line Tools (latest)" obsolete="False" preview="False" license="android-sdk-license" original-type="generic:genericDetailsType">
+	<cmdline-tools revision="22.0" path="cmdline-tools;22.0" filesystem-path="cmdline-tools/latest" manifest-url="https://dl.google.com/android/repository/repository2-3.xml" description="Android SDK Command-line Tools (latest)" obsolete="False" preview="False" license="android-sdk-license" original-type="generic:genericDetailsType">
+		<urls>
+			<url host-os="linux" host-bits="0" size="181833628" checksum-type="sha1" checksum="040d3996a65543d22ec4bf73e4c37aa37a8d4af4">https://dl.google.com/android/repository/commandlinetools-linux-15859902_latest.zip</url>
+			<url host-os="macosx" host-arch="x64" host-bits="0" size="156281494" checksum-type="sha1" checksum="1a79e61677b99cb0ce622792713cbea7ff2dc5de">https://dl.google.com/android/repository/commandlinetools-mac_x86_64-15859902_latest.zip</url>
+			<url host-os="macosx" host-arch="aarch64" host-bits="0" size="156083281" checksum-type="sha1" checksum="c4e0dbc53f1a4ce04fc2b11d4e2c4675001a95af">https://dl.google.com/android/repository/commandlinetools-mac_arm64-15859902_latest.zip</url>
+			<url host-os="windows" host-bits="0" size="155655386" checksum-type="sha1" checksum="b9862337a13e2809a5159dc3a08d058091bd59f6">https://dl.google.com/android/repository/commandlinetools-win-15859902_latest.zip</url>
+		</urls>
+	</cmdline-tools>
+	<cmdline-tools revision="21.0" path="cmdline-tools;21.0" filesystem-path="cmdline-tools/21.0" manifest-url="https://dl.google.com/android/repository/repository2-3.xml" description="Android SDK Command-line Tools" obsolete="False" preview="False" license="android-sdk-license" original-type="generic:genericDetailsType">
+		<urls>
+			<url host-os="linux" host-bits="0" size="174244366" checksum-type="sha1" checksum="63523a02a975a81102238566f2a16c057d52301e">https://dl.google.com/android/repository/commandlinetools-linux-15641748_latest.zip</url>
+			<url host-os="macosx" host-bits="0" size="152127646" checksum-type="sha1" checksum="b62a5d8cf63ded173b47be867be4ee058ceda6df">https://dl.google.com/android/repository/commandlinetools-mac-15641748_latest.zip</url>
+			<url host-os="windows" host-bits="0" size="151965705" checksum-type="sha1" checksum="2bea1388b8a248040a340a08ca0638138633f687">https://dl.google.com/android/repository/commandlinetools-win-15641748_latest.zip</url>
+		</urls>
+	</cmdline-tools>
+	<cmdline-tools revision="20.0" path="cmdline-tools;20.0" filesystem-path="cmdline-tools/20.0" manifest-url="https://dl.google.com/android/repository/repository2-3.xml" description="Android SDK Command-line Tools" obsolete="False" preview="False" license="android-sdk-license" original-type="generic:genericDetailsType">
+		<urls>
+			<url host-os="linux" host-bits="0" size="172789259" checksum-type="sha1" checksum="48833c34b761c10cb20bcd16582129395d121b27">https://dl.google.com/android/repository/commandlinetools-linux-14742923_latest.zip</url>
+			<url host-os="macosx" host-bits="0" size="150703968" checksum-type="sha1" checksum="cc27cca4b84bfdbc7df17e3d0a01d0c640d8ee71">https://dl.google.com/android/repository/commandlinetools-mac-14742923_latest.zip</url>
+			<url host-os="windows" host-bits="0" size="150532528" checksum-type="sha1" checksum="16b3f45ddb3d85ea6bbe6a1c0b47146daf0db450">https://dl.google.com/android/repository/commandlinetools-win-14742923_latest.zip</url>
+		</urls>
+	</cmdline-tools>
+	<cmdline-tools revision="19.0" path="cmdline-tools;19.0" filesystem-path="cmdline-tools/19.0" manifest-url="https://dl.google.com/android/repository/repository2-3.xml" description="Android SDK Command-line Tools" obsolete="False" preview="False" license="android-sdk-license" original-type="generic:genericDetailsType">
 		<urls>
 			<url host-os="linux" host-bits="0" size="164760899" checksum-type="sha1" checksum="5fdcc763663eefb86a5b8879697aa6088b041e70">https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip</url>
 			<url host-os="macosx" host-bits="0" size="143250852" checksum-type="sha1" checksum="c3e06a1959762e89167d1cbaa988605f6f7c1d24">https://dl.google.com/android/repository/commandlinetools-mac-13114758_latest.zip</url>

--- a/src/Xamarin.Installer.Build.Tasks/Tasks/InstallAndroidDependencies.cs
+++ b/src/Xamarin.Installer.Build.Tasks/Tasks/InstallAndroidDependencies.cs
@@ -184,11 +184,11 @@ namespace Xamarin.Installer.Build.Tasks
 					.FirstOrDefault ();
 				if (matchingComponent != null)
 				{
-					if (!matchingComponent.Present && !matchingComponent.Obsolete) {
+					if ((!matchingComponent.Present || matchingComponent.NeedsUpdate) && !matchingComponent.Obsolete) {
 						Debug ($"Adding dependency '{dependencyPath}/{version}'.");
 						components.Add (matchingComponent);
 					} else {
-						Debug ($"Skipping dependency '{dependencyPath}/{version}' as it is already installed or obsolete.");
+						Debug ($"Skipping dependency '{dependencyPath}/{version}' as it is already up-to-date or obsolete.");
 					}
 				}
 				else

--- a/src/Xamarin.Installer.Build.Tasks/Xamarin.Installer.Common.props
+++ b/src/Xamarin.Installer.Build.Tasks/Xamarin.Installer.Common.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">37.0.0</AndroidSdkBuildToolsVersion>
-    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">19.0</AndroidCommandLineToolsVersion>
+    <AndroidCommandLineToolsVersion Condition="'$(AndroidCommandLineToolsVersion)' == ''">22.0</AndroidCommandLineToolsVersion>
     <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">37.0.1</AndroidSdkPlatformToolsVersion>
     <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
     <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-37.0</AndroidSdkPlatformVersion>


### PR DESCRIPTION
## Description

An internal pipeline test began failing in `_LintChecks` after moving to JDK 25. The installed Android lint tooling threw `java.lang.IllegalArgumentException: 25.0.4.1` from IntelliJ's `JavaVersion.parse()`. Although the repository bootstrap selected newer command-line tools, the generated workload still selected command-line tools 19.0 and then fell back to `cmdline-tools/latest` when that version was unavailable.

The mismatch came from duplicated Android tooling defaults in `Xamarin.Installer.Common.props` and `Xamarin.Android.Common.props`. `Xamarin.Installer.Common.props` is imported first, followed by `Xamarin.Android.Common.props`. A later MSBuild property assignment would normally overwrite an earlier one, but both files guarded these assignments with `Condition="'$(Property)' == ''"`. The Installer props therefore set the values first, and the later Common props assignments were skipped because the properties were no longer empty. This change makes `Xamarin.Installer.Common.props` the shared source of those defaults and removes the duplicated generated properties and replacement tokens.

Command-line tools 23.0 cannot yet be the installer default because `sdkmanager --licenses` becomes a no-op starting in 23.0. It exits successfully after printing:

```
The --licenses option is no longer needed
```

The installer currently relies on that command to write Google's license hashes, so the default is updated to command-line tools 22.0 instead. Command-line tools 20.0, 21.0, and 22.0 are added to `AndroidManifestFeed_d18.0.xml`, allowing those versions to be installed by the Android SDK Manager in Visual Studio, with 22.0 marked as `latest`.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [x] Unit tests — existing installer projects build successfully; manifest XML and diff formatting validated.