### PR TITLE
[NativeAOT] Forward JCW Java annotations

### DIFF
--- a/Xamarin.Android.slnx
+++ b/Xamarin.Android.slnx
@@ -62,6 +62,7 @@
     <Project Path="tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests.csproj" />
     <Project Path="tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/UserTypesFixture/UserTypesFixture.csproj" />
     <Project Path="tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj" />
+    <Project Path="tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestAttributeFixtures/TestAttributeFixtures.csproj" />
     <Project Path="tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestFixtures.csproj" />
     <Project Path="tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj" />
     <Project Path="tests/Xamarin.Android.Tools.Aidl-Tests/Xamarin.Android.Tools.Aidl-Tests.csproj" />

--- a/src/Microsoft.Android.Build.BaseTasks/HexUtilities.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/HexUtilities.cs
@@ -2,11 +2,12 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 
 namespace Microsoft.Android.Build.Tasks
 {
 	/// <summary>
-	/// Allocation-free helpers for rendering bytes as hexadecimal.
+	/// Allocation-free helpers for rendering values as hexadecimal.
 	/// </summary>
 	/// <remarks>
 	/// This file is also linked into <c>Microsoft.Android.Sdk.TrimmableTypeMap</c>, which
@@ -63,6 +64,21 @@ namespace Microsoft.Android.Build.Tasks
 
 			writer.Write (GetHexValue (value >> 4, upperCase));
 			writer.Write (GetHexValue (value & 0x0f, upperCase));
+		}
+
+		/// <summary>
+		/// Append <paramref name="value"/> to <paramref name="builder"/> as exactly four
+		/// hexadecimal digits, without allocating.
+		/// </summary>
+		public static void WriteHex (StringBuilder builder, ushort value, bool upperCase = true)
+		{
+			if (builder == null)
+				throw new ArgumentNullException (nameof (builder));
+
+			builder.Append (GetHexValue (value >> 12, upperCase));
+			builder.Append (GetHexValue ((value >> 8) & 0x0f, upperCase));
+			builder.Append (GetHexValue ((value >> 4) & 0x0f, upperCase));
+			builder.Append (GetHexValue (value & 0x0f, upperCase));
 		}
 
 		/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
@@ -296,7 +295,14 @@ public sealed class JcwJavaSourceGenerator
 			writer.Write (annotation.Name);
 			if (annotation.Properties.Count > 0) {
 				writer.Write (" (");
-				writer.Write (string.Join (", ", annotation.Properties.Select (property => $"{property.Key} = {property.Value}")));
+				bool first = true;
+				foreach (var property in annotation.Properties) {
+					if (!first) {
+						writer.Write (", ");
+					}
+					writer.Write ($"{property.Key} = {property.Value}");
+					first = false;
+				}
 				writer.Write (')');
 			}
 			writer.WriteLine ();

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
@@ -65,6 +66,7 @@ public sealed class JcwJavaSourceGenerator
 	{
 		writer.NewLine = "\n";
 		WritePackageDeclaration (type, writer);
+		WriteAnnotations (type.Annotations, writer);
 		WriteClassDeclaration (type, writer, applicationJavaClass);
 		WriteStaticInitializer (type, writer);
 		WriteConstructors (type, writer);
@@ -176,6 +178,7 @@ public sealed class JcwJavaSourceGenerator
 			string superArgs = ctor.SuperArgumentsString ?? FormatArgumentList (ctorParams);
 			string args = FormatArgumentList (ctorParams);
 
+			WriteAnnotations (ctor.Annotations, writer);
 			writer.Write ($$"""
 	public {{simpleClassName}} ({{parameters}})
 	{
@@ -212,6 +215,7 @@ public sealed class JcwJavaSourceGenerator
 	static void WriteFields (JavaPeerInfo type, TextWriter writer)
 	{
 		foreach (var field in type.JavaFields) {
+			WriteAnnotations (field.Annotations, writer);
 			writer.Write ('\t');
 			writer.Write (field.Visibility);
 			writer.Write (' ');
@@ -257,8 +261,9 @@ public sealed class JcwJavaSourceGenerator
 			}
 
 			if (method.Connector != null && !method.IsExport) {
+				writer.WriteLine ();
+				WriteAnnotations (method.Annotations, writer);
 				writer.Write ($$"""
-
 	@Override
 	public {{javaReturnType}} {{method.JniName}} ({{parameters}}){{throwsClause}}
 	{
@@ -270,8 +275,9 @@ public sealed class JcwJavaSourceGenerator
 			} else {
 				string access = method.IsExport && method.JavaAccess != null ? method.JavaAccess : "public";
 				string staticKeyword = method.IsStatic ? "static " : "";
+				writer.WriteLine ();
+				WriteAnnotations (method.Annotations, writer);
 				writer.Write ($$"""
-
 	{{access}} {{staticKeyword}}{{javaReturnType}} {{method.JniName}} ({{parameters}}){{throwsClause}}
 	{
 {{registerNativesLine}}		{{returnPrefix}}{{method.NativeCallbackName}} ({{args}});
@@ -280,6 +286,20 @@ public sealed class JcwJavaSourceGenerator
 
 """);
 			}
+		}
+	}
+
+	static void WriteAnnotations (IReadOnlyList<JavaAnnotationInfo> annotations, TextWriter writer)
+	{
+		foreach (var annotation in annotations) {
+			writer.Write ('@');
+			writer.Write (annotation.Name);
+			if (annotation.Properties.Count > 0) {
+				writer.Write (" (");
+				writer.Write (string.Join (", ", annotation.Properties.Select (property => $"{property.Key} = {property.Value}")));
+				writer.Write (')');
+			}
+			writer.WriteLine ();
 		}
 	}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -300,7 +300,9 @@ public sealed class JcwJavaSourceGenerator
 					if (!first) {
 						writer.Write (", ");
 					}
