### PR TITLE
[typemap] Match legacy JCW interface declarations

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -120,7 +120,7 @@ public sealed class JcwJavaSourceGenerator
 		// implements clause — always includes IGCUserPeer, plus any implemented interfaces
 		writer.Write ("\timplements\n\t\tmono.android.IGCUserPeer");
 
-		foreach (var iface in type.ImplementedInterfaceJavaNames) {
+		foreach (var iface in type.JavaCallableWrapperInterfaceJavaNames ?? type.ImplementedInterfaceJavaNames) {
 			writer.Write ($",\n\t\t{JniSignatureHelper.JniNameToJavaName (iface)}");
 		}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -58,10 +58,15 @@ public sealed record JavaPeerInfo
 	public string? BaseJavaName { get; init; }
 
 	/// <summary>
-	/// JNI names of Java interfaces this type implements, e.g., ["android/view/View$OnClickListener"].
-	/// Needed by JCW Java source generation ("implements" clause).
+	/// JNI names of direct Java interfaces this type implements, in managed metadata order.
 	/// </summary>
 	public IReadOnlyList<string> ImplementedInterfaceJavaNames { get; init; } = Array.Empty<string> ();
+
+	/// <summary>
+	/// Ordered JNI names to emit in the Java callable wrapper's implements clause.
+	/// Redundant parent interfaces and duplicate Java names are omitted.
+	/// </summary>
+	internal IReadOnlyList<string>? JavaCallableWrapperInterfaceJavaNames { get; init; }
 
 	/// <summary>
 	/// Java annotations forwarded from managed custom attributes decorated with

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -26,6 +26,7 @@ public sealed class JavaPeerScanner : IDisposable
 
 	readonly record struct ResolvabilityResult (bool IsResolvable, string? UnresolvedTypeName, string? UnresolvedAssemblyName);
 	readonly record struct PublicConstructorInfo (ImmutableArray<TypeRefData> ParameterTypes, string JniParameterSignature);
+	readonly record struct ImplementedInterfaceInfo (TypeRefData Type, string JavaName);
 
 	readonly Dictionary<string, AssemblyIndex> assemblyCache = new (StringComparer.Ordinal);
 	readonly Dictionary<(string typeName, string assemblyName), ActivationCtorInfo> activationCtorCache = new ();
@@ -366,7 +367,7 @@ public sealed class JavaPeerScanner : IDisposable
 			var baseJavaName = ResolveBaseJavaName (typeDef, index, results);
 
 			// Resolve implemented Java interface names
-			var implementedInterfaces = ResolveImplementedInterfaceJavaNames (typeDef, index);
+			var (implementedInterfaces, javaCallableWrapperInterfaces) = ResolveImplementedInterfaceJavaNames (typeDef, index);
 
 			// Collect marshal methods (including constructors).
 			// Override and interface detection is only for user ACW class types:
@@ -403,6 +404,7 @@ public sealed class JavaPeerScanner : IDisposable
 				IsFrameworkAssembly = frameworkAssemblyNames.Contains (index.AssemblyName),
 				BaseJavaName = baseJavaName,
 				ImplementedInterfaceJavaNames = implementedInterfaces,
+				JavaCallableWrapperInterfaceJavaNames = javaCallableWrapperInterfaces,
 				Annotations = annotationParser.Parse (typeDef.GetCustomAttributes (), index),
 				IsInterface = isInterface,
 				IsAbstract = isAbstract,
@@ -1668,26 +1670,79 @@ public sealed class JavaPeerScanner : IDisposable
 		return null;
 	}
 
