### PR TITLE
[native] Remove the libc++ dependencies from FastTiming

### DIFF
--- a/src/native/common/include/runtime-base/timing-internal.hh
+++ b/src/native/common/include/runtime-base/timing-internal.hh
@@ -78,15 +78,18 @@ namespace xamarin::android {
 		// normal application startup.
 		static constexpr size_t EVENT_CHUNK_SIZE = 4096uz;
 
-		// Upper bound on how deeply timing events may nest on a single thread.  Every
-		// `start_event` is matched by exactly one `end_event` or `store_more_info`, so the
-		// depth is determined purely by how deeply the instrumented calls nest (currently 3).
-		static constexpr size_t MAX_OPEN_SEQUENCES = 16uz;
-
 		struct TimingEventChunk
 		{
 			TimingEvent events [EVENT_CHUNK_SIZE];
 			TimingEventChunk *next = nullptr;
+		};
+
+		// A single entry on the per-thread stack of timing events which have been started but
+		// not yet ended.
+		struct OpenSequence
+		{
+			TimingEvent *event;
+			OpenSequence *next;
 		};
 
 		// defaults
@@ -412,30 +415,38 @@ namespace xamarin::android {
 		[[gnu::always_inline]]
 		static void push_sequence_event (TimingEvent *event) noexcept
 		{
-			size_t depth = open_sequence_depth++;
-			if (depth < MAX_OPEN_SEQUENCES) [[likely]] {
-				open_sequences [depth] = event;
+			auto *entry = static_cast<OpenSequence*> (std::malloc (sizeof (OpenSequence)));
+			if (entry == nullptr) [[unlikely]] {
+				Helpers::abort_application (LOG_TIMING, "Unable to allocate memory for an open timing sequence");
 			}
+
+			entry->event = event;
+			entry->next = open_sequences;
+			open_sequences = entry;
 		}
 
 		[[gnu::always_inline]]
 		static auto get_sequence_event () noexcept -> TimingEvent*
 		{
-			size_t depth = open_sequence_depth;
-			if (depth == 0uz || depth > MAX_OPEN_SEQUENCES) [[unlikely]] {
+			OpenSequence *entry = open_sequences;
+			if (entry == nullptr) [[unlikely]] {
 				return nullptr;
 			}
 
-			return open_sequences [depth - 1uz];
+			return entry->event;
 		}
 
 		[[gnu::always_inline]]
 		static auto pop_sequence_event () noexcept -> TimingEvent*
 		{
-			TimingEvent *event = get_sequence_event ();
-			if (open_sequence_depth > 0uz) [[likely]] {
-				open_sequence_depth--;
+			OpenSequence *entry = open_sequences;
+			if (entry == nullptr) [[unlikely]] {
+				return nullptr;
 			}
+
+			TimingEvent *event = entry->event;
+			open_sequences = entry->next;
+			std::free (entry);
 
 			return event;
 		}
@@ -566,8 +577,7 @@ namespace xamarin::android {
 		TimingEventChunk *first_event_chunk = nullptr;
 		std::unique_ptr<std::string> output_file_name{};
 
-		static inline thread_local TimingEvent *open_sequences [MAX_OPEN_SEQUENCES] {};
-		static inline thread_local size_t open_sequence_depth = 0uz;
+		static inline thread_local OpenSequence *open_sequences = nullptr;
 		static inline thread_local TimingEventChunk *cached_event_chunk = nullptr;
 		static inline thread_local size_t cached_event_chunk_index = 0uz;
 		static inline bool is_enabled = false;

--- a/src/native/common/include/runtime-base/timing-internal.hh
+++ b/src/native/common/include/runtime-base/timing-internal.hh
@@ -5,11 +5,10 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <functional>
 #include <limits>
-#include <memory>
-#include <string>
 #include <string_view>
 #include <thread>
 
@@ -64,7 +63,7 @@ namespace xamarin::android {
 		time_point                   start;
 		time_point                   end;
 		TimingEventKind              kind;
-		std::string                 *more_info = nullptr;
+		char                        *more_info = nullptr;
 		bool                         complete = false;
 	};
 
@@ -103,6 +102,9 @@ namespace xamarin::android {
 		static constexpr std::string_view OPT_FILE_NAME     { "filename=" };
 		static constexpr std::string_view OPT_TO_FILE       { "to-file" };
 
+		// Enough to hold any value the `debug.mono.timing` property can carry, `PROP_VALUE_MAX` is 92.
+		static constexpr size_t MAX_TIMING_FILE_NAME_SIZE = 128uz;
+
 	protected:
 		void configure_for_use () noexcept
 		{
@@ -119,7 +121,7 @@ namespace xamarin::android {
 			while (chunk != nullptr) {
 				TimingEventChunk *next = chunk->next;
 				for (TimingEvent &event : chunk->events) {
-					delete event.more_info;
+					std::free (event.more_info);
 				}
 				std::free (chunk);
 				chunk = next;
@@ -214,7 +216,7 @@ namespace xamarin::android {
 				event.before_managed ? "[0/" : "[1/",
 				static_cast<unsigned int>(event.kind),
 				event_kind_description (event.kind),
-				event.more_info == nullptr ? "" : event.more_info->c_str (),
+				event.more_info == nullptr ? "" : event.more_info,
 				static_cast<unsigned long long>(chrono::duration_cast<chrono::seconds>(interval).count ()),
 				static_cast<unsigned long long>(chrono::duration_cast<chrono::milliseconds>(interval).count ()),
 				static_cast<unsigned long long>((interval % 1ms).count ())
@@ -275,7 +277,7 @@ namespace xamarin::android {
 				return;
 			}
 
-			if (skip_log_if_more_info_missing && (event.more_info == nullptr || event.more_info->empty ())) {
+			if (skip_log_if_more_info_missing && (event.more_info == nullptr || event.more_info[0] == '\0')) {
 				return;
 			}
 
@@ -316,7 +318,7 @@ namespace xamarin::android {
 		[[gnu::always_inline]]
 		void add_more_info (const char *str, size_t length) noexcept
 		{
-			store_more_info (new std::string (str, length));
+			store_more_info (duplicate_more_info (std::string_view { str, length }, {}));
 		}
 
 		// Builds the message from two parts, so that its exact length is known up front and the
@@ -324,9 +326,7 @@ namespace xamarin::android {
 		[[gnu::always_inline]]
 		void add_more_info (std::string_view const& first, std::string_view const& second) noexcept
 		{
-			auto *more_info = new std::string (first.data (), first.length ());
-			more_info->append (second);
-			store_more_info (more_info);
+			store_more_info (duplicate_more_info (first, second));
 		}
 
 		[[gnu::always_inline]]
@@ -396,13 +396,40 @@ namespace xamarin::android {
 		void dump_to_file (size_t entries) noexcept;
 		void dump (size_t entries, bool indent, std::function<void(std::string_view const&)> line_writer) noexcept;
 
+		// Returns a NUL-terminated copy of `first` and `second` concatenated, or `nullptr` if it
+		// cannot be allocated. Timing is a diagnostic facility, so a failure here only costs us the
+		// extra information attached to a single event and must not bring the application down.
+		[[gnu::always_inline]]
+		static auto duplicate_more_info (std::string_view const& first, std::string_view const& second) noexcept -> char*
+		{
+			size_t length = Helpers::add_with_overflow_check<size_t> (first.length (), second.length ());
+			auto *more_info = static_cast<char*> (std::malloc (Helpers::add_with_overflow_check<size_t> (length, 1uz)));
+			if (more_info == nullptr) [[unlikely]] {
+				return nullptr;
+			}
+
+			// `memcpy` must not be called with a `nullptr` source, not even for a zero length, and an
+			// empty `std::string_view` is allowed to have a `nullptr` data pointer.
+			if (!first.empty ()) {
+				std::memcpy (more_info, first.data (), first.length ());
+			}
+
+			if (!second.empty ()) {
+				std::memcpy (more_info + first.length (), second.data (), second.length ());
+			}
+
+			more_info[length] = '\0';
+
+			return more_info;
+		}
+
 		// Takes ownership of `more_info`.
 		[[gnu::always_inline]]
-		void store_more_info (std::string *more_info) noexcept
+		void store_more_info (char *more_info) noexcept
 		{
 			TimingEvent *event = pop_sequence_event ();
 			if (event == nullptr) [[unlikely]] {
-				delete more_info;
+				std::free (more_info);
 				log_warnf (LOG_TIMING, "FastTiming::add_more_info called without prior FastTiming::start_event called");
 				return;
 			}
@@ -575,7 +602,10 @@ namespace xamarin::android {
 	private:
 		std::atomic_size_t next_event_index = 0uz;
 		TimingEventChunk *first_event_chunk = nullptr;
-		std::unique_ptr<std::string> output_file_name{};
+		// The name is read from the `debug.mono.timing` system property, whose whole value is limited
+		// to `PROP_VALUE_MAX` (92) bytes, so a fixed buffer is always large enough. Keeping it inline
+		// also keeps `FastTiming` constant-initialized, so the global instance needs no guard variable.
+		char output_file_name[MAX_TIMING_FILE_NAME_SIZE] = {};
 
 		static inline thread_local OpenSequence *open_sequences = nullptr;
 		static inline thread_local TimingEventChunk *cached_event_chunk = nullptr;

--- a/src/native/common/include/runtime-base/timing-internal.hh
+++ b/src/native/common/include/runtime-base/timing-internal.hh
@@ -9,7 +9,6 @@
 #include <functional>
 #include <limits>
 #include <memory>
-#include <stack>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -78,6 +77,11 @@ namespace xamarin::android {
 		// value large enough to avoid allocating additional chunks during
 		// normal application startup.
 		static constexpr size_t EVENT_CHUNK_SIZE = 4096uz;
+
+		// Upper bound on how deeply timing events may nest on a single thread.  Every
+		// `start_event` is matched by exactly one `end_event` or `store_more_info`, so the
+		// depth is determined purely by how deeply the instrumented calls nest (currently 3).
+		static constexpr size_t MAX_OPEN_SEQUENCES = 16uz;
 
 		struct TimingEventChunk
 		{
@@ -283,7 +287,7 @@ namespace xamarin::android {
 			ev.start = get_time ();
 			ev.kind = kind;
 			ev.before_managed = MonodroidState::is_startup_in_progress ();
-			open_sequences.push (&ev);
+			push_sequence_event (&ev);
 		}
 
 		// If `uses_more_info` is `true`, the caller **MUST** call `add_more_info`, since the
@@ -406,21 +410,31 @@ namespace xamarin::android {
 		}
 
 		[[gnu::always_inline]]
-		auto get_sequence_event () noexcept -> TimingEvent*
+		static void push_sequence_event (TimingEvent *event) noexcept
 		{
-			if (open_sequences.empty ()) [[unlikely]] {
-				return nullptr;
+			size_t depth = open_sequence_depth++;
+			if (depth < MAX_OPEN_SEQUENCES) [[likely]] {
+				open_sequences [depth] = event;
 			}
-
-			return open_sequences.top ();
 		}
 
 		[[gnu::always_inline]]
-		auto pop_sequence_event () noexcept -> TimingEvent*
+		static auto get_sequence_event () noexcept -> TimingEvent*
+		{
+			size_t depth = open_sequence_depth;
+			if (depth == 0uz || depth > MAX_OPEN_SEQUENCES) [[unlikely]] {
+				return nullptr;
+			}
+
+			return open_sequences [depth - 1uz];
+		}
+
+		[[gnu::always_inline]]
+		static auto pop_sequence_event () noexcept -> TimingEvent*
 		{
 			TimingEvent *event = get_sequence_event ();
-			if (event != nullptr) [[likely]] {
-				open_sequences.pop ();
+			if (open_sequence_depth > 0uz) [[likely]] {
+				open_sequence_depth--;
 			}
 
 			return event;
@@ -552,7 +566,8 @@ namespace xamarin::android {
 		TimingEventChunk *first_event_chunk = nullptr;
 		std::unique_ptr<std::string> output_file_name{};
 
-		static inline thread_local std::stack<TimingEvent*> open_sequences;
+		static inline thread_local TimingEvent *open_sequences [MAX_OPEN_SEQUENCES] {};
+		static inline thread_local size_t open_sequence_depth = 0uz;
 		static inline thread_local TimingEventChunk *cached_event_chunk = nullptr;
 		static inline thread_local size_t cached_event_chunk_index = 0uz;
 		static inline bool is_enabled = false;

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -54,7 +54,14 @@ void FastTiming::parse_options (const char *options) noexcept
 		if (param_length == OPT_TO_FILE.length () && strncmp (param, OPT_TO_FILE.data (), param_length) == 0) {
 			log_to_file = true;
 		} else if (param_length >= OPT_FILE_NAME.length () && strncmp (param, OPT_FILE_NAME.data (), OPT_FILE_NAME.length ()) == 0) {
-			output_file_name = std::make_unique<std::string> (param + OPT_FILE_NAME.length (), param_length - OPT_FILE_NAME.length ());
+			const char *name = param + OPT_FILE_NAME.length ();
+			size_t name_length = param_length - OPT_FILE_NAME.length ();
+			if (name_length >= sizeof (output_file_name)) [[unlikely]] {
+				log_warnf (LOG_TIMING, "Timing file name '%.*s' is too long, will use the default one", static_cast<int>(name_length), name);
+			} else {
+				memcpy (output_file_name, name, name_length);
+				output_file_name[name_length] = '\0';
+			}
 		} else if (param_length >= OPT_DURATION.length () && strncmp (param, OPT_DURATION.data (), OPT_DURATION.length ()) == 0) {
 			const char *duration = param + OPT_DURATION.length ();
 			char *end;
@@ -71,7 +78,7 @@ void FastTiming::parse_options (const char *options) noexcept
 		param = separator == nullptr ? nullptr : separator + 1;
 	}
 
-	if (output_file_name) {
+	if (output_file_name[0] != '\0') {
 		log_to_file = true;
 	}
 
@@ -232,7 +239,7 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 		return;
 	}
 
-	std::string_view file_name = output_file_name == nullptr ? default_timing_file_name : *output_file_name;
+	std::string_view file_name = output_file_name[0] == '\0' ? default_timing_file_name : std::string_view { output_file_name };
 	char stack_buffer [Util::LocalPathBufferSize];
 	char *timing_log_path = Util::join_paths (stack_buffer, sizeof (stack_buffer), temporary_directory, file_name);
 

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -21,8 +21,8 @@ void FastTiming::really_initialize (bool log_immediately) noexcept
 
 	// TLS variables are initialized on first use, do it here so that we can have
 	// the overhead out of mind later, at least for the main thread.
-	open_sequences.push (0);
-	open_sequences.pop ();
+	push_sequence_event (nullptr);
+	pop_sequence_event ();
 
 	// Options in `debug.mono.timing` are relevant only when immediate logging is disabled
 	if (immediate_logging) {


### PR DESCRIPTION
Part of #12533. Stacked on top of #12545.

### The problem

`FastTiming::open_sequences` tracks the timing events which have been started but not yet ended on each thread:

```c++
static inline thread_local std::stack<TimingEvent*> open_sequences;
```

`std::stack` defaults to `std::deque` as its underlying container, and `std::deque` has both a non-trivial constructor and a non-trivial destructor. For a `thread_local`, that means every translation unit which includes `timing-internal.hh` emits a guarded dynamic initializer for it, plus a `__cxa_thread_atexit` registration so the deque is destroyed when the thread exits. `timing-internal.hh` is included by both the CoreCLR and the MonoVM hosts.

### The change

The stack is only ever used through `push`, `top`, `pop` and `empty`, so a naive singly linked list is enough — no need for libc++ here:

```c++
struct OpenSequence
{
    TimingEvent *event;
    OpenSequence *next;
};

static inline thread_local OpenSequence *open_sequences = nullptr;
```

The head pointer is a plain pointer, so it is trivially destructible and constant initialized: no guard variable, and nothing to register with `__cxa_thread_atexit`. The list itself is unbounded — any number of events may be open at once, exactly as before.

**Locking:** `open_sequences` is `thread_local`, so the list is private to its thread and needs no lock. This change keeps it that way — no state moves into shared storage — so there is still nothing to synchronize.

**Lifetime:** nodes are freed as they are popped rather than being recycled. That matters here because, unlike the process-wide timing sequence pool in #12545, this list is per thread and threads come and go — recycling nodes would mean every thread that ever recorded a timing event left its nodes behind. A thread that balances its `start_event` and `end_event` calls now leaves nothing allocated when it exits. Allocation failure aborts, matching how the timing sequence chunks behave.

### Results

Undefined libc++ references across the three archives the CoreCLR host links, `libnet-android.release-static-release.a`, `libruntime-base-release.a` and `libruntime-base-common-release.a`:

| symbol | before | after |
| --- | ---: | ---: |
| `__cxa_thread_atexit` | 4 | **0** |
| `std::__ndk1::__libcpp_verbose_abort(char const*, ...)` | 5 | 4 |
| **total** | **64** | **59** |

This removes the `__cxa_thread_atexit` category entirely.

### Verification

- CoreCLR and MonoVM both build clean (only the pre-existing `format_managed_type_name` warning).
- Symbol counts above measured with `llvm-nm --undefined-only` over all three archives, before and after, on the same build tree.
- The `push`/`top`/`pop`/`empty` semantics were checked against a standalone harness with instrumented `malloc`/`free`, covering the empty, balanced-LIFO, interleaved, over-pop and 100 000-deep cases, asserting strict LIFO order and that every node is freed. 20/20 pass.
- `src/native/mono/` is untouched.


---

## Also: the two `std::string`s the earlier timing pass missed

#12513 removed the *local* strings from the timing code, but two heap-allocated ones survived in `FastTiming` and were only spotted later while attributing the remaining `libc++` references. They live in the same two files as the change above, so they are fixed here.

### `TimingEvent::more_info`

```c++
std::string *more_info = nullptr;
```

It is always built from one or two `std::string_view`s whose combined length is known up front, so it becomes a plain NUL-terminated `char*` produced by a single `malloc` plus one or two `memcpy`s. If the allocation fails we drop the extra information for that one event rather than aborting — timing is a diagnostic facility and must not take the application down with it.

### `FastTiming::output_file_name`

```c++
std::unique_ptr<std::string> output_file_name{};
```

The name is parsed out of the `debug.mono.timing` system property, whose entire value is capped at `PROP_VALUE_MAX` (92) bytes, so a fixed 128 byte buffer inside `FastTiming` is always large enough. Keeping it inline also keeps the global `internal_timing` instance constant-initialized, so it needs no guard variable. A name that does not fit is rejected with a warning and the default is used.

`<memory>` and `<string>` are no longer needed by `timing-internal.hh` at all.

## Result

Together with the `calloc` commit added to #12545, this clears the last `operator new`/`operator delete` references from **`timing-internal.cc.o` (2 → 0)** and, as a side effect, from **`typemap.cc.o` (2 → 0)** — `typemap.cc` had been inheriting them purely from the inlined `new TimingEventChunk` in `FastTiming::get_event`.

At the tip of the stack the CoreCLR total goes from **26 to 22**, and only two objects still reference `libc++`: `host.cc.o` (11) and `assembly-store.cc.o` (11).