-					writer.Write ($"{property.Key} = {property.Value}");
+					writer.Write (property.Key);
+					writer.Write (" = ");
+					writer.Write (property.Value);
 					first = false;
 				}
 				writer.Write (')');

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -678,6 +678,7 @@ sealed record ExportInfo
 {
 	public IReadOnlyList<string>? ThrownNames { get; init; }
 	public string? SuperArgumentsString { get; init; }
+	public bool IsField { get; init; }
 	public IReadOnlyList<ExportParameterKindInfo> ParameterKinds { get; init; } = [];
 	public ExportParameterKindInfo ReturnKind { get; init; }
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaAnnotationParser.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaAnnotationParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection.Metadata;
 using System.Text;
+using Microsoft.Android.Build.Tasks;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
@@ -199,7 +200,7 @@ sealed class JavaAnnotationParser
 				default:
 					if (char.IsControl (c)) {
 						builder.Append ("\\u");
-						builder.Append (((int)c).ToString ("x4", CultureInfo.InvariantCulture));
+						HexUtilities.WriteHex (builder, c, upperCase: false);
 					} else {
 						builder.Append (c);
 					}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaAnnotationParser.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaAnnotationParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection.Metadata;
 using System.Text;
+using Microsoft.Android.Build.Tasks;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
@@ -199,7 +200,10 @@ sealed class JavaAnnotationParser
 				default:
 					if (char.IsControl (c)) {
 						builder.Append ("\\u");
-						builder.Append (((int)c).ToString ("x4", CultureInfo.InvariantCulture));
+						builder.Append (HexUtilities.GetHexValue (c >> 12, upperCase: false));
+						builder.Append (HexUtilities.GetHexValue ((c >> 8) & 0x0f, upperCase: false));
+						builder.Append (HexUtilities.GetHexValue ((c >> 4) & 0x0f, upperCase: false));
+						builder.Append (HexUtilities.GetHexValue (c & 0x0f, upperCase: false));
 					} else {
 						builder.Append (c);
 					}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaAnnotationParser.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaAnnotationParser.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection.Metadata;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+sealed class JavaAnnotationParser
+{
+	sealed record AnnotationTypeInfo (string JavaName, IReadOnlyDictionary<string, string> PropertyNames);
+
+	static readonly IReadOnlyList<JavaAnnotationInfo> noAnnotations = [];
+
+	readonly IReadOnlyDictionary<string, AssemblyIndex> assemblies;
+	readonly Func<string, string?> resolveTypeName;
+	readonly Dictionary<(AssemblyIndex Index, EntityHandle Type), AnnotationTypeInfo?> annotationTypes = new ();
+
+	public JavaAnnotationParser (IReadOnlyDictionary<string, AssemblyIndex> assemblies, Func<string, string?> resolveTypeName)
+	{
+		this.assemblies = assemblies;
+		this.resolveTypeName = resolveTypeName;
+	}
+
+	public IReadOnlyList<JavaAnnotationInfo> Parse (CustomAttributeHandleCollection attributes, AssemblyIndex index)
+	{
+		List<JavaAnnotationInfo>? annotations = null;
+		foreach (var attributeHandle in attributes) {
+			var attribute = index.Reader.GetCustomAttribute (attributeHandle);
+			var annotationType = GetAnnotationType (attribute, index);
+			if (annotationType is null) {
+				continue;
+			}
+
+			annotations ??= [];
+			annotations.Add (new JavaAnnotationInfo {
+				Name = annotationType.JavaName,
+				Properties = GetProperties (attribute, index, annotationType),
+			});
+		}
+		return annotations ?? noAnnotations;
+	}
+
+	static string? GetJavaName (TypeDefinition attributeType, AssemblyIndex index)
+	{
+		foreach (var markerHandle in attributeType.GetCustomAttributes ()) {
+			var marker = index.Reader.GetCustomAttribute (markerHandle);
+			if (!AssemblyIndex.IsCustomAttributeMatch (marker, index.Reader, "Android.Runtime", "AnnotationAttribute")) {
+				continue;
+			}
+
+			var value = index.DecodeAttribute (marker);
+			return value.FixedArguments.Length > 0 ? value.FixedArguments [0].Value as string : null;
+		}
+		return null;
+	}
+
+	IReadOnlyList<KeyValuePair<string, string>> GetProperties (
+		CustomAttribute attribute,
+		AssemblyIndex index,
+		AnnotationTypeInfo annotationType)
+	{
+		var properties = new List<KeyValuePair<string, string>> ();
+		foreach (var property in index.DecodeAttribute (attribute).NamedArguments) {
+			if (property.Kind != CustomAttributeNamedArgumentKind.Property || property.Name is null) {
+				continue;
+			}
+			var propertyName = annotationType.PropertyNames.TryGetValue (property.Name, out var javaName)
+				? javaName
+				: property.Name;
+			properties.Add (new KeyValuePair<string, string> (
+				propertyName,
+				ManagedValueToJavaSource (property.Type, property.Value)
+			));
+		}
+		return properties;
+	}
+
+	static IReadOnlyDictionary<string, string> GetJavaPropertyNames (TypeDefinition attributeType, AssemblyIndex index)
+	{
+		var names = new Dictionary<string, string> (StringComparer.Ordinal);
+		foreach (var propertyHandle in attributeType.GetProperties ()) {
+			var property = index.Reader.GetPropertyDefinition (propertyHandle);
+			var managedName = index.Reader.GetString (property.Name);
+			foreach (var attributeHandle in property.GetCustomAttributes ()) {
+				var attribute = index.Reader.GetCustomAttribute (attributeHandle);
+				if (!AssemblyIndex.IsCustomAttributeMatch (attribute, index.Reader, "Android.Runtime", "RegisterAttribute")) {
+					continue;
+				}
+				var value = index.DecodeAttribute (attribute);
+				if (value.FixedArguments.Length > 0 && value.FixedArguments [0].Value is string javaName) {
+					names [managedName] = javaName;
+				}
+				break;
+			}
+		}
+		return names;
+	}
+
+	AnnotationTypeInfo? GetAnnotationType (CustomAttribute attribute, AssemblyIndex index)
+	{
+		EntityHandle typeHandle = default;
+		if (attribute.Constructor.Kind == HandleKind.MethodDefinition) {
+			typeHandle = index.Reader.GetMethodDefinition ((MethodDefinitionHandle)attribute.Constructor).GetDeclaringType ();
+		} else if (attribute.Constructor.Kind == HandleKind.MemberReference) {
+			typeHandle = index.Reader.GetMemberReference ((MemberReferenceHandle)attribute.Constructor).Parent;
+		}
+
+		var key = (index, typeHandle);
+		if (typeHandle.IsNil || annotationTypes.TryGetValue (key, out var cached) && cached is null) {
+			return null;
+		}
+		if (cached is not null) {
+			return cached;
+		}
+
+		TypeDefinition attributeType;
+		AssemblyIndex attributeIndex;
+		if (typeHandle.Kind == HandleKind.TypeDefinition) {
+			attributeType = index.Reader.GetTypeDefinition ((TypeDefinitionHandle)typeHandle);
+			attributeIndex = index;
+		} else if (typeHandle.Kind == HandleKind.TypeReference) {
+			var typeReference = MetadataTypeNameResolver.GetTypeRefFromReference (
+				index.Reader,
+				(TypeReferenceHandle)typeHandle,
+				index.AssemblyName,
+				rawTypeKind: 0
+			);
+			if (!assemblies.TryGetValue (typeReference.AssemblyName, out attributeIndex) ||
+			    !attributeIndex.TypesByFullName.TryGetValue (typeReference.ManagedTypeName, out var resolvedHandle)) {
+				annotationTypes [key] = null;
+				return null;
+			}
+			attributeType = attributeIndex.Reader.GetTypeDefinition (resolvedHandle);
+		} else {
+			annotationTypes [key] = null;
+			return null;
+		}
+
+		var javaName = GetJavaName (attributeType, attributeIndex);
+		var result = javaName.IsNullOrEmpty ()
+			? null
+			: new AnnotationTypeInfo (javaName, GetJavaPropertyNames (attributeType, attributeIndex));
+		annotationTypes [key] = result;
+		return result;
+	}
+
+	string ManagedValueToJavaSource (string managedType, object? value)
+	{
+		if (value is null) {
+			return "null";
+		}
+		if (managedType == "String" || managedType == "System.String") {
+			return "\"" + value.ToString ()?.Replace ("\"", "\"\"") + '"';
+		}
+		if (managedType == "System.Type" && value is string typeName) {
+			var javaName = resolveTypeName (typeName);
+			if (javaName is not null) {
+				return JniSignatureHelper.JniNameToJavaName (javaName) + ".class";
+			}
+			throw new InvalidOperationException ($"Java annotation type value '{typeName}' does not resolve to a Java peer.");
+		}
+		if (value is bool boolean) {
+			return boolean ? "true" : "false";
+		}
+		return value.ToString () ?? "";
+	}
+}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaAnnotationParser.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaAnnotationParser.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection.Metadata;
+using System.Text;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
@@ -149,7 +151,7 @@ sealed class JavaAnnotationParser
 			return "null";
 		}
 		if (managedType == "String" || managedType == "System.String") {
-			return "\"" + value.ToString ()?.Replace ("\"", "\"\"") + '"';
+			return ToJavaStringLiteral (value.ToString () ?? "");
 		}
 		if (managedType == "System.Type" && value is string typeName) {
 			var javaName = resolveTypeName (typeName);
@@ -161,6 +163,50 @@ sealed class JavaAnnotationParser
 		if (value is bool boolean) {
 			return boolean ? "true" : "false";
 		}
+		if (value is IFormattable formattable) {
+			return formattable.ToString (null, CultureInfo.InvariantCulture) ?? "";
+		}
 		return value.ToString () ?? "";
+	}
+
+	static string ToJavaStringLiteral (string value)
+	{
+		var builder = new StringBuilder (value.Length + 2);
+		builder.Append ('"');
+		foreach (char c in value) {
+			switch (c) {
+				case '"':
+					builder.Append ("\\\"");
+					break;
+				case '\\':
+					builder.Append ("\\\\");
+					break;
+				case '\b':
+					builder.Append ("\\b");
+					break;
+				case '\t':
+					builder.Append ("\\t");
+					break;
+				case '\n':
+					builder.Append ("\\n");
+					break;
+				case '\f':
+					builder.Append ("\\f");
+					break;
+				case '\r':
+					builder.Append ("\\r");
+					break;
+				default:
+					if (char.IsControl (c)) {
+						builder.Append ("\\u");
+						builder.Append (((int)c).ToString ("x4", CultureInfo.InvariantCulture));
+					} else {
+						builder.Append (c);
+					}
+					break;
+			}
+		}
+		builder.Append ('"');
+		return builder.ToString ();
 	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaAnnotationParser.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaAnnotationParser.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection.Metadata;
 using System.Text;
-using Microsoft.Android.Build.Tasks;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
@@ -200,10 +199,7 @@ sealed class JavaAnnotationParser
 				default:
 					if (char.IsControl (c)) {
 						builder.Append ("\\u");
-						builder.Append (HexUtilities.GetHexValue (c >> 12, upperCase: false));
-						builder.Append (HexUtilities.GetHexValue ((c >> 8) & 0x0f, upperCase: false));
-						builder.Append (HexUtilities.GetHexValue ((c >> 4) & 0x0f, upperCase: false));
-						builder.Append (HexUtilities.GetHexValue (c & 0x0f, upperCase: false));
+						builder.Append (((int)c).ToString ("x4", CultureInfo.InvariantCulture));
 					} else {
 						builder.Append (c);
 					}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -63,6 +63,12 @@ public sealed record JavaPeerInfo
 	/// </summary>
 	public IReadOnlyList<string> ImplementedInterfaceJavaNames { get; init; } = Array.Empty<string> ();
 
+	/// <summary>
+	/// Java annotations forwarded from managed custom attributes decorated with
+	/// <c>Android.Runtime.AnnotationAttribute</c>.
+	/// </summary>
+	public IReadOnlyList<JavaAnnotationInfo> Annotations { get; init; } = [];
+
 	public bool IsInterface { get; init; }
 	public bool IsAbstract { get; init; }
 
@@ -296,6 +302,20 @@ public sealed record MarshalMethodInfo
 	/// <c>new virtual</c> while reusing the same JNI name and signature.
 	/// </summary>
 	public bool CallManagedMethodDirectly { get; init; }
+
+	/// <summary>
+	/// Java annotations forwarded from the managed method or constructor.
+	/// </summary>
+	public IReadOnlyList<JavaAnnotationInfo> Annotations { get; init; } = [];
+}
+
+/// <summary>
+/// Describes a Java annotation forwarded from a managed custom attribute.
+/// </summary>
+public sealed record JavaAnnotationInfo
+{
+	public required string Name { get; init; }
+	public IReadOnlyList<KeyValuePair<string, string>> Properties { get; init; } = [];
 }
 
 /// <summary>
