### PR TITLE
Forward debugger ports for dotnet run

### DIFF
--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -24,6 +24,9 @@ int ctrlCRequested = 0;
 string? logcatArgs = null;
 bool isDotnetTestMode = false;
 string? dotnetTestPipe = null;
+bool waitForExit = true;
+List<PortMapping> forwardPorts = [];
+List<PortMapping> reversePorts = [];
 
 try {
 	return await RunAsync (args);
@@ -82,6 +85,15 @@ async Task<int> RunAsync (string[] args)
 		{ "logcat-args=",
 			"Extra {ARGUMENTS} to pass to 'adb logcat' (e.g., 'monodroid-assembly:S' to silence a tag).",
 			v => logcatArgs = v },
+		{ "no-wait",
+			"Launch the application without waiting for it to exit or streaming logcat.",
+			v => waitForExit = v == null },
+		{ "forward-port=",
+			"Forward a TCP port from the host to the device in {MAPPING} format (HOST_PORT:DEVICE_PORT). May be repeated.",
+			v => forwardPorts.Add (ParsePortMapping (v, "--forward-port")) },
+		{ "reverse-port=",
+			"Reverse a TCP port from the device to the host in {MAPPING} format (DEVICE_PORT:HOST_PORT). May be repeated.",
+			v => reversePorts.Add (ParsePortMapping (v, "--reverse-port")) },
 		{ "version",
 			"Show version information and exit.",
 			v => showVersion = v != null },
@@ -189,6 +201,9 @@ async Task<int> RunAsync (string[] args)
 			Console.WriteLine ($"dotnet test mode (pipe: {dotnetTestPipe})");
 	}
 
+	if (!await ConfigurePortMappingsAsync ())
+		return 1;
+
 	// Set up Ctrl+C handler
 	Console.CancelKeyPress += OnCancelKeyPress;
 
@@ -226,7 +241,10 @@ async Task<int> RunInstrumentationAsync (List<string> instrumentationArgs)
 {
 	// '-w' waits for the run to complete; '-r' prints raw INSTRUMENTATION_STATUS
 	// blocks as they arrive instead of buffering everything until the end.
-	var cmdArgs = new List<string> { "shell", "am", "instrument", "-w", "-r" };
+	var cmdArgs = new List<string> { "shell", "am", "instrument" };
+	if (waitForExit)
+		cmdArgs.Add ("-w");
+	cmdArgs.Add ("-r");
 	if (!string.IsNullOrEmpty (deviceUserId)) {
 		cmdArgs.Add ("--user");
 		cmdArgs.Add (deviceUserId);
@@ -263,6 +281,10 @@ async Task<int> RunInstrumentationAsync (List<string> instrumentationArgs)
 	instrumentProcess.Start ();
 	instrumentProcess.BeginOutputReadLine ();
 	instrumentProcess.BeginErrorReadLine ();
+	if (!waitForExit) {
+		await instrumentProcess.WaitForExitAsync (cts.Token);
+		return instrumentProcess.ExitCode == 0 ? 0 : 1;
+	}
 
 	// Also stream logcat in the background, which is where Console output from the
 	// app ends up. The app process does not exist yet when `am instrument` starts,
@@ -493,6 +515,8 @@ async Task<int> RunAppAsync ()
 	// 1. Start the app
 	if (!await StartAppAsync ())
 		return 1;
+	if (!waitForExit)
+		return 0;
 
 	// 2. Get the PID
 	logcatPid = await GetAppPidAsync ();
@@ -518,7 +542,8 @@ async Task<bool> StartAppAsync ()
 	var userArg = string.IsNullOrEmpty (deviceUserId) ? "" : $" --user {deviceUserId}";
 	// Device preparation is best effort; am start must run and determine the shell exit code.
 	var wakeDeviceCommand = wakeDevice ? "input keyevent KEYCODE_WAKEUP; wm dismiss-keyguard; " : "";
-	var cmdArgs = $"shell {wakeDeviceCommand}am start -S -W{userArg} -n \"{package}/{activity}\"";
+	var waitArg = waitForExit ? " -W" : "";
+	var cmdArgs = $"shell {wakeDeviceCommand}am start -S{waitArg}{userArg} -n \"{package}/{activity}\"";
 	var (exitCode, output, error) = await AdbHelper.RunAsync (adbPath, adbTarget, cmdArgs, cts.Token, verbose);
 	if (exitCode != 0) {
 		Console.Error.WriteLine ($"Error: Failed to start app: {error}");
@@ -529,6 +554,43 @@ async Task<bool> StartAppAsync ()
 		Console.WriteLine (output);
 
 	return true;
+}
+
+async Task<bool> ConfigurePortMappingsAsync ()
+{
+	foreach (var port in forwardPorts) {
+		var (forwardExitCode, _, forwardError) = await AdbHelper.RunAsync (
+			adbPath, adbTarget, $"forward tcp:{port.Source} tcp:{port.Destination}", cts.Token, verbose);
+		if (forwardExitCode != 0) {
+			Console.Error.WriteLine ($"Error: Failed to forward port {port.Source}:{port.Destination}: {forwardError}");
+			return false;
+		}
+	}
+
+	foreach (var port in reversePorts) {
+		var (reverseExitCode, _, reverseError) = await AdbHelper.RunAsync (
+			adbPath, adbTarget, $"reverse tcp:{port.Source} tcp:{port.Destination}", cts.Token, verbose);
+		if (reverseExitCode != 0) {
+			Console.Error.WriteLine ($"Error: Failed to reverse port {port.Source}:{port.Destination}: {reverseError}");
+			return false;
+		}
+	}
+
+	return true;
+}
+
+PortMapping ParsePortMapping (string value, string option)
+{
+	var ports = value.Split (':');
+	if (ports.Length != 2 ||
+			!int.TryParse (ports [0], out int source) ||
+			!int.TryParse (ports [1], out int destination) ||
+			source is < 1 or > 65535 ||
+			destination is < 1 or > 65535) {
+		throw new OptionException ("Expected two TCP ports between 1 and 65535 in SOURCE:DESTINATION format.", option);
+	}
+
+	return new PortMapping (source, destination);
 }
 
 async Task<int?> GetAppPidAsync ()
@@ -691,3 +753,5 @@ string? FindAdbPath ()
 		return (null, null);
 	}
 }
