### PR TITLE
[native] Remove libc++ dependencies from the CoreCLR assembly store

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.R8.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.R8.apkdesc
@@ -8,16 +8,16 @@
       "Size": 402716
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 2522592
+      "Size": 2529368
     },
     "lib/arm64-v8a/libclrjit.so": {
-      "Size": 2817680
+      "Size": 2818032
     },
     "lib/arm64-v8a/libcoreclr.so": {
-      "Size": 4843904
+      "Size": 4844000
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 537592
+      "Size": 203592
     },
     "lib/arm64-v8a/libSystem.Globalization.Native.so": {
       "Size": 72432
@@ -59,5 +59,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 6829499
+  "PackageSize": 6751675
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.apkdesc
@@ -8,16 +8,16 @@
       "Size": 405040
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 2522592
+      "Size": 2529336
     },
     "lib/arm64-v8a/libclrjit.so": {
-      "Size": 2817680
+      "Size": 2818032
     },
     "lib/arm64-v8a/libcoreclr.so": {
-      "Size": 4843904
+      "Size": 4844000
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 537592
+      "Size": 203592
     },
     "lib/arm64-v8a/libSystem.Globalization.Native.so": {
       "Size": 72432
@@ -59,5 +59,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 6829499
+  "PackageSize": 6751675
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.R8.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.R8.apkdesc
@@ -29,16 +29,16 @@
       "Size": 2396
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 9438128
+      "Size": 9453656
     },
     "lib/arm64-v8a/libclrjit.so": {
-      "Size": 2817680
+      "Size": 2818032
     },
     "lib/arm64-v8a/libcoreclr.so": {
-      "Size": 4843904
+      "Size": 4844000
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 537592
+      "Size": 203592
     },
     "lib/arm64-v8a/libSystem.Globalization.Native.so": {
       "Size": 72432
@@ -2231,5 +2231,5 @@
       "Size": 794696
     }
   },
-  "PackageSize": 16133651
+  "PackageSize": 16064019
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.apkdesc
@@ -32,16 +32,16 @@
       "Size": 2396
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 9438312
+      "Size": 9453632
     },
     "lib/arm64-v8a/libclrjit.so": {
-      "Size": 2817680
+      "Size": 2818032
     },
     "lib/arm64-v8a/libcoreclr.so": {
-      "Size": 4843904
+      "Size": 4844000
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 537592
+      "Size": 203592
     },
     "lib/arm64-v8a/libSystem.Globalization.Native.so": {
       "Size": 72432
@@ -2234,5 +2234,5 @@
       "Size": 794696
     }
   },