@@ -344,6 +364,11 @@ public sealed record JavaConstructorInfo
 	/// True when this Java constructor has a matching public managed constructor on the target type.
 	/// </summary>
 	public bool HasMatchingManagedCtor { get; init; }
+
+	/// <summary>
+	/// Java annotations forwarded from the managed constructor.
+	/// </summary>
+	public IReadOnlyList<JavaAnnotationInfo> Annotations { get; init; } = [];
 }
 
 /// <summary>
@@ -376,6 +401,11 @@ public sealed record JavaFieldInfo
 	/// Whether the field is static.
 	/// </summary>
 	public bool IsStatic { get; init; }
+
+	/// <summary>
+	/// Java annotations forwarded from the managed field initializer method.
+	/// </summary>
+	public IReadOnlyList<JavaAnnotationInfo> Annotations { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -33,6 +33,7 @@ public sealed class JavaPeerScanner : IDisposable
 	readonly HashedPackageNamingPolicy packageNamingPolicy;
 	readonly HashSet<string> frameworkAssemblyNames;
 	readonly bool errorOnCustomJavaObject;
+	readonly JavaAnnotationParser annotationParser;
 
 	public JavaPeerScanner (string? packageNamingPolicy = null, ITrimmableTypeMapLogger? logger = null, HashSet<string>? frameworkAssemblyNames = null, bool errorOnCustomJavaObject = true)
 	{
@@ -40,6 +41,7 @@ public sealed class JavaPeerScanner : IDisposable
 		this.logger = logger;
 		this.frameworkAssemblyNames = frameworkAssemblyNames ?? new HashSet<string> (StringComparer.OrdinalIgnoreCase);
 		this.errorOnCustomJavaObject = errorOnCustomJavaObject;
+		annotationParser = new JavaAnnotationParser (assemblyCache, ResolveTypeOfArgumentToJniName);
 	}
 
 	/// <summary>
@@ -385,6 +387,7 @@ public sealed class JavaPeerScanner : IDisposable
 				IsFrameworkAssembly = frameworkAssemblyNames.Contains (index.AssemblyName),
 				BaseJavaName = baseJavaName,
 				ImplementedInterfaceJavaNames = implementedInterfaces,
+				Annotations = annotationParser.Parse (typeDef.GetCustomAttributes (), index),
 				IsInterface = isInterface,
 				IsAbstract = isAbstract,
 				DoNotGenerateAcw = doNotGenerateAcw,
@@ -818,7 +821,7 @@ public sealed class JavaPeerScanner : IDisposable
 				continue;
 			}
 
