### PR TITLE
[native] Replace std::function with function pointers

### DIFF
--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -791,7 +791,7 @@ auto AssemblyStore::open_assembly (std::string_view const& name, int64_t &size) 
 	return assembly_data;
 }
 
-void AssemblyStore::configure_from_payload (const void *payload_start, const std::function<std::string()>& get_full_store_path) noexcept
+void AssemblyStore::configure_from_payload (const void *payload_start, const char *store_path) noexcept
 {
 	auto header = static_cast<const AssemblyStoreHeader*>(payload_start);
 
@@ -800,7 +800,7 @@ void AssemblyStore::configure_from_payload (const void *payload_start, const std
 			LOG_ASSEMBLY,
 			std::source_location::current (),
 			"Assembly store '%s' is not a valid .NET for Android assembly store file",
-			get_full_store_path ().c_str ()
+			optional_string (store_path)
 		);
 	}
 
@@ -809,7 +809,7 @@ void AssemblyStore::configure_from_payload (const void *payload_start, const std
 			LOG_ASSEMBLY,
 			std::source_location::current (),
 			"Assembly store '%s' uses format version %x, instead of the expected %x",
-			get_full_store_path ().c_str (),
+			optional_string (store_path),
 			header->version,
 			ASSEMBLY_STORE_FORMAT_VERSION
 		);
@@ -841,5 +841,5 @@ void AssemblyStore::configure_from_payload (const void *payload_start, const std
 		names_cursor += name_length;
 	}
 
-	log_debugf (LOG_ASSEMBLY, "Mapped assembly store %s; content ID 0x%" PRIx64, get_full_store_path ().c_str (), assembly_store_content_id);
+	log_debugf (LOG_ASSEMBLY, "Mapped assembly store %s; content ID 0x%" PRIx64, optional_string (store_path), assembly_store_content_id);
 }

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -197,7 +197,7 @@ void Host::map_assembly_store_via_dlopen (const char *store_path) noexcept
 	}
 
 	log_debugf (LOG_ASSEMBLY, "Assembly store payload via dynamic symbol: %p (%s)", payload, optional_string (store_path));
-	AssemblyStore::configure_from_payload (payload, [store_path]() -> std::string { return std::string { store_path }; });
+	AssemblyStore::configure_from_payload (payload, store_path);
 	found_assembly_store = true;
 }
 

--- a/src/native/clr/include/host/assembly-store.hh
+++ b/src/native/clr/include/host/assembly-store.hh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 #include <limits>
 #include <pthread.h>
 #include <string>
