### PR TITLE
[native] Use a raw pointer for the CoreCLR host's Timing instance

### DIFF
--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -316,7 +316,7 @@ void Host::Java_mono_android_Runtime_initInternal (
 	FastTiming::initialize ((Logger::log_timing_categories() & LogTimingCategories::FastBare) != LogTimingCategories::FastBare);
 
 	if (FastTiming::enabled ()) [[unlikely]] {
-		_timing = std::make_shared<Timing> ();
+		_timing = new Timing ();
 		internal_timing.start_event (TimingEventKind::TotalRuntimeInit);
 	}
 

--- a/src/native/clr/host/internal-pinvokes-clr.cc
+++ b/src/native/clr/host/internal-pinvokes-clr.cc
@@ -41,11 +41,8 @@ _monodroid_lookup_replacement_method_info (const char *jniSourceType, const char
 
 managed_timing_sequence* monodroid_timing_start (const char *message)
 {
-	// Technically a reference here is against the idea of shared pointers, but
-	// in this instance it's fine since we know we won't be storing the pointer
-	// and this way things are slightly faster.
-	std::shared_ptr<Timing> const &timing = Host::get_timing ();
-	if (!timing) {
+	Timing *timing = Host::get_timing ();
+	if (timing == nullptr) {
 		return nullptr;
 	}
 
@@ -64,8 +61,8 @@ void monodroid_timing_stop (managed_timing_sequence *sequence, const char *messa
 		return;
 	}
 
-	std::shared_ptr<Timing> const &timing = Host::get_timing ();
-	if (!timing) [[unlikely]] {
+	Timing *timing = Host::get_timing ();
+	if (timing == nullptr) [[unlikely]] {
 		return;
 	}
 

--- a/src/native/clr/include/host/host.hh
+++ b/src/native/clr/include/host/host.hh
@@ -23,7 +23,7 @@ namespace xamarin::android {
 		static void Java_mono_android_Runtime_registerNatives (JNIEnv *env, jclass nativeClass) noexcept;
 		static void propagate_uncaught_exception (JNIEnv *env, jobject javaThread, jthrowable javaException) noexcept;
 
-		static auto get_timing () -> std::shared_ptr<Timing>
+		static auto get_timing () noexcept -> Timing*
 		{
 			return _timing;
 		}
@@ -54,7 +54,7 @@ namespace xamarin::android {
 	private:
 		static inline void *clr_host = nullptr;
 		static inline unsigned int domain_id = 0;
-		static inline std::shared_ptr<Timing> _timing{};
+		static inline Timing *_timing = nullptr;
 		static inline bool found_assembly_store = false;
 		static inline jnienv_register_jni_natives_fn jnienv_register_jni_natives = nullptr;
 		static inline jnienv_propagate_uncaught_exception_fn jnienv_propagate_uncaught_exception = nullptr;

--- a/src/native/clr/include/host/host.hh
+++ b/src/native/clr/include/host/host.hh
@@ -54,6 +54,8 @@ namespace xamarin::android {
 	private:
 		static inline void *clr_host = nullptr;
 		static inline unsigned int domain_id = 0;
+		// Allocated once, if fast timing is enabled, and intentionally never freed: the instance
+		// is used for the whole lifetime of the process and released by the OS when it exits.
 		static inline Timing *_timing = nullptr;
 		static inline bool found_assembly_store = false;
 		static inline jnienv_register_jni_natives_fn jnienv_register_jni_natives = nullptr;


### PR DESCRIPTION
Part of #12533.

`Host::_timing` is a process-lifetime singleton: it is created once, when fast timing is enabled, and never released. Holding it in a `std::shared_ptr` bought us nothing but a control block allocation and atomic refcount traffic on every `get_timing ()` call — the call sites even bound the returned shared pointer to a `const&` to dodge the refcount, with a comment apologising for it:

```c++
// Technically a reference here is against the idea of shared pointers, but
// in this instance it's fine since we know we won't be storing the pointer
// and this way things are slightly faster.
std::shared_ptr<Timing> const &timing = Host::get_timing ();
```

Store a plain `Timing*` instead.

### Effect

This removes the last `std::shared_ptr` from the CoreCLR host, dropping all five `std::__ndk1::__shared_weak_count` references plus one static initialisation guard pair:

| | undefined libc++ symbols in `libnet-android.release-static-release.a` |
|---|---|
| before | 55 |
| after | **48** |

For reference, the NativeAOT host is already at **0**, which is the target for CoreCLR.

The allocation itself is deliberately unchanged — removing the remaining `new`/`delete` calls is a separate cause, tracked in #12533.