-			var baseRegistration = FindBaseRegisteredProperty (typeDef, index, getterName, getterDef);
+			var baseRegistration = FindBaseRegisteredProperty (typeDef, index, getterName, getterDef, index);
 			if (baseRegistration is not null) {
 				methods.Add (baseRegistration);
 				alreadyRegistered.Add (sigKey);
@@ -961,6 +964,7 @@ public sealed class JavaPeerScanner : IDisposable
 					ManagedMethodName = ".ctor",
 					NativeCallbackName = "n_ctor",
 					IsConstructor = true,
+					Annotations = annotationParser.Parse (baseCtor.Method.GetCustomAttributes (), baseCtor.Index),
 				});
 				alreadyRegisteredSignatures.Add (signature);
 			}
@@ -1394,6 +1398,7 @@ public sealed class JavaPeerScanner : IDisposable
 			DeclaringTypeName = result.Value.DeclaringType.ManagedTypeName,
 			DeclaringAssemblyName = result.Value.DeclaringType.AssemblyName,
 			DeclaringType = result.Value.DeclaringType,
+			Annotations = annotationParser.Parse (derivedMethod.GetCustomAttributes (), index),
 		};
 	}
 
@@ -1402,7 +1407,7 @@ public sealed class JavaPeerScanner : IDisposable
 	/// matches the given getter name and has a compatible signature.
 	/// </summary>
 	MarshalMethodInfo? FindBaseRegisteredProperty (TypeDefinition typeDef, AssemblyIndex index,
-		string getterName, MethodDefinition derivedGetter, TypeRefData? currentTypeRef = null)
+		string getterName, MethodDefinition derivedGetter, AssemblyIndex derivedIndex, TypeRefData? currentTypeRef = null)
 	{
 		if (!TryResolveBaseType (typeDef, index, currentTypeRef, out var baseTypeDef, out _, out var baseIndex, out _, out _, out var baseTypeRef)) {
 			return null;
@@ -1446,13 +1451,14 @@ public sealed class JavaPeerScanner : IDisposable
 					DeclaringTypeName = baseTypeRef.ManagedTypeName,
 					DeclaringAssemblyName = baseTypeRef.AssemblyName,
 					DeclaringType = baseTypeRef,
+					Annotations = annotationParser.Parse (derivedGetter.GetCustomAttributes (), derivedIndex),
 				};
 			}
 		}
 
 		// Keep walking the full base hierarchy so property overrides can inherit
 		// [Register] metadata declared above an intermediate MCW base type.
