### PR TITLE
Remove legacy installer packaging

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -2,6 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\scripts\XAVersionInfo.targets" />
   <Import Project="..\scripts\LocalizationLanguages.projitems" />
+  <Import Project="..\..\src\Mono.Android\Mono.Android.Apis.projitems" />
   <PropertyGroup>
     <MSBuildTargetsSrcDir>$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\Android</MSBuildTargetsSrcDir>
     <DefaultRuntimeEntitlementsPath>$(MSBuildThisFileDirectory)runtime-entitlements.plist</DefaultRuntimeEntitlementsPath>

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -2,38 +2,17 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\scripts\XAVersionInfo.targets" />
   <Import Project="..\scripts\LocalizationLanguages.projitems" />
-  <Import Project="..\..\bin\Build$(Configuration)\ProfileAssemblies.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\ProfileAssemblies.projitems')" />
-  <Import Project="..\..\src\Mono.Android\Mono.Android.Apis.projitems" />
-  <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" TaskFactory="TaskHostFactory" Runtime="NET" />
   <PropertyGroup>
-    <FrameworkSrcDir>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\</FrameworkSrcDir>
-    <_LatestStableFrameworkDir>$(FrameworkSrcDir)$(AndroidLatestStableFrameworkVersion)\</_LatestStableFrameworkDir>
-    <_MonoDocOutputPath>$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\monodoc\</_MonoDocOutputPath>
-    <LegacyMSBuildSrcDir>$(XAInstallPrefix)xbuild\Xamarin\Android\</LegacyMSBuildSrcDir>
     <MSBuildTargetsSrcDir>$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\Android</MSBuildTargetsSrcDir>
     <DefaultRuntimeEntitlementsPath>$(MSBuildThisFileDirectory)runtime-entitlements.plist</DefaultRuntimeEntitlementsPath>
-    <FirstInstallerFrameworkVersion Condition="'$(FirstInstallerFrameworkVersion)' == ''">$(AndroidLatestStableFrameworkVersion)</FirstInstallerFrameworkVersion>
-    <BclFrameworkVersion>v1.0</BclFrameworkVersion>
     <LibExtension Condition=" '$(HostOS)' == 'Darwin' ">dylib</LibExtension>
     <LibExtension Condition=" '$(HostOS)' == 'Linux' ">so</LibExtension>
     <LibExtension Condition=" '$(HostOS)' == 'Windows' ">dll</LibExtension>
-    <UseCommercialInstallerName Condition="'$(UseCommercialInstallerName)' == ''">False</UseCommercialInstallerName>
   </PropertyGroup>
-  <Target Name="_FindFrameworkDirs">
-    <ItemGroup>
-      <_FrameworkDirs Include="@(AndroidApiInfo->'$(FrameworkSrcDir)%(Identity)\')" />
-      <_FrameworkDirsThatExist Condition="Exists('%(Identity)')" Include="@(_FrameworkDirs)" Exclude="$(FrameworkSrcDir)v13.0.99\" />
-      <_EarlierFrameworkDir Include="@(_FrameworkDirsThatExist)" Exclude="$(_LatestStableFrameworkDir)" />
-    </ItemGroup>
-  </Target>
   <ItemGroup>
     <VersionFiles Include="$(MicrosoftAndroidSdkOutDir)Version" />
     <VersionFiles Include="$(MicrosoftAndroidSdkOutDir)Version.commit" />
     <VersionFiles Include="$(MicrosoftAndroidSdkOutDir)Version.rev" />
-  </ItemGroup>
-  <ItemGroup>
-    <_DesignerFilesUnix Include="$(LegacyMSBuildSrcDir)$(HostOS)\bcl\**\*" />
-    <_DesignerFilesWin Include="$(LegacyMSBuildSrcDir)bcl\**\* "/>
   </ItemGroup>
   <ItemGroup>
     <JIUtilityFile Include="Java.Interop.Localization.dll" />