-	List<string> ResolveImplementedInterfaceJavaNames (TypeDefinition typeDef, AssemblyIndex index)
+	(List<string> ImplementedInterfaces, List<string> JavaCallableWrapperInterfaces) ResolveImplementedInterfaceJavaNames (
+		TypeDefinition typeDef,
+		AssemblyIndex index)
 	{
-		var result = new List<string> ();
-		var interfaceImpls = typeDef.GetInterfaceImplementations ();
-
-		foreach (var implHandle in interfaceImpls) {
+		var interfaces = new List<ImplementedInterfaceInfo> ();
+		foreach (var implHandle in typeDef.GetInterfaceImplementations ()) {
 			var impl = index.Reader.GetInterfaceImplementation (implHandle);
-			var ifaceJniName = ResolveInterfaceJniName (impl.Interface, index);
-			if (ifaceJniName is not null) {
-				result.Add (ifaceJniName);
+			var resolved = ResolveEntityHandle (impl.Interface, index);
+			if (resolved is null) {
+				continue;
+			}
+
+			var javaName = ResolveRegisterJniName (resolved.ManagedTypeName, resolved.AssemblyName);
+			if (javaName is not null) {
+				interfaces.Add (new ImplementedInterfaceInfo (resolved, javaName));
 			}
 		}
 
-		return result;
+		var implementedInterfaces = interfaces.Select (iface => iface.JavaName).ToList ();
+		var javaCallableWrapperInterfaces = new List<string> ();
+		var addedJavaNames = new HashSet<string> (StringComparer.Ordinal);
+		foreach (var iface in interfaces) {
+			if (interfaces.Any (other =>
+				!IsSameTypeDefinition (iface.Type, other.Type) &&
+				IsInterfaceAssignableFrom (iface.Type, other.Type))) {
+				continue;
+			}
+
+			if (addedJavaNames.Add (iface.JavaName)) {
+				javaCallableWrapperInterfaces.Add (iface.JavaName);
+			}
+		}
+
+		return (implementedInterfaces, javaCallableWrapperInterfaces);
 	}
 
-	string? ResolveInterfaceJniName (EntityHandle interfaceHandle, AssemblyIndex index)
+	bool IsInterfaceAssignableFrom (TypeRefData target, TypeRefData candidate)
 	{
-		var resolved = ResolveEntityHandle (interfaceHandle, index);
-		return resolved is not null ? ResolveRegisterJniName (resolved.ManagedTypeName, resolved.AssemblyName) : null;
+		var visited = new HashSet<(string ManagedTypeName, string AssemblyName)> ();
+		return IsInterfaceAssignableFrom (target, candidate, visited);
+	}
+
+	bool IsInterfaceAssignableFrom (
+		TypeRefData target,
+		TypeRefData candidate,
+		HashSet<(string ManagedTypeName, string AssemblyName)> visited)
+	{
+		if (IsSameTypeDefinition (target, candidate)) {
+			return true;
+		}
+
+		var candidateKey = (candidate.ManagedTypeName, candidate.AssemblyName);
+		if (!visited.Add (candidateKey) ||
+		    !TryResolveType (candidate.ManagedTypeName, candidate.AssemblyName, out var candidateHandle, out var candidateIndex)) {
+			return false;
+		}
+
+		var candidateDefinition = candidateIndex.Reader.GetTypeDefinition (candidateHandle);
+		foreach (var implHandle in candidateDefinition.GetInterfaceImplementations ()) {
+			var impl = candidateIndex.Reader.GetInterfaceImplementation (implHandle);
+			var parent = ResolveEntityHandle (impl.Interface, candidateIndex);
+			if (parent is not null && IsInterfaceAssignableFrom (target, parent, visited)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	static bool IsSameTypeDefinition (TypeRefData left, TypeRefData right)
+	{
+		return string.Equals (left.ManagedTypeName, right.ManagedTypeName, StringComparison.Ordinal) &&
+			string.Equals (left.AssemblyName, right.AssemblyName, StringComparison.Ordinal);
 	}
 
 	bool TryGetMethodRegisterInfo (MethodDefinition methodDef, AssemblyIndex index, out RegisterInfo? registerInfo, out ExportInfo? exportInfo)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -1675,6 +1675,7 @@ public sealed class JavaPeerScanner : IDisposable
 		AssemblyIndex index)
 	{
 		var interfaces = new List<ImplementedInterfaceInfo> ();
+		var implementedInterfaces = new List<string> ();
 		foreach (var implHandle in typeDef.GetInterfaceImplementations ()) {
 			var impl = index.Reader.GetInterfaceImplementation (implHandle);
 			var resolved = ResolveEntityHandle (impl.Interface, index);
@@ -1685,16 +1686,28 @@ public sealed class JavaPeerScanner : IDisposable
 			var javaName = ResolveRegisterJniName (resolved.ManagedTypeName, resolved.AssemblyName);
 			if (javaName is not null) {
 				interfaces.Add (new ImplementedInterfaceInfo (resolved, javaName));
+				implementedInterfaces.Add (javaName);
 			}
 		}
 
-		var implementedInterfaces = interfaces.Select (iface => iface.JavaName).ToList ();
 		var javaCallableWrapperInterfaces = new List<string> ();
 		var addedJavaNames = new HashSet<string> (StringComparer.Ordinal);
+		var assignabilityVisited = new HashSet<(string ManagedTypeName, string AssemblyName)> ();
 		foreach (var iface in interfaces) {
-			if (interfaces.Any (other =>
-				!IsSameTypeDefinition (iface.Type, other.Type) &&
-				IsInterfaceAssignableFrom (iface.Type, other.Type))) {
+			var isRedundant = false;
+			foreach (var other in interfaces) {
+				if (IsSameTypeDefinition (iface.Type, other.Type)) {
+					continue;
+				}
+
+				assignabilityVisited.Clear ();
+				if (IsInterfaceAssignableFrom (iface.Type, other.Type, assignabilityVisited)) {
+					isRedundant = true;
+					break;
+				}
+			}
+
+			if (isRedundant) {
 				continue;
 			}
 
@@ -1704,12 +1717,6 @@ public sealed class JavaPeerScanner : IDisposable
 		}
 
 		return (implementedInterfaces, javaCallableWrapperInterfaces);
-	}
-
-	bool IsInterfaceAssignableFrom (TypeRefData target, TypeRefData candidate)
-	{
-		var visited = new HashSet<(string ManagedTypeName, string AssemblyName)> ();
-		return IsInterfaceAssignableFrom (target, candidate, visited);
 	}
 
 	bool IsInterfaceAssignableFrom (

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -103,7 +103,7 @@ public class TrimmableTypeMapGenerator
 			if (peer.BaseJavaName is not null) {
 				ReportInvalidJniSourceType (peer.BaseJavaName);
 			}
-			foreach (var interfaceName in peer.ImplementedInterfaceJavaNames) {
+			foreach (var interfaceName in peer.JavaCallableWrapperInterfaceJavaNames ?? peer.ImplementedInterfaceJavaNames) {
 				ReportInvalidJniSourceType (interfaceName);
 			}
 			foreach (var constructor in peer.JavaConstructors) {

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -132,6 +132,23 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 		}
 
 		[Fact]
+		public void Generate_RedundantInterfaceView_OmitsParentsAndDuplicateJavaNames ()
+		{
+			var java = GenerateFixture ("my/app/RedundantInterfaceView");
+
+			AssertContainsLine (
+				"""
+					implements
+						mono.android.IGCUserPeer,
+						android.view.View.INamedClickListener,
+						android.view.View.OnLongClickListener
+				{
+				""",
+				java
+			);
+		}
+
+		[Fact]
 		public void Generate_DeclaredDollarKeyword_PreservesDollar ()
 		{
 			var type = new JavaPeerInfo {

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.Behavior.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.Behavior.cs
@@ -194,6 +194,23 @@ public partial class JavaPeerScannerTests
 		Assert.Empty (FindFixtureByJavaName ("my/app/MyHelper").ImplementedInterfaceJavaNames);
 	}
 
+	[Fact]
+	public void Scan_JavaCallableWrapperInterfaces_OmitsParentsAndDuplicateJavaNames ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/RedundantInterfaceView");
+
+		Assert.Equal ([
+			"android/view/View$OnClickListener",
+			"android/view/View$INamedClickListener",
+			"android/view/View$INamedClickListener",
+			"android/view/View$OnLongClickListener",
+		], peer.ImplementedInterfaceJavaNames);
+		Assert.Equal ([
+			"android/view/View$INamedClickListener",
+			"android/view/View$OnLongClickListener",
+		], peer.JavaCallableWrapperInterfaceJavaNames);
+	}
+
 	[Theory]
 	[InlineData ("android/app/Activity", "android/app/Activity")]
 	[InlineData ("my/app/MainActivity", "my/app/MainActivity")]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -187,6 +187,11 @@ namespace Android.Views
 		string? Label { get; }
 	}
 
+	[Register ("android/view/View$INamedClickListener")]
+	public interface INamedClickListenerAlias
+	{
+	}
+
 	[Register ("mono/android/view/View_IOnClickListenerImplementor")]
 	public class View_IOnClickListenerImplementor : Java.Lang.Object
 	{
@@ -791,6 +796,17 @@ namespace MyApp
 
 		public void OnClick (Android.Views.View v) { }
 		public string? Label => "test";
+	}
+
+	[Register ("my/app/RedundantInterfaceView")]
+	public class RedundantInterfaceView : Android.Views.View, Android.Views.IOnClickListener,
+		Android.Views.INamedClickListener, Android.Views.INamedClickListenerAlias, Android.Views.IOnLongClickListener
+	{
+		protected RedundantInterfaceView (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		public void OnClick (Android.Views.View v) { }
+		public string? Label => "test";
+		public bool OnLongClick (Android.Views.View v) => false;
 	}
 
 	// --- Override detection test types ---


### PR DESCRIPTION
## Summary

- preserve the scanner's complete ordered direct-interface list for typemap and alias semantics
- add an internal JCW declaration list that filters redundant parent interfaces and deduplicates Java names in first-seen order, matching legacy `CecilImporter`
- add focused scanner and Java source tests for parent/derived redundancy, colliding managed aliases, stable order, and an unrelated-interface control

## Regression coverage

Before the fix, the trimmable generator emitted the parent interface, derived interface, and a second managed alias for the same derived Java interface. The duplicate Java name produced an invalid `implements` declaration.

The focused fixture declares all four inputs directly. Scanner coverage verifies the complete ordered metadata list remains available for typemap semantics, while generator coverage verifies the JCW emits only the derived and unrelated interfaces in stable order.

## Validation

- `Microsoft.Android.Sdk.TrimmableTypeMap.Tests`
- focused scanner and JCW source regression tests
- `git diff --check`

Tracks #12561.