-		return FindBaseRegisteredProperty (baseTypeDef, baseIndex, getterName, derivedGetter, baseTypeRef);
+		return FindBaseRegisteredProperty (baseTypeDef, baseIndex, getterName, derivedGetter, derivedIndex, baseTypeRef);
 	}
 
 	/// <summary>
@@ -1554,6 +1560,7 @@ public sealed class JavaPeerScanner : IDisposable
 			ThrownNames = exportInfo?.ThrownNames,
 			SuperArgumentsString = exportInfo?.SuperArgumentsString,
 			CallManagedMethodDirectly = callManagedMethodDirectly,
+			Annotations = exportInfo?.IsField == true ? [] : annotationParser.Parse (methodDef.GetCustomAttributes (), index),
 		});
 	}
 
@@ -1878,7 +1885,7 @@ public sealed class JavaPeerScanner : IDisposable
 
 		return (
 			new RegisterInfo { JniName = managedName, Signature = jniSig, Connector = "__export__", DoNotGenerateAcw = false },
-			new ExportInfo { ThrownNames = null, SuperArgumentsString = null }
+			new ExportInfo { ThrownNames = null, SuperArgumentsString = null, IsField = true }
 		);
 	}
 
@@ -2481,6 +2488,7 @@ public sealed class JavaPeerScanner : IDisposable
 				SuperArgumentsString = mm.SuperArgumentsString,
 				HasMatchingManagedCtor = managedParams != null,
 				ManagedParameterTypes = managedParams ?? [],
+				Annotations = mm.Annotations,
 			});
 			ctorIndex++;
 		}