@@ -58,33 +37,6 @@
     <JIUtilityFile Include="Xamarin.Android.Tools.Bytecode.pdb" />
     <JIUtilityFile Include="Xamarin.SourceWriter.dll" />
     <JIUtilityFile Include="Xamarin.SourceWriter.pdb" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)class-parse.exe" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)class-parse.pdb" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)generator.exe" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)generator.pdb" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)javadoc-to-mdoc.exe" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)javadoc-to-mdoc.pdb" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)Xamarin.Android.Tools.JavadocImporter.dll" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)Xamarin.Android.Tools.JavadocImporter.pdb" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)SgmlReaderDll.dll" /> <!-- Required by Xamarin.Android.Tools.JavadocImporter -->
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)jcw-gen.exe" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)jcw-gen.pdb" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)jit-times.exe" />
-    <_LegacyJIFiles Include="$(LegacyMSBuildSrcDir)jit-times.pdb" />
-  </ItemGroup>
-  <ItemGroup>
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\Mono.Android.Export.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\Mono.Android.Export.pdb" />
-    <_FrameworkFiles Include="@(MonoProfileAssembly->'$(FrameworkSrcDir)\$(BclFrameworkVersion)\%(Identity)')" />
-    <_FrameworkFiles Include="@(MonoProfileAssemblySymbol->'$(FrameworkSrcDir)\$(BclFrameworkVersion)\%(Identity)')" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Java.Interop.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Java.Interop.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.Data.Sqlite.dll.config" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.Posix.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.Posix.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\RedistList\FrameworkList.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.EnterpriseServices.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.EnterpriseServices.pdb" />
   </ItemGroup>
   <ItemGroup>
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)android-support-multidex.jar" />
@@ -119,16 +71,16 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)startup-xf.aotprofile" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)r8.jar" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)bundletool.jar" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime.jar" ExcludeFromLegacy="true" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_fastdev.jar" ExcludeFromLegacy="true" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_trimmable.jar" ExcludeFromLegacy="true" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime.dex" ExcludeFromLegacy="true" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_fastdev.dex" ExcludeFromLegacy="true" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_trimmable.dex" ExcludeFromLegacy="true" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_clr.jar" ExcludeFromLegacy="true" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_fastdev_clr.jar" ExcludeFromLegacy="true" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_clr.dex" ExcludeFromLegacy="true" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_fastdev_clr.dex" ExcludeFromLegacy="true" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime.jar" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_fastdev.jar" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_trimmable.jar" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime.dex" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_fastdev.dex" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_trimmable.dex" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_clr.jar" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_fastdev_clr.jar" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_clr.dex" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_fastdev_clr.dex" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)manifestmerger.jar" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)proguard-android.txt" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)protobuf-net.dll" />
@@ -207,12 +159,6 @@
     <_MSBuildFilesWin Include="$(MicrosoftAndroidSdkOutDir)binutils\bin\x86_64-linux-android-as.cmd" />
     <_MSBuildFilesWin Include="$(MicrosoftAndroidSdkOutDir)binutils\bin\x86_64-linux-android-ld.cmd" />
     <_MSBuildFilesWin Include="$(MicrosoftAndroidSdkOutDir)binutils\bin\x86_64-linux-android-strip.cmd" />
-    <_MSBuildLibHostFilesWin Include="$(MicrosoftAndroidSdkOutDir)lib\host-mxe-Win64\libmono-android.debug.dll"   Condition=" '$(HostOS)' != 'Windows' " />
-    <_MSBuildLibHostFilesWin Include="$(MicrosoftAndroidSdkOutDir)lib\host-mxe-Win64\libmono-android.release.dll" Condition=" '$(HostOS)' != 'Windows' " />
-    <_MSBuildLibHostFilesWin Include="$(MicrosoftAndroidSdkOutDir)lib\host-mxe-Win64\libMonoPosixHelper.dll" />
-    <_MSBuildLibHostFilesWin Include="$(MicrosoftAndroidSdkOutDir)lib\host-mxe-Win64\libmonosgen-2.0.dll" />
-    <_MSBuildLibHostFilesWin Include="$(MicrosoftAndroidSdkOutDir)lib\host-mxe-Win64\libxamarin-app.dll" Condition=" '$(HostOS)' != 'Windows' " />
-    <_MSBuildLibHostFilesWin Include="$(MicrosoftAndroidSdkOutDir)lib\host-mxe-Win64\libxa-internal-api.dll" Condition=" '$(HostOS)' != 'Windows' " />
   </ItemGroup>
   <ItemDefinitionGroup>
     <_MSBuildFilesUnixSignAndHarden>