+
+readonly record struct PortMapping (int Source, int Destination);

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -127,25 +127,22 @@ This file contains targets specific for Android application projects.
     </GetAndroidInstrumentationName>
     <PropertyGroup>
       <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
-    </PropertyGroup>
-    <!-- By default, use `Microsoft.Android.Run` tool to stream logcat and handle Ctrl+C -->
-    <PropertyGroup Condition=" '$(WaitForExit)' != 'false' ">
+      <AndroidSdbTargetPort Condition=" '$(AndroidSdbTargetPort)' == '' ">10000</AndroidSdbTargetPort>
+      <AndroidSdbHostPort Condition=" '$(AndroidSdbHostPort)' == '' ">10000</AndroidSdbHostPort>
+      <AndroidAttachDebugger Condition=" '$(AndroidAttachDebugger)' == '' ">False</AndroidAttachDebugger>
+      <AndroidDebuggerServer Condition=" '$(AndroidDebuggerServer)' == '' ">True</AndroidDebuggerServer>
       <_AndroidRunPath Condition=" '$(_AndroidRunPath)' == '' ">$(MSBuildThisFileDirectory)..\tools\Microsoft.Android.Run.dll</_AndroidRunPath>
       <_AndroidRunLogcatArgs Condition=" '$(_AndroidRunLogcatArgs)' == '' ">monodroid-assembly:S</_AndroidRunLogcatArgs>
       <_AndroidRunAdbTargetArg Condition=" '$(AdbTarget)' != '' ">--adb-target &quot;$(AdbTarget)&quot;</_AndroidRunAdbTargetArg>
       <_AndroidRunUserArg Condition=" '$(AndroidDeviceUserId)' != '' ">--user &quot;$(AndroidDeviceUserId)&quot;</_AndroidRunUserArg>
       <_AndroidRunInstrumentArg Condition=" '$(AndroidInstrumentation)' != '' ">--instrument &quot;$(AndroidInstrumentation)&quot;</_AndroidRunInstrumentArg>
       <_AndroidRunActivityArg Condition=" '$(AndroidInstrumentation)' == '' ">--activity &quot;$(AndroidLaunchActivity)&quot;</_AndroidRunActivityArg>