@@ -2592,6 +2600,7 @@ public sealed class JavaPeerScanner : IDisposable
 				InitializerMethodName = managedName,
 				Visibility = access,
 				IsStatic = isStatic,
+				Annotations = annotationParser.Parse (methodDef.GetCustomAttributes (), index),
 			});
 		}
 	}

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/HexUtilitiesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/HexUtilitiesTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.Android.Build.Tasks;
 using NUnit.Framework;
 
@@ -103,6 +104,21 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		public void WriteHex_TextWriter_NullThrows ()
 		{
 			Assert.Throws<ArgumentNullException> (() => HexUtilities.WriteHex (writer: null, value: 0x00));
+		}
+
+		[Test]
+		public void WriteHex_StringBuilder_UInt16 ()
+		{
+			var builder = new StringBuilder ("_");
+			HexUtilities.WriteHex (builder, 0xabcd);
+			HexUtilities.WriteHex (builder, 0x012f, upperCase: false);
+			Assert.AreEqual ("_ABCD012f", builder.ToString ());
+		}
+
+		[Test]
+		public void WriteHex_StringBuilder_NullThrows ()
+		{
+			Assert.Throws<ArgumentNullException> (() => HexUtilities.WriteHex (builder: null, value: 0x0000));
 		}
 
 		[TestCase (0)]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -22,15 +22,27 @@ public abstract class FixtureTestBase
 		}
 	}
 
+	static string TestAttributeFixtureAssemblyPath {
+		get {
+			var testAssemblyDir = Path.GetDirectoryName (typeof (FixtureTestBase).Assembly.Location)
+				?? throw new InvalidOperationException ("Cannot determine test assembly directory");
+			var fixtureAssembly = Path.Combine (testAssemblyDir, "TestAttributeFixtures.dll");
+			Assert.True (File.Exists (fixtureAssembly),
+				$"TestAttributeFixtures.dll not found at {fixtureAssembly}. Ensure the TestAttributeFixtures project builds.");
+			return fixtureAssembly;
+		}
+	}
+
 	static readonly Lazy<(List<JavaPeerInfo> peers, AssemblyManifestInfo manifestInfo)> _cachedScanResult = new (() => {
 		using var scanner = new JavaPeerScanner ();
-		var peReader = new PEReader (File.OpenRead (TestFixtureAssemblyPath));
-		var mdReader = peReader.GetMetadataReader ();
-		var assemblyName = mdReader.GetString (mdReader.GetAssemblyDefinition ().Name);
-		var assemblies = new [] { (assemblyName, peReader) };
+		using var peReader = new PEReader (File.OpenRead (TestFixtureAssemblyPath));
+		using var attributePeReader = new PEReader (File.OpenRead (TestAttributeFixtureAssemblyPath));
+		var assemblies = new [] {
+			GetAssemblyInput (peReader),
+			GetAssemblyInput (attributePeReader),
+		};
 		var peers = scanner.Scan (assemblies);
 		var manifestInfo = scanner.ScanAssemblyManifestInfo ();
-		peReader.Dispose ();
 		return (peers, manifestInfo);
 	});
 
@@ -40,10 +52,18 @@ public abstract class FixtureTestBase
 	{
 		using var scanner = new JavaPeerScanner (packageNamingPolicy);
 		using var peReader = new PEReader (File.OpenRead (TestFixtureAssemblyPath));
-		var mdReader = peReader.GetMetadataReader ();
-		var assemblyName = mdReader.GetString (mdReader.GetAssemblyDefinition ().Name);
-		var assemblies = new [] { (assemblyName, peReader) };
+		using var attributePeReader = new PEReader (File.OpenRead (TestAttributeFixtureAssemblyPath));
+		var assemblies = new [] {
+			GetAssemblyInput (peReader),
+			GetAssemblyInput (attributePeReader),
+		};
 		return scanner.Scan (assemblies);
+	}
+
+	static (string Name, PEReader Reader) GetAssemblyInput (PEReader peReader)
+	{
+		var reader = peReader.GetMetadataReader ();
+		return (reader.GetString (reader.GetAssemblyDefinition ().Name), peReader);
 	}
 
 	private protected static AssemblyManifestInfo ScanAssemblyManifestInfo () => _cachedScanResult.Value.manifestInfo;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -348,6 +348,38 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 		}
 
 		[Fact]