@@ -19,9 +18,8 @@ namespace xamarin::android {
 		// Configure the store directly from an in-memory payload pointer (obtained via
 		// dlopen()+dlsym() of the `_assembly_store` dynamic symbol). The payload is mapped
 		// read-only and is never modified, so it (and every pointer derived from it) is `const`.
-		// `get_full_store_path` is invoked only to build diagnostics if the payload turns out
-		// to be invalid.
-		static void configure_from_payload (const void *payload_start, const std::function<std::string()>& get_full_store_path) noexcept;
+		// `store_path` is used only in diagnostic messages.
+		static void configure_from_payload (const void *payload_start, const char *store_path) noexcept;
 
 	private:
 		static void set_assembly_data_and_size (uint8_t* source_assembly_data, uint32_t source_assembly_data_size, uint8_t*& dest_assembly_data, uint32_t& dest_assembly_data_size) noexcept;

--- a/src/native/clr/include/host/assembly-store.hh
+++ b/src/native/clr/include/host/assembly-store.hh
@@ -18,7 +18,8 @@ namespace xamarin::android {
 		// Configure the store directly from an in-memory payload pointer (obtained via
 		// dlopen()+dlsym() of the `_assembly_store` dynamic symbol). The payload is mapped
 		// read-only and is never modified, so it (and every pointer derived from it) is `const`.
-		// `store_path` is used only in diagnostic messages.
+		// `store_path` is used only in diagnostic messages and may be `nullptr` - every use of it
+		// goes through `optional_string ()`.
 		static void configure_from_payload (const void *payload_start, const char *store_path) noexcept;
 
 	private:

--- a/src/native/common/include/runtime-base/timing-internal.hh
+++ b/src/native/common/include/runtime-base/timing-internal.hh
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
-#include <functional>
 #include <limits>
 #include <string_view>
 #include <thread>
@@ -391,10 +390,14 @@ namespace xamarin::android {
 		}
 
 	private:
+		// Writes a single output line.  `context` is the opaque value passed to `dump`, which
+		// lets a caller thread state through without needing a capturing lambda.
+		using LineWriter = void (*) (void *context, std::string_view const& line);
+
 		bool no_events_logged (size_t entries) noexcept;
 		void dump_to_logcat (size_t entries) noexcept;
 		void dump_to_file (size_t entries) noexcept;
-		void dump (size_t entries, bool indent, std::function<void(std::string_view const&)> line_writer) noexcept;
+		void dump (size_t entries, bool indent, LineWriter line_writer, void *context) noexcept;
 
 		// Returns a NUL-terminated copy of `first` and `second` concatenated, or `nullptr` if it
 		// cannot be allocated. Timing is a diagnostic facility, so a failure here only costs us the

--- a/src/native/common/include/runtime-base/timing-internal.hh
+++ b/src/native/common/include/runtime-base/timing-internal.hh
@@ -390,14 +390,14 @@ namespace xamarin::android {
 		}
 
 	private:
-		// Writes a single output line.  `context` is the opaque value passed to `dump`, which
-		// lets a caller thread state through without needing a capturing lambda.
-		using LineWriter = void (*) (void *context, std::string_view const& line);
+		// Writes a single output line.  `output` is the file passed to `dump`, or `nullptr` when
+		// the caller doesn't write to a file.
+		using LineWriter = void (*) (FILE *output, std::string_view const& line);
 
 		bool no_events_logged (size_t entries) noexcept;
 		void dump_to_logcat (size_t entries) noexcept;
 		void dump_to_file (size_t entries) noexcept;
-		void dump (size_t entries, bool indent, LineWriter line_writer, void *context) noexcept;
+		void dump (size_t entries, bool indent, LineWriter line_writer, FILE *output) noexcept;
 
 		// Returns a NUL-terminated copy of `first` and `second` concatenated, or `nullptr` if it
 		// cannot be allocated. Timing is a diagnostic facility, so a failure here only costs us the

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -98,15 +98,15 @@ bool FastTiming::no_events_logged (size_t entries) noexcept
 	return true;
 }
 
-void FastTiming::dump (size_t entries, bool indent, LineWriter line_writer, void *context) noexcept
+void FastTiming::dump (size_t entries, bool indent, LineWriter line_writer, FILE *output) noexcept
 {
 	char stack_buffer [Constants::MAX_LOGCAT_MESSAGE_LENGTH];
 
-	line_writer (context, "Startup costs:"sv);
+	line_writer (output, "Startup costs:"sv);
 	auto log = [&] (TimingEvent const& event) -> uint64_t {
 		size_t message_length;
 		char *message = build_message (event, stack_buffer, sizeof (stack_buffer), &message_length, indent);
-		line_writer (context, std::string_view { message, message_length });
+		line_writer (output, std::string_view { message, message_length });
 		if (message != stack_buffer) {
 			std::free (message);
 		}
@@ -115,7 +115,7 @@ void FastTiming::dump (size_t entries, bool indent, LineWriter line_writer, void
 	log (start_end_event_time);
 	log (get_time_overhead);
 	log (init_time);
-	line_writer (context, Constants::EMPTY);
+	line_writer (output, Constants::EMPTY);
 
 	// Values are in nanoseconds
 	uint64_t total_assembly_load_time = 0u;
@@ -123,7 +123,7 @@ void FastTiming::dump (size_t entries, bool indent, LineWriter line_writer, void
 	uint64_t total_managed_to_java_time = 0u;
 	uint64_t total_assembly_decompression_time = 0u;
 
-	line_writer (context, "All logged events:"sv);
+	line_writer (output, "All logged events:"sv);
 	for (size_t i = 0uz; i < entries; i++) {
 		TimingEvent const& event = get_event (i);
 		if (!__atomic_load_n (&event.complete, __ATOMIC_ACQUIRE)) {
@@ -154,10 +154,10 @@ void FastTiming::dump (size_t entries, bool indent, LineWriter line_writer, void
 		}
 	}
 
-	line_writer (context, Constants::EMPTY);
-	line_writer (context, "[2/4] Accumulated performance results"sv);
+	line_writer (output, Constants::EMPTY);
+	line_writer (output, "[2/4] Accumulated performance results"sv);
 
-	auto log_time = [&line_writer, context] (std::string_view const& msg, uint64_t ns)
+	auto log_time = [&line_writer, output] (std::string_view const& msg, uint64_t ns)
 	{
 		chrono::nanoseconds time_ns (ns);
 		// Do not change the string format after the first colon, its format is required by performance measuring
@@ -193,7 +193,7 @@ void FastTiming::dump (size_t entries, bool indent, LineWriter line_writer, void
 			);
 		}
 
-		line_writer (context, std::string_view { buffer, length });
+		line_writer (output, std::string_view { buffer, length });
 		if (buffer != stack_buffer) {
 			std::free (buffer);
 		}
@@ -214,7 +214,7 @@ void FastTiming::dump_to_logcat (size_t entries) noexcept
 		return;
 	}
 
-	auto line_writer = [](void *, std::string_view const& msg) {
+	auto line_writer = [](FILE *, std::string_view const& msg) {
 		// Don't add empty messages to the logcat, waste of time
 		if (msg.empty ()) {
 			return;
@@ -263,8 +263,7 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 
 	log_infof (LOG_TIMING, "[2/2] Performance measurement results logged to file: %s", timing_log_path);
 
-	auto line_writer = [](void *context, std::string_view const& msg) {
-		auto *output = static_cast<FILE*> (context);
+	auto line_writer = [](FILE *output, std::string_view const& msg) {
 		if (!msg.empty ()) {
 			fwrite (msg.data (), msg.size (), 1, output);
 		}

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -98,15 +98,15 @@ bool FastTiming::no_events_logged (size_t entries) noexcept
 	return true;
 }
 
-void FastTiming::dump (size_t entries, bool indent, std::function<void(std::string_view const&)> line_writer) noexcept
+void FastTiming::dump (size_t entries, bool indent, LineWriter line_writer, void *context) noexcept
 {
 	char stack_buffer [Constants::MAX_LOGCAT_MESSAGE_LENGTH];
 
-	line_writer ("Startup costs:"sv);
+	line_writer (context, "Startup costs:"sv);
 	auto log = [&] (TimingEvent const& event) -> uint64_t {
 		size_t message_length;
 		char *message = build_message (event, stack_buffer, sizeof (stack_buffer), &message_length, indent);
-		line_writer (std::string_view { message, message_length });
+		line_writer (context, std::string_view { message, message_length });
 		if (message != stack_buffer) {
 			std::free (message);
 		}
@@ -115,7 +115,7 @@ void FastTiming::dump (size_t entries, bool indent, std::function<void(std::stri
 	log (start_end_event_time);
 	log (get_time_overhead);
 	log (init_time);
-	line_writer (Constants::EMPTY);
+	line_writer (context, Constants::EMPTY);
 
 	// Values are in nanoseconds
 	uint64_t total_assembly_load_time = 0u;
@@ -123,7 +123,7 @@ void FastTiming::dump (size_t entries, bool indent, std::function<void(std::stri
 	uint64_t total_managed_to_java_time = 0u;
 	uint64_t total_assembly_decompression_time = 0u;
 
-	line_writer ("All logged events:"sv);
+	line_writer (context, "All logged events:"sv);
 	for (size_t i = 0uz; i < entries; i++) {
 		TimingEvent const& event = get_event (i);
 		if (!__atomic_load_n (&event.complete, __ATOMIC_ACQUIRE)) {
@@ -154,10 +154,10 @@ void FastTiming::dump (size_t entries, bool indent, std::function<void(std::stri
 		}
 	}
 
-	line_writer (Constants::EMPTY);
-	line_writer ("[2/4] Accumulated performance results"sv);
+	line_writer (context, Constants::EMPTY);
+	line_writer (context, "[2/4] Accumulated performance results"sv);
 
-	auto log_time = [&line_writer] (std::string_view const& msg, uint64_t ns)
+	auto log_time = [&line_writer, context] (std::string_view const& msg, uint64_t ns)
 	{
 		chrono::nanoseconds time_ns (ns);
 		// Do not change the string format after the first colon, its format is required by performance measuring
@@ -193,7 +193,7 @@ void FastTiming::dump (size_t entries, bool indent, std::function<void(std::stri
 			);
 		}
 
-		line_writer (std::string_view { buffer, length });
+		line_writer (context, std::string_view { buffer, length });
 		if (buffer != stack_buffer) {
 			std::free (buffer);
 		}
@@ -214,14 +214,14 @@ void FastTiming::dump_to_logcat (size_t entries) noexcept
 		return;
 	}
 
-	auto line_writer = [](std::string_view const& msg) {
+	auto line_writer = [](void *, std::string_view const& msg) {
 		// Don't add empty messages to the logcat, waste of time
 		if (msg.empty ()) {
 			return;
 		}
 		log_writef (LOG_TIMING, LogLevel::Info, "%.*s", static_cast<int>(msg.length ()), msg.data ());
 	};
-	dump (entries, true /* indent */, line_writer);
+	dump (entries, true /* indent */, line_writer, nullptr);
 }
 
 void FastTiming::dump_to_file (size_t entries) noexcept
@@ -263,14 +263,15 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 
 	log_infof (LOG_TIMING, "[2/2] Performance measurement results logged to file: %s", timing_log_path);
 
-	auto line_writer = [=](std::string_view const& msg) {
+	auto line_writer = [](void *context, std::string_view const& msg) {
+		auto *output = static_cast<FILE*> (context);
 		if (!msg.empty ()) {
-			fwrite (msg.data (), msg.size (), 1, timing_log);
+			fwrite (msg.data (), msg.size (), 1, output);
 		}
-		fwrite (Constants::NEWLINE.data (), Constants::NEWLINE.size (), 1, timing_log);
+		fwrite (Constants::NEWLINE.data (), Constants::NEWLINE.size (), 1, output);
 	};
 
-	dump (entries, true /* indent */, line_writer);
+	dump (entries, true /* indent */, line_writer, timing_log);
 	fflush (timing_log);
 	fclose (timing_log);
 	if (timing_log_path != stack_buffer) {

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -14,6 +14,27 @@ using namespace std::literals;
 
 namespace chrono = std::chrono;
 
+namespace {
+	void write_line_to_logcat ([[maybe_unused]] FILE *output, std::string_view const& line) noexcept
+	{
+		// Don't add empty messages to the logcat, waste of time
+		if (line.empty ()) {
+			return;
+		}
+
+		log_writef (LOG_TIMING, LogLevel::Info, "%.*s", static_cast<int>(line.length ()), line.data ());
+	}
+
+	void write_line_to_file (FILE *output, std::string_view const& line) noexcept
+	{
+		if (!line.empty ()) {
+			fwrite (line.data (), line.size (), 1, output);
+		}
+
+		fwrite (Constants::NEWLINE.data (), Constants::NEWLINE.size (), 1, output);
+	}
+}
+
 void FastTiming::really_initialize (bool log_immediately) noexcept
 {
 	internal_timing.configure_for_use ();
@@ -214,14 +235,7 @@ void FastTiming::dump_to_logcat (size_t entries) noexcept
 		return;
 	}
 
-	auto line_writer = [](FILE *, std::string_view const& msg) {
-		// Don't add empty messages to the logcat, waste of time
-		if (msg.empty ()) {
-			return;
-		}
-		log_writef (LOG_TIMING, LogLevel::Info, "%.*s", static_cast<int>(msg.length ()), msg.data ());
-	};
-	dump (entries, true /* indent */, line_writer, nullptr);
+	dump (entries, true /* indent */, write_line_to_logcat, nullptr);
 }
 
 void FastTiming::dump_to_file (size_t entries) noexcept
@@ -263,14 +277,7 @@ void FastTiming::dump_to_file (size_t entries) noexcept
 
 	log_infof (LOG_TIMING, "[2/2] Performance measurement results logged to file: %s", timing_log_path);
 
-	auto line_writer = [](FILE *output, std::string_view const& msg) {
-		if (!msg.empty ()) {
-			fwrite (msg.data (), msg.size (), 1, output);
-		}
-		fwrite (Constants::NEWLINE.data (), Constants::NEWLINE.size (), 1, output);
-	};
-
-	dump (entries, true /* indent */, line_writer, timing_log);
+	dump (entries, true /* indent */, write_line_to_file, timing_log);
 	fflush (timing_log);
 	fclose (timing_log);
 	if (timing_log_path != stack_buffer) {


### PR DESCRIPTION
Part of #12533. Stacked on top of #12547.

`std::function` is a type-erasing wrapper: it has to be able to store, copy and destroy an arbitrary callable, and it pulls `<functional>` into every translation unit that sees the declaration. Neither of the two remaining uses in the CoreCLR host needs any of that.

### `FastTiming::dump`

The line writer was taken by value:

```c++
void dump (size_t entries, bool indent, std::function<void(std::string_view const&)> line_writer) noexcept;
```

Of its two callers, `dump_to_logcat` passes a captureless lambda and `dump_to_file` captures a single `FILE*`. A plain function pointer plus an opaque context covers both:

```c++
using LineWriter = void (*) (FILE *output, std::string_view const& line);

void dump (size_t entries, bool indent, LineWriter line_writer, FILE *output) noexcept;
```

The context is typed as `FILE*` rather than `void*`, since the only caller that needs one writes to a file — that avoids a cast in the writer. `dump_to_file` passes its `FILE*` through instead of capturing it, and `dump` stays out of line — no template, so no code duplication per callback type.

The two writers are plain functions in an anonymous namespace rather than captureless lambdas. A lambda converted to a function pointer goes through a compiler generated static invoker, so using functions directly removes a level of indirection.

### `AssemblyStore::configure_from_payload`

```c++
static void configure_from_payload (const void *payload_start, const std::function<std::string()>& get_full_store_path) noexcept;
```

The callback existed only to produce a store path for diagnostics, but the single caller was:

```c++
AssemblyStore::configure_from_payload (payload, [store_path]() -> std::string { return std::string { store_path }; });
```

That wraps a `const char *` in a `std::string` purely so that all three use sites can call `.c_str ()` on it again. One of those three is the success-path `log_debugf` at the end of the function, so the callback runs on every startup and this allocated a string every time.

It now takes the `const char *` directly and uses the existing `optional_string ()` helper, which also makes it null-safe. The stale comment describing the callback was updated — it claimed the path was only used for invalid payloads, which was not true.

### Results

| | before | after |
| --- | ---: | ---: |
| undefined libc++ refs | 59 | 59 |
| `libnet-android.release.so` | 546,904 B | **539,912 B** |

The undefined reference count is **unchanged**: both uses were fully inlined by the optimizer at `-O2`, so `std::function`'s machinery was emitted into the objects rather than left as undefined references. What goes away is that generated machinery — **6,992 bytes** come off the shared library overall (mostly `.text` and `.bss`), plus one `std::string` allocation per startup.

### Verification

- CoreCLR and MonoVM both build clean (only the pre-existing `format_managed_type_name` warning).
- Reference counts and sizes measured with `llvm-nm --undefined-only` / `llvm-size` over the same build tree, before and after.
- `<functional>` is no longer included by `timing-internal.hh` or `assembly-store.hh`. The only remaining `std::function` references in `src/native` are in `src/native/mono/`, which this stack does not touch.

### On the unchanged reference count

Worth recording, since it is easy to misread as "no progress": `llvm-nm --undefined-only` lists each undefined symbol **once per object file**, so this metric counts *(object, symbol)* pairs rather than call sites. `host.cc.o` still has 24 relocations against `operator delete` and 8 against `~basic_string` from its other `std::string` uses, so dropping one use cannot remove the symbol from its undefined list. Measured per object across this change:

| object | undefined symbol set | relocations | `.text` |
| --- | --- | ---: | ---: |
| `host.cc.o` | identical | 60 → 56 | 30,550 → 30,026 |
| `assembly-store.cc.o` | identical | 84 → 83 | 24,424 → 24,106 |

The count only moves when the *last* use of a symbol in a given file goes away, so it behaves as a per-file cliff rather than a gradual measure.

The lambdas remaining inside `dump` are called directly instead of being converted to function pointers, so the optimizer already inlines them; replacing them with named functions measured 2 bytes *larger*, so they were left as they are.