+      <_AndroidRunNoWaitArg Condition=" '$(WaitForExit)' == 'false' ">--no-wait</_AndroidRunNoWaitArg>
+      <_AndroidRunNoWakeDeviceArg Condition=" '$(WaitForExit)' == 'false' ">--no-wake-device</_AndroidRunNoWakeDeviceArg>
+      <!-- Preserve the legacy _Run argument order: target port is the host-side forward. -->
+      <_AndroidRunForwardPortArg Condition=" '$(AndroidAttachDebugger)' == 'true' and '$(AndroidDebuggerServer)' == 'true' ">--forward-port &quot;$(AndroidSdbTargetPort):$(AndroidSdbHostPort)&quot;</_AndroidRunForwardPortArg>
       <RunCommand>dotnet</RunCommand>
-      <RunArguments>exec &quot;$(_AndroidRunPath)&quot; --adb &quot;$(_AdbToolPath)&quot; $(_AndroidRunAdbTargetArg) --package &quot;$(_AndroidPackage)&quot; $(_AndroidRunActivityArg) $(_AndroidRunInstrumentArg) --logcat-args &quot;$(_AndroidRunLogcatArgs)&quot; $(_AndroidRunUserArg) $(_AndroidRunExtraArgs)</RunArguments>
-    </PropertyGroup>
-    <!-- When WaitForExit is false, use direct adb command (no logcat streaming) -->
-    <PropertyGroup Condition=" '$(WaitForExit)' == 'false' ">
-      <_AmStartUserArg Condition=" '$(AndroidDeviceUserId)' != '' "> --user $(AndroidDeviceUserId)</_AmStartUserArg>
-      <RunCommand>$(_AdbToolPath)</RunCommand>
-      <RunArguments Condition=" '$(AndroidInstrumentation)' == '' ">$(AdbTarget) shell am start -S$(_AmStartUserArg) -n &quot;$(_AndroidPackage)/$(AndroidLaunchActivity)&quot;</RunArguments>
-      <!-- No `-w`, the caller asked not to wait for the instrumentation to finish -->
-      <RunArguments Condition=" '$(AndroidInstrumentation)' != '' ">$(AdbTarget) shell am instrument -r$(_AmStartUserArg) &quot;$(_AndroidPackage)/$(AndroidInstrumentation)&quot;</RunArguments>
+      <RunArguments>exec &quot;$(_AndroidRunPath)&quot; --adb &quot;$(_AdbToolPath)&quot; $(_AndroidRunAdbTargetArg) --package &quot;$(_AndroidPackage)&quot; $(_AndroidRunActivityArg) $(_AndroidRunInstrumentArg) --logcat-args &quot;$(_AndroidRunLogcatArgs)&quot; $(_AndroidRunUserArg) $(_AndroidRunNoWaitArg) $(_AndroidRunNoWakeDeviceArg) $(_AndroidRunForwardPortArg) $(_AndroidRunExtraArgs)</RunArguments>
     </PropertyGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildOrderTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildOrderTests.cs
@@ -46,5 +46,57 @@ namespace Xamarin.Android.Build.Tests
 			StringAssertEx.Contains ("Running target: 'MyPrepareTarget'", builder.LastBuildOutput);
 		}
 