+		public void Generate_MarshalMethod_ForwardsJavaAnnotation ()
+		{
+			var peer = FindFixtureByManagedName ("MyApp.MyWebViewHandler");
+			var java = GenerateToString (peer);
+
+			AssertContainsLine ("@android.webkit.JavascriptInterface\n\t@Override\n\tpublic void postMessage (java.lang.String p0)\n", java);
+		}
+
+		[Fact]
+		public void Generate_ForwardsAnnotationsOnJcwMembers ()
+		{
+			var typeJava = GenerateFixture ("my/app/MyHelper");
+			AssertContainsLine ("@com.example.Custom (text = \"hello\", Enabled = true)\npublic class MyHelper\n", typeJava);
+
+			var constructorJava = GenerateFixture ("my/app/CustomView");
+			AssertContainsLine ("@com.example.Custom\n\tpublic CustomView ()\n", constructorJava);
+
+			var fieldJava = GenerateFixture ("my/app/ExportFieldExample");
+			AssertContainsLine ("@com.example.Custom\n\tpublic java.lang.String VALUE = GetValue ();\n", fieldJava);
+			Assert.Equal (1, fieldJava.Split ("@com.example.Custom").Length - 1);
+		}
+
+		[Fact]
+		public void Generate_PropertyOverride_ForwardsGetterAnnotation ()
+		{
+			var peer = FindFixtureByManagedName ("MyApp.AnnotatedPropertyDerived");
+			var java = GenerateToString (peer);
+
+			AssertContainsLine ("@com.example.Custom\n\t@Override\n\tpublic int getValue ()\n", java);
+		}
+
+		[Fact]
 		public void Generate_OverrideAcrossIntermediateMcwBase_HasMethodStub ()
 		{
 			var java = GenerateFixture ("my/app/SelectableList");

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -360,7 +361,7 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 		public void Generate_ForwardsAnnotationsOnJcwMembers ()
 		{
 			var typeJava = GenerateFixture ("my/app/MyHelper");
-			AssertContainsLine ("@com.example.Custom (text = \"hello\", Enabled = true)\npublic class MyHelper\n", typeJava);
+			AssertContainsLine ("@com.example.Custom (text = \"say \\\"hi\\\"\\\\path\\n\", Enabled = true, Number = 1.5)\npublic class MyHelper\n", typeJava);
 
 			var constructorJava = GenerateFixture ("my/app/CustomView");
 			AssertContainsLine ("@com.example.Custom\n\tpublic CustomView ()\n", constructorJava);
@@ -368,6 +369,21 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 			var fieldJava = GenerateFixture ("my/app/ExportFieldExample");
 			AssertContainsLine ("@com.example.Custom\n\tpublic java.lang.String VALUE = GetValue ();\n", fieldJava);
 			Assert.Equal (1, fieldJava.Split ("@com.example.Custom").Length - 1);
+		}
+
+		[Fact]
+		public void Generate_AnnotationValues_UseInvariantCulture ()
+		{
+			var originalCulture = CultureInfo.CurrentCulture;
+			try {
+				CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo ("fr-FR");
+				var peer = FindFixtureByManagedName ("MyApp.MyHelper", "Crc64");
+				var java = GenerateToString (peer);
+
+				AssertContainsLine ("Number = 1.5", java);
+			} finally {
+				CultureInfo.CurrentCulture = originalCulture;
+			}
 		}
 
 		[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj
@@ -13,6 +13,7 @@
   <!-- Exclude TestFixtures subdirectory — it's a separate project compiled independently -->
   <ItemGroup>
     <Compile Remove="TestFixtures\**" />
+    <Compile Remove="TestAttributeFixtures\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,6 +24,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Android.Sdk.TrimmableTypeMap\Microsoft.Android.Sdk.TrimmableTypeMap.csproj" />
+    <ProjectReference Include="TestAttributeFixtures\TestAttributeFixtures.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="TestFixtures\TestFixtures.csproj">
       <!-- Don't add as a compile-time reference — we only need the built DLL as scanner test input -->
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
@@ -33,6 +37,7 @@
   <Target Name="_CopyTestFixturesOutput" AfterTargets="Build">
     <ItemGroup>
       <_TestFixtureFiles Include="TestFixtures\bin\$(Configuration)\$(DotNetStableTargetFramework)\TestFixtures.dll" />
+      <_TestFixtureFiles Include="TestAttributeFixtures\bin\$(Configuration)\$(DotNetStableTargetFramework)\TestAttributeFixtures.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(_TestFixtureFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
   </Target>

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestAttributeFixtures/Attributes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestAttributeFixtures/Attributes.cs
@@ -60,5 +60,6 @@ namespace MyApp
 		public string? Text { get; set; }
 
 		public bool Enabled { get; set; }
+		public double Number { get; set; }
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestAttributeFixtures/Attributes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestAttributeFixtures/Attributes.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace Java.Interop
+{
+	public interface IJniNameProviderAttribute
+	{
+		string Name { get; }
+	}
+}
+
+namespace Android.Runtime
+{
+	[AttributeUsage (AttributeTargets.Class)]
+	public sealed class AnnotationAttribute : Attribute
+	{
+		public string JavaName { get; }
+
+		public AnnotationAttribute (string javaName) => JavaName = javaName;
+	}
+
+	[AttributeUsage (
+		AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Field |
+		AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Property,
+		AllowMultiple = false)]
+	public sealed class RegisterAttribute : Attribute, Java.Interop.IJniNameProviderAttribute
+	{
+		public string Name { get; }
+		public string? Signature { get; set; }
+		public string? Connector { get; set; }
+		public bool DoNotGenerateAcw { get; set; }
+		public int ApiSince { get; set; }
+
+		public RegisterAttribute (string name) => Name = name;
+
+		public RegisterAttribute (string name, string signature, string connector)
+		{
+			Name = name;
+			Signature = signature;
+			Connector = connector;
+		}
+	}
+}
+
+namespace Android.Webkit
+{
+	[Android.Runtime.Annotation ("android.webkit.JavascriptInterface")]
+	[AttributeUsage (AttributeTargets.Method)]
+	public sealed class JavascriptInterfaceAttribute : Attribute
+	{
+	}
+}
+
+namespace MyApp
+{
+	[Android.Runtime.Annotation ("com.example.Custom")]
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method)]
+	public sealed class JavaAnnotationAttribute : Attribute
+	{
+		[Android.Runtime.Register ("text")]
+		public string? Text { get; set; }
+
+		public bool Enabled { get; set; }
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestAttributeFixtures/TestAttributeFixtures.csproj
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestAttributeFixtures/TestAttributeFixtures.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DotNetStableTargetFramework)</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/StubAttributes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/StubAttributes.cs
@@ -1,37 +1,7 @@
 using System;
 
-namespace Java.Interop
-{
-	public interface IJniNameProviderAttribute
-	{
-		string Name { get; }
-	}
-}
-
 namespace Android.Runtime
 {
-	[AttributeUsage (
-		AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Field |
-		AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Property,
-		AllowMultiple = false)]
-	public sealed class RegisterAttribute : Attribute, Java.Interop.IJniNameProviderAttribute
-	{
-		public string Name { get; }
-		public string? Signature { get; set; }
-		public string? Connector { get; set; }
-		public bool DoNotGenerateAcw { get; set; }
-		public int ApiSince { get; set; }
-
-		public RegisterAttribute (string name) => Name = name;
-
-		public RegisterAttribute (string name, string signature, string connector)
-		{
-			Name = name;
-			Signature = signature;
-			Connector = connector;
-		}
-	}
-
 	public enum JniHandleOwnership
 	{
 		DoNotTransfer = 0,

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestFixtures.csproj
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestFixtures.csproj
@@ -10,4 +10,8 @@
     <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\TestAttributeFixtures\TestAttributeFixtures.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -4,6 +4,7 @@ using System.Xml;
 using Android.App;
 using Android.Content;
 using Android.Runtime;
+using Android.Webkit;
 
 namespace Java.Lang
 {
@@ -275,10 +276,39 @@ namespace MyApp
 	}
 
 	[Register ("my/app/MyHelper")]
+	[JavaAnnotation (Text = "hello", Enabled = true)]
 	public class MyHelper : Java.Lang.Object
 	{
 		[Register ("doSomething", "()V", "GetDoSomethingHandler")]
 		public virtual void DoSomething () { }
+	}
+
+	[Register ("my/app/WebViewHandlerBase")]
+	public abstract class WebViewHandlerBase : Java.Lang.Object
+	{
+		[Register ("postMessage", "(Ljava/lang/String;)V", "GetPostMessage_Ljava_lang_String_Handler")]
+		public abstract void PostMessage (string? message);
+	}
+
+	public class MyWebViewHandler : WebViewHandlerBase
+	{
+		[JavascriptInterface]
+		public override void PostMessage (string? message) { }
+	}
+
+	[Register ("my/app/AnnotatedPropertyBase", DoNotGenerateAcw = true)]
+	public class AnnotatedPropertyBase : Java.Lang.Object
+	{
+		[Register ("getValue", "()I", "GetGetValueHandler")]
+		public virtual int Value => 0;
+	}
+
+	public class AnnotatedPropertyDerived : AnnotatedPropertyBase
+	{
+		public override int Value {
+			[JavaAnnotation]
+			get => 1;
+		}
 	}
 
 	// Fixture for the trimmable typemap's [JniAddNativeMethodRegistrationAttribute] detection.
@@ -350,6 +380,7 @@ namespace MyApp
 		protected CustomView (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
 		[Register ("<init>", "()V", "")]
+		[JavaAnnotation]
 		public CustomView () : base (default, default) { }
 
 		[Register ("<init>", "(Landroid/content/Context;)V", "")]
@@ -583,6 +614,7 @@ namespace MyApp
 		public static ExportFieldExample? GetInstance () => default;
 
 		[Java.Interop.ExportField ("VALUE")]
+		[JavaAnnotation]
 		public string GetValue () => "";
 	}
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -276,7 +276,7 @@ namespace MyApp
 	}
 
 	[Register ("my/app/MyHelper")]
-	[JavaAnnotation (Text = "hello", Enabled = true)]
+	[JavaAnnotation (Text = "say \"hi\"\\path\n", Enabled = true, Number = 1.5)]
 	public class MyHelper : Java.Lang.Object
 	{
 		[Register ("doSomething", "()V", "GetDoSomethingHandler")]


### PR DESCRIPTION
Fixes #12542

## Summary

- forward Java annotations from managed custom attributes through the trimmable NativeAOT JCW pipeline
- preserve annotations on types, methods, registered constructors, property overrides, and exported fields
- cache annotation metadata and support cross-assembly attribute definitions such as `Android.Webkit.JavascriptInterfaceAttribute`
- add regression coverage matching the app-to-`Mono.Android` assembly boundary

## Testing

- `dotnet test tests\Microsoft.Android.Sdk.TrimmableTypeMap.Tests\Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj -v minimal` (773 passed)