### PR TITLE
[typemap] Compare generated Java semantics

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
@@ -34,6 +35,57 @@ namespace Xamarin.Android.Build.Tests {
 
 			var intermediateDir = builder.Output.GetIntermediaryPath ("typemap");
 			AssertTrimmableTypeMapOutputs (intermediateDir);
+		}
+
+		[Test]
+		public void Build_JavaSourceSemanticParityFixture_Compiles (
+			[Values (AndroidRuntime.MonoVM, AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
+		{
+			bool isRelease = runtime == AndroidRuntime.NativeAOT;
+			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
+				return;
+			}
+
+			var fixtureProject = Path.Combine (
+				XABuildPaths.TopDirectory,
+				"tests",
+				"Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests",
+				"JavaSourceParityFixture",
+				"JavaSourceParityFixture.csproj");
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+				References = {
+					new BuildItem.ProjectReference (fixtureProject, "JavaSourceParityFixture"),
+				},
+			};
+			proj.SetRuntime (runtime);
+			if (runtime == AndroidRuntime.MonoVM) {
+				proj.SetProperty ("_DisableCheckForUnsupportedMonoMobileRuntime", "true");
+				proj.SetProperty ("AndroidTypeMapImplementation", "llvm-ir");
+			} else {
+				proj.SetProperty ("AndroidTypeMapImplementation", "trimmable");
+			}
+			proj.MainActivity = proj.DefaultMainActivity.Replace (
+				"//${AFTER_ONCREATE}",
+				"System.GC.KeepAlive (new UserApp.JavaSourceParity.SemanticPeer ());");
+			proj.AndroidJavaSources.Add (new AndroidItem.AndroidJavaSource ("com\\example\\parity\\Base.java") {
+				Encoding = Encoding.ASCII,
+				TextContent = () => """
+					package com.example.parity;
+
+					public class Base {
+						public Base () {}
+						public Base (int value) {}
+						public java.lang.String getValue () { return ""; }
+					}
+					""",
+			});
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), $"{runtime} should compile the shared semantic parity fixture.");
+
+			var compiledClass = builder.Output.GetIntermediaryPath (
+				Path.Combine ("android", "bin", "classes", "com", "example", "parity", "SemanticPeer.class"));
+			FileAssert.Exists (compiledClass, $"{runtime} should compile the generated SemanticPeer Java source.");
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -37,9 +37,12 @@ namespace Xamarin.Android.Build.Tests {
 			AssertTrimmableTypeMapOutputs (intermediateDir);
 		}
 
