### PR TITLE
[typemap] Preserve exported constructor throws metadata

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -175,9 +175,10 @@ public sealed class JcwJavaSourceGenerator
 			string parameters = FormatParameterList (ctorParams);
 			string superArgs = ctor.SuperArgumentsString ?? FormatArgumentList (ctorParams);
 			string args = FormatArgumentList (ctorParams);
+			string throwsClause = FormatThrowsClause (ctor.ThrownNames);
 
 			writer.Write ($$"""
-	public {{simpleClassName}} ({{parameters}})
+	public {{simpleClassName}} ({{parameters}}){{throwsClause}}
 	{
 		super ({{superArgs}});
 
@@ -251,10 +252,7 @@ public sealed class JcwJavaSourceGenerator
 			string returnPrefix = isVoid ? "" : "return ";
 
 			// throws clause for [Export] methods
-			string throwsClause = "";
-			if (method.ThrownNames != null && method.ThrownNames.Count > 0) {
-				throwsClause = $"\n\t\tthrows {string.Join (", ", method.ThrownNames)}";
-			}
+			string throwsClause = FormatThrowsClause (method.ThrownNames);
 
 			if (method.Connector != null && !method.IsExport) {
 				writer.Write ($$"""
@@ -307,6 +305,19 @@ public sealed class JcwJavaSourceGenerator
 	static void WriteClassClose (TextWriter writer)
 	{
 		writer.WriteLine ('}');
+	}
+
+	static string FormatThrowsClause (IReadOnlyList<string>? thrownNames)
+	{
+		if (thrownNames == null || thrownNames.Count == 0) {
+			return "";
+		}
+
+		var javaNames = new string [thrownNames.Count];
+		for (int i = 0; i < thrownNames.Count; i++) {
+			javaNames [i] = JniSignatureHelper.JniNameToJavaName (thrownNames [i]);
+		}
+		return $"\n\t\tthrows {string.Join (", ", javaNames)}";
 	}
 
 	static string FormatParameterList (IReadOnlyList<JniParameterInfo> parameters)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -336,6 +336,12 @@ public sealed record JavaConstructorInfo
 	public string? SuperArgumentsString { get; init; }
 
 	/// <summary>
+	/// For [Export] constructors: Java exception types that the constructor declares it can throw.
+	/// Null for [Register] constructors.
+	/// </summary>
+	public IReadOnlyList<string>? ThrownNames { get; init; }
+
+	/// <summary>
 	/// Managed constructor parameter types, in declaration order.
 	/// </summary>
 	internal IReadOnlyList<TypeRefData> ManagedParameterTypes { get; init; } = [];

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -2479,6 +2479,7 @@ public sealed class JavaPeerScanner : IDisposable
 				JniSignature = mm.JniSignature,
 				ConstructorIndex = ctorIndex,
 				SuperArgumentsString = mm.SuperArgumentsString,
+				ThrownNames = mm.ThrownNames,
 				HasMatchingManagedCtor = managedParams != null,
 				ManagedParameterTypes = managedParams ?? [],
 			});

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -98,6 +98,13 @@ public class TrimmableTypeMapGenerator
 			}
 			foreach (var constructor in peer.JavaConstructors) {
 				ValidateJniSignature (constructor.JniSignature);
+				if (constructor.ThrownNames is not null) {
+					foreach (var thrownName in constructor.ThrownNames) {
+						if (JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (thrownName, out invalidIdentifier)) {
+							ReportInvalidName (thrownName, invalidIdentifier);
+						}
+					}
+				}
 			}
 			foreach (var method in peer.MarshalMethods) {
 				if (!method.IsConstructor) {

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -100,7 +100,8 @@ public class TrimmableTypeMapGenerator
 				ValidateJniSignature (constructor.JniSignature);
 				if (constructor.ThrownNames is not null) {
 					foreach (var thrownName in constructor.ThrownNames) {
-						if (JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (thrownName, out invalidIdentifier)) {
+						var javaThrownName = JniSignatureHelper.JniNameToJavaName (thrownName);
+						if (JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (javaThrownName, out invalidIdentifier)) {
 							ReportInvalidName (thrownName, invalidIdentifier);
 						}
 					}
@@ -112,7 +113,8 @@ public class TrimmableTypeMapGenerator
 				}
 				if (method.ThrownNames is not null) {
 					foreach (var thrownName in method.ThrownNames) {
-						if (JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (thrownName, out invalidIdentifier)) {
+						var javaThrownName = JniSignatureHelper.JniNameToJavaName (thrownName);
+						if (JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (javaThrownName, out invalidIdentifier)) {
 							ReportInvalidName (thrownName, invalidIdentifier);
 						}
 					}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerExportShapesTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerExportShapesTests.cs
@@ -29,6 +29,11 @@ public class ScannerExportShapesTests
 
 	static MarshalMethodInfo[] GetMarshalMethods (string javaName)
 	{
+		return GetPeer (javaName).MarshalMethods.ToArray ();
+	}
+
+	static JavaPeerInfo GetPeer (string javaName)
+	{
 		var fixturePath = UserTypesFixturePath;
 		var dir = AssertNotNull (Path.GetDirectoryName (fixturePath));
 
@@ -53,7 +58,7 @@ public class ScannerExportShapesTests
 
 			var peers = scanner.Scan (assemblies);
 			var peer = peers.FirstOrDefault (p => p.ManagedTypeName.EndsWith (javaName));
-			return AssertNotNull (peer).MarshalMethods.ToArray ();
+			return AssertNotNull (peer);
 		} finally {
 			foreach (var pe in peReaders)
 				pe.Dispose ();
@@ -118,6 +123,16 @@ public class ScannerExportShapesTests
 		var multiThrownNames = AssertNotNull (multiThrow.ThrownNames);
 		Assert.Contains ("java/io/IOException", multiThrownNames);
 		Assert.Contains ("java/lang/IllegalStateException", multiThrownNames);
+	}
+
+	[Fact]
+	public void ExportConstructor_WithThrowsClause_SurfacesDeclaredExceptions ()
+	{
+		var peer = GetPeer ("ExportThrowsShapes");
+		var constructor = Assert.Single (peer.JavaConstructors);
+		var thrownNames = AssertNotNull (constructor.ThrownNames);
+
+		Assert.Equal (["java/io/IOException", "java/lang/IllegalStateException"], thrownNames);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/UserTypesFixture/UserTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/UserTypesFixture/UserTypes.cs
@@ -252,6 +252,9 @@ namespace UserApp
 	// A.2: [Export(Throws = ...)] — declared exceptions in JNI signature.
 	public class ExportThrowsShapes : Java.Lang.Object
 	{
+		[Export (Throws = new [] { typeof (Java.IO.IOException), typeof (Java.Lang.IllegalStateException) }, SuperArgumentsString = "")]
+		public ExportThrowsShapes () { }
+
 		[Export ("ioCall", Throws = new [] { typeof (Java.IO.IOException) })]
 		public void IoCall () { }
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -464,6 +464,13 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 			AssertContainsLine ("throws java.io.IOException, java.lang.IllegalStateException\n", java);
 		}
 
+		[Fact]
+		public void Generate_ExportConstructorWithThrows_HasThrowsClause ()
+		{
+			var java = GenerateFixture ("my/app/ExportWithThrows");
+			AssertContainsLine ("public ExportWithThrows ()\n\t\tthrows java.io.IOException, java.lang.IllegalStateException\n", java);
+		}
+
 	}
 
 	public class StaticExportMethods

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -180,6 +180,7 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 					new JavaConstructorInfo {
 						JniSignature = "(Lcom/example/Outer$for;)V",
 						ConstructorIndex = 0,
+						ThrownNames = ["com/example/Outer$permits"],
 					},
 				],
 				MarshalMethods = [
@@ -188,7 +189,7 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 						JniSignature = "([Lcom/example/Outer$record;)Lcom/example/Outer$yield;",
 						ManagedMethodName = "Method",
 						NativeCallbackName = "n_method",
-						ThrownNames = ["com.example.Outer.permits"],
+						ThrownNames = ["com/example/Outer$sealed"],
 					},
 				],
 				JavaFields = [
@@ -206,7 +207,8 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 		Assert.Contains (logMessages, message => message.Contains ("Java name 'com/example/Outer$for' contains reserved Java identifier 'for'."));
 		Assert.Contains (logMessages, message => message.Contains ("Java name 'com/example/Outer$record' contains reserved Java identifier 'record'."));
 		Assert.Contains (logMessages, message => message.Contains ("Java name 'com/example/Outer$yield' contains reserved Java identifier 'yield'."));
-		Assert.Contains (logMessages, message => message.Contains ("Java name 'com.example.Outer.permits' contains reserved Java identifier 'permits'."));
+		Assert.Contains (logMessages, message => message.Contains ("Java name 'com/example/Outer$permits' contains reserved Java identifier 'permits'."));
+		Assert.Contains (logMessages, message => message.Contains ("Java name 'com/example/Outer$sealed' contains reserved Java identifier 'sealed'."));
 		Assert.Contains (logMessages, message => message.Contains ("Java name 'com.example.Outer.sealed' contains reserved Java identifier 'sealed'."));
 	}
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/StubAttributes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/StubAttributes.cs
@@ -178,11 +178,12 @@ namespace Android.Content
 
 namespace Java.Interop
 {
-	[AttributeUsage (AttributeTargets.Method, AllowMultiple = false)]
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, AllowMultiple = false)]
 	public sealed class ExportAttribute : Attribute
 	{
 		public string? Name { get; set; }
 		public string[]? ThrownNames { get; set; }
+		public string? SuperArgumentsString { get; set; }
 
 		public ExportAttribute () { }
 		public ExportAttribute (string name) => Name = name;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -1244,6 +1244,9 @@ namespace MyApp.Generic
 	{
 		protected ExportWithThrows (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
+		[Java.Interop.Export (SuperArgumentsString = "", ThrownNames = new [] { "java.io.IOException", "java.lang.IllegalStateException" })]
+		public ExportWithThrows () { }
+
 		[Java.Interop.Export ("riskyMethod", ThrownNames = new [] { "java.io.IOException", "java.lang.IllegalStateException" })]
 		public void RiskyMethod () { }
 	}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ConstructorActivationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ConstructorActivationTests.cs
@@ -163,6 +163,18 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		[Category ("ConstructorParity")]
+		public void JavaSideExportConstructorWithThrowsRunsOnce ()
+		{
+			ConstructorActivationWithThrows.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationWithThrows> ("()V")) {
+				Assert.AreEqual (1, ConstructorActivationWithThrows.ConstructorInvocations);
+				AssertRegisteredSame (instance);
+			}
+		}
+
+		[Test]
 		public void JavaSideContextConstructorForwardsArgument ()
 		{
 			ConstructorActivationContextView.Reset ();
@@ -788,6 +800,23 @@ namespace Java.InteropTests
 		{
 			ConstructorInvocations++;
 			throw new InvalidOperationException (ExceptionMessage);
+		}
+
+		public static void Reset ()
+		{
+			ConstructorInvocations = 0;
+		}
+	}
+
+	[Register ("net/dot/android/test/ConstructorActivationWithThrows")]
+	public class ConstructorActivationWithThrows : Java.Lang.Object
+	{
+		public static int ConstructorInvocations;
+
+		[Export (SuperArgumentsString = "", Throws = new [] { typeof (Java.IO.IOException) })]
+		public ConstructorActivationWithThrows ()
+		{
+			ConstructorInvocations++;
 		}
 
 		public static void Reset ()

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -156,10 +156,14 @@ namespace Java.InteropTests
 			try {
 				using var first = Java.Lang.Object.GetObject<GenericHolder<int>> (handle, JniHandleOwnership.DoNotTransfer);
 				var second = Java.Lang.Object.GetObject<GenericHolder<int>> (handle, JniHandleOwnership.DoNotTransfer);
-
-				Assert.IsNotNull (first);
-				Assert.AreSame (first, second);
-				Assert.AreEqual (1, GenericHolder<int>.ActivationConstructorInvocations);
+				try {
+					Assert.IsNotNull (first);
+					Assert.AreSame (first, second);
+					Assert.AreEqual (1, GenericHolder<int>.ActivationConstructorInvocations);
+				} finally {
+					if (!ReferenceEquals (first, second))
+						second?.Dispose ();
+				}
 			} finally {
 				JNIEnv.DeleteLocalRef (handle);
 			}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -147,6 +147,25 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		[Category ("ConstructorParity")]
+		public void ExistingJavaObjectWrapsAsKnownClosedGenericType ()
+		{
+			GenericHolder<int>.ActivationConstructorInvocations = 0;
+
+			IntPtr handle = JNIEnv.CreateInstance (typeof (GenericHolder<int>), "()V");
+			try {
+				using var first = Java.Lang.Object.GetObject<GenericHolder<int>> (handle, JniHandleOwnership.DoNotTransfer);
+				var second = Java.Lang.Object.GetObject<GenericHolder<int>> (handle, JniHandleOwnership.DoNotTransfer);
+
+				Assert.IsNotNull (first);
+				Assert.AreSame (first, second);
+				Assert.AreEqual (1, GenericHolder<int>.ActivationConstructorInvocations);
+			} finally {
+				JNIEnv.DeleteLocalRef (handle);
+			}
+		}
+
+		[Test]
 		public void NewObjectArrayWithNullArray ()
 		{
 			Assert.AreEqual (IntPtr.Zero, JNIEnv.NewObjectArray<Java.Lang.Object> (null), "#1");
@@ -685,6 +704,18 @@ namespace Java.InteropTests
 	}
 
 	class GenericHolder<T> : Java.Lang.Object {
+
+		public static int ActivationConstructorInvocations;
+
+		public GenericHolder ()
+		{
+		}
+
+		protected GenericHolder (IntPtr handle, JniHandleOwnership transfer)
+			: base (handle, transfer)
+		{
+			ActivationConstructorInvocations++;
+		}
 
 		public T Value {get; set;}
 


### PR DESCRIPTION
## Summary

- preserve `[Export(Throws = ...)]` metadata on generated Java constructors
- convert JNI exception names to valid Java source names for constructor and method `throws` clauses
- validate converted exception names for reserved Java identifiers
- add scanner, generator, integration, and constructor activation coverage
- add closed-generic wrapping coverage for exactly-once activation and stable peer identity

## TDD matrix

The constructor fixture passed with `llvm-ir` and failed with the original trimmable typemap because its generated Java constructor omitted the checked exception declaration. After the fix, the unchanged constructor parity category passes under:

- llvm-ir + CoreCLR: 2/2
- trimmable + CoreCLR: 2/2
- trimmable + NativeAOT: 2/2

Additional validation:

- `Microsoft.Android.Sdk.TrimmableTypeMap.Tests`: 771/771
- `Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests`: 24/24

Fixes #12561