### PR TITLE
[native] Fix a JNI reference leak and drop new[] from jstring_array_wrapper

### DIFF
--- a/src/native/common/include/runtime-base/jni-wrappers.hh
+++ b/src/native/common/include/runtime-base/jni-wrappers.hh
@@ -178,7 +178,8 @@ namespace xamarin::android
 				return;
 			}
 
-			wrappers = static_cast<jstring_wrapper*> (std::malloc (len * sizeof (jstring_wrapper)));
+			size_t alloc_size = Helpers::multiply_with_overflow_check<size_t> (len, sizeof (jstring_wrapper));
+			wrappers = static_cast<jstring_wrapper*> (std::malloc (alloc_size));
 			abort_unless (wrappers != nullptr, "Failed to allocate the JNI string array wrapper");
 			for (size_t i = 0; i < len; i++) {
 				new (&wrappers [i]) jstring_wrapper ();

--- a/src/native/common/include/runtime-base/jni-wrappers.hh
+++ b/src/native/common/include/runtime-base/jni-wrappers.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <iterator>
 #include <new>
 
 #include <jni.h>
@@ -11,6 +12,7 @@ namespace xamarin::android
 {
 	class jstring_array_wrapper;
 
+	// Owns each non-null JNI reference it receives until reassignment or destruction.
 	class jstring_wrapper
 	{
 	public:
@@ -97,9 +99,10 @@ namespace xamarin::android
 	protected:
 		void release () noexcept
 		{
-			if (env == nullptr || jstr == nullptr) {
+			if (jstr == nullptr) {
 				return;
 			}
+			abort_unless (env != nullptr, "Cannot release a JNI string reference without a JNIEnv");
 
 			// The UTF characters are fetched lazily, so there may be nothing to release here even
 			// though we still own the reference itself.
@@ -137,7 +140,6 @@ namespace xamarin::android
 			}
 
 			jstr = new_js;
-			cstr = nullptr;
 		}
 
 		friend class jstring_array_wrapper;
@@ -172,8 +174,10 @@ namespace xamarin::android
 				return;
 			}
 
-			len = static_cast<size_t>(_env->GetArrayLength (_arr));
-			if (len <= sizeof (static_wrappers) / sizeof (jstring_wrapper)) {
+			jsize array_length = _env->GetArrayLength (_arr);
+			abort_unless (array_length >= 0, "Failed to obtain the JNI string array length");
+			len = static_cast<size_t>(array_length);
+			if (len <= std::size (static_wrappers)) {
 				wrappers = static_wrappers;
 				return;
 			}
@@ -205,9 +209,7 @@ namespace xamarin::android
 
 		jstring_wrapper& operator[] (size_t index) noexcept
 		{
-			if (index >= len) {
-				return invalid_wrapper;
-			}
+			abort_unless (index < len, "JNI string array index out of range");
 
 			if (wrappers [index].env == nullptr) {
 				wrappers [index].env = env;
@@ -221,8 +223,8 @@ namespace xamarin::android
 		JNIEnv *env;
 		jobjectArray arr;
 		size_t len;
+		// Points to static_wrappers or storage allocated with malloc().
 		jstring_wrapper *wrappers;
 		jstring_wrapper  static_wrappers[5];
-		jstring_wrapper  invalid_wrapper;
 	};
 }

--- a/src/native/common/include/runtime-base/jni-wrappers.hh
+++ b/src/native/common/include/runtime-base/jni-wrappers.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <new>
 
 #include <jni.h>
 
@@ -96,10 +97,17 @@ namespace xamarin::android
 	protected:
 		void release () noexcept
 		{
-			if (jstr == nullptr || cstr == nullptr || env == nullptr) {
+			if (env == nullptr || jstr == nullptr) {
 				return;
 			}
-			env->ReleaseStringUTFChars (jstr, cstr);
+
+			// The UTF characters are fetched lazily, so there may be nothing to release here even
+			// though we still own the reference itself.
+			if (cstr != nullptr) {
+				env->ReleaseStringUTFChars (jstr, cstr);
+				cstr = nullptr;
+			}
+
 			jobjectRefType type = env->GetObjectRefType (jstr);
 			switch (type) {
 				case JNILocalRefType:
@@ -119,7 +127,6 @@ namespace xamarin::android
 			}
 
 			jstr = nullptr;
-			cstr = nullptr;
 		}
 
 		void assign (const jstring new_js) noexcept
@@ -159,24 +166,35 @@ namespace xamarin::android
 			  arr (_arr)
 		{
 			abort_if_invalid_pointer_argument (_env, "_env");
-			if (_arr != nullptr) {
-				len = static_cast<size_t>(_env->GetArrayLength (_arr));
-				if (len > sizeof (static_wrappers) / sizeof (jstring_wrapper)) {
-					wrappers = new jstring_wrapper [len];
-				} else {
-					wrappers = static_wrappers;
-				}
-			} else {
+			if (_arr == nullptr) {
 				len = 0;
 				wrappers = nullptr;
+				return;
+			}
+
+			len = static_cast<size_t>(_env->GetArrayLength (_arr));
+			if (len <= sizeof (static_wrappers) / sizeof (jstring_wrapper)) {
+				wrappers = static_wrappers;
+				return;
+			}
+
+			wrappers = static_cast<jstring_wrapper*> (std::malloc (len * sizeof (jstring_wrapper)));
+			abort_unless (wrappers != nullptr, "Failed to allocate the JNI string array wrapper");
+			for (size_t i = 0; i < len; i++) {
+				new (&wrappers [i]) jstring_wrapper ();
 			}
 		}
 
 		~jstring_array_wrapper () noexcept
 		{
-			if (wrappers != nullptr && wrappers != static_wrappers) {
-				delete[] wrappers;
+			if (wrappers == nullptr || wrappers == static_wrappers) {
+				return;
 			}
+
+			for (size_t i = 0; i < len; i++) {
+				wrappers [i].~jstring_wrapper ();
+			}
+			std::free (wrappers);
 		}
 
 		size_t get_length () const noexcept


### PR DESCRIPTION
<!-- stack-prerequisites -->
> **PR relationship:** No code prerequisite; this PR is based directly on `main`. The absolute CoreCLR totals below were measured in the former serialized stack.
<!-- /stack-prerequisites -->

Part of the [drop-libc++](https://github.com/dotnet/android/issues/12533) effort.

Split out of #12560, where it had been sitting alongside the DSO loader changes despite being unrelated to them.

`jstring_array_wrapper` had two problems.

### A JNI local reference leak

`jstring_wrapper::release ()` bailed out early when it had no UTF chars to release:

```cpp
if (cstr == nullptr) {
    return;
}
```

But `jstring_array_wrapper::operator[]` fetches the array element's reference eagerly, while `cstr` is only populated on the first `get_cstr ()` call. So any element that was indexed but never read kept its local reference until the frame was popped. The reference and the UTF chars have independent lifetimes, so they are now released independently.

### `new[]` / `delete[]`

The wrapper allocated its elements with `new jstring_wrapper[len]`, which is where `_Znam` and `_ZdaPv` in `host.cc.o` came from. It now uses `malloc()` with explicit placement construction and destruction.

`jstring_wrapper` is not an implicit-lifetime type — it has a user-provided destructor — so `malloc()` alone cannot begin its lifetime; placement new is required. Its default constructor is private, with `jstring_array_wrapper` as a friend, which is what makes that legal here.

## Results

| | before | after |
|---|---|---|
| `host.cc.o` refs | 11 | **9** |
| CoreCLR total refs | 23 | **21** |

All three runtime lanes build clean.