-		[Test]
+		[TestCase ("llvm-ir", AndroidRuntime.CoreCLR)]
+		[TestCase ("trimmable", AndroidRuntime.CoreCLR)]
+		[TestCase ("trimmable", AndroidRuntime.NativeAOT)]
 		public void Build_JavaSourceSemanticParityFixture_Compiles (
-			[Values (AndroidRuntime.MonoVM, AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
+			string typeMapImplementation,
+			AndroidRuntime runtime)
 		{
 			bool isRelease = runtime == AndroidRuntime.NativeAOT;
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
@@ -56,15 +59,11 @@ namespace Xamarin.Android.Build.Tests {
 				IsRelease = isRelease,
 				References = {
 					new BuildItem.ProjectReference (fixtureProject, "JavaSourceParityFixture"),
+					new BuildItem.Reference ("Mono.Android.Export"),
 				},
 			};
 			proj.SetRuntime (runtime);
-			if (runtime == AndroidRuntime.MonoVM) {
-				proj.SetProperty ("_DisableCheckForUnsupportedMonoMobileRuntime", "true");
-				proj.SetProperty ("AndroidTypeMapImplementation", "llvm-ir");
-			} else {
-				proj.SetProperty ("AndroidTypeMapImplementation", "trimmable");
-			}
+			proj.SetProperty ("AndroidTypeMapImplementation", typeMapImplementation);
 			proj.MainActivity = proj.DefaultMainActivity.Replace (
 				"//${AFTER_ONCREATE}",
 				"System.GC.KeepAlive (new UserApp.JavaSourceParity.SemanticPeer ());");
@@ -81,11 +80,11 @@ namespace Xamarin.Android.Build.Tests {
 					""",
 			});
 			using var builder = CreateApkBuilder ();
-			Assert.IsTrue (builder.Build (proj), $"{runtime} should compile the shared semantic parity fixture.");
+			Assert.IsTrue (builder.Build (proj), $"{runtime}/{typeMapImplementation} should compile the shared semantic parity fixture.");
 
 			var compiledClass = builder.Output.GetIntermediaryPath (
 				Path.Combine ("android", "bin", "classes", "com", "example", "parity", "SemanticPeer.class"));
-			FileAssert.Exists (compiledClass, $"{runtime} should compile the generated SemanticPeer Java source.");
+			FileAssert.Exists (compiledClass, $"{runtime}/{typeMapImplementation} should compile the generated SemanticPeer Java source.");
 		}
 
 		[Test]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceParityFixture/JavaSourceParityFixture.csproj
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceParityFixture/JavaSourceParityFixture.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\Configuration.props" />
+
+  <PropertyGroup>
+    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Library</OutputType>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\product.snk</AssemblyOriginatorKeyFile>
+    <OutputPath>..\..\..\bin\Test$(Configuration)\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Mono.Android\Mono.Android.csproj"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <Target Name="_AddMonoAndroidReference" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <_MonoAndroidRefCandidate
+          Condition=" '%(AndroidBuildApiLevel.Unstable)' == 'false' "
+          Include="$(MSBuildThisFileDirectory)..\..\..\bin\$(Configuration)\lib\packs\Microsoft.Android.Ref.%(AndroidBuildApiLevel.Identity)\*\ref\net*\Mono.Android.dll"
+      />
+      <_JavaInteropRefCandidate
+          Condition=" '%(AndroidBuildApiLevel.Unstable)' == 'false' "
+          Include="$(MSBuildThisFileDirectory)..\..\..\bin\$(Configuration)\lib\packs\Microsoft.Android.Ref.%(AndroidBuildApiLevel.Identity)\*\ref\net*\Java.Interop.dll"
+      />
+    </ItemGroup>
+    <PropertyGroup>
+      <_MonoAndroidRefAssembly>@(_MonoAndroidRefCandidate, ';')</_MonoAndroidRefAssembly>
+      <_MonoAndroidRefAssembly>$(_MonoAndroidRefAssembly.Split(';')[0])</_MonoAndroidRefAssembly>
+      <_JavaInteropRefAssembly>@(_JavaInteropRefCandidate, ';')</_JavaInteropRefAssembly>
+      <_JavaInteropRefAssembly>$(_JavaInteropRefAssembly.Split(';')[0])</_JavaInteropRefAssembly>
+    </PropertyGroup>
+    <ItemGroup Condition=" '$(_MonoAndroidRefAssembly)' != '' ">
+      <Reference Include="Mono.Android">
+        <HintPath>$(_MonoAndroidRefAssembly)</HintPath>
+      </Reference>
+    </ItemGroup>
+    <ItemGroup Condition=" '$(_JavaInteropRefAssembly)' != '' ">
+      <Reference Include="Java.Interop">
+        <HintPath>$(_JavaInteropRefAssembly)</HintPath>
+      </Reference>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceParityFixture/JavaSourceParityTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceParityFixture/JavaSourceParityTypes.cs
@@ -23,7 +23,7 @@ public class Base : Java.Lang.Object
 }
 
 [Register ("com/example/parity/SemanticPeer")]
-public class SemanticPeer : Base, Android.Views.View.IOnClickListener
+public class SemanticPeer : Base, Android.Views.View.IOnClickListener, Android.Views.View.IOnLongClickListener
 {
 	public SemanticPeer () { }
 
@@ -32,6 +32,8 @@ public class SemanticPeer : Base, Android.Views.View.IOnClickListener
 	public override string GetValue () => "derived";
 
 	public void OnClick (Android.Views.View? view) { }
+
+	public bool OnLongClick (Android.Views.View? view) => true;
 
 	[Export ("checkedExport", Throws = new [] { typeof (Java.IO.IOException) })]
 	protected int CheckedExport (string value) => value.Length;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceParityFixture/JavaSourceParityTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceParityFixture/JavaSourceParityTypes.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Runtime.Versioning;
+using Android.Runtime;
+using Java.Interop;
+
+[assembly: SupportedOSPlatform ("android24.0")]
+
+namespace UserApp.JavaSourceParity;
+
+[Register ("com/example/parity/Base", DoNotGenerateAcw = true)]
+public class Base : Java.Lang.Object
+{
+	protected Base (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+	[Register (".ctor", "()V", "")]
+	public Base () { }
+
+	[Register (".ctor", "(I)V", "")]
+	public Base (int value) { }
+
+	[Register ("getValue", "()Ljava/lang/String;", "GetGetValueHandler")]
+	public virtual string GetValue () => "";
+}
+
+[Register ("com/example/parity/SemanticPeer")]
+public class SemanticPeer : Base, Android.Views.View.IOnClickListener
+{
+	public SemanticPeer () { }
+
+	public SemanticPeer (int value) : base (value) { }
+
+	public override string GetValue () => "derived";
+
+	public void OnClick (Android.Views.View? view) { }
+
+	[Export ("checkedExport", Throws = new [] { typeof (Java.IO.IOException) })]
+	protected int CheckedExport (string value) => value.Length;
+
+	[ExportField ("STATIC_LABEL")]
+	public static string GetStaticLabel () => "static";
+
+	[ExportField ("LABEL")]
+	public string GetLabel () => "instance";
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceSemanticParityTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceSemanticParityTests.cs
@@ -397,12 +397,46 @@ public partial class ScannerComparisonTests
 			"android/view/View$OnClickListener",
 			"android/view/View$OnLongClickListener",
 		}, model.Interfaces);
-		Assert.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|<init>|()V|final=False|synchronized=False|varargs=False|strict=False|throws=", model.Constructors);
-		Assert.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|<init>|(I)V|final=False|synchronized=False|varargs=False|strict=False|throws=", model.Constructors);
-		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|getValue|()Ljava/lang/String;", StringComparison.Ordinal));
-		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|onClick|(Landroid/view/View;)V", StringComparison.Ordinal));
-		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|onLongClick|(Landroid/view/View;)Z", StringComparison.Ordinal));
-		Assert.Contains (model.Methods, method => method.Contains ("protected|static=False|abstract=False|bridge=False|synthetic=False|checkedExport|(Ljava/lang/String;)I|final=False|synchronized=False|varargs=False|strict=False|throws=java/io/IOException", StringComparison.Ordinal));
+		const string publicInstanceMethod = "public|static=False|abstract=False|bridge=False|synthetic=False|";
+		const string protectedInstanceMethod = "protected|static=False|abstract=False|bridge=False|synthetic=False|";
+		const string ordinaryMethodModifiers = "final=False|synchronized=False|varargs=False|strict=False|";
+		Assert.Contains (
+			publicInstanceMethod + "<init>|()V|" + ordinaryMethodModifiers + "throws=",
+			model.Constructors
+		);
+		Assert.Contains (
+			publicInstanceMethod + "<init>|(I)V|" + ordinaryMethodModifiers + "throws=",
+			model.Constructors
+		);
+		Assert.Contains (
+			model.Methods,
+			method => method.Contains (
+				publicInstanceMethod + "getValue|()Ljava/lang/String;",
+				StringComparison.Ordinal
+			)
+		);
+		Assert.Contains (
+			model.Methods,
+			method => method.Contains (
+				publicInstanceMethod + "onClick|(Landroid/view/View;)V",
+				StringComparison.Ordinal
+			)
+		);
+		Assert.Contains (
+			model.Methods,
+			method => method.Contains (
+				publicInstanceMethod + "onLongClick|(Landroid/view/View;)Z",
+				StringComparison.Ordinal
+			)
+		);
+		Assert.Contains (
+			model.Methods,
+			method => method.Contains (
+				protectedInstanceMethod + "checkedExport|(Ljava/lang/String;)I|" +
+					ordinaryMethodModifiers + "throws=java/io/IOException",
+				StringComparison.Ordinal
+			)
+		);
 		Assert.Contains (model.Fields, field => field.Contains ("public|static=True|final=False|STATIC_LABEL|Ljava/lang/String;", StringComparison.Ordinal));
 		Assert.Contains (model.Fields, field => field.Contains ("public|static=False|final=False|LABEL|Ljava/lang/String;", StringComparison.Ordinal));
 	}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceSemanticParityTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceSemanticParityTests.cs
@@ -29,8 +29,7 @@ public partial class ScannerComparisonTests
 		IReadOnlyList<string> Interfaces,
 		IReadOnlyList<string> Constructors,
 		IReadOnlyList<string> Methods,
-		IReadOnlyList<string> Fields,
-		IReadOnlyList<string> Annotations
+		IReadOnlyList<string> Fields
 	);
 
 	[Fact]
@@ -272,8 +271,7 @@ public partial class ScannerComparisonTests
 
 	static JavaSemanticModel CreateSemanticModel (ClassFile classFile)
 	{
-		// Classfiles preserve declaration semantics while discarding source formatting
-		// and source-only annotations such as @Override, which javac validates above.
+		// Classfiles preserve declaration semantics while discarding source formatting.
 		var constructors = classFile.Methods
 			.Where (method => method.IsConstructor)
 			.Select (FormatMethod)
@@ -300,8 +298,7 @@ public partial class ScannerComparisonTests
 			interfaces,
 			constructors,
 			methods,
-			fields,
-			GetAnnotations (classFile.Attributes)
+			fields
 		);
 	}
 
@@ -321,7 +318,6 @@ public partial class ScannerComparisonTests
 		var throws = method.GetThrows ()
 			.Select (type => type.BinaryName)
 			.OrderBy (type => type, StringComparer.Ordinal);
-		var annotations = GetAnnotations (method.Attributes);
 		return $"{GetVisibility (method.AccessFlags)}|" +
 			$"static={method.AccessFlags.HasFlag (MethodAccessFlags.Static)}|" +
 			$"abstract={method.AccessFlags.HasFlag (MethodAccessFlags.Abstract)}|" +
@@ -332,13 +328,11 @@ public partial class ScannerComparisonTests
 			$"synchronized={method.AccessFlags.HasFlag (MethodAccessFlags.Synchronized)}|" +
 			$"varargs={method.AccessFlags.HasFlag (MethodAccessFlags.Varargs)}|" +
 			$"strict={method.AccessFlags.HasFlag (MethodAccessFlags.Strict)}|" +
-			$"throws={string.Join (",", throws)}|" +
-			$"annotations={string.Join (",", annotations)}";
+			$"throws={string.Join (",", throws)}";
 	}
 
 	static string FormatField (Xamarin.Android.Tools.Bytecode.FieldInfo field)
 	{
-		var annotations = GetAnnotations (field.Attributes);
 		return $"{GetVisibility (field.AccessFlags)}|" +
 			$"static={field.AccessFlags.HasFlag (FieldAccessFlags.Static)}|" +
 			$"final={field.AccessFlags.HasFlag (FieldAccessFlags.Final)}|" +
@@ -346,21 +340,7 @@ public partial class ScannerComparisonTests
 			$"volatile={field.AccessFlags.HasFlag (FieldAccessFlags.Volatile)}|" +
 			$"transient={field.AccessFlags.HasFlag (FieldAccessFlags.Transient)}|" +
 			$"synthetic={field.AccessFlags.HasFlag (FieldAccessFlags.Synthetic)}|" +
-			$"enum={field.AccessFlags.HasFlag (FieldAccessFlags.Enum)}|" +
-			$"annotations={string.Join (",", annotations)}";
-	}
-
-	static string[] GetAnnotations (AttributeCollection attributes)
-	{
-		return attributes
-			.OfType<RuntimeVisibleAnnotationsAttribute> ()
-			.SelectMany (attribute => attribute.Annotations)
-			.Concat (attributes
-				.OfType<RuntimeInvisibleAnnotationsAttribute> ()
-				.SelectMany (attribute => attribute.Annotations))
-			.Select (annotation => annotation.ToString ())
-			.OrderBy (annotation => annotation, StringComparer.Ordinal)
-			.ToArray ();
+			$"enum={field.AccessFlags.HasFlag (FieldAccessFlags.Enum)}";
 	}
 
 	static ClassAccessFlags GetDeclarationModifiers (ClassAccessFlags flags)
@@ -417,8 +397,8 @@ public partial class ScannerComparisonTests
 			"android/view/View$OnClickListener",
 			"android/view/View$OnLongClickListener",
 		}, model.Interfaces);
-		Assert.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|<init>|()V|final=False|synchronized=False|varargs=False|strict=False|throws=|annotations=", model.Constructors);
-		Assert.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|<init>|(I)V|final=False|synchronized=False|varargs=False|strict=False|throws=|annotations=", model.Constructors);
+		Assert.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|<init>|()V|final=False|synchronized=False|varargs=False|strict=False|throws=", model.Constructors);
+		Assert.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|<init>|(I)V|final=False|synchronized=False|varargs=False|strict=False|throws=", model.Constructors);
 		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|getValue|()Ljava/lang/String;", StringComparison.Ordinal));
 		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|onClick|(Landroid/view/View;)V", StringComparison.Ordinal));
 		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|onLongClick|(Landroid/view/View;)Z", StringComparison.Ordinal));
@@ -436,6 +416,5 @@ public partial class ScannerComparisonTests
 		Assert.Equal (expected.Constructors, actual.Constructors);
 		Assert.Equal (expected.Methods, actual.Methods);
 		Assert.Equal (expected.Fields, actual.Fields);
-		Assert.Equal (expected.Annotations, actual.Annotations);
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceSemanticParityTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceSemanticParityTests.cs
@@ -1,0 +1,423 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Java.Interop.Tools.Cecil;
+using Java.Interop.Tools.JavaCallableWrappers;
+using Java.Interop.Tools.JavaCallableWrappers.Adapters;
+using Java.Interop.Tools.TypeNameMappings;
+using Mono.Cecil;
+using Xamarin.Android.Tools.Bytecode;
+using Xunit;
+using CecilAssemblyDefinition = Mono.Cecil.AssemblyDefinition;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests;
+
+public partial class ScannerComparisonTests
+{
+	const string SemanticPeerManagedName = "UserApp.JavaSourceParity.SemanticPeer";
+	const string SemanticPeerJavaName = "com/example/parity/SemanticPeer";
+
+	sealed record JavaSemanticModel (
+		string Name,
+		string BaseName,
+		string Visibility,
+		bool IsAbstract,
+		IReadOnlyList<string> Interfaces,
+		IReadOnlyList<string> Constructors,
+		IReadOnlyList<string> Methods,
+		IReadOnlyList<string> Fields,
+		IReadOnlyList<string> Annotations
+	);
+
+	[Fact]
+	public void GeneratedJava_HasSemanticParityAndCompiles ()
+	{
+		var assemblyPaths = JavaSourceParityAssemblyPaths;
+
+		var legacySource = GenerateLegacyJava (assemblyPaths [0]);
+		var trimmableSource = GenerateTrimmableJava (assemblyPaths);
+
+		var legacyModel = CompileAndReadSemanticModel ("legacy", legacySource);
+		var trimmableModel = CompileAndReadSemanticModel ("trimmable", trimmableSource);
+
+		AssertFixtureCoverage (legacyModel);
+		AssertSemanticEquality (legacyModel, trimmableModel);
+	}
+
+	static string[] JavaSourceParityAssemblyPaths {
+		get {
+			var testDirectory = Path.GetDirectoryName (typeof (ScannerComparisonTests).Assembly.Location);
+			if (testDirectory is null) {
+				throw new InvalidOperationException ("Could not determine the integration test output directory.");
+			}
+
+			var paths = new List<string> {
+				Path.Combine (testDirectory, "JavaSourceParityFixture.dll"),
+				Path.Combine (testDirectory, "Mono.Android.dll"),
+			};
+			var javaInteropPath = Path.Combine (testDirectory, "Java.Interop.dll");
+			if (File.Exists (javaInteropPath)) {
+				paths.Add (javaInteropPath);
+			}
+			foreach (var path in paths) {
+				if (!File.Exists (path)) {
+					throw new InvalidOperationException ($"Required fixture dependency '{path}' was not found.");
+				}
+			}
+			return paths.ToArray ();
+		}
+	}
+
+	static string GenerateLegacyJava (string assemblyPath)
+	{
+		var cache = new TypeDefinitionCache ();
+		var resolver = new DefaultAssemblyResolver ();
+		var assemblyDirectory = Path.GetDirectoryName (assemblyPath);
+		if (assemblyDirectory is null) {
+			throw new InvalidOperationException ($"Could not determine the directory for '{assemblyPath}'.");
+		}
+		resolver.AddSearchDirectory (assemblyDirectory);
+
+		var runtimeDirectory = Path.GetDirectoryName (typeof (object).Assembly.Location);
+		if (runtimeDirectory is not null) {
+			resolver.AddSearchDirectory (runtimeDirectory);
+		}
+
+		var readerParameters = new ReaderParameters { AssemblyResolver = resolver };
+		using var assembly = CecilAssemblyDefinition.ReadAssembly (assemblyPath, readerParameters);
+		var type = assembly.MainModule.GetType (SemanticPeerManagedName);
+		if (type is null) {
+			throw new InvalidOperationException ($"Could not find '{SemanticPeerManagedName}' in '{assemblyPath}'.");
+		}
+
+		var wrapper = CecilImporter.CreateType (type, cache);
+		using var writer = new StringWriter ();
+		wrapper.Generate (writer, new CallableWrapperWriterOptions {
+			CodeGenerationTarget = JavaPeerStyle.XAJavaInterop1,
+		});
+		return writer.ToString ();
+	}
+
+	static string GenerateTrimmableJava (IReadOnlyList<string> assemblyPaths)
+	{
+		using var scanner = new JavaPeerScanner ();
+		var peReaders = new List<PEReader> ();
+		var assemblies = new List<(string Name, PEReader Reader)> ();
+		List<JavaPeerInfo> peers;
+		try {
+			foreach (var path in assemblyPaths) {
+				var peReader = new PEReader (File.OpenRead (path));
+				peReaders.Add (peReader);
+				var metadataReader = peReader.GetMetadataReader ();
+				assemblies.Add ((metadataReader.GetString (metadataReader.GetAssemblyDefinition ().Name), peReader));
+			}
+			peers = scanner.Scan (assemblies);
+		} finally {
+			foreach (var peReader in peReaders) {
+				peReader.Dispose ();
+			}
+		}
+
+		var peer = peers.SingleOrDefault (p => p.ManagedTypeName == SemanticPeerManagedName);
+		if (peer is null) {
+			throw new InvalidOperationException ($"Could not scan '{SemanticPeerManagedName}'.");
+		}
+
+		using var writer = new StringWriter ();
+		new JcwJavaSourceGenerator ().Generate (peer, writer);
+		return writer.ToString ();
+	}
+
+	static JavaSemanticModel CompileAndReadSemanticModel (string name, string generatedSource)
+	{
+		var root = Path.Combine (Path.GetTempPath (), $"jcw-semantic-parity-{name}-{Guid.NewGuid ():N}");
+		var sourceDirectory = Path.Combine (root, "src");
+		var classesDirectory = Path.Combine (root, "classes");
+		Directory.CreateDirectory (sourceDirectory);
+		Directory.CreateDirectory (classesDirectory);
+
+		try {
+			var sourceFiles = WriteJavaSourceSet (sourceDirectory, generatedSource);
+			CompileJavaSourceSet (name, sourceFiles, classesDirectory, generatedSource);
+
+			var classPath = Path.Combine (classesDirectory, SemanticPeerJavaName + ".class");
+			Assert.True (File.Exists (classPath), $"javac did not produce '{classPath}'.");
+			using var stream = File.OpenRead (classPath);
+			return CreateSemanticModel (new ClassFile (stream));
+		} finally {
+			Directory.Delete (root, recursive: true);
+		}
+	}
+
+	static List<string> WriteJavaSourceSet (string sourceDirectory, string generatedSource)
+	{
+		var sources = new Dictionary<string, string> {
+			[SemanticPeerJavaName + ".java"] = generatedSource,
+			["com/example/parity/Base.java"] = """
+				package com.example.parity;
+
+				public class Base {
+					public Base () {}
+					public Base (int value) {}
+					public java.lang.String getValue () { return ""; }
+				}
+				""",
+			["android/view/View.java"] = """
+				package android.view;
+
+				public class View {
+					public interface OnClickListener {
+						void onClick (View view);
+					}
+				}
+				""",
+			["mono/android/IGCUserPeer.java"] = """
+				package mono.android;
+
+				public interface IGCUserPeer {
+					void monodroidAddReference (java.lang.Object value);
+					void monodroidClearReferences ();
+				}
+				""",
+			["mono/android/Runtime.java"] = """
+				package mono.android;
+
+				public final class Runtime {
+					public static void register (java.lang.String managedName, java.lang.Class<?> javaType, java.lang.String methods) {}
+					public static void registerNatives (java.lang.Class<?> javaType) {}
+				}
+				""",
+			["mono/android/TypeManager.java"] = """
+				package mono.android;
+
+				public final class TypeManager {
+					public static void Activate (java.lang.String managedName, java.lang.String signature, java.lang.Object instance, java.lang.Object[] arguments) {}
+				}
+				""",
+		};
+
+		var paths = new List<string> ();
+		foreach (var source in sources) {
+			var path = Path.Combine (sourceDirectory, source.Key);
+			var directory = Path.GetDirectoryName (path);
+			if (directory is null) {
+				throw new InvalidOperationException ($"Could not determine the directory for '{path}'.");
+			}
+			Directory.CreateDirectory (directory);
+			File.WriteAllText (path, source.Value);
+			paths.Add (path);
+		}
+		return paths;
+	}
+
+	static void CompileJavaSourceSet (string name, IReadOnlyList<string> sourceFiles, string classesDirectory, string generatedSource)
+	{
+		var compilerPath = GetJavaCompilerPath ();
+		var startInfo = new ProcessStartInfo {
+			FileName = compilerPath,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			UseShellExecute = false,
+		};
+		startInfo.ArgumentList.Add ("-d");
+		startInfo.ArgumentList.Add (classesDirectory);
+		foreach (var sourceFile in sourceFiles) {
+			startInfo.ArgumentList.Add (sourceFile);
+		}
+
+		using var process = Process.Start (startInfo);
+		if (process is null) {
+			throw new InvalidOperationException ($"Could not start '{compilerPath}'.");
+		}
+		var standardOutput = process.StandardOutput.ReadToEndAsync ();
+		var standardError = process.StandardError.ReadToEndAsync ();
+		if (!process.WaitForExit ((int) TimeSpan.FromMinutes (1).TotalMilliseconds)) {
+			process.Kill (entireProcessTree: true);
+			throw new TimeoutException ($"javac timed out compiling the {name} Java source set.");
+		}
+
+		var output = standardOutput.GetAwaiter ().GetResult ();
+		var error = standardError.GetAwaiter ().GetResult ();
+		Assert.True (process.ExitCode == 0,
+			$"javac failed compiling the {name} Java source set.{Environment.NewLine}" +
+			$"stdout:{Environment.NewLine}{output}{Environment.NewLine}" +
+			$"stderr:{Environment.NewLine}{error}{Environment.NewLine}" +
+			$"generated source:{Environment.NewLine}{generatedSource}");
+	}
+
+	static string GetJavaCompilerPath ()
+	{
+		var attribute = typeof (ScannerComparisonTests).Assembly
+			.GetCustomAttributes<AssemblyMetadataAttribute> ()
+			.SingleOrDefault (a => a.Key == "JavaCPath");
+		if (attribute is null || attribute.Value.IsNullOrEmpty ()) {
+			throw new InvalidOperationException ("The JavaCPath assembly metadata value is missing.");
+		}
+		return attribute.Value;
+	}
+
+	static JavaSemanticModel CreateSemanticModel (ClassFile classFile)
+	{
+		// Classfiles preserve declaration semantics while discarding source formatting
+		// and source-only annotations such as @Override, which javac validates above.
+		var constructors = classFile.Methods
+			.Where (method => method.IsConstructor)
+			.Select (FormatMethod)
+			.OrderBy (method => method, StringComparer.Ordinal)
+			.ToArray ();
+		var methods = classFile.Methods
+			.Where (IsSemanticMethod)
+			.Select (FormatMethod)
+			.OrderBy (method => method, StringComparer.Ordinal)
+			.ToArray ();
+		var fields = classFile.Fields
+			.Where (field => field.Name != "refList" && !field.Name.StartsWith ("__md_", StringComparison.Ordinal))
+			.Select (FormatField)
+			.OrderBy (field => field, StringComparer.Ordinal)
+			.ToArray ();
+		var interfaces = classFile.Interfaces
+			.Select (iface => iface.Name.Value)
+			.OrderBy (iface => iface, StringComparer.Ordinal)
+			.ToArray ();
+
+		return new JavaSemanticModel (
+			classFile.ThisClass.Name.Value,
+			classFile.SuperClass.Name.Value,
+			GetVisibility (classFile.AccessFlags),
+			classFile.AccessFlags.HasFlag (ClassAccessFlags.Abstract),
+			interfaces,
+			constructors,
+			methods,
+			fields,
+			GetAnnotations (classFile.Attributes)
+		);
+	}
+
+	static bool IsSemanticMethod (Xamarin.Android.Tools.Bytecode.MethodInfo method)
+	{
+		if (method.Name is "<init>" or "<clinit>" ||
+		    method.AccessFlags.HasFlag (MethodAccessFlags.Native) ||
+		    method.Name is "monodroidAddReference" or "monodroidClearReferences" ||
+		    method.Name.StartsWith ("__md_", StringComparison.Ordinal)) {
+			return false;
+		}
+		return true;
+	}
+
+	static string FormatMethod (Xamarin.Android.Tools.Bytecode.MethodInfo method)
+	{
+		var throws = method.GetThrows ()
+			.Select (type => type.BinaryName)
+			.OrderBy (type => type, StringComparer.Ordinal);
+		var annotations = GetAnnotations (method.Attributes);
+		return $"{GetVisibility (method.AccessFlags)}|" +
+			$"static={method.AccessFlags.HasFlag (MethodAccessFlags.Static)}|" +
+			$"abstract={method.AccessFlags.HasFlag (MethodAccessFlags.Abstract)}|" +
+			$"bridge={method.AccessFlags.HasFlag (MethodAccessFlags.Bridge)}|" +
+			$"synthetic={method.AccessFlags.HasFlag (MethodAccessFlags.Synthetic)}|" +
+			$"{method.Name}|{method.Descriptor}|" +
+			$"throws={string.Join (",", throws)}|" +
+			$"annotations={string.Join (",", annotations)}";
+	}
+
+	static string FormatField (Xamarin.Android.Tools.Bytecode.FieldInfo field)
+	{
+		var annotations = GetAnnotations (field.Attributes);
+		return $"{GetVisibility (field.AccessFlags)}|" +
+			$"static={field.AccessFlags.HasFlag (FieldAccessFlags.Static)}|" +
+			$"final={field.AccessFlags.HasFlag (FieldAccessFlags.Final)}|" +
+			$"{field.Name}|{field.Descriptor}|" +
+			$"annotations={string.Join (",", annotations)}";
+	}
+
+	static string[] GetAnnotations (AttributeCollection attributes)
+	{
+		return attributes
+			.OfType<RuntimeVisibleAnnotationsAttribute> ()
+			.SelectMany (attribute => attribute.Annotations)
+			.Concat (attributes
+				.OfType<RuntimeInvisibleAnnotationsAttribute> ()
+				.SelectMany (attribute => attribute.Annotations))
+			.Select (annotation => annotation.ToString ())
+			.OrderBy (annotation => annotation, StringComparer.Ordinal)
+			.ToArray ();
+	}
+
+	static string GetVisibility (ClassAccessFlags flags)
+	{
+		if (flags.HasFlag (ClassAccessFlags.Public)) {
+			return "public";
+		}
+		if (flags.HasFlag (ClassAccessFlags.Protected)) {
+			return "protected";
+		}
+		if (flags.HasFlag (ClassAccessFlags.Private)) {
+			return "private";
+		}
+		return "package";
+	}
+
+	static string GetVisibility (MethodAccessFlags flags)
+	{
+		if (flags.HasFlag (MethodAccessFlags.Public)) {
+			return "public";
+		}
+		if (flags.HasFlag (MethodAccessFlags.Protected)) {
+			return "protected";
+		}
+		if (flags.HasFlag (MethodAccessFlags.Private)) {
+			return "private";
+		}
+		return "package";
+	}
+
+	static string GetVisibility (FieldAccessFlags flags)
+	{
+		if (flags.HasFlag (FieldAccessFlags.Public)) {
+			return "public";
+		}
+		if (flags.HasFlag (FieldAccessFlags.Protected)) {
+			return "protected";
+		}
+		if (flags.HasFlag (FieldAccessFlags.Private)) {
+			return "private";
+		}
+		return "package";
+	}
+
+	static void AssertFixtureCoverage (JavaSemanticModel model)
+	{
+		Assert.Equal (SemanticPeerJavaName, model.Name);
+		Assert.Equal ("com/example/parity/Base", model.BaseName);
+		Assert.Equal ("public", model.Visibility);
+		Assert.False (model.IsAbstract);
+		Assert.Equal (new [] {
+			"android/view/View$OnClickListener",
+			"mono/android/IGCUserPeer",
+		}, model.Interfaces);
+		Assert.Contains (model.Constructors, constructor => constructor.Contains ("<init>|()V", StringComparison.Ordinal));
+		Assert.Contains (model.Constructors, constructor => constructor.Contains ("<init>|(I)V", StringComparison.Ordinal));
+		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|getValue|()Ljava/lang/String;", StringComparison.Ordinal));
+		Assert.Contains (model.Methods, method => method.Contains ("protected|static=False|abstract=False|bridge=False|synthetic=False|checkedExport|(Ljava/lang/String;)I|throws=java/io/IOException", StringComparison.Ordinal));
+		Assert.Contains (model.Fields, field => field.Contains ("public|static=True|final=False|STATIC_LABEL|Ljava/lang/String;", StringComparison.Ordinal));
+		Assert.Contains (model.Fields, field => field.Contains ("public|static=False|final=False|LABEL|Ljava/lang/String;", StringComparison.Ordinal));
+	}
+
+	static void AssertSemanticEquality (JavaSemanticModel expected, JavaSemanticModel actual)
+	{
+		Assert.Equal (expected.Name, actual.Name);
+		Assert.Equal (expected.BaseName, actual.BaseName);
+		Assert.Equal (expected.Visibility, actual.Visibility);
+		Assert.Equal (expected.IsAbstract, actual.IsAbstract);
+		Assert.Equal (expected.Interfaces, actual.Interfaces);
+		Assert.Equal (expected.Constructors, actual.Constructors);
+		Assert.Equal (expected.Methods, actual.Methods);
+		Assert.Equal (expected.Fields, actual.Fields);
+		Assert.Equal (expected.Annotations, actual.Annotations);
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceSemanticParityTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceSemanticParityTests.cs
@@ -25,8 +25,7 @@ public partial class ScannerComparisonTests
 	sealed record JavaSemanticModel (
 		string Name,
 		string BaseName,
-		string Visibility,
-		bool IsAbstract,
+		ClassAccessFlags Modifiers,
 		IReadOnlyList<string> Interfaces,
 		IReadOnlyList<string> Constructors,
 		IReadOnlyList<string> Methods,
@@ -238,7 +237,13 @@ public partial class ScannerComparisonTests
 		var standardError = process.StandardError.ReadToEndAsync ();
 		if (!process.WaitForExit ((int) TimeSpan.FromMinutes (1).TotalMilliseconds)) {
 			process.Kill (entireProcessTree: true);
-			throw new TimeoutException ($"javac timed out compiling the {name} Java source set.");
+			process.WaitForExit ();
+			var timeoutOutput = standardOutput.GetAwaiter ().GetResult ();
+			var timeoutError = standardError.GetAwaiter ().GetResult ();
+			throw new TimeoutException (
+				$"javac timed out compiling the {name} Java source set.{Environment.NewLine}" +
+				$"stdout:{Environment.NewLine}{timeoutOutput}{Environment.NewLine}" +
+				$"stderr:{Environment.NewLine}{timeoutError}");
 		}
 
 		var output = standardOutput.GetAwaiter ().GetResult ();
@@ -288,8 +293,7 @@ public partial class ScannerComparisonTests
 		return new JavaSemanticModel (
 			classFile.ThisClass.Name.Value,
 			classFile.SuperClass.Name.Value,
-			GetVisibility (classFile.AccessFlags),
-			classFile.AccessFlags.HasFlag (ClassAccessFlags.Abstract),
+			GetDeclarationModifiers (classFile.AccessFlags),
 			interfaces,
 			constructors,
 			methods,
@@ -321,6 +325,10 @@ public partial class ScannerComparisonTests
 			$"bridge={method.AccessFlags.HasFlag (MethodAccessFlags.Bridge)}|" +
 			$"synthetic={method.AccessFlags.HasFlag (MethodAccessFlags.Synthetic)}|" +
 			$"{method.Name}|{method.Descriptor}|" +
+			$"final={method.AccessFlags.HasFlag (MethodAccessFlags.Final)}|" +
+			$"synchronized={method.AccessFlags.HasFlag (MethodAccessFlags.Synchronized)}|" +
+			$"varargs={method.AccessFlags.HasFlag (MethodAccessFlags.Varargs)}|" +
+			$"strict={method.AccessFlags.HasFlag (MethodAccessFlags.Strict)}|" +
 			$"throws={string.Join (",", throws)}|" +
 			$"annotations={string.Join (",", annotations)}";
 	}
@@ -332,6 +340,10 @@ public partial class ScannerComparisonTests
 			$"static={field.AccessFlags.HasFlag (FieldAccessFlags.Static)}|" +
 			$"final={field.AccessFlags.HasFlag (FieldAccessFlags.Final)}|" +
 			$"{field.Name}|{field.Descriptor}|" +
+			$"volatile={field.AccessFlags.HasFlag (FieldAccessFlags.Volatile)}|" +
+			$"transient={field.AccessFlags.HasFlag (FieldAccessFlags.Transient)}|" +
+			$"synthetic={field.AccessFlags.HasFlag (FieldAccessFlags.Synthetic)}|" +
+			$"enum={field.AccessFlags.HasFlag (FieldAccessFlags.Enum)}|" +
 			$"annotations={string.Join (",", annotations)}";
 	}
 
@@ -348,18 +360,20 @@ public partial class ScannerComparisonTests
 			.ToArray ();
 	}
 
-	static string GetVisibility (ClassAccessFlags flags)
+	static ClassAccessFlags GetDeclarationModifiers (ClassAccessFlags flags)
 	{
-		if (flags.HasFlag (ClassAccessFlags.Public)) {
-			return "public";
-		}
-		if (flags.HasFlag (ClassAccessFlags.Protected)) {
-			return "protected";
-		}
-		if (flags.HasFlag (ClassAccessFlags.Private)) {
-			return "private";
-		}
-		return "package";
+		return flags & (
+			ClassAccessFlags.Public |
+			ClassAccessFlags.Private |
+			ClassAccessFlags.Protected |
+			ClassAccessFlags.Static |
+			ClassAccessFlags.Final |
+			ClassAccessFlags.Interface |
+			ClassAccessFlags.Abstract |
+			ClassAccessFlags.Synthetic |
+			ClassAccessFlags.Annotation |
+			ClassAccessFlags.Enum
+		);
 	}
 
 	static string GetVisibility (MethodAccessFlags flags)
@@ -394,16 +408,16 @@ public partial class ScannerComparisonTests
 	{
 		Assert.Equal (SemanticPeerJavaName, model.Name);
 		Assert.Equal ("com/example/parity/Base", model.BaseName);
-		Assert.Equal ("public", model.Visibility);
-		Assert.False (model.IsAbstract);
+		Assert.Equal (ClassAccessFlags.Public, model.Modifiers);
 		Assert.Equal (new [] {
 			"android/view/View$OnClickListener",
 			"mono/android/IGCUserPeer",
 		}, model.Interfaces);
-		Assert.Contains (model.Constructors, constructor => constructor.Contains ("<init>|()V", StringComparison.Ordinal));
-		Assert.Contains (model.Constructors, constructor => constructor.Contains ("<init>|(I)V", StringComparison.Ordinal));
+		Assert.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|<init>|()V|final=False|synchronized=False|varargs=False|strict=False|throws=|annotations=", model.Constructors);
+		Assert.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|<init>|(I)V|final=False|synchronized=False|varargs=False|strict=False|throws=|annotations=", model.Constructors);
 		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|getValue|()Ljava/lang/String;", StringComparison.Ordinal));
-		Assert.Contains (model.Methods, method => method.Contains ("protected|static=False|abstract=False|bridge=False|synthetic=False|checkedExport|(Ljava/lang/String;)I|throws=java/io/IOException", StringComparison.Ordinal));
+		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|onClick|(Landroid/view/View;)V", StringComparison.Ordinal));
+		Assert.Contains (model.Methods, method => method.Contains ("protected|static=False|abstract=False|bridge=False|synthetic=False|checkedExport|(Ljava/lang/String;)I|final=False|synchronized=False|varargs=False|strict=False|throws=java/io/IOException", StringComparison.Ordinal));
 		Assert.Contains (model.Fields, field => field.Contains ("public|static=True|final=False|STATIC_LABEL|Ljava/lang/String;", StringComparison.Ordinal));
 		Assert.Contains (model.Fields, field => field.Contains ("public|static=False|final=False|LABEL|Ljava/lang/String;", StringComparison.Ordinal));
 	}
@@ -412,8 +426,7 @@ public partial class ScannerComparisonTests
 	{
 		Assert.Equal (expected.Name, actual.Name);
 		Assert.Equal (expected.BaseName, actual.BaseName);
-		Assert.Equal (expected.Visibility, actual.Visibility);
-		Assert.Equal (expected.IsAbstract, actual.IsAbstract);
+		Assert.Equal (expected.Modifiers, actual.Modifiers);
 		Assert.Equal (expected.Interfaces, actual.Interfaces);
 		Assert.Equal (expected.Constructors, actual.Constructors);
 		Assert.Equal (expected.Methods, actual.Methods);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceSemanticParityTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/JavaSourceSemanticParityTests.cs
@@ -173,6 +173,10 @@ public partial class ScannerComparisonTests
 					public interface OnClickListener {
 						void onClick (View view);
 					}
+					public interface OnLongClickListener {
+						boolean onLongClick (View view);
+						boolean onLongClickUseDefaultHapticFeedback (View view);
+					}
 				}
 				""",
 			["mono/android/IGCUserPeer.java"] = """
@@ -287,7 +291,6 @@ public partial class ScannerComparisonTests
 			.ToArray ();
 		var interfaces = classFile.Interfaces
 			.Select (iface => iface.Name.Value)
-			.OrderBy (iface => iface, StringComparer.Ordinal)
 			.ToArray ();
 
 		return new JavaSemanticModel (
@@ -410,13 +413,15 @@ public partial class ScannerComparisonTests
 		Assert.Equal ("com/example/parity/Base", model.BaseName);
 		Assert.Equal (ClassAccessFlags.Public, model.Modifiers);
 		Assert.Equal (new [] {
-			"android/view/View$OnClickListener",
 			"mono/android/IGCUserPeer",
+			"android/view/View$OnClickListener",
+			"android/view/View$OnLongClickListener",
 		}, model.Interfaces);
 		Assert.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|<init>|()V|final=False|synchronized=False|varargs=False|strict=False|throws=|annotations=", model.Constructors);
 		Assert.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|<init>|(I)V|final=False|synchronized=False|varargs=False|strict=False|throws=|annotations=", model.Constructors);
 		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|getValue|()Ljava/lang/String;", StringComparison.Ordinal));
 		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|onClick|(Landroid/view/View;)V", StringComparison.Ordinal));
+		Assert.Contains (model.Methods, method => method.Contains ("public|static=False|abstract=False|bridge=False|synthetic=False|onLongClick|(Landroid/view/View;)Z", StringComparison.Ordinal));
 		Assert.Contains (model.Methods, method => method.Contains ("protected|static=False|abstract=False|bridge=False|synthetic=False|checkedExport|(Ljava/lang/String;)I|final=False|synchronized=False|varargs=False|strict=False|throws=java/io/IOException", StringComparison.Ordinal));
 		Assert.Contains (model.Fields, field => field.Contains ("public|static=True|final=False|STATIC_LABEL|Ljava/lang/String;", StringComparison.Ordinal));
 		Assert.Contains (model.Fields, field => field.Contains ("public|static=False|final=False|LABEL|Ljava/lang/String;", StringComparison.Ordinal));

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests.csproj
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests.csproj
@@ -22,11 +22,13 @@
   <!-- Exclude the fixture assembly source files from this project -->
   <ItemGroup>
     <Compile Remove="UserTypesFixture\**" />
+    <Compile Remove="JavaSourceParityFixture\**" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Android.Sdk.TrimmableTypeMap\Microsoft.Android.Sdk.TrimmableTypeMap.csproj" />
     <ProjectReference Include="..\..\src\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj" />
+    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj" />
     <!-- Mono.Android is built as a dependency so the ref assembly is available on disk.
          ReferenceOutputAssembly=false because we read it with SRM/Cecil, not compile against it directly.
          Instead, we reference the ref assembly below so we can use typeof(Java.Lang.Object). -->
@@ -35,6 +37,8 @@
     <!-- User-type fixture assembly: built as a dependency, scanned via SRM/Cecil in tests.
          ReferenceOutputAssembly=false because we don't compile against it — we just need the DLL on disk. -->
     <ProjectReference Include="UserTypesFixture\UserTypesFixture.csproj"
+                      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="JavaSourceParityFixture\JavaSourceParityFixture.csproj"
                       ReferenceOutputAssembly="false" />
   </ItemGroup>
 
@@ -57,5 +61,12 @@
       </Reference>
     </ItemGroup>
   </Target>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>JavaCPath</_Parameter1>
+      <_Parameter2>$(JavaCPath)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- add a bounded managed fixture shared by legacy XAJavaInterop1 and the trimmable typemap
- compile both generated Java source sets with javac and compare parsed classfile declarations
- cover hierarchy, ordered interfaces, constructors, methods, export fields, visibility/modifiers, and checked throws
- validate llvm-ir CoreCLR, trimmable CoreCLR, and trimmable NativeAOT builds

Stacked on #12564 so the fixture consumes its shared constructor/method throws formatting fix. This is semantic-comparison groundwork; managed annotation forwarding remains covered by #12549, and the broader generated-Java parity checklist remains open.