@@ -230,16 +176,6 @@
     <_MSBuildFilesUnixSignAndHarden Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\aapt2" />
     <_MSBuildFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)libZipSharpNative-*.$(LibExtension)" />
     <_MSBuildFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)libMono.Unix.$(LibExtension)" />
-  </ItemGroup>
-  <ItemGroup>
-  </ItemGroup>
-  <ItemGroup>
-    <MonoDocFiles Include="$(_MonoDocOutputPath)MonoAndroid-docs.source" />
-    <MonoDocFiles Include="$(_MonoDocOutputPath)MonoAndroid-lib.tree" />
-    <MonoDocFiles Include="$(_MonoDocOutputPath)MonoAndroid-lib.zip" />
-  </ItemGroup>
-  <ItemGroup>
-    <ThirdPartyNotice Include="$(XamarinAndroidSourcePath)THIRD-PARTY-NOTICES.TXT" />
   </ItemGroup>
   <!-- monodroid: in-tree installer/debugging projects under src/Xamarin.Installer.*,
        src/Mono.AndroidTools, src/Xamarin.AndroidTools,
@@ -265,8 +201,6 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Installer.Common.pdb" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Installer.Common.props" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Installer.Common.targets" />
-    <LegacyTargetsFiles Include="$(XAInstallPrefix)xbuild\Novell\Xamarin.Android.Bindings.targets" />
-    <LegacyTargetsFiles Include="$(XAInstallPrefix)xbuild\Novell\Xamarin.Android.VisualBasic.targets" />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MicrosoftAndroidSdkOutDir)lib\%(Identity)\xamarin.sync')" />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MicrosoftAndroidSdkOutDir)lib\%(Identity)\xamarin.find')" />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MicrosoftAndroidSdkOutDir)lib\%(Identity)\xamarin.stat')" />
@@ -274,59 +208,20 @@
   </ItemGroup>
   <!-- end monodroid -->
   <Target Name="ConstructInstallerItems"
-      DependsOnTargets="_FindFrameworkDirs"
-      Returns="@(FrameworkItemsWin);@(FrameworkItemsUnix);@(MSBuildItemsWin);@(LegacyMSBuildItemsWin);@(MSBuildItemsUnix);@(LegacyMSBuildItemsUnix)">
+      Returns="@(MSBuildItemsWin);@(MSBuildItemsUnix)">
     <ItemGroup>
-      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\AndroidApiInfo.xml')" />
-      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\mono.android.dex')" />
-      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\Mono.Android.dll')" />
-      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\mono.android.jar')" />
-      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\Mono.Android.pdb')" />
-      <_FrameworkFilesWin Include="@(_FrameworkDirsThatExist->'%(Identity)\Mono.Android.xml')" />
-      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\RedistList\FrameworkList.xml')" />
-      <FrameworkItemsWin Include="@(_FrameworkFiles);@(_FrameworkFilesWin)">
-        <RelativePath>$([MSBuild]::MakeRelative($(FrameworkSrcDir), %(FullPath)))</RelativePath>
-      </FrameworkItemsWin>
-      <FrameworkItemsUnix Include="@(_FrameworkFiles)">
-        <RelativePath>$([MSBuild]::MakeRelative($(FrameworkSrcDir), %(FullPath)))</RelativePath>
-      </FrameworkItemsUnix>
       <MSBuildItemsWin Include="@(_MSBuildFiles);@(_MSBuildFilesWin)">
         <RelativePath>$([MSBuild]::MakeRelative($(MicrosoftAndroidSdkOutDir), %(FullPath)))</RelativePath>
       </MSBuildItemsWin>
       <MSBuildItemsWin Include="@(_MSBuildTargetsSrcFiles)">
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildTargetsSrcDir), %(FullPath)))</RelativePath>
       </MSBuildItemsWin>