-  "PackageSize": 18284109
+  "PackageSize": 18214477
 }

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -76,13 +76,9 @@ namespace {
 		struct alignas (16) WriteRequest final
 		{
 			WriteRequest *next;
+			uint8_t      *payload;
 			size_t        size;
 			uint32_t      descriptor_index;
-
-			auto payload () noexcept -> uint8_t*
-			{
-				return reinterpret_cast<uint8_t*>(this) + sizeof (WriteRequest);
-			}
 		};
 
 		static_assert (sizeof (WriteRequest) % alignof (std::max_align_t) == 0uz);
@@ -111,9 +107,10 @@ namespace {
 				return nullptr;
 			}
 
-			auto *request = static_cast<WriteRequest*>(std::malloc (sizeof (WriteRequest) + payload_size));
+			auto *request = static_cast<WriteRequest*>(std::malloc (sizeof (WriteRequest) + payload_size * sizeof (uint8_t)));
 			if (request != nullptr) {
 				request->next = nullptr;
+				request->payload = reinterpret_cast<uint8_t*>(request + 1);
 			}
 
 			return request;
@@ -180,7 +177,7 @@ namespace {
 				return WriteResult::Failed;
 			}
 
-			bool ok = write_fully (fd, req->payload (), req->size);
+			bool ok = write_fully (fd, req->payload, req->size);
 			int error = ok ? 0 : errno;
 			if (close (fd) != 0 && ok) {
 				ok = false;
@@ -540,17 +537,17 @@ namespace {
 
 			// The runtime can modify the shared decompression buffer after this
 			// method returns, so the background writer needs an immutable copy.
-			memcpy (req->payload (), data, size);
+			memcpy (req->payload, data, size);
 
 			CacheFileFooter footer {
 				.magic = CACHE_FILE_MAGIC,
 				.version = CACHE_FILE_FORMAT_VERSION,
 				.store_id = store_id,
-				.payload_hash = hash_payload (req->payload (), size),
+				.payload_hash = hash_payload (req->payload, size),
 				.descriptor_index = descriptor_index,
 				.payload_size = static_cast<uint32_t>(size),
 			};
-			memcpy (req->payload () + size, &footer, sizeof (footer));
+			memcpy (req->payload + size, &footer, sizeof (footer));
 
 			{
 				lock_guard lock (state_lock);

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -144,7 +144,11 @@ namespace {
 		auto format_cache_path (char *buffer, size_t buffer_size, uint32_t descriptor_index) noexcept -> bool
 		{
 			int length = snprintf (buffer, buffer_size, "%s/%u.bin", cache_dir, descriptor_index);
-			return length > 0 && static_cast<size_t>(length) < buffer_size;
+			if (length <= 0 || static_cast<size_t>(length) >= buffer_size) [[unlikely]] {
+				log_file_error ("path formatting", cache_dir, length < 0 ? errno : ENAMETOOLONG);
+				return false;
+			}
+			return true;
 		}
 
 		auto write_cache_file (WriteRequest *req) noexcept -> WriteResult
@@ -157,6 +161,7 @@ namespace {
 			char tmp_path[Util::LocalPathBufferSize];
 			int tmp_path_length = snprintf (tmp_path, sizeof (tmp_path), "%s.tmp.%d", path, getpid ());
 			if (tmp_path_length <= 0 || static_cast<size_t>(tmp_path_length) >= sizeof (tmp_path)) [[unlikely]] {
+				log_file_error ("temporary-file path formatting", path, tmp_path_length < 0 ? errno : ENAMETOOLONG);
 				return WriteResult::Failed;
 			}
 
@@ -320,6 +325,8 @@ namespace {
 				int length = snprintf (path, sizeof (path), "%s/%s", dir, entry->d_name);
 				if (length > 0 && static_cast<size_t>(length) < sizeof (path)) {
 					unlink (path);
+				} else {
+					log_file_error ("stale temporary-file path formatting", dir, length < 0 ? errno : ENAMETOOLONG);
 				}
 			}
 
@@ -379,6 +386,7 @@ namespace {
 			store_id = assembly_store_id;
 			int store_id_length = snprintf (path + length, sizeof (path) - static_cast<size_t>(length), "/%" PRIx64, store_id);
 			if (store_id_length <= 0 || static_cast<size_t>(length + store_id_length) >= sizeof (path)) [[unlikely]] {
+				log_file_error ("store-directory path formatting", code_cache_dir, store_id_length < 0 ? errno : ENAMETOOLONG);
 				return;
 			}
 

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -138,39 +138,89 @@ namespace {
 			log_debugf (LOG_ASSEMBLY, "Decompressed-assembly cache %s failed for '%s': %s", operation, path, std::strerror (error));
 		}
 
-		// Formats the cache file path for `descriptor_index` into `buffer`, returning `false` if the
-		// path does not fit. `cache_dir` is only assigned once, before the cache is enabled, so this
-		// is safe to call from the writer thread without holding `state_lock`.
-		auto format_cache_path (char *buffer, size_t buffer_size, uint32_t descriptor_index) noexcept -> bool
+		// Unlike Util::format_with_retry, cache path allocation must not abort the application on failure.
+		class CachePath final
 		{
-			int length = snprintf (buffer, buffer_size, "%s/%u.bin", cache_dir, descriptor_index);
-			if (length <= 0 || static_cast<size_t>(length) >= buffer_size) [[unlikely]] {
-				log_file_error ("path formatting", cache_dir, length < 0 ? errno : ENAMETOOLONG);
-				return false;
+		public:
+			template<typename TFormatter>
+			CachePath (const char *operation, const char *source, TFormatter formatter) noexcept
+			{
+				int length = formatter (stack_buffer, sizeof (stack_buffer));
+				if (length < 0) [[unlikely]] {
+					log_file_error (operation, source, errno);
+					return;
+				}
+				if (static_cast<size_t>(length) < sizeof (stack_buffer)) {
+					path = stack_buffer;
+					return;
+				}
+
+				size_t capacity = static_cast<size_t>(length) + 1uz;
+				char *heap_buffer = static_cast<char*>(std::malloc (capacity));
+				if (heap_buffer == nullptr) [[unlikely]] {
+					log_file_error (operation, source, ENOMEM);
+					return;
+				}
+
+				length = formatter (heap_buffer, capacity);
+				if (length < 0 || static_cast<size_t>(length) >= capacity) [[unlikely]] {
+					int error = length < 0 ? errno : ENAMETOOLONG;
+					std::free (heap_buffer);
+					log_file_error (operation, source, error);
+					return;
+				}
+				path = heap_buffer;
 			}
-			return true;
-		}
+
+			// `cache_dir` is immutable once enabled, including on the writer thread.
+			explicit CachePath (uint32_t descriptor_index) noexcept
+				: CachePath ("path formatting", cache_dir, [descriptor_index](char *buffer, size_t size) noexcept {
+					return snprintf (buffer, size, "%s/%u.bin", cache_dir, descriptor_index);
+				})
+			{}
+
+			CachePath (CachePath const&) = delete;
+			CachePath (CachePath&&) = delete;
+			auto operator= (CachePath const&) -> CachePath& = delete;
+			auto operator= (CachePath&&) -> CachePath& = delete;
+
+			~CachePath () noexcept
+			{
+				if (path != stack_buffer) {
+					std::free (path);
+				}
+			}
+
+			auto get () const noexcept -> const char*
+			{
+				return path;
+			}
+
+		private:
+			char stack_buffer[Util::LocalPathBufferSize];
+			char *path = nullptr;
+		};
 
 		auto write_cache_file (WriteRequest *req) noexcept -> WriteResult
 		{
-			char path[Util::LocalPathBufferSize];
-			if (!format_cache_path (path, sizeof (path), req->descriptor_index)) [[unlikely]] {
+			CachePath path { req->descriptor_index };
+			if (path.get () == nullptr) [[unlikely]] {
 				return WriteResult::Failed;
 			}
 
-			char tmp_path[Util::LocalPathBufferSize];
-			int tmp_path_length = snprintf (tmp_path, sizeof (tmp_path), "%s.tmp.%d", path, getpid ());
-			if (tmp_path_length <= 0 || static_cast<size_t>(tmp_path_length) >= sizeof (tmp_path)) [[unlikely]] {
-				log_file_error ("temporary-file path formatting", path, tmp_path_length < 0 ? errno : ENAMETOOLONG);
+			CachePath tmp_path { "temporary-file path formatting", path.get (), [&path](char *buffer, size_t size) noexcept {
+				return snprintf (buffer, size, "%s.tmp.%d", path.get (), getpid ());
+			}};
+			if (tmp_path.get () == nullptr) [[unlikely]] {
 				return WriteResult::Failed;
 			}
 
 			int fd;
 			do {
-				fd = open (tmp_path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, 0600);
+				fd = open (tmp_path.get (), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, 0600);
 			} while (fd < 0 && errno == EINTR);
 			if (fd < 0) {
-				log_file_error ("temporary-file creation", path, errno);
+				log_file_error ("temporary-file creation", path.get (), errno);
 				return WriteResult::Failed;
 			}
 
@@ -182,20 +232,20 @@ namespace {
 			}
 
 			if (!ok) {
-				log_file_error ("write", path, error);
-				unlink (tmp_path);
+				log_file_error ("write", path.get (), error);
+				unlink (tmp_path.get ());
 				return WriteResult::Failed;
 			}
 
 			int rename_result;
 			do {
-				rename_result = rename (tmp_path, path);
+				rename_result = rename (tmp_path.get (), path.get ());
 			} while (rename_result != 0 && errno == EINTR);
 
 			if (rename_result != 0) {
 				error = errno;
-				log_file_error ("publish", path, error);
-				unlink (tmp_path);
+				log_file_error ("publish", path.get (), error);
+				unlink (tmp_path.get ());
 				return WriteResult::Failed;
 			}
 
@@ -321,12 +371,11 @@ namespace {
 					continue;
 				}
 
-				char path[Util::LocalPathBufferSize];
-				int length = snprintf (path, sizeof (path), "%s/%s", dir, entry->d_name);
-				if (length > 0 && static_cast<size_t>(length) < sizeof (path)) {
-					unlink (path);
-				} else {
-					log_file_error ("stale temporary-file path formatting", dir, length < 0 ? errno : ENAMETOOLONG);
+				CachePath path { "stale temporary-file path formatting", dir, [dir, entry](char *buffer, size_t size) noexcept {
+					return snprintf (buffer, size, "%s/%s", dir, entry->d_name);
+				}};
+				if (path.get () != nullptr) {
+					unlink (path.get ());
 				}
 			}
 
@@ -369,39 +418,38 @@ namespace {
 				return;
 			}
 
-			// The cache lives at `<code cache>/<CACHE_DIR_NAME>/<store id>`, with both levels
-			// created in turn. The path is built up in place: the store ID is appended after the
-			// first directory has been validated.
-			char path[Util::LocalPathBufferSize];
-			int length = snprintf (path, sizeof (path), "%s/%.*s", code_cache_dir, static_cast<int>(CACHE_DIR_NAME.length ()), CACHE_DIR_NAME.data ());
-			if (length <= 0 || static_cast<size_t>(length) >= sizeof (path)) [[unlikely]] {
-				log_debugf (LOG_ASSEMBLY, "Decompressed-assembly cache path is too long for '%s'", code_cache_dir);
+			// The cache lives at `<code cache>/<CACHE_DIR_NAME>/<store id>`, with both levels created in turn.
+			CachePath root { "cache-directory path formatting", code_cache_dir, [code_cache_dir](char *buffer, size_t size) noexcept {
+				return snprintf (buffer, size, "%s/%.*s", code_cache_dir, static_cast<int>(CACHE_DIR_NAME.length ()), CACHE_DIR_NAME.data ());
+			}};
+			if (root.get () == nullptr) [[unlikely]] {
 				return;
 			}
 
-			if (!ensure_directory (path)) {
+			if (!ensure_directory (root.get ())) {
 				return;
 			}
 
 			store_id = assembly_store_id;
-			int store_id_length = snprintf (path + length, sizeof (path) - static_cast<size_t>(length), "/%" PRIx64, store_id);
-			if (store_id_length <= 0 || static_cast<size_t>(length + store_id_length) >= sizeof (path)) [[unlikely]] {
-				log_file_error ("store-directory path formatting", code_cache_dir, store_id_length < 0 ? errno : ENAMETOOLONG);
+			CachePath path { "store-directory path formatting", root.get (), [&root](char *buffer, size_t size) noexcept {
+				return snprintf (buffer, size, "%s/%" PRIx64, root.get (), store_id);
+			}};
+			if (path.get () == nullptr) [[unlikely]] {
 				return;
 			}
 
-			if (!ensure_directory (path)) {
+			if (!ensure_directory (path.get ())) {
 				return;
 			}
 
-			remove_stale_temp_files (path);
+			remove_stale_temp_files (path.get ());
 
 			if (compressed_assembly_count == 0) {
 				return;
 			}
 
 			// Neither allocation is ever freed: both live for as long as the process does.
-			cache_dir = strdup (path);
+			cache_dir = strdup (path.get ());
 			if (cache_dir == nullptr) [[unlikely]] {
 				return;
 			}
@@ -435,12 +483,12 @@ namespace {
 				return nullptr;
 			}
 
-			char path[Util::LocalPathBufferSize];
-			if (!format_cache_path (path, sizeof (path), descriptor_index)) [[unlikely]] {
+			CachePath path { descriptor_index };
+			if (path.get () == nullptr) [[unlikely]] {
 				return nullptr;
 			}
 
-			int fd = open (path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+			int fd = open (path.get (), O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
 			if (fd < 0) {
 				return nullptr;
 			}

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -1,10 +1,10 @@
 #include <cerrno>
 #include <cinttypes>
+#include <cstddef>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <deque>
-#include <memory>
-#include <string>
+#include <string_view>
 
 #include <dirent.h>
 #include <fcntl.h>
@@ -65,12 +65,27 @@ namespace {
 
 		static_assert (sizeof (CacheFileFooter) == 32uz);
 
-		struct WriteRequest final
+		// A queued cache write. The payload is stored immediately after the structure so that a
+		// request and the assembly bytes it carries are a single allocation, and `next` links the
+		// request into the intrusive FIFO drained by the writer thread. The destination path is
+		// not stored: `cache_dir` is immutable once the cache is enabled, so the writer thread can
+		// rebuild the path from `descriptor_index` alone.
+		//
+		// The over-alignment keeps `sizeof (WriteRequest)` a multiple of the maximum fundamental
+		// alignment, so that the payload is as aligned as the `malloc` block it lives in.
+		struct alignas (16) WriteRequest final
 		{
-			std::string                path;
-			std::unique_ptr<uint8_t[]> data;
-			size_t                     size;
+			WriteRequest *next;
+			size_t        size;
+			uint32_t      descriptor_index;
+
+			auto payload () noexcept -> uint8_t*
+			{
+				return reinterpret_cast<uint8_t*>(this) + sizeof (WriteRequest);
+			}
 		};
+
+		static_assert (sizeof (WriteRequest) % alignof (std::max_align_t) == 0uz);
 
 		enum class WriteResult
 		{
@@ -79,15 +94,30 @@ namespace {
 		};
 
 		pthread_mutex_t                   state_lock = PTHREAD_MUTEX_INITIALIZER;
-		std::deque<WriteRequest>          write_queue;
-		std::string                       cache_dir;
-		std::unique_ptr<uint8_t*[]>       tracking;
+		WriteRequest                     *write_queue_head = nullptr;
+		WriteRequest                     *write_queue_tail = nullptr;
+		char                             *cache_dir = nullptr;
+		uint8_t                         **tracking = nullptr;
 		size_t                            queued_bytes = 0;
 		uint64_t                          store_id = 0;
 		bool                              initialized = false;
 		bool                              enabled = false;
 		bool                              writes_enabled = false;
 		bool                              writer_running = false;
+
+		auto allocate_write_request (size_t payload_size) noexcept -> WriteRequest*
+		{
+			if (payload_size > SIZE_MAX - sizeof (WriteRequest)) [[unlikely]] {
+				return nullptr;
+			}
+
+			auto *request = static_cast<WriteRequest*>(std::malloc (sizeof (WriteRequest) + payload_size));
+			if (request != nullptr) {
+				request->next = nullptr;
+			}
+
+			return request;
+		}
 
 		auto hash_payload (const uint8_t *data, size_t size) noexcept -> uint64_t
 		{
@@ -114,27 +144,43 @@ namespace {
 			return true;
 		}
 
-		void log_file_error (std::string_view operation, std::string const& path, int error) noexcept
+		void log_file_error (const char *operation, const char *path, int error) noexcept
 		{
-			log_debugf (LOG_ASSEMBLY, "Decompressed-assembly cache %.*s failed for '%s': %s", static_cast<int>(operation.length ()), operation.data (), path.c_str (), std::strerror (error));
+			log_debugf (LOG_ASSEMBLY, "Decompressed-assembly cache %s failed for '%s': %s", operation, path, std::strerror (error));
 		}
 
-		auto write_cache_file (WriteRequest const& req) noexcept -> WriteResult
+		// Formats the cache file path for `descriptor_index` into `buffer`, returning `false` if the
+		// path does not fit. `cache_dir` is only assigned once, before the cache is enabled, so this
+		// is safe to call from the writer thread without holding `state_lock`.
+		auto format_cache_path (char *buffer, size_t buffer_size, uint32_t descriptor_index) noexcept -> bool
 		{
-			std::string tmp_path = req.path;
-			tmp_path.append (".tmp."sv);
-			tmp_path.append (std::to_string (getpid ()));
+			int length = snprintf (buffer, buffer_size, "%s/%u.bin", cache_dir, descriptor_index);
+			return length > 0 && static_cast<size_t>(length) < buffer_size;
+		}
 
-			int fd;
-			do {
-				fd = open (tmp_path.c_str (), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, 0600);
-			} while (fd < 0 && errno == EINTR);
-			if (fd < 0) {
-				log_file_error ("temporary-file creation"sv, req.path, errno);
+		auto write_cache_file (WriteRequest *req) noexcept -> WriteResult
+		{
+			char path[Util::LocalPathBufferSize];
+			if (!format_cache_path (path, sizeof (path), req->descriptor_index)) [[unlikely]] {
 				return WriteResult::Failed;
 			}
 
-			bool ok = write_fully (fd, req.data.get (), req.size);
+			char tmp_path[Util::LocalPathBufferSize];
+			int tmp_path_length = snprintf (tmp_path, sizeof (tmp_path), "%s.tmp.%d", path, getpid ());
+			if (tmp_path_length <= 0 || static_cast<size_t>(tmp_path_length) >= sizeof (tmp_path)) [[unlikely]] {
+				return WriteResult::Failed;
+			}
+
+			int fd;
+			do {
+				fd = open (tmp_path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, 0600);
+			} while (fd < 0 && errno == EINTR);
+			if (fd < 0) {
+				log_file_error ("temporary-file creation", path, errno);
+				return WriteResult::Failed;
+			}
+
+			bool ok = write_fully (fd, req->payload (), req->size);
 			int error = ok ? 0 : errno;
 			if (close (fd) != 0 && ok) {
 				ok = false;
@@ -142,53 +188,63 @@ namespace {
 			}
 
 			if (!ok) {
-				log_file_error ("write"sv, req.path, error);
-				unlink (tmp_path.c_str ());
+				log_file_error ("write", path, error);
+				unlink (tmp_path);
 				return WriteResult::Failed;
 			}
 
 			int rename_result;
 			do {
-				rename_result = rename (tmp_path.c_str (), req.path.c_str ());
+				rename_result = rename (tmp_path, path);
 			} while (rename_result != 0 && errno == EINTR);
 
 			if (rename_result != 0) {
 				error = errno;
-				log_file_error ("publish"sv, req.path, error);
-				unlink (tmp_path.c_str ());
+				log_file_error ("publish", path, error);
+				unlink (tmp_path);
 				return WriteResult::Failed;
 			}
 
 			return WriteResult::Succeeded;
 		}
 
+		// Discards every queued request without writing it. Must be called with `state_lock` held.
 		void clear_write_queue_locked () noexcept
 		{
-			for (WriteRequest const& request : write_queue) {
-				queued_bytes -= request.size;
+			WriteRequest *request = write_queue_head;
+			write_queue_head = nullptr;
+			write_queue_tail = nullptr;
+
+			while (request != nullptr) {
+				WriteRequest *next = request->next;
+				queued_bytes -= request->size;
+				std::free (request);
+				request = next;
 			}
-			write_queue.clear ();
 		}
 
 		[[gnu::cold]]
 		auto writer_loop ([[maybe_unused]] void *arg) noexcept -> void*
 		{
 			while (true) {
-				WriteRequest request;
+				WriteRequest *request;
 				{
 					lock_guard lock (state_lock);
-					if (write_queue.empty ()) {
+					request = write_queue_head;
+					if (request == nullptr) {
 						writer_running = false;
 						return nullptr;
 					}
 
-					request = std::move (write_queue.front ());
-					write_queue.pop_front ();
+					write_queue_head = request->next;
+					if (write_queue_head == nullptr) {
+						write_queue_tail = nullptr;
+					}
 				}
 
-				size_t request_size = request.size;
+				size_t request_size = request->size;
 				WriteResult write_result = write_cache_file (request);
-				request.data.reset ();
+				std::free (request);
 
 				{
 					lock_guard lock (state_lock);
@@ -229,25 +285,25 @@ namespace {
 			return true;
 		}
 
-		bool ensure_directory (std::string const& path) noexcept
+		bool ensure_directory (const char *path) noexcept
 		{
-			if (mkdir (path.c_str (), 0700) == 0) {
+			if (mkdir (path, 0700) == 0) {
 				return true;
 			}
 
 			int error = errno;
 			if (error != EEXIST) {
-				log_file_error ("directory creation"sv, path, error);
+				log_file_error ("directory creation", path, error);
 				return false;
 			}
 
 			struct stat st {};
-			if (lstat (path.c_str (), &st) != 0) {
-				log_file_error ("directory validation"sv, path, errno);
+			if (lstat (path, &st) != 0) {
+				log_file_error ("directory validation", path, errno);
 				return false;
 			}
 			if (!S_ISDIR (st.st_mode)) {
-				log_file_error ("directory validation"sv, path, ENOTDIR);
+				log_file_error ("directory validation", path, ENOTDIR);
 				return false;
 			}
 
@@ -257,24 +313,23 @@ namespace {
 		// Best-effort removal of staging files left behind by a previous process whose writer was
 		// killed (e.g. by Android) between creating a `.tmp.<pid>` file and renaming it into place.
 		// Such files are never reclaimed otherwise and would accumulate outside the queue bound.
-		void remove_stale_temp_files (std::string const& dir) noexcept
+		void remove_stale_temp_files (const char *dir) noexcept
 		{
-			DIR *handle = opendir (dir.c_str ());
+			DIR *handle = opendir (dir);
 			if (handle == nullptr) {
 				return;
 			}
 
-			std::string prefix = dir;
-			prefix.append ("/");
 			for (dirent *entry = readdir (handle); entry != nullptr; entry = readdir (handle)) {
-				std::string_view name { entry->d_name };
-				if (name.find (".tmp."sv) == std::string_view::npos) {
+				if (strstr (entry->d_name, ".tmp.") == nullptr) {
 					continue;
 				}
 
-				std::string path = prefix;
-				path.append (name);
-				unlink (path.c_str ());
+				char path[Util::LocalPathBufferSize];
+				int length = snprintf (path, sizeof (path), "%s/%s", dir, entry->d_name);
+				if (length > 0 && static_cast<size_t>(length) < sizeof (path)) {
+					unlink (path);
+				}
 			}
 
 			closedir (handle);
@@ -316,32 +371,50 @@ namespace {
 				return;
 			}
 
-			cache_dir.assign (code_cache_dir);
-			cache_dir.append ("/");
-			cache_dir.append (CACHE_DIR_NAME);
-			if (!ensure_directory (cache_dir)) {
+			// The cache lives at `<code cache>/<CACHE_DIR_NAME>/<store id>`, with both levels
+			// created in turn. The path is built up in place: the store ID is appended after the
+			// first directory has been validated.
+			char path[Util::LocalPathBufferSize];
+			int length = snprintf (path, sizeof (path), "%s/%.*s", code_cache_dir, static_cast<int>(CACHE_DIR_NAME.length ()), CACHE_DIR_NAME.data ());
+			if (length <= 0 || static_cast<size_t>(length) >= sizeof (path)) [[unlikely]] {
+				log_debugf (LOG_ASSEMBLY, "Decompressed-assembly cache path is too long for '%s'", code_cache_dir);
+				return;
+			}
+
+			if (!ensure_directory (path)) {
 				return;
 			}
 
 			store_id = assembly_store_id;
-			cache_dir.append ("/");
-			char store_id_text[(sizeof (store_id) * 2) + 1];
-			snprintf (store_id_text, sizeof (store_id_text), "%" PRIx64, store_id);
-			cache_dir.append (store_id_text);
-			if (!ensure_directory (cache_dir)) {
+			int store_id_length = snprintf (path + length, sizeof (path) - static_cast<size_t>(length), "/%" PRIx64, store_id);
+			if (store_id_length <= 0 || static_cast<size_t>(length + store_id_length) >= sizeof (path)) [[unlikely]] {
 				return;
 			}
 
-			remove_stale_temp_files (cache_dir);
-
-			if (compressed_assembly_count > 0) {
-				tracking.reset (new (std::nothrow) uint8_t*[compressed_assembly_count]());
-			}
-
-			enabled = (tracking != nullptr);
-			if (!enabled) {
+			if (!ensure_directory (path)) {
 				return;
 			}
+
+			remove_stale_temp_files (path);
+
+			if (compressed_assembly_count == 0) {
+				return;
+			}
+
+			// Neither allocation is ever freed: both live for as long as the process does.
+			cache_dir = strdup (path);
+			if (cache_dir == nullptr) [[unlikely]] {
+				return;
+			}
+
+			tracking = static_cast<uint8_t**>(std::calloc (compressed_assembly_count, sizeof (uint8_t*)));
+			if (tracking == nullptr) [[unlikely]] {
+				std::free (cache_dir);
+				cache_dir = nullptr;
+				return;
+			}
+
+			enabled = true;
 
 			{
 				lock_guard lock (state_lock);
@@ -351,19 +424,10 @@ namespace {
 			log_debugf (
 				LOG_ASSEMBLY,
 				"Enabled decompressed-assembly cache at '%s'; store ID 0x%" PRIx64 "; write queue limit %zu bytes",
-				cache_dir.c_str (),
+				cache_dir,
 				store_id,
 				MAX_QUEUED_BYTES
 			);
-		}
-
-		auto build_path (uint32_t descriptor_index) noexcept -> std::string
-		{
-			std::string path = cache_dir;
-			path.append ("/");
-			path.append (std::to_string (descriptor_index));
-			path.append (".bin"sv);
-			return path;
 		}
 
 		auto try_load (uint32_t descriptor_index, std::string_view name, uint32_t expected_size) noexcept -> uint8_t*
@@ -372,8 +436,12 @@ namespace {
 				return nullptr;
 			}
 
-			std::string path = build_path (descriptor_index);
-			int fd = open (path.c_str (), O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+			char path[Util::LocalPathBufferSize];
+			if (!format_cache_path (path, sizeof (path), descriptor_index)) [[unlikely]] {
+				return nullptr;
+			}
+
+			int fd = open (path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
 			if (fd < 0) {
 				return nullptr;
 			}
@@ -460,40 +528,45 @@ namespace {
 				return;
 			}
 
-			auto snapshot = std::unique_ptr<uint8_t[]> (new (std::nothrow) uint8_t[total]);
-			if (snapshot == nullptr) {
+			WriteRequest *req = allocate_write_request (total);
+			if (req == nullptr) [[unlikely]] {
 				lock_guard lock (state_lock);
 				queued_bytes -= total;
 				return;
 			}
+
+			req->size = total;
+			req->descriptor_index = descriptor_index;
+
 			// The runtime can modify the shared decompression buffer after this
 			// method returns, so the background writer needs an immutable copy.
-			memcpy (snapshot.get (), data, size);
+			memcpy (req->payload (), data, size);
 
 			CacheFileFooter footer {
 				.magic = CACHE_FILE_MAGIC,
 				.version = CACHE_FILE_FORMAT_VERSION,
 				.store_id = store_id,
-				.payload_hash = hash_payload (snapshot.get (), size),
+				.payload_hash = hash_payload (req->payload (), size),
 				.descriptor_index = descriptor_index,
 				.payload_size = static_cast<uint32_t>(size),
 			};
-			memcpy (snapshot.get () + size, &footer, sizeof (footer));
-
-			WriteRequest req {
-				.path = build_path (descriptor_index),
-				.data = std::move (snapshot),
-				.size = total,
-			};
+			memcpy (req->payload () + size, &footer, sizeof (footer));
 
 			{
 				lock_guard lock (state_lock);
 				if (!writes_enabled) {
 					queued_bytes -= total;
+					std::free (req);
 					return;
 				}
 
-				write_queue.push_back (std::move (req));
+				if (write_queue_tail == nullptr) {
+					write_queue_head = req;
+				} else {
+					write_queue_tail->next = req;
+				}
+				write_queue_tail = req;
+
 				if (!writer_running) {
 					writer_running = true;
 					if (!start_writer_locked ()) {
@@ -817,12 +890,16 @@ void AssemblyStore::configure_from_payload (const void *payload_start, const cha
 	// Build a lookup of assembly names indexed by descriptor index, used to disambiguate CRC32 hash
 	// collisions during lookup. The names section follows the descriptor table and consists of
 	// `entry_count` length-prefixed (uint32 length followed by the UTF-8 bytes) records, stored in
-	// descriptor-index order. `delete[]` guards against a leak should the (single) store ever be
+	// descriptor-index order. The `free` guards against a leak should the (single) store ever be
 	// re-mapped; `assembly_store_names` is nullptr on first call, for which it is a no-op.
 	const uint8_t *names_cursor = assembly_store.data_start + header_size + header->index_size +
 		(static_cast<size_t>(header->entry_count) * sizeof (AssemblyStoreEntryDescriptor));
-	delete[] assembly_store_names;
-	assembly_store_names = new std::string_view[header->entry_count];
+	std::free (assembly_store_names);
+	assembly_store_names = static_cast<std::string_view*>(std::calloc (header->entry_count, sizeof (std::string_view)));
+	if (assembly_store_names == nullptr) [[unlikely]] {
+		Helpers::abort_application (LOG_ASSEMBLY, "Unable to allocate memory for the assembly store name table");
+	}
+
 	for (uint32_t i = 0; i < header->entry_count; i++) {
 		uint32_t name_length;
 		memcpy (&name_length, names_cursor, sizeof (name_length));

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -65,23 +65,13 @@ namespace {
 
 		static_assert (sizeof (CacheFileFooter) == 32uz);
 
-		// A queued cache write. The payload is stored immediately after the structure so that a
-		// request and the assembly bytes it carries are a single allocation, and `next` links the
-		// request into the intrusive FIFO drained by the writer thread. The destination path is
-		// not stored: `cache_dir` is immutable once the cache is enabled, so the writer thread can
-		// rebuild the path from `descriptor_index` alone.
-		//
-		// The over-alignment keeps `sizeof (WriteRequest)` a multiple of the maximum fundamental
-		// alignment, so that the payload is as aligned as the `malloc` block it lives in.
-		struct alignas (16) WriteRequest final
+		struct WriteRequest final
 		{
 			WriteRequest *next;
 			uint8_t      *payload;
 			size_t        size;
 			uint32_t      descriptor_index;
 		};
-
-		static_assert (sizeof (WriteRequest) % alignof (std::max_align_t) == 0uz);
 
 		enum class WriteResult
 		{
@@ -103,16 +93,18 @@ namespace {
 
 		auto allocate_write_request (size_t payload_size) noexcept -> WriteRequest*
 		{
-			if (payload_size > SIZE_MAX - sizeof (WriteRequest)) [[unlikely]] {
+			auto *request = static_cast<WriteRequest*>(std::malloc (sizeof (WriteRequest)));
+			if (request == nullptr) [[unlikely]] {
 				return nullptr;
 			}
 
-			auto *request = static_cast<WriteRequest*>(std::malloc (sizeof (WriteRequest) + payload_size * sizeof (uint8_t)));
-			if (request != nullptr) {
-				request->next = nullptr;
-				request->payload = reinterpret_cast<uint8_t*>(request + 1);
+			request->payload = static_cast<uint8_t*>(std::malloc (payload_size));
+			if (request->payload == nullptr) [[unlikely]] {
+				std::free (request);
+				return nullptr;
 			}
 
+			request->next = nullptr;
 			return request;
 		}
 
@@ -215,6 +207,7 @@ namespace {
 			while (request != nullptr) {
 				WriteRequest *next = request->next;
 				queued_bytes -= request->size;
+				std::free (request->payload);
 				std::free (request);
 				request = next;
 			}
@@ -241,6 +234,7 @@ namespace {
 
 				size_t request_size = request->size;
 				WriteResult write_result = write_cache_file (request);
+				std::free (request->payload);
 				std::free (request);
 
 				{
@@ -527,6 +521,12 @@ namespace {
 
 			WriteRequest *req = allocate_write_request (total);
 			if (req == nullptr) [[unlikely]] {
+				log_debugf (
+					LOG_ASSEMBLY,
+					"Skipping decompressed-assembly cache write for '%.*s': unable to allocate the request or payload",
+					static_cast<int>(name.length ()),
+					name.data ()
+				);
 				lock_guard lock (state_lock);
 				queued_bytes -= total;
 				return;
@@ -553,6 +553,7 @@ namespace {
 				lock_guard lock (state_lock);
 				if (!writes_enabled) {
 					queued_bytes -= total;
+					std::free (req->payload);
 					std::free (req);
 					return;
 				}

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -734,19 +734,48 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 		}
 
 		[Test]
-		public void AssemblyStoreDecompressionCacheMapsPersistedAssemblies ()
+		public void AssemblyStoreDecompressionCacheMapsPersistedAssemblies ([Values] bool longCachePath)
 		{
 			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {
 				return;
 			}
 
-			var app = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (AndroidRuntime.CoreCLR, "assemblycache")) {
+			var app = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (AndroidRuntime.CoreCLR, longCachePath ? "assemblycachelong" : "assemblycache")) {
 				IsRelease = true,
 			};
 			app.SetRuntime (AndroidRuntime.CoreCLR);
 			app.SetRuntimeIdentifiers (new [] { DeviceAbi });
 			app.SetProperty ("AndroidEnableAssemblyStoreDecompressionCache", "true");
 			app.AndroidManifest = app.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
+
+			string cacheDirectory = "code_cache";
+			if (longCachePath) {
+				// Exceed Util::LocalPathBufferSize (1024), keeping each component below NAME_MAX.
+				string subdirectory = string.Join ("/", Enumerable.Repeat (new string ('a', 128), 9));
+				cacheDirectory += "/" + subdirectory;
+				app.AndroidManifest = app.AndroidManifest.Replace ("<application ", "<application android:name=\"com.test.CachePathApplication\" ");
+				app.AndroidJavaSources.Add (new AndroidItem.AndroidJavaSource ("CachePathApplication.java") {
+					Encoding = Encoding.ASCII,
+					Metadata = {
+						{ "Bind", "False" },
+					},
+					TextContent = () => $$"""
+						package com.test;
+
+						public class CachePathApplication extends android.app.Application {
+							@Override
+							public java.io.File getCodeCacheDir () {
+								java.io.File directory = new java.io.File (super.getCodeCacheDir (), "{{subdirectory}}");
+								if (!directory.isDirectory () && !directory.mkdirs ()) {
+									throw new IllegalStateException ("Unable to create the long code cache directory");
+								}
+								return directory;
+							}
+						}
+						""",
+				});
+			}
+			string cacheRoot = cacheDirectory + "/decompressed-assembly-cache-v1";
 
 			using var appBuilder = CreateApkBuilder ();
 			Assert.IsTrue (appBuilder.Install (app), "Install should have succeeded.");
@@ -767,15 +796,22 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 			for (int attempt = 0; attempt < 40 && cacheFiles.Length < 2; attempt++) {
 				Thread.Sleep (250);
 				cacheFiles = RunAdbCommand (
-					$"shell run-as {app.PackageName} find code_cache/decompressed-assembly-cache-v1 -type f -name '*.bin'"
+					$"shell run-as {app.PackageName} find {cacheRoot} -type f -name '*.bin'"
 				)
 					.Split (new [] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
 					.Where (line => line.EndsWith (".bin", StringComparison.Ordinal))
 					.ToArray ();
 			}
 			Assert.That (cacheFiles.Length, Is.GreaterThanOrEqualTo (2), "The first launch should persist multiple decompressed assemblies.");
+			if (longCachePath) {
+				Assert.IsTrue (cacheFiles.All (path => path.Length > 1024), "Cache paths should exceed the native stack buffer size.");
+			}
 
 			RunAdbCommand ($"shell am force-stop --user all {app.PackageName}");
+			string staleTempFile = cacheFiles.Last () + ".tmp.stale";
+			RunAdbCommand ($"shell run-as {app.PackageName} touch {staleTempFile}");
+			StringAssert.Contains (staleTempFile, RunAdbCommand ($"shell run-as {app.PackageName} ls {staleTempFile}"),
+				"The stale temporary file should exist before restarting.");
 			string cacheFileToCorrupt = cacheFiles.First ();
 			string ValidFileHash () => RunAdbCommand (
 				$"shell run-as {app.PackageName} md5sum {cacheFileToCorrupt}"
@@ -810,6 +846,11 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 				rewritten = ValidFileHash () == validHash;
 			}
 			Assert.IsTrue (rewritten, $"The corrupted cache file '{cacheFileToCorrupt}' should be rewritten with valid contents after fallback.");
+			Assert.That (
+				RunAdbCommand ($"shell run-as {app.PackageName} find {cacheRoot} -type f -name '*.tmp.stale'").Trim (),
+				Is.Empty,
+				"The second launch should remove stale temporary files."
+			);
 
 			string [] pids = RunAdbCommand ($"shell pidof {app.PackageName}")
 				.Split (new [] { ' ', '\r', '\n', '\t' }, StringSplitOptions.RemoveEmptyEntries);
@@ -819,7 +860,7 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 				maps.Append (RunAdbCommand ($"shell run-as {app.PackageName} cat /proc/{pid}/maps"));
 			}
 			StringAssert.Contains (
-				"/code_cache/decompressed-assembly-cache-v1/",
+				"/" + cacheRoot + "/",
 				maps.ToString (),
 				"The second launch should map persisted decompressed assemblies."
 			);


### PR DESCRIPTION
Part of #12533: remove the remaining allocating C++ library types from the CoreCLR assembly store and its decompressed-assembly cache.

<!-- stack-prerequisites -->
All prerequisites (#12541, #12545, #12551, #12552, #12560, #12568, and #12570) have merged. This branch was rebuilt on `main` at `4b0cc8efa9`. The runtime changes are confined to `src/native/clr/host/assembly-store.cc`, with cache regression coverage and APK size baseline updates alongside them. The already-merged startup, timing, DSO-loader, and other prerequisite changes are no longer included in this PR's diff. Upstream's pthread-backed `lock_guard` is preserved.
<!-- /stack-prerequisites -->

### Changes

- Replace `std::deque<WriteRequest>` with an intrusive FIFO linked through `WriteRequest::next`.
- Replace the queued request's `std::unique_ptr<uint8_t[]>` with an explicit `uint8_t *payload`. Allocate the request and payload separately with two `malloc` calls and release both with two `free` calls on every completed or discarded write. If payload allocation fails, release the request and skip the write. No trailing-storage pointer arithmetic or explicit over-alignment is needed.
- Replace the cache directory and per-request `std::string` paths with a process-lifetime directory string and checked `snprintf` formatting. Requests store the descriptor index instead of a path; the writer reconstructs the destination from the immutable cache directory. Replace temporary-file name construction and matching with `snprintf` and `strstr`.
- Use a scoped `CachePath` buffer for directory creation, reads, writes, and stale-file cleanup. Short paths remain on the stack; longer paths retry in an exactly sized `malloc` allocation that is freed on every exit. Formatting and allocation failures are logged and remain non-fatal for the optional cache, unlike the abort-on-failure `Util::format_with_retry` helper.
- Allocate the decompression tracking array and assembly-name table with `calloc`, replacing their `unique_ptr`/`new[]` allocations.
- Extend the existing device cache regression test with a Java Application that supplies a code-cache directory longer than 1 KB. Cover persistence, mapping, corruption recovery, and stale temporary-file cleanup for both ordinary and long paths.

The asynchronous writer, queue byte limit, cache footer validation, and scope-based pthread locking are retained. `Util::LocalPathBufferSize` is the stack fast-path size, not a hard path limit; truncated paths are never used for I/O. The change does not alter linker flags or other runtime hosts.

### Original measurements

These results were recorded on the original pre-rebuild branch, **not on the current revision**:

| Release, arm64 | Before | After |
|---|---:|---:|
| Undefined libc++ references in `assembly-store.cc.o` | 12 | 0 |
| Undefined libc++ references across the CoreCLR host | 12 | 0 |
| `libnet-android.release.so` size | 520,112 bytes | 203,776 bytes |

Reaching zero references allowed the linker to stop pulling members from `libc++_static.a`. Relinking without libc++ also succeeded on that original branch; dropping the linker flag remains a follow-up.

### Current validation status

The malloc fallback passed sanitizer-backed host cases covering stack/heap boundaries, nested lifetimes, allocation failure, and formatting/retry failures. The cache namespace extracted unchanged from the current source, using the real CRC32 and mutex helpers with runtime configuration/property stubs, compiled with the Android NDK for arm64, arm32, and x86_64. A standalone arm64 emulator harness passed cache initialization, asynchronous persistence, mmap reads, corruption recovery, and stale-file cleanup with both short and greater-than-1-KB paths. The generated Java regression-test application also compiled against the Android API. `git diff --check` passes.

A local `dotnet build src/native/native-clr.csproj` restored packages but could not reach native compilation because this worktree lacks `xa-prep-tasks.dll` and `Xamarin.Android.Tools.BootstrapTasks.dll`. The complete native host build and repository device regression suite have **not** been run for this revision; the locally built SDK is unavailable. Binary measurements have not been repeated. The original branch's reported full native builds and binary measurements remain historical, not validation of this revision.