### PR TITLE
[native] Drop <chrono> from the timing code

### DIFF
--- a/src/native/common/include/runtime-base/mainthread-dso-loader.hh
+++ b/src/native/common/include/runtime-base/mainthread-dso-loader.hh
@@ -5,7 +5,6 @@
 #include <unistd.h>
 
 #include <array>
-#include <chrono>
 #include <semaphore>
 #include <string_view>
 

--- a/src/native/common/include/runtime-base/timing-internal.hh
+++ b/src/native/common/include/runtime-base/timing-internal.hh
@@ -33,8 +33,12 @@ namespace xamarin::android {
 	// A monotonic point in time, or an interval between two such points, in nanoseconds.
 	using time_point = uint64_t;
 
-	// Splits an interval into the components used by the timing output format: whole seconds,
-	// whole milliseconds and the nanoseconds left over within the last millisecond.
+	// Splits an interval into the components used by the timing output format. Note that `seconds`
+	// and `milliseconds` are both totals for the *entire* interval rather than a breakdown of it:
+	// an interval of 1.5s has `seconds == 1` and `milliseconds == 1500`, and both are printed. This
+	// is what `duration_cast<seconds>` and `duration_cast<milliseconds>` used to return and it must
+	// not be "corrected" to milliseconds-within-the-second, because the output format is consumed by
+	// performance measuring utilities. Only `nanoseconds` is a remainder, within the last millisecond.
 	struct time_interval
 	{
 		unsigned long long seconds;

--- a/src/native/common/include/runtime-base/timing-internal.hh
+++ b/src/native/common/include/runtime-base/timing-internal.hh
@@ -2,7 +2,6 @@
 
 #include <atomic>
 #include <cerrno>
-#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -28,9 +27,26 @@ using namespace xamarin::android::internal;
 #include <shared/log_types.hh>
 
 namespace xamarin::android {
-	namespace chrono = std::chrono;
+	inline constexpr uint64_t NANOSECONDS_PER_MILLISECOND = 1000000ull;
+	inline constexpr uint64_t NANOSECONDS_PER_SECOND = 1000000000ull;
 
-	using time_point = chrono::time_point<chrono::steady_clock, chrono::nanoseconds>;
+	// A monotonic point in time, or an interval between two such points, in nanoseconds.
+	using time_point = uint64_t;
+
+	// Splits an interval into the components used by the timing output format: whole seconds,
+	// whole milliseconds and the nanoseconds left over within the last millisecond.
+	struct time_interval
+	{
+		unsigned long long seconds;
+		unsigned long long milliseconds;
+		unsigned long long nanoseconds;
+
+		explicit constexpr time_interval (time_point interval) noexcept
+			: seconds { interval / NANOSECONDS_PER_SECOND },
+			  milliseconds { interval / NANOSECONDS_PER_MILLISECOND },
+			  nanoseconds { interval % NANOSECONDS_PER_MILLISECOND }
+		{}
+	};
 
 	// Events should never change their assigned values and no values should be reused.
 	// Values are used by the test runner to determine what measurement was taken.
@@ -198,15 +214,13 @@ namespace xamarin::android {
 		[[gnu::always_inline]]
 		static auto event_duration_ns (TimingEvent const& event) noexcept -> uint64_t
 		{
-			return static_cast<uint64_t>((event.end - event.start).count ());
+			return event.end - event.start;
 		}
 
 		// Returns the message length excluding NUL, or the negative required capacity including NUL.
 		static auto format_message (TimingEvent const& event, char *buffer, size_t buffer_size, bool indent) noexcept -> ssize_t
 		{
-			using namespace std::literals;
-
-			auto interval = event.end - event.start; // nanoseconds
+			time_interval interval { event.end - event.start };
 			int length = snprintf (
 				buffer,
 				buffer_size,
@@ -216,9 +230,9 @@ namespace xamarin::android {
 				static_cast<unsigned int>(event.kind),
 				event_kind_description (event.kind),
 				event.more_info == nullptr ? "" : event.more_info,
-				static_cast<unsigned long long>(chrono::duration_cast<chrono::seconds>(interval).count ()),
-				static_cast<unsigned long long>(chrono::duration_cast<chrono::milliseconds>(interval).count ()),
-				static_cast<unsigned long long>((interval % 1ms).count ())
+				interval.seconds,
+				interval.milliseconds,
+				interval.nanoseconds
 			);
 			if (length < 0) {
 				if (buffer != nullptr && buffer_size > 0uz) {
@@ -382,11 +396,11 @@ namespace xamarin::android {
 		static auto get_time () noexcept -> time_point
 		{
 			struct timespec t;
-			if (clock_gettime (CLOCK_MONOTONIC_RAW, &t) != 0) [[unlikely]] {
-				log_warnf (LOG_TIMING, "clock_gettime failed for CLOCK_MONOTONIC_RAW: %s", optional_string (strerror (errno)));
+			if (clock_gettime (CLOCK_MONOTONIC, &t) != 0) [[unlikely]] {
+				log_warnf (LOG_TIMING, "clock_gettime failed for CLOCK_MONOTONIC: %s", optional_string (strerror (errno)));
 				return {}; // Results will be nonsensical, but no point in aborting the app
 			}
-			return time_point (chrono::seconds (t.tv_sec) + chrono::nanoseconds (t.tv_nsec));
+			return (static_cast<time_point>(t.tv_sec) * NANOSECONDS_PER_SECOND) + static_cast<time_point>(t.tv_nsec);
 		}
 
 	private:

--- a/src/native/common/include/runtime-base/timing.hh
+++ b/src/native/common/include/runtime-base/timing.hh
@@ -3,7 +3,6 @@
 #include <pthread.h>
 #include <sys/time.h>
 
-#include <chrono>
 #include <cstdlib>
 #include <string_view>
 
@@ -46,8 +45,8 @@ namespace xamarin::android
 				ret = allocate_chunk ();
 			}
 
-			ret->start = time_point::min ();
-			ret->end = time_point::min ();
+			ret->start = 0;
+			ret->end = 0;
 			ret->in_use = true;
 
 			pthread_mutex_unlock (&sequence_lock);
@@ -114,16 +113,15 @@ namespace xamarin::android
 				return;
 			}
 
-			using namespace std::literals;
-			auto interval = seq->end - seq->start; // nanoseconds
+			time_interval interval { seq->end - seq->start };
 			log_writef (
 				LOG_TIMING,
 				level,
 				"%s; elapsed: %llu:%llu::%llu",
 				optional_string (message, ""),
-				static_cast<unsigned long long>(std::chrono::duration_cast<std::chrono::seconds>(interval).count ()),
-				static_cast<unsigned long long>(std::chrono::duration_cast<std::chrono::milliseconds>(interval).count ()),
-				static_cast<unsigned long long>((interval % 1ms).count ())
+				interval.seconds,
+				interval.milliseconds,
+				interval.nanoseconds
 			);
 		}
 

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -1,4 +1,3 @@
-#include <chrono>
 #include <cstdlib>
 
 #include <runtime-base/android-system.hh>
@@ -11,8 +10,6 @@ namespace xamarin::android {
 
 using namespace xamarin::android;
 using namespace std::literals;
-
-namespace chrono = std::chrono;
 
 namespace {
 	void write_line_to_logcat ([[maybe_unused]] FILE *output, std::string_view const& line) noexcept
@@ -180,19 +177,19 @@ void FastTiming::dump (size_t entries, bool indent, LineWriter line_writer, FILE
 
 	auto log_time = [&line_writer, output] (std::string_view const& msg, uint64_t ns)
 	{
-		chrono::nanoseconds time_ns (ns);
+		time_interval interval { ns };
 		// Do not change the string format after the first colon, its format is required by performance measuring
 		// utilities.
 		auto format_time = [&] (char *buffer, size_t buffer_size) noexcept -> int {
 			return snprintf (
 				buffer,
 				buffer_size,
-				"  %.*s: %lld:%lld::%lld",
+				"  %.*s: %llu:%llu::%llu",
 				static_cast<int>(msg.length ()),
 				msg.data (),
-				static_cast<long long>(chrono::duration_cast<chrono::seconds> (time_ns).count ()),
-				static_cast<long long>(chrono::duration_cast<chrono::milliseconds> (time_ns).count ()),
-				static_cast<long long>((time_ns % 1ms).count ())
+				interval.seconds,
+				interval.milliseconds,
+				interval.nanoseconds
 			);
 		};
 

--- a/src/native/mono/monodroid/monodroid-glue.cc
+++ b/src/native/mono/monodroid/monodroid-glue.cc
@@ -116,15 +116,15 @@ MonodroidRuntime::log_jit_event (MonoMethod *method, const char *event_name) noe
 
 	char* name = mono_method_full_name (method, 1);
 
-	auto interval = jit_time_end - jit_time_start; // nanoseconds
+	time_interval interval { jit_time_end - jit_time_start };
 	fprintf (
 		jit_log,
 		"JIT method %6s: %s elapsed: %zus:%zu::%zu\n",
 		event_name,
 		name,
-		static_cast<size_t>((chrono::duration_cast<chrono::seconds>(interval).count ())),
-		static_cast<size_t>((chrono::duration_cast<chrono::milliseconds>(interval)).count ()),
-		static_cast<size_t>((interval % 1ms).count ())
+		static_cast<size_t>(interval.seconds),
+		static_cast<size_t>(interval.milliseconds),
+		static_cast<size_t>(interval.nanoseconds)
 	);
 
 	free (name);


### PR DESCRIPTION
Part of the [drop-libc++](https://github.com/dotnet/android/issues/12533) work for CoreCLR.

`FastTiming::get_time()` has always read the clock with `clock_gettime()` directly — the comment above it even says we do that to avoid calling into libc++:

```c++
// We cheat a bit here, by avoiding a call to libc++ code that performs the same action.
// We can do it because we know our target platform.
```

`std::chrono::steady_clock` was then used only as the *type tag* of the `chrono::time_point` we wrapped the result in. So we were paying for `<chrono>` without using the clock it provides.

This PR stores timestamps as a plain `uint64_t` nanosecond count and removes `<chrono>` from the four files that included it. In `mainthread-dso-loader.hh` the include was entirely unused.

### Sharing the interval formatting

Four places repeated the same seconds / milliseconds / nanoseconds-within-the-millisecond split, so they now share one helper:

```c++
struct time_interval
{
	unsigned long long seconds;
	unsigned long long milliseconds;
	unsigned long long nanoseconds;

	explicit constexpr time_interval (time_point interval) noexcept
		: seconds { interval / NANOSECONDS_PER_SECOND },
		  milliseconds { interval / NANOSECONDS_PER_MILLISECOND },
		  nanoseconds { interval % NANOSECONDS_PER_MILLISECOND }
	{}
};
```

The split reproduces `chrono::duration_cast` exactly, including the fact that the middle field is the *total* milliseconds rather than a remainder. **The timing output is byte-for-byte unchanged**, which matters because the format after the first colon is parsed by our performance measuring utilities.

I verified this rather than assuming it: a standalone harness compared the old `chrono` computation against `time_interval` over the nine interesting edge cases (`0`, `999999`, `1000000`, `1000001`, `999999999`, `1000000000`, …, `INT64_MAX`) plus 2,000,000 random values — **2,000,009 checked, 0 mismatches**.

### CLOCK_MONOTONIC_RAW → CLOCK_MONOTONIC

We now read `CLOCK_MONOTONIC`, the clock `steady_clock` is specified to use, instead of `CLOCK_MONOTONIC_RAW`. The two differ only in that `CLOCK_MONOTONIC` is slewed by NTP, which is irrelevant at the granularity we measure.

### Results

**This does not remove any undefined libc++ symbols — the count stays at 59.** `<chrono>` is header-only, so it never contributed any. What it does do is shrink the binary slightly and remove one more libc++ header from the build, which is a prerequisite for eventually building without libc++ headers at all:

| | before | after | delta |
|---|---:|---:|---:|
| `libnet-android.release.so` | 539,912 | 539,832 | **−80 B** |
| `timing-internal.cc.o` | 39,880 | 39,872 | −8 B |

(Measured against a real rebuild of the parent commit, not remembered numbers.)

### Testing

* CoreCLR and MonoVM both build clean (only the pre-existing `format_managed_type_name` warning).
* `time_interval` verified against `chrono` over 2,000,009 inputs as described above.