+		[Test]
+		public void ComputeRunArgumentsIncludesDebuggerPortForwarding ()
+		{
+			var setupTargets = new Import (() => "SetupRun.targets") {
+				TextContent = () => """
+<Project>
+  <PropertyGroup>
+    <_AndroidComputeRunArgumentsDependsOn>NoOp</_AndroidComputeRunArgumentsDependsOn>
+  </PropertyGroup>
+
+  <Target Name="NoOp" />
+  <Target Name="ReportRunArguments" AfterTargets="ComputeRunArguments">
+    <Message Text="RunCommand=$(RunCommand)" Importance="high" />
+    <Message Text="RunArguments=$(RunArguments)" Importance="high" />
+  </Target>
+</Project>
+"""
+			};
+			var proj = new XamarinAndroidApplicationProject {
+				Imports = { setupTargets },
+			};
+			proj.SetProperty ("AndroidLaunchActivity", "com.example.MainActivity");
+			proj.SetProperty ("_AndroidPackage", "com.example");
+			proj.SetProperty ("_AdbToolPath", "adb");
+			proj.SetProperty ("AdbTarget", "-s emulator-5554");
+			proj.SetProperty ("AndroidAttachDebugger", "true");
+			proj.SetProperty ("AndroidSdbTargetPort", "12345");
+			proj.SetProperty ("AndroidSdbHostPort", "54321");
+
+			using var builder = CreateApkBuilder ();
+			builder.Target = "ComputeRunArguments";
+			builder.Verbosity = LoggerVerbosity.Detailed;
+			Assert.IsTrue (builder.Build (proj), "ComputeRunArguments should succeed.");
+			StringAssertEx.Contains ("RunCommand=dotnet", builder.LastBuildOutput);
+			StringAssertEx.Contains ("--activity \"com.example.MainActivity\"", builder.LastBuildOutput);
+			StringAssertEx.Contains ("--adb-target \"-s emulator-5554\"", builder.LastBuildOutput);
+			StringAssertEx.Contains ("--forward-port \"12345:54321\"", builder.LastBuildOutput);
+			Assert.IsFalse (builder.LastBuildOutput.ContainsText ("--debugger-"), "RunArguments should use generic port forwarding.");
+
+			proj.SetProperty ("WaitForExit", "false");
+			Assert.IsTrue (builder.Build (proj), "ComputeRunArguments should succeed without waiting.");
+			StringAssertEx.Contains ("RunCommand=dotnet", builder.LastBuildOutput);
+			StringAssertEx.Contains ("--no-wait", builder.LastBuildOutput);
+			StringAssertEx.Contains ("--no-wake-device", builder.LastBuildOutput);
+			StringAssertEx.Contains ("--forward-port \"12345:54321\"", builder.LastBuildOutput);
+
+			proj.SetProperty ("AndroidDebuggerServer", "false");
+			Assert.IsTrue (builder.Build (proj), "ComputeRunArguments should succeed for a debugger client.");
+			StringAssertEx.Contains ("RunCommand=dotnet", builder.LastBuildOutput);
+			Assert.IsFalse (builder.LastBuildOutput.ContainsText ("--forward-port"), "A debugger client should connect without adb forwarding.");
+		}
+
 	}
 }


### PR DESCRIPTION
## Summary

- route both `WaitForExit=true` and `WaitForExit=false` `ComputeRunArguments` paths through `Microsoft.Android.Run`
- pass the existing `AndroidSdbTargetPort` / `AndroidSdbHostPort` values as a generic ADB forward mapping when `AndroidAttachDebugger=true` and `AndroidDebuggerServer=true`
- add repeatable generic `--forward-port` and `--reverse-port` runner options
- preserve the existing legacy `Run`, `_Run`, `RunActivity`, Mono debugger, and JDWP behavior unchanged

## Background

We are testing the debugger connection through `dotnet watch`, and these changes facilitate that scenario. `dotnet watch` launches a `dotnet run --no-build` child process, which executes the command returned by `ComputeRunArguments`; it does not invoke `_Run`. The debugger properties therefore reached MSBuild, but the legacy `_Run` target that established `adb forward` never executed.

This change establishes the requested port mapping in `Microsoft.Android.Run` before launching the application. Both `WaitForExit=true` and `WaitForExit=false` use the runner, so forwarding works for direct `dotnet run` and the child process launched by `dotnet watch` without changing the legacy MSBuild `Run` / `_Run` paths.

CoreCLR debugger configuration remains owned by vscode-maui, which ships the native debugger libraries and configures the runtime. See [DevDiv/vscode-maui PR 716837](https://dev.azure.com/devdiv/DevDiv/_git/vscode-maui/pullrequest/716837) for that implementation.

A broader cleanup is intentionally deferred to .NET 12: #12577 tracks unifying the `Run` target behavior, deleting `_Run`, and removing obsolete Mono-specific launch paths.

## Validation

- built `Microsoft.Android.Run` for `net10.0`
- validated `Microsoft.Android.Sdk.Application.targets` as XML
- added focused `ComputeRunArguments` coverage for waiting, no-wait, debugger-server, and forwarding behavior

The full `Xamarin.Android.Build.Tests` assembly was not run because this checkout does not contain the locally built Android SDK/reference packs.