### PR TITLE
[tests] Route XBD Google Maven downloads through mirror

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -76,6 +76,9 @@ variables:
   value: true
 - name: DOTNET_GENERATE_ASPNET_CERTIFICATE
   value: false
+# XBD Google Maven mirror support: https://github.com/dotnet/android-libraries/commit/4fe06d57f3ef7905fab0257d7246c97464d29e74
+- name: XamarinBuildDownloadGoogleMavenRepository
+  value: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1
 # Fix network isolation requirements
 # See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
 - name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -835,6 +835,7 @@ class MemTest {
 					new Package { Id = "Xamarin.GooglePlayServices.Base", Version = "118.2.0.5" },
 					new Package { Id = "Xamarin.GooglePlayServices.Basement", Version = "118.2.0.5" },
 					new Package { Id = "Xamarin.GooglePlayServices.Tasks", Version = "118.0.2.6" },
+					KnownPackages.Xamarin_Build_Download,
 				}
 			};
 			proj.SetRuntime (runtime);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -127,7 +127,7 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package Xamarin_Build_Download = new Package {
 			Id = "Xamarin.Build.Download",
-			Version = "0.11.4",
+			Version = "0.11.6",
 		};
 		public static Package NuGet_Build_Packaging = new Package {
 			Id = "NuGet.Build.Packaging",


### PR DESCRIPTION
## Summary

- update the test Xamarin.Build.Download pin from 0.11.4 to 0.11.6
- expose `XamarinBuildDownloadGoogleMavenRepository` repository-wide through the shared Azure Pipelines variables template
- route eligible Google Maven downloads through dnceng's `dotnet-public-maven` feed
- directly pin the Google Play Services test that would otherwise resolve XBD 0.11.4 transitively

The XBD implementation only rewrites URLs beginning with `https://dl.google.com/dl/android/maven2/`; Android SDK/NDK and partial ZIP URLs such as `dl-ssl.google.com/android/repository/...` remain unchanged.

## Validation

- parsed the shared pipeline variables YAML
- verified an uppercase Azure Pipelines-style environment variable reaches nested `dotnet msbuild` as `$(XamarinBuildDownloadGoogleMavenRepository)`
- built `xa-prep-tasks` and `Xamarin.ProjectTools`
- inspected the relevant NuGet dependency graphs to identify transitive XBD consumers
- migrated Xamarin.Build.Download 0.11.6 through the quarantine feed and verified it is available on dnceng `dotnet-public`

Implementation reference: https://github.com/dotnet/android-libraries/commit/4fe06d57f3ef7905fab0257d7246c97464d29e74