### PR TITLE
[native] Replace the bundled properties map with a linked list

### DIFF
--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -6,7 +6,6 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
 #include "../constants.hh"
 #include <shared/log_types.hh>
@@ -14,9 +13,20 @@
 #include <runtime-base/jni-wrappers.hh>
 #include "util.hh"
 
-struct BundledProperty;
-
 namespace xamarin::android {
+#if defined (DEBUG)
+	// A system property bundled with the application, read from the environment override files.
+	// `name` is allocated together with the structure and never changes, `value` is allocated
+	// separately so that it can be replaced when the same property is set more than once.
+	struct BundledProperty
+	{
+		BundledProperty *next;
+		char            *name;
+		char            *value;
+		size_t           value_len;
+	};
+#endif
+
 	class AndroidSystem
 	{
 #if !defined (XA_HOST_NATIVEAOT)
@@ -170,6 +180,9 @@ namespace xamarin::android {
 		static auto load_dso_from_app_lib_dirs (std::string_view const& name, int dl_flags, bool is_jni) noexcept -> void*;
 		static auto load_dso_from_override_dirs (std::string_view const& name, int dl_flags, bool is_jni) noexcept -> void*;
 		static auto lookup_system_property (const char *name, size_t &value_len) noexcept -> const char*;
+#if defined (DEBUG)
+		static auto find_bundled_property (const char *name) noexcept -> BundledProperty*;
+#endif
 		static auto monodroid__system_property_get (const char *name, char *sp_value) noexcept -> int;
 		static auto get_max_gref_count_from_system () noexcept -> long;
 		static void add_apk_libdir (std::string_view const& apk, size_t &index, std::string_view const& abi) noexcept;
@@ -247,7 +260,7 @@ namespace xamarin::android {
 		static inline std::string app_code_cache_dir;
 
 #if defined (DEBUG)
-		static inline std::unordered_map<std::string, std::string> bundled_properties;
+		static inline BundledProperty *bundled_properties = nullptr;
 #endif
 #endif
 	};

--- a/src/native/clr/runtime-base/android-system.cc
+++ b/src/native/clr/runtime-base/android-system.cc
@@ -18,6 +18,18 @@ using namespace xamarin::android;
 using std::operator""sv;
 
 #if defined(DEBUG)
+auto
+AndroidSystem::find_bundled_property (const char *name) noexcept -> BundledProperty*
+{
+	for (BundledProperty *p = bundled_properties; p != nullptr; p = p->next) {
+		if (strcmp (name, p->name) == 0) {
+			return p;
+		}
+	}
+
+	return nullptr;
+}
+
 [[gnu::always_inline]]
 void
 AndroidSystem::add_system_property (const char *name, const char *value) noexcept
@@ -31,7 +43,37 @@ AndroidSystem::add_system_property (const char *name, const char *value) noexcep
 		value = "";
 	}
 
-	bundled_properties[name] = value;
+	size_t value_len = strlen (value);
+	char *new_value = strdup (value);
+	if (new_value == nullptr) [[unlikely]] {
+		Helpers::abort_application (LOG_DEFAULT, "Unable to allocate memory for a bundled system property value");
+	}
+
+	// Setting the same property again replaces its value, the name is kept.
+	BundledProperty *p = find_bundled_property (name);
+	if (p != nullptr) {
+		std::free (p->value);
+		p->value = new_value;
+		p->value_len = value_len;
+		return;
+	}
+
+	// The name is stored right after the structure, so that a single allocation covers both.
+	// Bundled properties are never removed, they live for as long as the process does.
+	size_t name_len = strlen (name);
+	size_t alloc_size = Helpers::add_with_overflow_check<size_t> (sizeof (BundledProperty), name_len + 1uz);
+	p = static_cast<BundledProperty*> (std::malloc (alloc_size));
+	if (p == nullptr) [[unlikely]] {
+		Helpers::abort_application (LOG_DEFAULT, "Unable to allocate memory for a bundled system property");
+	}
+
+	p->name = reinterpret_cast<char*>(p) + sizeof (BundledProperty);
+	memcpy (p->name, name, name_len);
+	p->name [name_len] = '\0';
+	p->value = new_value;
+	p->value_len = value_len;
+	p->next = bundled_properties;
+	bundled_properties = p;
 }
 
 void
@@ -296,12 +338,10 @@ AndroidSystem::lookup_system_property (const char *name, size_t &value_len) noex
 {
 	value_len = 0;
 #if defined (DEBUG)
-	if (!bundled_properties.empty ()) {
-		auto prop_iter = bundled_properties.find (name);
-		if (prop_iter != bundled_properties.end ()) {
-			value_len = prop_iter->second.length ();
-			return prop_iter->second.c_str ();
-		}
+	BundledProperty *p = find_bundled_property (name);
+	if (p != nullptr) {
+		value_len = p->value_len;
+		return p->value;
 	}
 #endif // DEBUG
 


### PR DESCRIPTION
<!-- stack-prerequisites -->
> **PR relationship:** No open PR prerequisite. This is the bottom of stack #12654.
<!-- /stack-prerequisites -->

Part of the [drop-libc++](https://github.com/dotnet/android/issues/12533) work for CoreCLR.

`AndroidSystem::bundled_properties` was an `std::unordered_map<std::string, std::string>` and the only user of `<unordered_map>` in the CoreCLR host.

A sorted static array + binary search isn't an option here: bundled properties are read from the environment override files **at run time**, so the set isn't known at build time. But the map isn't buying us anything either — the entries are added once during startup, looked up a handful of times, and there are only a few of them.

So this uses the same malloc'd singly linked list that **MonoVM has always used** for exactly this purpose (`BundledProperty`), keeping the two runtimes consistent:

```c++
struct BundledProperty
{
	BundledProperty *next;
	char            *name;
	char            *value;
	size_t           value_len;
};
```

The name is allocated together with the node (one allocation covers both); the value is allocated separately so that setting the same property twice can replace it. Allocation failure aborts, as elsewhere in this stack.

### This also fixes a real bug

The lookup returned the map **key** instead of the value:

```c++
value_len = prop_iter->second.length ();   // the value's length
return prop_iter->first.c_str ();          // ...but the *name*
```

So in Debug builds every bundled property resolved to its own *name*, reported with the *value's* length. When the value is longer than the name that's an over-read past the end of the name's buffer. This is pre-existing on `main`, and falls out of the rewrite for free.

### Results

This code is `#if defined (DEBUG)` only, so **Release builds are completely unaffected** — I verified the undefined-libc++-symbol list per object file is byte-for-byte identical before and after (58 both ways).

The win is in Debug builds. Compiling `android-system.cc` with the real build flags plus `-DDEBUG`:

| | before | after |
|---|---:|---:|
| undefined libc++ symbols | 13 | **12** |
| object size | 83,400 | **77,984** (−5,416) |

The symbol that disappears is `std::__ndk1::__next_prime()` — the bucket-count helper that is `unordered_map`'s only out-of-line dependency.

### Testing

* CoreCLR and MonoVM Release builds are clean.
* The Debug path was compile-checked with the real build flags plus `-DDEBUG`, and I confirmed via `llvm-nm` that the new code is genuinely being compiled (`find_bundled_property` and `add_system_property` are present in the object) rather than silently skipped.