-      <LegacyMSBuildItemsWin Include="@(_MSBuildLibHostFilesWin)">
-        <RelativePath>%(Filename)%(Extension)</RelativePath>
-      </LegacyMSBuildItemsWin>
-      <LegacyMSBuildItemsWin Include="@(_DesignerFilesWin)">
-        <RelativePath>bcl\%(RecursiveDir)\%(Filename)%(Extension)</RelativePath>
-      </LegacyMSBuildItemsWin>
-      <LegacyMSBuildItemsWin Include="@(_LegacyJIFiles);@(JIUtilityFile->'$(LegacyMSBuildSrcDir)%(Identity)')">
-        <RelativePath>%(Filename)%(Extension)</RelativePath>
-      </LegacyMSBuildItemsWin>
       <MSBuildItemsUnix Include="@(_MSBuildFiles);@(_MSBuildFilesUnix);@(_MSBuildFilesUnixSign);@(_MSBuildFilesUnixSignAndHarden);@(_BinUtilsFilesUnixSign);@(_BinUtilsFilesUnixSignAndHarden)">
         <RelativePath>$([MSBuild]::MakeRelative($(MicrosoftAndroidSdkOutDir), %(FullPath)))</RelativePath>
       </MSBuildItemsUnix>
       <MSBuildItemsUnix Include="@(_MSBuildTargetsSrcFiles)">
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildTargetsSrcDir), %(FullPath)))</RelativePath>
       </MSBuildItemsUnix>
-      <LegacyMSBuildItemsUnix Include="@(_DesignerFilesUnix)">
-        <RelativePath>$(HostOS)\bcl\%(RecursiveDir)\%(Filename)%(Extension)</RelativePath>
-      </LegacyMSBuildItemsUnix>
-      <LegacyMSBuildItemsUnix Include="@(_LegacyJIFiles);@(JIUtilityFile->'$(LegacyMSBuildSrcDir)%(Identity)')">
-        <RelativePath>%(Filename)%(Extension)</RelativePath>
-      </LegacyMSBuildItemsUnix>
     </ItemGroup>
-  </Target>
-  <Target Name="GetXAVersion"
-      DependsOnTargets="GetXAVersionInfo"
-      Returns="$(XAVersion)">
-    <PropertyGroup>
-      <XAVersion>$(ProductVersion).$(XAVersionCommitCount)</XAVersion>
-      <_Branch>$(XAVersionBranch.Replace ('/', '-'))</_Branch>
-      <_Branch>$(_Branch.Replace ('\', '-'))</_Branch>
-      <XAOSSInstallerSuffix>OSS-$(ProductVersion).$(XAVersionCommitCount)_$(_Branch)_$(XAVersionHash)</XAOSSInstallerSuffix>
-    </PropertyGroup>
   </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -546,12 +546,6 @@ $@"<Project>
 						Directory.CreateDirectory (filedir);
 				}
 
-				// LastWriteTime is inaccurate without milliseconds, but neither mono FileSystemInfo nor UnixFileSystemInfo (in Mono.Posix)
-				// handles this precisely. And that causes comparison problem.
-				// To avoid this issue, we compare time after removing milliseconds field here.
-				//
-				// Mono.Posix after mono 367d417 will handle file time precisely.
-				// 
 				/*
 				// The code below debug prints time comparison. Current code could still result in unwanted comparison,
 				// so in case of doubtful results, use this to get comparison results.


### PR DESCRIPTION
## Summary

- remove unused xbuild framework packaging from `create-installers.targets`
- remove dead legacy installer outputs, properties, metadata, and supporting item lists
- remove the obsolete `Mono.Posix` timestamp comment

## Testing

- evaluated `ConstructInstallerItems` for Windows and Linux
- validated `create-installers.targets` as XML