### PR TITLE
Optimize trimmable typemap generation

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
@@ -174,15 +174,17 @@ static class JniSignatureHelper
 	/// </summary>
 	public static bool HasAmbiguousCallbackType (string jniSignature)
 	{
-		if (IsAmbiguousCallbackKind (ParseReturnType (jniSignature))) {
-			return true;
-		}
-		foreach (var kind in ParseParameterTypes (jniSignature)) {
-			if (IsAmbiguousCallbackKind (kind)) {
+		int i = 1;
+		while (i < jniSignature.Length && jniSignature [i] != ')') {
+			if (IsAmbiguousCallbackKind (ParseSingleType (jniSignature, ref i))) {
 				return true;
 			}
 		}
-		return false;
+		if (i >= jniSignature.Length) {
+			throw new ArgumentException ($"Malformed JNI signature '{jniSignature}': missing ')'");
+		}
+		i++;
+		return IsAmbiguousCallbackKind (ParseSingleType (jniSignature, ref i));
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/MetadataHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/MetadataHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -29,8 +30,8 @@ static class MetadataHelper
 	public static byte [] ComputeContentFingerprint (TypeMapAssemblyData data)
 	{
 		using var sha = SHA256.Create ();
-		using var stream = new System.IO.MemoryStream ();
-		using var writer = new System.IO.BinaryWriter (stream, Encoding.UTF8);
+		using var stream = new MemoryStream ();
+		using var writer = new BinaryWriter (stream, Encoding.UTF8);
 		foreach (var entry in data.Entries) {
 			writer.Write (entry.MapKey);
 			writer.Write (entry.ProxyTypeReference);
@@ -62,10 +63,10 @@ static class MetadataHelper
 			writer.Write (assoc.AliasProxyTypeReference);
 		}
 		writer.Flush ();
-		return sha.ComputeHash (stream.ToArray ());
+		return sha.ComputeHash (stream.GetBuffer (), 0, checked ((int) stream.Length));
 	}
 
-	static void WriteTypeRef (this System.IO.BinaryWriter writer, TypeRefData type)
+	static void WriteTypeRef (this BinaryWriter writer, TypeRefData type)
 	{
 		writer.Write (type.ManagedTypeName);
 		writer.Write (type.AssemblyName);
@@ -77,7 +78,7 @@ static class MetadataHelper
 		}
 	}
 
-	static void WriteUcoMethod (this System.IO.BinaryWriter writer, UcoMethodData method)
+	static void WriteUcoMethod (this BinaryWriter writer, UcoMethodData method)
 	{
 		writer.Write (method.WrapperName);
 		writer.Write (method.CallbackMethodName);
@@ -86,7 +87,7 @@ static class MetadataHelper
 		writer.WriteExportMethodDispatch (method.ExportMethodDispatch);
 	}
 
-	static void WriteExportMethodDispatch (this System.IO.BinaryWriter writer, ExportMethodDispatchData? dispatch)
+	static void WriteExportMethodDispatch (this BinaryWriter writer, ExportMethodDispatchData? dispatch)
 	{
 		writer.Write (dispatch is not null);
 		if (dispatch is null) {
@@ -107,7 +108,7 @@ static class MetadataHelper
 		writer.Write (dispatch.IsStatic);
 	}
 
-	static void WriteUcoConstructor (this System.IO.BinaryWriter writer, UcoConstructorData constructor)
+	static void WriteUcoConstructor (this BinaryWriter writer, UcoConstructorData constructor)
 	{
 		writer.Write (constructor.WrapperName);
 		writer.WriteTypeRef (constructor.TargetType);
@@ -119,7 +120,7 @@ static class MetadataHelper
 		}
 	}
 
-	static void WriteNativeRegistration (this System.IO.BinaryWriter writer, NativeRegistrationData registration)
+	static void WriteNativeRegistration (this BinaryWriter writer, NativeRegistrationData registration)
 	{
 		writer.Write (registration.JniMethodName);
 		writer.Write (registration.JniSignature);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -408,14 +408,14 @@ static class ModelBuilder
 		}
 
 		foreach (var proxy in model.ProxyTypes) {
-			var reusedUcoMethods = new HashSet<UcoMethodData> ();
+			HashSet<UcoMethodData>? reusedUcoMethods = null;
 
 			foreach (var uco in proxy.UcoMethods) {
 				var wrapperTarget = UcoWrapperTargetData.From (proxy, uco.WrapperName);
 				if (CanReuseUcoWrapper (proxy, uco) &&
 				    sharedWrapperTargets.TryGetValue (CreateUcoWrapperReuseKey (uco), out var sharedWrapperTarget)) {
 					wrapperTarget = sharedWrapperTarget;
-					reusedUcoMethods.Add (uco);
+					(reusedUcoMethods ??= new ()).Add (uco);
 				}
 				proxy.NativeRegistrations.Add (new NativeRegistrationData {
 					JniMethodName = uco.CallbackMethodName,
@@ -425,7 +425,7 @@ static class ModelBuilder
 				});
 			}
 
-			if (reusedUcoMethods.Count > 0) {
+			if (reusedUcoMethods is not null) {
 				proxy.UcoMethods.RemoveAll (uco => reusedUcoMethods.Contains (uco));
 			}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
@@ -114,6 +114,9 @@ sealed class PEAssemblyBuilder
 			deterministicIdProvider: DeterministicContentId);
 		var peBlob = new BlobBuilder ();
 		peBuilder.Serialize (peBlob);
+		if (stream is MemoryStream memoryStream && memoryStream.Length == 0 && memoryStream.Capacity < peBlob.Count) {
+			memoryStream.Capacity = peBlob.Count;
+		}
 		peBlob.WriteContentTo (stream);
 	}
 
@@ -289,24 +292,20 @@ sealed class PEAssemblyBuilder
 		foreach (var group in valuesBySize) {
 			var sizedType = GetOrCreateSizedType (group.Key);
 			foreach (string value in group.Value) {
-				AddUtf8Field (value, group.Key, sizedType);
+				AddUtf8Field (value, sizedType);
 			}
 		}
 	}
 
-	void AddUtf8Field (string value, int size, TypeDefinitionHandle sizedType)
+	void AddUtf8Field (string value, TypeDefinitionHandle sizedType)
 	{
 		// Encode to null-terminated UTF-8 (all JNI names/signatures are ASCII).
-		int byteCount = size - 1;
-		var bytes = new byte [size];
-		System.Text.Encoding.UTF8.GetBytes (value, 0, value.Length, bytes, 0);
-		// bytes[byteCount] is already 0 (null terminator)
-
 		_sigBlob.Clear ();
 		new BlobEncoder (_sigBlob).FieldSignature ().Type (sizedType, true);
 
 		int rva = _mappedFieldData.Count;
-		_mappedFieldData.WriteBytes (bytes);
+		_mappedFieldData.WriteUTF8 (value);
+		_mappedFieldData.WriteByte (0);
 
 		var fieldHandle = Metadata.AddFieldDefinition (
 			FieldAttributes.Static | FieldAttributes.Assembly | FieldAttributes.HasFieldRVA | FieldAttributes.InitOnly,
@@ -510,6 +509,27 @@ sealed class PEAssemblyBuilder
 		_attrBlob.WriteUInt16 (0x0001); // Prolog
 		writePayload (_attrBlob);
 		_attrBlob.WriteUInt16 (0x0000); // NumNamed
+		return Metadata.GetOrAddBlob (_attrBlob);
+	}
+
+	public BlobHandle BuildAttributeBlob (string first, string second)
+	{
+		_attrBlob.Clear ();
+		_attrBlob.WriteUInt16 (0x0001);
+		_attrBlob.WriteSerializedString (first);
+		_attrBlob.WriteSerializedString (second);
+		_attrBlob.WriteUInt16 (0x0000);
+		return Metadata.GetOrAddBlob (_attrBlob);
+	}
+
+	public BlobHandle BuildAttributeBlob (string first, string second, string third)
+	{
+		_attrBlob.Clear ();
+		_attrBlob.WriteUInt16 (0x0001);
+		_attrBlob.WriteSerializedString (first);
+		_attrBlob.WriteSerializedString (second);
+		_attrBlob.WriteSerializedString (third);
+		_attrBlob.WriteUInt16 (0x0000);
 		return Metadata.GetOrAddBlob (_attrBlob);
 	}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -196,10 +195,7 @@ sealed class TypeMapAssemblyEmitter
 		}
 		EmitMemberReferences ();
 
-		_pe.PrepareUtf8Fields (model.ProxyTypes
-			.Where (proxy => proxy.IsAcw)
-			.SelectMany (proxy => proxy.NativeRegistrations)
-			.SelectMany (registration => new [] { registration.JniMethodName, registration.JniSignature }));
+		_pe.PrepareUtf8Fields (EnumerateNativeRegistrationStrings (model.ProxyTypes));
 
 		// Track wrapper targets → handles for RegisterNatives.
 		var wrapperHandles = new Dictionary<UcoWrapperTargetData, MethodDefinitionHandle> ();
@@ -221,6 +217,19 @@ sealed class TypeMapAssemblyEmitter
 		}
 
 		_pe.EmitIgnoresAccessChecksToAttribute (model.IgnoresAccessChecksTo);
+	}
+
+	static IEnumerable<string> EnumerateNativeRegistrationStrings (IReadOnlyList<JavaPeerProxyData> proxies)
+	{
+		foreach (var proxy in proxies) {
+			if (!proxy.IsAcw) {
+				continue;
+			}
+			foreach (var registration in proxy.NativeRegistrations) {
+				yield return registration.JniMethodName;
+				yield return registration.JniSignature;
+			}
+		}
 	}
 
 	static List<JavaPeerProxyData> OrderProxiesForWrapperTargets (IReadOnlyList<JavaPeerProxyData> proxies)
@@ -1717,16 +1726,15 @@ sealed class TypeMapAssemblyEmitter
 	{
 		var ctorRef = entry.IsUnconditional ? _typeMapAttrCtorRef2Arg : _typeMapAttrCtorRef3Arg;
 
-		var blob = _pe.BuildAttributeBlob (b => {
-			b.WriteSerializedString (entry.MapKey);
-			b.WriteSerializedString (entry.ProxyTypeReference);
-			if (!entry.IsUnconditional) {
-				if (entry.TargetTypeReference is null) {
-					throw new InvalidOperationException ($"TargetTypeReference must not be null for conditional entry '{entry.MapKey}'");
-				}
-				b.WriteSerializedString (entry.TargetTypeReference);
+		BlobHandle blob;
+		if (entry.IsUnconditional) {
+			blob = _pe.BuildAttributeBlob (entry.MapKey, entry.ProxyTypeReference);
+		} else {
+			if (entry.TargetTypeReference is null) {
+				throw new InvalidOperationException ($"TargetTypeReference must not be null for conditional entry '{entry.MapKey}'");
 			}
-		});
+			blob = _pe.BuildAttributeBlob (entry.MapKey, entry.ProxyTypeReference, entry.TargetTypeReference);
+		}
 		_pe.Metadata.AddCustomAttribute (EntityHandle.AssemblyDefinition, ctorRef, blob);
 	}
 
@@ -1734,10 +1742,7 @@ sealed class TypeMapAssemblyEmitter
 	{
 		var ctorRef = _typeMapAssociationAttrCtorRef;
 
-		var blob = _pe.BuildAttributeBlob (b => {
-			b.WriteSerializedString (assoc.SourceTypeReference);
-			b.WriteSerializedString (assoc.AliasProxyTypeReference);
-		});
+		var blob = _pe.BuildAttributeBlob (assoc.SourceTypeReference, assoc.AliasProxyTypeReference);
 		_pe.Metadata.AddCustomAttribute (EntityHandle.AssemblyDefinition, ctorRef, blob);
 	}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
@@ -12,12 +13,25 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 /// </summary>
 sealed class AssemblyIndex : IDisposable
 {
+	const byte ElementTypeValueType = 0x11;
+
 	readonly PEReader peReader;
 	readonly CustomAttributeTypeProvider customAttributeTypeProvider;
+	readonly string? [] typeFullNames;
+	readonly string? [] typeReferenceFullNames;
+	readonly string? [] typeReferenceAssemblyNames;
+	readonly string? [] assemblyReferenceNames;
+	readonly TypeRefData? [] classTypeDefinitions;
+	readonly TypeRefData? [] valueTypeDefinitions;
+	readonly TypeRefData? [] classTypeReferences;
+	readonly TypeRefData? [] valueTypeReferences;
+	readonly Dictionary<EntityHandle, string?> customAttributeNames = new ();
+	readonly Dictionary<EntityHandle, int> constructorParameterCounts = new ();
 
 	public MetadataReader Reader { get; }
 	public string AssemblyName { get; }
 	public string AssemblyPath { get; }
+	internal TypeRefSignatureTypeProvider TypeRefSignatureProvider { get; }
 
 	/// <summary>
 	/// Maps full managed type name (e.g., "Android.App.Activity") to its TypeDefinitionHandle.
@@ -53,9 +67,18 @@ sealed class AssemblyIndex : IDisposable
 	{
 		this.peReader = peReader;
 		this.customAttributeTypeProvider = new CustomAttributeTypeProvider (reader);
+		typeFullNames = new string? [reader.TypeDefinitions.Count + 1];
+		typeReferenceFullNames = new string? [reader.TypeReferences.Count + 1];
+		typeReferenceAssemblyNames = new string? [reader.TypeReferences.Count + 1];
+		assemblyReferenceNames = new string? [reader.AssemblyReferences.Count + 1];
+		classTypeDefinitions = new TypeRefData? [reader.TypeDefinitions.Count + 1];
+		valueTypeDefinitions = new TypeRefData? [reader.TypeDefinitions.Count + 1];
+		classTypeReferences = new TypeRefData? [reader.TypeReferences.Count + 1];
+		valueTypeReferences = new TypeRefData? [reader.TypeReferences.Count + 1];
 		Reader = reader;
 		AssemblyName = assemblyName;
 		AssemblyPath = assemblyPath;
+		TypeRefSignatureProvider = new TypeRefSignatureTypeProvider (this);
 	}
 
 	public static AssemblyIndex Create (PEReader peReader, string assemblyName, string assemblyPath = "")
@@ -95,7 +118,7 @@ sealed class AssemblyIndex : IDisposable
 				MayUseJniAddNativeMethodRegistrationAttribute = true;
 			}
 
-			var fullName = MetadataTypeNameResolver.GetFullName (typeDef, Reader);
+			var fullName = GetTypeFullName (typeHandle);
 			if (fullName.Length == 0) {
 				continue;
 			}
@@ -139,7 +162,7 @@ sealed class AssemblyIndex : IDisposable
 
 		foreach (var caHandle in typeDef.GetCustomAttributes ()) {
 			var ca = Reader.GetCustomAttribute (caHandle);
-			var attrName = GetCustomAttributeName (ca, Reader);
+			var attrName = GetCustomAttributeName (ca);
 
 			if (attrName is null) {
 				continue;
@@ -214,6 +237,116 @@ sealed class AssemblyIndex : IDisposable
 		return (registerInfo, attrInfo);
 	}
 
+	internal string GetTypeFullName (TypeDefinitionHandle handle)
+	{
+		int row = MetadataTokens.GetRowNumber (handle);
+		var fullName = typeFullNames [row];
+		if (fullName is not null) {
+			return fullName;
+		}
+
+		var typeDef = Reader.GetTypeDefinition (handle);
+		var name = Reader.GetString (typeDef.Name);
+		if (typeDef.IsNested) {
+			fullName = MetadataTypeNameResolver.JoinNestedTypeName (GetTypeFullName (typeDef.GetDeclaringType ()), name);
+		} else {
+			fullName = MetadataTypeNameResolver.JoinNamespaceAndName (Reader.GetString (typeDef.Namespace), name);
+		}
+		typeFullNames [row] = fullName;
+		return fullName;
+	}
+
+	internal TypeRefData GetTypeRef (TypeDefinitionHandle handle, byte rawTypeKind)
+	{
+		var cache = rawTypeKind == ElementTypeValueType ? valueTypeDefinitions : classTypeDefinitions;
+		int row = MetadataTokens.GetRowNumber (handle);
+		var type = cache [row];
+		if (type is not null) {
+			return type;
+		}
+
+		type = new TypeRefData {
+			ManagedTypeName = GetTypeFullName (handle),
+			AssemblyName = AssemblyName,
+			IsValueType = rawTypeKind == ElementTypeValueType,
+		};
+		cache [row] = type;
+		return type;
+	}
+
+	internal TypeRefData GetTypeRef (TypeReferenceHandle handle, byte rawTypeKind)
+	{
+		var cache = rawTypeKind == ElementTypeValueType ? valueTypeReferences : classTypeReferences;
+		int row = MetadataTokens.GetRowNumber (handle);
+		var type = cache [row];
+		if (type is not null) {
+			return type;
+		}
+
+		type = new TypeRefData {
+			ManagedTypeName = GetTypeReferenceFullName (handle),
+			AssemblyName = GetTypeReferenceAssemblyName (handle),
+			IsValueType = rawTypeKind == ElementTypeValueType,
+		};
+		cache [row] = type;
+		return type;
+	}
+
+	string GetTypeReferenceFullName (TypeReferenceHandle handle)
+	{
+		int row = MetadataTokens.GetRowNumber (handle);
+		var fullName = typeReferenceFullNames [row];
+		if (fullName is not null) {
+			return fullName;
+		}
+
+		var typeRef = Reader.GetTypeReference (handle);
+		var name = Reader.GetString (typeRef.Name);
+		fullName = typeRef.ResolutionScope.Kind == HandleKind.TypeReference
+			? MetadataTypeNameResolver.JoinNestedTypeName (GetTypeReferenceFullName ((TypeReferenceHandle) typeRef.ResolutionScope), name)
+			: MetadataTypeNameResolver.JoinNamespaceAndName (Reader.GetString (typeRef.Namespace), name);
+		typeReferenceFullNames [row] = fullName;
+		return fullName;
+	}
+
+	string GetTypeReferenceAssemblyName (TypeReferenceHandle handle)
+	{
+		int row = MetadataTokens.GetRowNumber (handle);
+		var assemblyName = typeReferenceAssemblyNames [row];
+		if (assemblyName is not null) {
+			return assemblyName;
+		}
+
+		var typeRef = Reader.GetTypeReference (handle);
+		if (typeRef.ResolutionScope.Kind == HandleKind.TypeReference) {
+			assemblyName = GetTypeReferenceAssemblyName ((TypeReferenceHandle) typeRef.ResolutionScope);
+		} else if (typeRef.ResolutionScope.Kind == HandleKind.AssemblyReference) {
+			var assemblyHandle = (AssemblyReferenceHandle) typeRef.ResolutionScope;
+			int assemblyRow = MetadataTokens.GetRowNumber (assemblyHandle);
+			assemblyName = assemblyReferenceNames [assemblyRow];
+			if (assemblyName is null) {
+				assemblyName = Reader.GetString (Reader.GetAssemblyReference (assemblyHandle).Name);
+				assemblyReferenceNames [assemblyRow] = assemblyName;
+			}
+		} else {
+			assemblyName = AssemblyName;
+		}
+
+		typeReferenceAssemblyNames [row] = assemblyName;
+		return assemblyName;
+	}
+
+	internal string? GetCustomAttributeName (CustomAttribute ca)
+	{
+		if (customAttributeNames.TryGetValue (ca.Constructor, out var name)) {
+			return name;
+		}
+
+		name = GetCustomAttributeName (ca, Reader);
+		customAttributeNames.Add (ca.Constructor, name);
+		return name;
+	}
+
 	static readonly HashSet<string> KnownComponentAttributes = new (StringComparer.Ordinal) {
 		"ActivityAttribute",
 		"ServiceAttribute",
@@ -246,14 +379,14 @@ sealed class AssemblyIndex : IDisposable
 			var impl = Reader.GetInterfaceImplementation (implHandle);
 			if (impl.Interface.Kind == HandleKind.TypeReference) {
 				var typeRef = Reader.GetTypeReference ((TypeReferenceHandle)impl.Interface);
-				if (Reader.GetString (typeRef.Name) == "IJniNameProviderAttribute" &&
-				    Reader.GetString (typeRef.Namespace) == "Java.Interop") {
+				if (Reader.StringComparer.Equals (typeRef.Name, "IJniNameProviderAttribute") &&
+				    Reader.StringComparer.Equals (typeRef.Namespace, "Java.Interop")) {
 					return true;
 				}
 			} else if (impl.Interface.Kind == HandleKind.TypeDefinition) {
 				var ifaceDef = Reader.GetTypeDefinition ((TypeDefinitionHandle)impl.Interface);
-				if (Reader.GetString (ifaceDef.Name) == "IJniNameProviderAttribute" &&
-				    Reader.GetString (ifaceDef.Namespace) == "Java.Interop") {
+				if (Reader.StringComparer.Equals (ifaceDef.Name, "IJniNameProviderAttribute") &&
+				    Reader.StringComparer.Equals (ifaceDef.Namespace, "Java.Interop")) {
 					return true;
 				}
 			}
@@ -296,16 +429,86 @@ sealed class AssemblyIndex : IDisposable
 	}
 
 	static bool IsTypeReferenceMatch (TypeReference typeRef, MetadataReader reader, string typeNamespace, string typeName) =>
-		reader.GetString (typeRef.Name) == typeName &&
-		reader.GetString (typeRef.Namespace) == typeNamespace;
+		reader.StringComparer.Equals (typeRef.Name, typeName) &&
+		reader.StringComparer.Equals (typeRef.Namespace, typeNamespace);
 
 	static bool IsTypeDefinitionMatch (TypeDefinition typeDef, MetadataReader reader, string typeNamespace, string typeName) =>
-		reader.GetString (typeDef.Name) == typeName &&
-		reader.GetString (typeDef.Namespace) == typeNamespace;
+		reader.StringComparer.Equals (typeDef.Name, typeName) &&
+		reader.StringComparer.Equals (typeDef.Namespace, typeNamespace);
 
 	internal RegisterInfo ParseRegisterAttribute (CustomAttribute ca)
 	{
-		return ParseRegisterInfo (DecodeAttribute (ca));
+		// RegisterAttribute has only string constructor arguments and bool/int/string
+		// named properties. Reading that stable shape directly avoids the generic
+		// custom-attribute decoder's arrays and boxed values for every Java method.
+		var reader = Reader.GetBlobReader (ca.Value);
+		if (reader.ReadUInt16 () != 1) {
+			throw new BadImageFormatException ("Invalid custom attribute prolog.");
+		}
+
+		int parameterCount = GetConstructorParameterCount (ca.Constructor);
+		if (parameterCount > 3) {
+			return ParseRegisterInfo (DecodeAttribute (ca));
+		}
+		string jniName = parameterCount > 0 ? reader.ReadSerializedString () ?? "" : "";
+		string? signature = parameterCount > 1 ? reader.ReadSerializedString () : null;
+		string? connector = parameterCount > 2 ? reader.ReadSerializedString () : null;
+
+		bool doNotGenerateAcw = false;
+		int namedArgumentCount = reader.ReadUInt16 ();
+		for (int i = 0; i < namedArgumentCount; i++) {
+			reader.ReadByte ();
+			var typeCode = (SerializationTypeCode) reader.ReadByte ();
+			var name = reader.ReadSerializedString ();
+			switch (typeCode) {
+			case SerializationTypeCode.Boolean:
+				bool value = reader.ReadByte () != 0;
+				if (name == "DoNotGenerateAcw") {
+					doNotGenerateAcw = value;
+				}
+				break;
+			case SerializationTypeCode.Int32:
+				reader.ReadInt32 ();
+				break;
+			case SerializationTypeCode.String:
+				reader.ReadSerializedString ();
+				break;
+			default:
+				return ParseRegisterInfo (DecodeAttribute (ca));
+			}
+		}
+
+		return new RegisterInfo {
+			JniName = jniName,
+			Signature = signature,
+			Connector = connector,
+			DoNotGenerateAcw = doNotGenerateAcw,
+		};
+	}
+
+	int GetConstructorParameterCount (EntityHandle constructor)
+	{
+		if (constructorParameterCounts.TryGetValue (constructor, out int count)) {
+			return count;
+		}
+
+		BlobHandle signature = constructor.Kind switch {
+			HandleKind.MemberReference => Reader.GetMemberReference ((MemberReferenceHandle) constructor).Signature,
+			HandleKind.MethodDefinition => Reader.GetMethodDefinition ((MethodDefinitionHandle) constructor).Signature,
+			_ => default,
+		};
+		if (signature.IsNil) {
+			return 0;
+		}
+
+		var reader = Reader.GetBlobReader (signature);
+		var header = reader.ReadSignatureHeader ();
+		if (header.IsGeneric) {
+			reader.ReadCompressedInteger ();
+		}
+		count = reader.ReadCompressedInteger ();
+		constructorParameterCounts.Add (constructor, count);
+		return count;
 	}
 
 	internal RegisterInfo ParseJniTypeSignatureAttribute (CustomAttribute ca)
@@ -525,7 +728,7 @@ sealed class AssemblyIndex : IDisposable
 		var asmDef = Reader.GetAssemblyDefinition ();
 		foreach (var caHandle in asmDef.GetCustomAttributes ()) {
 			var ca = Reader.GetCustomAttribute (caHandle);
-			var attrName = GetCustomAttributeName (ca, Reader);
+			var attrName = GetCustomAttributeName (ca);
 			if (attrName is null || !KnownAssemblyAttributes.Contains (attrName)) {
 				continue;
 			}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -165,6 +165,11 @@ public sealed record JavaPeerInfo
 /// </summary>
 public sealed record MarshalMethodInfo
 {
+	internal static readonly TypeRefData DefaultReturnType = new () {
+		ManagedTypeName = "System.Void",
+		AssemblyName = "System.Runtime",
+	};
+
 	/// <summary>
 	/// JNI method name, e.g., "onCreate".
 	/// This is the Java method name (without n_ prefix).
@@ -273,10 +278,7 @@ public sealed record MarshalMethodInfo
 	/// <summary>
 	/// Managed return type, including the defining assembly.
 	/// </summary>
-	internal TypeRefData ManagedReturnType { get; init; } = new () {
-		ManagedTypeName = "System.Void",
-		AssemblyName = "System.Runtime",
-	};
+	internal TypeRefData ManagedReturnType { get; init; } = DefaultReturnType;
 
 	/// <summary>
 	/// [ExportParameter] kind applied to the return value, if any.

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Text;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
@@ -24,23 +25,33 @@ public sealed class JavaPeerScanner : IDisposable
 	}
 
 	readonly record struct ResolvabilityResult (bool IsResolvable, string? UnresolvedTypeName, string? UnresolvedAssemblyName);
+	readonly record struct PublicConstructorInfo (ImmutableArray<TypeRefData> ParameterTypes, string JniParameterSignature);
 
 	readonly Dictionary<string, AssemblyIndex> assemblyCache = new (StringComparer.Ordinal);
 	readonly Dictionary<(string typeName, string assemblyName), ActivationCtorInfo> activationCtorCache = new ();
-	readonly Dictionary<(string AssemblyName, int TypeRow), ResolvabilityResult> resolvabilityCache = new ();
+	readonly Dictionary<string, ResolvabilityResult? []> resolvabilityCache = new (StringComparer.Ordinal);
 	readonly HashSet<(string AssemblyName, int TypeRow)> resolvabilityVisited = new ();
+	readonly Dictionary<int, IReadOnlyList<ExportParameterKindInfo>> defaultExportKinds = new ();
 	readonly ITrimmableTypeMapLogger? logger;
 	readonly HashedPackageNamingPolicy packageNamingPolicy;
 	readonly HashSet<string> frameworkAssemblyNames;
 	readonly bool errorOnCustomJavaObject;
+	readonly bool collectMarshalMethodsForNonAcw;
 	readonly JavaAnnotationParser annotationParser;
 
 	public JavaPeerScanner (string? packageNamingPolicy = null, ITrimmableTypeMapLogger? logger = null, HashSet<string>? frameworkAssemblyNames = null, bool errorOnCustomJavaObject = true)
+		: this (packageNamingPolicy, logger, frameworkAssemblyNames, errorOnCustomJavaObject, collectMarshalMethodsForNonAcw: true)
+	{
+	}
+
+	internal JavaPeerScanner (string? packageNamingPolicy, ITrimmableTypeMapLogger? logger, HashSet<string>? frameworkAssemblyNames,
+		bool errorOnCustomJavaObject, bool collectMarshalMethodsForNonAcw)
 	{
 		this.packageNamingPolicy = ParsePackageNamingPolicy (packageNamingPolicy);
 		this.logger = logger;
 		this.frameworkAssemblyNames = frameworkAssemblyNames ?? new HashSet<string> (StringComparer.OrdinalIgnoreCase);
 		this.errorOnCustomJavaObject = errorOnCustomJavaObject;
+		this.collectMarshalMethodsForNonAcw = collectMarshalMethodsForNonAcw;
 		annotationParser = new JavaAnnotationParser (assemblyCache, ResolveTypeOfArgumentToJniName);
 	}
 
@@ -113,7 +124,7 @@ public sealed class JavaPeerScanner : IDisposable
 			if ((methodDef.Attributes & MethodAttributes.Static) == 0) {
 				continue;
 			}
-			if (reader.GetString (methodDef.Name) != nativeCallbackName) {
+			if (!reader.StringComparer.Equals (methodDef.Name, nativeCallbackName)) {
 				continue;
 			}
 
@@ -180,6 +191,7 @@ public sealed class JavaPeerScanner : IDisposable
 		foreach (var assembly in assemblies) {
 			var index = AssemblyIndex.Create (assembly.Reader, assembly.Name, assembly.Path);
 			assemblyCache [index.AssemblyName] = index;
+			resolvabilityCache [index.AssemblyName] = new ResolvabilityResult? [index.Reader.TypeDefinitions.Count + 1];
 		}
 
 		// Key by (managedTypeName, assemblyName) to avoid collisions when two assemblies
@@ -264,11 +276,11 @@ public sealed class JavaPeerScanner : IDisposable
 			var typeDef = index.Reader.GetTypeDefinition (typeHandle);
 
 			// Skip module-level types
-			if (index.Reader.GetString (typeDef.Name) == "<Module>") {
+			if (index.Reader.StringComparer.Equals (typeDef.Name, "<Module>")) {
 				continue;
 			}
 
-			var fullName = MetadataTypeNameResolver.GetFullName (typeDef, index.Reader);
+			var fullName = index.GetTypeFullName (typeHandle);
 
 			if (IsUnsupportedByTrimmableTypeMap (fullName, index.AssemblyName)) {
 				continue;
@@ -315,14 +327,14 @@ public sealed class JavaPeerScanner : IDisposable
 			} else {
 				// No explicit JNI name — check if this type extends a known Java peer.
 				// If so, auto-compute JNI name from the managed type name via CRC64.
-				if (ExtendsJavaPeer (typeDef, index)) {
+				if (ExtendsJavaPeer (typeHandle, typeDef, index)) {
 					(jniName, compatJniName) = ComputeAutoJniNames (typeDef, index);
 				} else {
 					// A managed class that implements Android.Runtime.IJavaObject but does not
 					// derive from a Java peer (Java.Lang.Object / Java.Lang.Throwable) cannot be
 					// marshaled to Java. Mirror the legacy XAJavaTypeScanner XA4212 diagnostic,
 					// which the managed/llvm-ir typemap paths raise via GenerateJavaStubs.
-					if (IsCustomJavaObject (typeDef, index)) {
+					if (IsCustomJavaObject (typeHandle, typeDef, index)) {
 						if (errorOnCustomJavaObject) {
 							logger?.LogCustomJavaObjectError (fullName);
 						} else {
@@ -360,7 +372,11 @@ public sealed class JavaPeerScanner : IDisposable
 			// Override and interface detection is only for user ACW class types:
 			// - MCW types (DoNotGenerateAcw) already have [Register] on every method
 			// - Interface types don't implement other interfaces' methods in JCWs
-			var (marshalMethods, exportFields) = CollectMarshalMethods (typeDef, index, detectBaseOverrides: !doNotGenerateAcw && !isInterface);
+			List<MarshalMethodInfo>? marshalMethods = null;
+			List<JavaFieldInfo>? exportFields = null;
+			if (!doNotGenerateAcw || collectMarshalMethodsForNonAcw) {
+				(marshalMethods, exportFields) = CollectMarshalMethods (typeDef, index, detectBaseOverrides: !doNotGenerateAcw && !isInterface);
+			}
 
 			// Resolve activation constructor
 			var activationCtor = ResolveActivationCtor (fullName, typeDef, index);
@@ -394,9 +410,9 @@ public sealed class JavaPeerScanner : IDisposable
 				IsFromJniTypeSignature = registerInfo?.IsFromJniTypeSignature ?? false,
 				IsUnconditional = isUnconditional,
 				CannotRegisterInStaticConstructor = cannotRegisterInStaticConstructor,
-				MarshalMethods = marshalMethods,
-				JavaConstructors = BuildJavaConstructors (marshalMethods, typeDef, index),
-				JavaFields = exportFields,
+				MarshalMethods = marshalMethods ?? [],
+				JavaConstructors = marshalMethods is not null ? BuildJavaConstructors (marshalMethods, typeDef, index) : [],
+				JavaFields = exportFields ?? [],
 				ActivationCtor = activationCtor,
 				InvokerTypeName = invokerTypeName,
 				InvokerActivationCtorStyle = invokerActivationCtorStyle,
@@ -431,14 +447,16 @@ public sealed class JavaPeerScanner : IDisposable
 		[NotNullWhen (false)] out string? unresolvedTypeName,
 		[NotNullWhen (false)] out string? unresolvedAssemblyName)
 	{
-		var cacheKey = (index.AssemblyName, MetadataTokens.GetRowNumber (typeDefHandle));
+		int typeRow = MetadataTokens.GetRowNumber (typeDefHandle);
+		var cache = resolvabilityCache [index.AssemblyName];
 
-		if (resolvabilityCache.TryGetValue (cacheKey, out var cached)) {
+		if (cache [typeRow] is ResolvabilityResult cached) {
 			unresolvedTypeName = cached.UnresolvedTypeName;
 			unresolvedAssemblyName = cached.UnresolvedAssemblyName;
 			return cached.IsResolvable;
 		}
 
+		var cacheKey = (index.AssemblyName, typeRow);
 		if (!visited.Add (cacheKey)) {
 			unresolvedTypeName = null;
 			unresolvedAssemblyName = null;
@@ -448,14 +466,14 @@ public sealed class JavaPeerScanner : IDisposable
 		var typeDef = index.Reader.GetTypeDefinition (typeDefHandle);
 
 		if (!IsResolvableTypeHandle (typeDef.BaseType, index, visited, out unresolvedTypeName, out unresolvedAssemblyName)) {
-			resolvabilityCache [cacheKey] = new (false, unresolvedTypeName, unresolvedAssemblyName);
+			cache [typeRow] = new (false, unresolvedTypeName, unresolvedAssemblyName);
 			return false;
 		}
 
 		foreach (var interfaceHandle in typeDef.GetInterfaceImplementations ()) {
 			var interfaceImplementation = index.Reader.GetInterfaceImplementation (interfaceHandle);
 			if (!IsResolvableTypeHandle (interfaceImplementation.Interface, index, visited, out unresolvedTypeName, out unresolvedAssemblyName)) {
-				resolvabilityCache [cacheKey] = new (false, unresolvedTypeName, unresolvedAssemblyName);
+				cache [typeRow] = new (false, unresolvedTypeName, unresolvedAssemblyName);
 				return false;
 			}
 		}
@@ -468,7 +486,7 @@ public sealed class JavaPeerScanner : IDisposable
 			foreach (var constraintHandle in genericParameter.GetConstraints ()) {
 				var constraint = index.Reader.GetGenericParameterConstraint (constraintHandle);
 				if (!IsResolvableTypeHandle (constraint.Type, index, visited, out unresolvedTypeName, out unresolvedAssemblyName)) {
-					resolvabilityCache [cacheKey] = new (false, unresolvedTypeName, unresolvedAssemblyName);
+					cache [typeRow] = new (false, unresolvedTypeName, unresolvedAssemblyName);
 					return false;
 				}
 			}
@@ -476,7 +494,7 @@ public sealed class JavaPeerScanner : IDisposable
 
 		unresolvedTypeName = null;
 		unresolvedAssemblyName = null;
-		resolvabilityCache [cacheKey] = new (true, null, null);
+		cache [typeRow] = new (true, null, null);
 		return true;
 	}
 
@@ -514,7 +532,7 @@ public sealed class JavaPeerScanner : IDisposable
 		[NotNullWhen (false)] out string? unresolvedTypeName,
 		[NotNullWhen (false)] out string? unresolvedAssemblyName)
 	{
-		var typeRef = MetadataTypeNameResolver.GetTypeRefFromReference (index.Reader, handle, index.AssemblyName, rawTypeKind: 0);
+		var typeRef = index.GetTypeRef (handle, rawTypeKind: 0);
 		var typeName = typeRef.ManagedTypeName;
 		var assemblyName = typeRef.AssemblyName;
 		if (!assemblyCache.TryGetValue (assemblyName, out var resolvedIndex)) {
@@ -648,7 +666,7 @@ public sealed class JavaPeerScanner : IDisposable
 	{
 		var methods = new List<MarshalMethodInfo> ();
 		var fields = new List<JavaFieldInfo> ();
-		var registeredMethodKeys = new HashSet<string> (StringComparer.Ordinal);
+		HashSet<string>? registeredMethodKeys = detectBaseOverrides ? new (StringComparer.Ordinal) : null;
 
 		// Pass 1: collect methods with [Register], [Export], or [ExportField] directly on them
 		foreach (var methodHandle in typeDef.GetMethods ()) {
@@ -668,7 +686,7 @@ public sealed class JavaPeerScanner : IDisposable
 			// e.g., `[Export("foo")] public override void OnCreate(...)` needs both
 			// the [Register]-driven override entry (Get*Handler connector) AND the
 			// [Export]-driven entry. Skip the dedup key for [Export]/[ExportField].
-			if (exportInfo is null) {
+			if (registeredMethodKeys is not null && exportInfo is null) {
 				var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
 				registeredMethodKeys.Add ($"{index.Reader.GetString (methodDef.Name)}({string.Join (",", sig.ParameterTypes)})");
 			}
@@ -686,8 +704,10 @@ public sealed class JavaPeerScanner : IDisposable
 			if (!accessors.Getter.IsNil) {
 				var getterDef = index.Reader.GetMethodDefinition (accessors.Getter);
 				AddMarshalMethod (methods, propRegister, getterDef, index);
-				var sig = getterDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
-				registeredMethodKeys.Add ($"{index.Reader.GetString (getterDef.Name)}({string.Join (",", sig.ParameterTypes)})");
+				if (registeredMethodKeys is not null) {
+					var sig = getterDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+					registeredMethodKeys.Add ($"{index.Reader.GetString (getterDef.Name)}({string.Join (",", sig.ParameterTypes)})");
+				}
 			}
 		}
 
@@ -695,7 +715,7 @@ public sealed class JavaPeerScanner : IDisposable
 		// Only for user ACW types — MCW types (DoNotGenerateAcw=true) already have
 		// [Register] on every method that matters. Running override detection on them
 		// would incorrectly pick up internal overrides (e.g., JavaObject.equals).
-		if (detectBaseOverrides) {
+		if (registeredMethodKeys is not null) {
 			CollectBaseMethodOverrides (typeDef, index, methods, registeredMethodKeys);
 		}
 
@@ -703,12 +723,12 @@ public sealed class JavaPeerScanner : IDisposable
 		// When a type implements a Java interface (e.g., IOnClickListener), the
 		// implementing method may not have [Register]. The legacy pipeline adds
 		// these via the interface loop in CecilImporter.cs lines 100-120.
-		if (detectBaseOverrides) {
+		if (registeredMethodKeys is not null) {
 			CollectInterfaceMethodImplementations (typeDef, index, methods, registeredMethodKeys);
 		}
 
 		// Pass 5: detect Java constructors that chain from base registered ctors.
-		if (detectBaseOverrides) {
+		if (registeredMethodKeys is not null) {
 			CollectBaseConstructorChain (typeDef, index, methods);
 		}
 
@@ -976,9 +996,7 @@ public sealed class JavaPeerScanner : IDisposable
 		// Check each ctor on this type for additional constructors not yet covered
 		foreach (var methodHandle in typeDef.GetMethods ()) {
 			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
-			var name = index.Reader.GetString (methodDef.Name);
-
-			if (name != ".ctor") {
+			if (!index.Reader.StringComparer.Equals (methodDef.Name, ".ctor")) {
 				continue;
 			}
 
@@ -1082,7 +1100,7 @@ public sealed class JavaPeerScanner : IDisposable
 				// emit the correct peer descriptor instead of falling back to
 				// java/lang/Object.
 				var typeDef = index.Reader.GetTypeDefinition (handle);
-				if (ExtendsJavaPeer (typeDef, index)) {
+				if (ExtendsJavaPeer (handle, typeDef, index)) {
 					var (jniName, _) = ComputeAutoJniNames (typeDef, index);
 					return $"L{jniName};";
 				}
@@ -1229,8 +1247,7 @@ public sealed class JavaPeerScanner : IDisposable
 		while (TryResolveBaseType (currentTypeDef, currentIndex, currentTypeRef, out var baseTypeDef, out var baseHandle, out var baseIndex, out _, out _, out var baseTypeRef)) {
 			foreach (var methodHandle in baseTypeDef.GetMethods ()) {
 				var methodDef = baseIndex.Reader.GetMethodDefinition (methodHandle);
-				var name = baseIndex.Reader.GetString (methodDef.Name);
-				if (name != ".ctor") {
+				if (!baseIndex.Reader.StringComparer.Equals (methodDef.Name, ".ctor")) {
 					continue;
 				}
 
@@ -1343,9 +1360,7 @@ public sealed class JavaPeerScanner : IDisposable
 		// Check methods on this base type
 		foreach (var baseMethodHandle in baseTypeDef.GetMethods ()) {
 			var baseMethodDef = baseIndex.Reader.GetMethodDefinition (baseMethodHandle);
-			var baseName = baseIndex.Reader.GetString (baseMethodDef.Name);
-
-			if (baseName != methodName) {
+			if (!baseIndex.Reader.StringComparer.Equals (baseMethodDef.Name, methodName)) {
 				continue;
 			}
 
@@ -1422,8 +1437,7 @@ public sealed class JavaPeerScanner : IDisposable
 			}
 
 			var baseGetterDef = baseIndex.Reader.GetMethodDefinition (baseAccessors.Getter);
-			var baseGetterName = baseIndex.Reader.GetString (baseGetterDef.Name);
-			if (baseGetterName != getterName) {
+			if (!baseIndex.Reader.StringComparer.Equals (baseGetterDef.Name, getterName)) {
 				continue;
 			}
 
@@ -1466,8 +1480,8 @@ public sealed class JavaPeerScanner : IDisposable
 	/// </summary>
 	static bool HaveIdenticalParameterTypes (MethodDefinition derivedMethod, AssemblyIndex derivedIndex, MethodDefinition baseMethod, AssemblyIndex baseIndex, TypeRefData baseTypeRef)
 	{
-		var derivedSig = derivedMethod.DecodeSignature (TypeRefSignatureTypeProvider.Instance, genericContext: derivedIndex);
-		var baseSig = baseMethod.DecodeSignature (TypeRefSignatureTypeProvider.Instance, genericContext: baseIndex);
+		var derivedSig = derivedMethod.DecodeSignature (derivedIndex.TypeRefSignatureProvider, genericContext: derivedIndex);
+		var baseSig = baseMethod.DecodeSignature (baseIndex.TypeRefSignatureProvider, genericContext: baseIndex);
 
 		if (derivedSig.ParameterTypes.Length != baseSig.ParameterTypes.Length) {
 			return false;
@@ -1493,7 +1507,6 @@ public sealed class JavaPeerScanner : IDisposable
 		bool isConstructor = registerInfo.JniName == "<init>" || registerInfo.JniName == ".ctor";
 		bool isExport = exportInfo is not null;
 		string managedName = index.Reader.GetString (methodDef.Name);
-		var managedSig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
 		string jniSignature = registerInfo.Signature ?? "()V";
 
 		string declaringTypeName = "";
@@ -1505,16 +1518,19 @@ public sealed class JavaPeerScanner : IDisposable
 		// Only decode TypeRefData signatures for methods that need direct dispatch IL
 		// generation; static n_* callback forwarders already encode from the JNI signature.
 		var managedTypeSig = mayCallManagedMethodDirectly
-			? methodDef.DecodeSignature (TypeRefSignatureTypeProvider.Instance, index)
+			? methodDef.DecodeSignature (index.TypeRefSignatureProvider, index)
 			: default;
 		bool callManagedMethodDirectly = isExport || (mayCallManagedMethodDirectly && SupportsDirectManagedMethodCall (managedTypeSig));
-		var parameterKinds = exportInfo?.ParameterKinds ?? CreateDefaultExportKinds (managedSig.ParameterTypes.Length);
+		var parameterKinds = exportInfo?.ParameterKinds ??
+			(callManagedMethodDirectly ? GetDefaultExportKinds (managedTypeSig.ParameterTypes.Length) : []);
 
-		var managedParameterTypes = new List<TypeRefData> ();
+		IReadOnlyList<TypeRefData> managedParameterTypes = [];
 		if (callManagedMethodDirectly) {
-			foreach (var parameterType in managedTypeSig.ParameterTypes) {
-				managedParameterTypes.Add (EnrichTypeRefWithEnumInfo (parameterType));
+			var parameters = new TypeRefData [managedTypeSig.ParameterTypes.Length];
+			for (int i = 0; i < parameters.Length; i++) {
+				parameters [i] = EnrichTypeRefWithEnumInfo (managedTypeSig.ParameterTypes [i]);
 			}
+			managedParameterTypes = parameters;
 		}
 
 		string nativeCallbackName = GetNativeCallbackName (registerInfo.Connector, managedName, isConstructor);
@@ -1547,10 +1563,9 @@ public sealed class JavaPeerScanner : IDisposable
 			NativeCallbackReturnTypeName = nativeCallbackReturnTypeName,
 			ManagedParameterTypes = managedParameterTypes,
 			ManagedParameterExportKinds = parameterKinds,
-			ManagedReturnType = callManagedMethodDirectly ? EnrichTypeRefWithEnumInfo (managedTypeSig.ReturnType) : new TypeRefData {
-				ManagedTypeName = managedSig.ReturnType,
-				AssemblyName = "System.Runtime",
-			},
+			ManagedReturnType = callManagedMethodDirectly
+				? EnrichTypeRefWithEnumInfo (managedTypeSig.ReturnType)
+				: MarshalMethodInfo.DefaultReturnType,
 			ManagedReturnExportKind = exportInfo?.ReturnKind ?? ExportParameterKindInfo.Unspecified,
 			IsStatic = (methodDef.Attributes & MethodAttributes.Static) == MethodAttributes.Static,
 			IsConstructor = isConstructor,
@@ -1627,7 +1642,7 @@ public sealed class JavaPeerScanner : IDisposable
 
 	string? ResolveBaseJavaName (TypeDefinition typeDef, AssemblyIndex index, Dictionary<(string ManagedName, string AssemblyName), JavaPeerInfo> results)
 	{
-		if (!TryResolveBaseType (typeDef, index, out var baseTypeDef, out _, out var baseIndex, out var baseTypeName, out _, out _)) {
+		if (!TryResolveBaseType (typeDef, index, out var baseTypeDef, out var baseTypeHandle, out var baseIndex, out var baseTypeName, out _, out _)) {
 			return null;
 		}
 
@@ -1645,7 +1660,7 @@ public sealed class JavaPeerScanner : IDisposable
 		// Base type may be a Java peer without [Register] that hasn't been scanned yet
 		// (scan order within an assembly is not guaranteed). Resolve it the same way
 		// ScanAssembly does: check ExtendsJavaPeer and compute the auto JNI name.
-		if (ExtendsJavaPeer (baseTypeDef, baseIndex)) {
+		if (ExtendsJavaPeer (baseTypeHandle, baseTypeDef, baseIndex)) {
 			var (jniName, _) = ComputeAutoJniNames (baseTypeDef, baseIndex);
 			return jniName;
 		}
@@ -1680,7 +1695,7 @@ public sealed class JavaPeerScanner : IDisposable
 		exportInfo = null;
 		foreach (var caHandle in methodDef.GetCustomAttributes ()) {
 			var ca = index.Reader.GetCustomAttribute (caHandle);
-			var attrName = AssemblyIndex.GetCustomAttributeName (ca, index.Reader);
+			var attrName = index.GetCustomAttributeName (ca);
 
 			if (attrName == "RegisterAttribute") {
 				registerInfo = index.ParseRegisterAttribute (ca);
@@ -1716,7 +1731,7 @@ public sealed class JavaPeerScanner : IDisposable
 	{
 		foreach (var caHandle in propDef.GetCustomAttributes ()) {
 			var ca = index.Reader.GetCustomAttribute (caHandle);
-			var attrName = AssemblyIndex.GetCustomAttributeName (ca, index.Reader);
+			var attrName = index.GetCustomAttributeName (ca);
 
 			if (attrName == "RegisterAttribute") {
 				return index.ParseRegisterAttribute (ca);
@@ -1775,7 +1790,7 @@ public sealed class JavaPeerScanner : IDisposable
 		string resolvedExportName = exportName ?? throw new InvalidOperationException ("Export name should not be null at this point.");
 
 		// Build JNI signature from method signature
-		var sig = methodDef.DecodeSignature (TypeRefSignatureTypeProvider.Instance, index);
+		var sig = methodDef.DecodeSignature (index.TypeRefSignatureProvider, index);
 		var (parameterKinds, returnKind) = GetExportParameterKinds (methodDef, index, sig.ParameterTypes.Length);
 		var jniSig = BuildJniSignatureFromManaged (sig, parameterKinds, returnKind);
 
@@ -1790,18 +1805,21 @@ public sealed class JavaPeerScanner : IDisposable
 		);
 	}
 
-	static List<ExportParameterKindInfo> CreateDefaultExportKinds (int parameterCount)
+	IReadOnlyList<ExportParameterKindInfo> GetDefaultExportKinds (int parameterCount)
 	{
-		var kinds = new List<ExportParameterKindInfo> (parameterCount);
-		for (int i = 0; i < parameterCount; i++) {
-			kinds.Add (ExportParameterKindInfo.Unspecified);
+		if (parameterCount == 0) {
+			return [];
+		}
+		if (!defaultExportKinds.TryGetValue (parameterCount, out var kinds)) {
+			kinds = new ExportParameterKindInfo [parameterCount];
+			defaultExportKinds.Add (parameterCount, kinds);
 		}
 		return kinds;
 	}
 
-	static (List<ExportParameterKindInfo> parameterKinds, ExportParameterKindInfo returnKind) GetExportParameterKinds (MethodDefinition methodDef, AssemblyIndex index, int parameterCount)
+	static (IReadOnlyList<ExportParameterKindInfo> parameterKinds, ExportParameterKindInfo returnKind) GetExportParameterKinds (MethodDefinition methodDef, AssemblyIndex index, int parameterCount)
 	{
-		var parameterKinds = CreateDefaultExportKinds (parameterCount);
+		var parameterKinds = new ExportParameterKindInfo [parameterCount];
 		var returnKind = ExportParameterKindInfo.Unspecified;
 
 		foreach (var parameterHandle in methodDef.GetParameters ()) {
@@ -1815,7 +1833,7 @@ public sealed class JavaPeerScanner : IDisposable
 				returnKind = kind;
 			} else {
 				int parameterIndex = parameter.SequenceNumber - 1;
-				if (parameterIndex >= 0 && parameterIndex < parameterKinds.Count) {
+				if (parameterIndex >= 0 && parameterIndex < parameterKinds.Length) {
 					parameterKinds [parameterIndex] = kind;
 				}
 			}
@@ -1828,7 +1846,7 @@ public sealed class JavaPeerScanner : IDisposable
 	{
 		foreach (var caHandle in parameter.GetCustomAttributes ()) {
 			var ca = index.Reader.GetCustomAttribute (caHandle);
-			var attrName = AssemblyIndex.GetCustomAttributeName (ca, index.Reader);
+			var attrName = index.GetCustomAttributeName (ca);
 			if (attrName != "ExportParameterAttribute") {
 				continue;
 			}
@@ -1880,8 +1898,8 @@ public sealed class JavaPeerScanner : IDisposable
 	(RegisterInfo registerInfo, ExportInfo exportInfo) ParseExportFieldAsMethod (CustomAttribute ca, MethodDefinition methodDef, AssemblyIndex index)
 	{
 		var managedName = index.Reader.GetString (methodDef.Name);
-		var sig = methodDef.DecodeSignature (TypeRefSignatureTypeProvider.Instance, index);
-		var jniSig = BuildJniSignatureFromManaged (sig, CreateDefaultExportKinds (sig.ParameterTypes.Length), ExportParameterKindInfo.Unspecified);
+		var sig = methodDef.DecodeSignature (index.TypeRefSignatureProvider, index);
+		var jniSig = BuildJniSignatureFromManaged (sig, GetDefaultExportKinds (sig.ParameterTypes.Length), ExportParameterKindInfo.Unspecified);
 
 		return (
 			new RegisterInfo { JniName = managedName, Signature = jniSig, Connector = "__export__", DoNotGenerateAcw = false },
@@ -2023,30 +2041,62 @@ public sealed class JavaPeerScanner : IDisposable
 	{
 		foreach (var methodHandle in typeDef.GetMethods ()) {
 			var method = index.Reader.GetMethodDefinition (methodHandle);
-			var name = index.Reader.GetString (method.Name);
-
-			if (name != ".ctor") {
+			if (!index.Reader.StringComparer.Equals (method.Name, ".ctor") ||
+			    (method.Attributes & MethodAttributes.Static) != 0) {
 				continue;
 			}
 
-			var sig = method.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+			var signature = index.Reader.GetBlobReader (method.Signature);
+			var header = signature.ReadSignatureHeader ();
+			if (header.IsGeneric) {
+				signature.ReadCompressedInteger ();
+			}
+			if (signature.ReadCompressedInteger () != 2 ||
+			    (SignatureTypeCode) signature.ReadByte () != SignatureTypeCode.Void) {
+				continue;
+			}
 
 			// XI style: (IntPtr, JniHandleOwnership)
-			if (sig.ParameterTypes.Length == 2 &&
-			    sig.ParameterTypes [0] == "System.IntPtr" &&
-			    sig.ParameterTypes [1] == "Android.Runtime.JniHandleOwnership") {
+			var firstParameter = signature;
+			if ((SignatureTypeCode) signature.ReadByte () == SignatureTypeCode.IntPtr &&
+			    IsSignatureType (ref signature, index, "Android.Runtime", "JniHandleOwnership")) {
 				return ActivationCtorStyle.XamarinAndroid;
 			}
 
 			// JI style: (ref JniObjectReference, JniObjectReferenceOptions)
-			if (sig.ParameterTypes.Length == 2 &&
-			    (sig.ParameterTypes [0] == "Java.Interop.JniObjectReference&" || sig.ParameterTypes [0] == "Java.Interop.JniObjectReference") &&
-			    sig.ParameterTypes [1] == "Java.Interop.JniObjectReferenceOptions") {
+			signature = firstParameter;
+			if ((SignatureTypeCode) signature.ReadByte () != SignatureTypeCode.ByReference) {
+				signature = firstParameter;
+			}
+			if (IsSignatureType (ref signature, index, "Java.Interop", "JniObjectReference") &&
+			    IsSignatureType (ref signature, index, "Java.Interop", "JniObjectReferenceOptions")) {
 				return ActivationCtorStyle.JavaInterop;
 			}
 		}
 
 		return null;
+	}
+
+	static bool IsSignatureType (ref BlobReader signature, AssemblyIndex index, string typeNamespace, string typeName)
+	{
+		var kind = (SignatureTypeKind) signature.ReadByte ();
+		if (kind is not (SignatureTypeKind.Class or SignatureTypeKind.ValueType)) {
+			return false;
+		}
+
+		var handle = signature.ReadTypeHandle ();
+		switch (handle.Kind) {
+		case HandleKind.TypeReference:
+			var typeRef = index.Reader.GetTypeReference ((TypeReferenceHandle) handle);
+			return index.Reader.StringComparer.Equals (typeRef.Namespace, typeNamespace) &&
+				index.Reader.StringComparer.Equals (typeRef.Name, typeName);
+		case HandleKind.TypeDefinition:
+			var typeDef = index.Reader.GetTypeDefinition ((TypeDefinitionHandle) handle);
+			return index.Reader.StringComparer.Equals (typeDef.Namespace, typeNamespace) &&
+				index.Reader.StringComparer.Equals (typeDef.Name, typeName);
+		default:
+			return false;
+		}
 	}
 
 	/// <summary>
@@ -2056,7 +2106,7 @@ public sealed class JavaPeerScanner : IDisposable
 	TypeRefData? ResolveTypeSpecification (TypeSpecificationHandle specHandle, AssemblyIndex index)
 	{
 		var typeSpec = index.Reader.GetTypeSpecification (specHandle);
-		return typeSpec.DecodeSignature (TypeRefSignatureTypeProvider.Instance, index);
+		return typeSpec.DecodeSignature (index.TypeRefSignatureProvider, index);
 	}
 
 	/// <summary>
@@ -2066,15 +2116,10 @@ public sealed class JavaPeerScanner : IDisposable
 	TypeRefData? ResolveEntityHandle (EntityHandle handle, AssemblyIndex index)
 	{
 		switch (handle.Kind) {
-		case HandleKind.TypeDefinition: {
-			var td = index.Reader.GetTypeDefinition ((TypeDefinitionHandle)handle);
-			return new TypeRefData {
-				ManagedTypeName = MetadataTypeNameResolver.GetFullName (td, index.Reader),
-				AssemblyName = index.AssemblyName,
-			};
-		}
+		case HandleKind.TypeDefinition:
+			return index.GetTypeRef ((TypeDefinitionHandle)handle, rawTypeKind: 0);
 		case HandleKind.TypeReference:
-			return MetadataTypeNameResolver.GetTypeRefFromReference (index.Reader, (TypeReferenceHandle)handle, index.AssemblyName, rawTypeKind: 0);
+			return index.GetTypeRef ((TypeReferenceHandle)handle, rawTypeKind: 0);
 		case HandleKind.TypeSpecification:
 			return ResolveTypeSpecification ((TypeSpecificationHandle)handle, index);
 		default:
@@ -2144,11 +2189,11 @@ public sealed class JavaPeerScanner : IDisposable
 		assemblyCache.Clear ();
 	}
 
-	readonly Dictionary<string, bool> extendsJavaPeerCache = new (StringComparer.Ordinal);
+	readonly Dictionary<(string AssemblyName, int TypeRow), bool> extendsJavaPeerCache = new ();
 
 	const string IJavaObjectFullName = "Android.Runtime.IJavaObject";
 
-	readonly Dictionary<string, bool> implementsIJavaObjectCache = new (StringComparer.Ordinal);
+	readonly Dictionary<(string AssemblyName, int TypeRow), bool> implementsIJavaObjectCache = new ();
 
 	/// <summary>
 	/// Determines whether a type is a "custom" Java object: a managed class that implements
@@ -2156,12 +2201,12 @@ public sealed class JavaPeerScanner : IDisposable
 	/// Java.Lang.Throwable). Such types cannot be marshaled and produce XA4212. Interfaces and
 	/// System.Exception subclasses are excluded, matching the legacy XAJavaTypeScanner.
 	/// </summary>
-	bool IsCustomJavaObject (TypeDefinition typeDef, AssemblyIndex index)
+	bool IsCustomJavaObject (TypeDefinitionHandle typeHandle, TypeDefinition typeDef, AssemblyIndex index)
 	{
 		if ((typeDef.Attributes & TypeAttributes.Interface) != 0) {
 			return false;
 		}
-		if (!ImplementsIJavaObject (typeDef, index)) {
+		if (!ImplementsIJavaObject (typeHandle, typeDef, index)) {
 			return false;
 		}
 		if (IsSubclassOfSystemException (typeDef, index)) {
@@ -2175,10 +2220,9 @@ public sealed class JavaPeerScanner : IDisposable
 	/// interface that extends it, or via a base class. Results are cached; false-before-recurse
 	/// prevents cycles.
 	/// </summary>
-	bool ImplementsIJavaObject (TypeDefinition typeDef, AssemblyIndex index)
+	bool ImplementsIJavaObject (TypeDefinitionHandle typeHandle, TypeDefinition typeDef, AssemblyIndex index)
 	{
-		var fullName = MetadataTypeNameResolver.GetFullName (typeDef, index.Reader);
-		var key = $"{index.AssemblyName}:{fullName}";
+		var key = (index.AssemblyName, MetadataTokens.GetRowNumber (typeHandle));
 
 		if (implementsIJavaObjectCache.TryGetValue (key, out var cached)) {
 			return cached;
@@ -2202,7 +2246,7 @@ public sealed class JavaPeerScanner : IDisposable
 			// Recurse into the interface's own base interfaces
 			if (TryResolveType (resolved.ManagedTypeName, resolved.AssemblyName, out var ifaceHandle, out var ifaceIndex)) {
 				var ifaceDef = ifaceIndex.Reader.GetTypeDefinition (ifaceHandle);
-				if (ImplementsIJavaObject (ifaceDef, ifaceIndex)) {
+				if (ImplementsIJavaObject (ifaceHandle, ifaceDef, ifaceIndex)) {
 					implementsIJavaObjectCache [key] = true;
 					return true;
 				}
@@ -2214,7 +2258,7 @@ public sealed class JavaPeerScanner : IDisposable
 		if (baseInfo is not null &&
 		    TryResolveType (baseInfo.ManagedTypeName, baseInfo.AssemblyName, out var baseHandle, out var baseIndex)) {
 			var baseDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
-			if (ImplementsIJavaObject (baseDef, baseIndex)) {
+			if (ImplementsIJavaObject (baseHandle, baseDef, baseIndex)) {
 				implementsIJavaObjectCache [key] = true;
 				return true;
 			}
@@ -2247,10 +2291,9 @@ public sealed class JavaPeerScanner : IDisposable
 	/// Check if a type extends a known Java peer (has [Register] or component attribute)
 	/// by walking the base type chain. Results are cached; false-before-recurse prevents cycles.
 	/// </summary>
-	bool ExtendsJavaPeer (TypeDefinition typeDef, AssemblyIndex index)
+	bool ExtendsJavaPeer (TypeDefinitionHandle typeHandle, TypeDefinition typeDef, AssemblyIndex index)
 	{
-		var fullName = MetadataTypeNameResolver.GetFullName (typeDef, index.Reader);
-		var key = $"{index.AssemblyName}:{fullName}";
+		var key = (index.AssemblyName, MetadataTokens.GetRowNumber (typeHandle));
 
 		if (extendsJavaPeerCache.TryGetValue (key, out var cached)) {
 			return cached;
@@ -2283,7 +2326,7 @@ public sealed class JavaPeerScanner : IDisposable
 
 		// Recurse up the hierarchy
 		var baseDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
-		var result = ExtendsJavaPeer (baseDef, baseIndex);
+		var result = ExtendsJavaPeer (baseHandle, baseDef, baseIndex);
 		extendsJavaPeerCache [key] = result;
 		return result;
 	}
@@ -2473,6 +2516,7 @@ public sealed class JavaPeerScanner : IDisposable
 	List<JavaConstructorInfo> BuildJavaConstructors (List<MarshalMethodInfo> marshalMethods, TypeDefinition typeDef, AssemblyIndex index)
 	{
 		var ctors = new List<JavaConstructorInfo> ();
+		List<PublicConstructorInfo>? publicConstructors = null;
 		int ctorIndex = 0;
 		foreach (var mm in marshalMethods) {
 			if (!mm.IsConstructor) {
@@ -2481,7 +2525,8 @@ public sealed class JavaPeerScanner : IDisposable
 			// Try to find a managed ctor whose signature matches the JNI ctor.
 			// Unsupported managed parameter shapes fail in model building for [Export]
 			// constructors; non-[Export] registrations keep the legacy activation fallback.
-			var managedParams = TryGetMatchingPublicConstructorParameterTypes (typeDef, mm.JniSignature, index);
+			publicConstructors ??= GetSupportedPublicConstructors (typeDef, index);
+			var managedParams = TryGetMatchingPublicConstructorParameterTypes (publicConstructors, mm.JniSignature);
 			ctors.Add (new JavaConstructorInfo {
 				JniSignature = mm.JniSignature,
 				ConstructorIndex = ctorIndex,
@@ -2495,71 +2540,66 @@ public sealed class JavaPeerScanner : IDisposable
 		return ctors;
 	}
 
+	List<PublicConstructorInfo> GetSupportedPublicConstructors (TypeDefinition typeDef, AssemblyIndex index)
+	{
+		var constructors = new List<PublicConstructorInfo> ();
+		foreach (var methodHandle in typeDef.GetMethods ()) {
+			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
+			if ((methodDef.Attributes & MethodAttributes.Static) != 0 ||
+			    (methodDef.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public ||
+			    !index.Reader.StringComparer.Equals (methodDef.Name, ".ctor")) {
+				continue;
+			}
+
+			var sig = methodDef.DecodeSignature (index.TypeRefSignatureProvider, genericContext: index);
+			bool unsupported = false;
+			foreach (var parameter in sig.ParameterTypes) {
+				var typeName = parameter.ManagedTypeName;
+				if (parameter.GenericArguments.Count > 0 ||
+				    typeName.EndsWith ("&", StringComparison.Ordinal) ||
+				    typeName.EndsWith ("*", StringComparison.Ordinal)) {
+					unsupported = true;
+					break;
+				}
+			}
+			if (!unsupported) {
+				var signature = new StringBuilder ();
+				signature.Append ('(');
+				foreach (var parameter in sig.ParameterTypes) {
+					signature.Append (ManagedTypeToJniDescriptor (parameter));
+				}
+				signature.Append (')');
+				constructors.Add (new (sig.ParameterTypes, signature.ToString ()));
+			}
+		}
+		return constructors;
+	}
+
 	/// <summary>
-	/// Attempts to find a managed instance constructor on <paramref name="typeDef"/>
+	/// Attempts to find a managed instance constructor in <paramref name="publicConstructors"/>
 	/// whose parameters match the supplied JNI signature, and returns its managed
 	/// parameter types. Returns <see langword="null"/> when no compatible
 	/// constructor exists.
 	/// </summary>
-	IReadOnlyList<TypeRefData>? TryGetMatchingPublicConstructorParameterTypes (TypeDefinition typeDef, string jniSignature, AssemblyIndex index)
+	static IReadOnlyList<TypeRefData>? TryGetMatchingPublicConstructorParameterTypes (
+		List<PublicConstructorInfo> publicConstructors,
+		string jniSignature)
 	{
-		var jniParams = JniSignatureHelper.ParseParameters (jniSignature);
-		foreach (var methodHandle in typeDef.GetMethods ()) {
-			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
-			if ((methodDef.Attributes & MethodAttributes.Static) != 0) {
-				continue;
-			}
-			var name = index.Reader.GetString (methodDef.Name);
-			if (name != ".ctor") {
-				continue;
-			}
-			if ((methodDef.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public) {
-				continue;
-			}
-			var sig = methodDef.DecodeSignature (TypeRefSignatureTypeProvider.Instance, genericContext: index);
-			if (sig.ParameterTypes.Length != jniParams.Count) {
-				continue;
-			}
-			// Skip ctors whose managed parameter signatures are not supported by the
-			// trimmable [Export]-style argument marshaller (generic instantiations,
-			// by-ref, pointers). Returning null here makes EmitUcoConstructor fall
-			// back to the legacy `(IntPtr, JniHandleOwnership)` activation ctor,
-			// which matches the legacy LLVM-IR behaviour for these shapes.
-			bool unsupportedParam = false;
-			foreach (var p in sig.ParameterTypes) {
-				var paramTypeName = p.ManagedTypeName;
-				if (p.GenericArguments.Count > 0 || paramTypeName.EndsWith ("&", StringComparison.Ordinal) || paramTypeName.EndsWith ("*", StringComparison.Ordinal)) {
-					unsupportedParam = true;
-					break;
-				}
-			}
-			if (unsupportedParam) {
-				continue;
-			}
-			if (!ManagedConstructorParametersMatchJniSignature (sig.ParameterTypes, jniParams)) {
+		int closeParen = jniSignature.IndexOf (')');
+		if (closeParen < 0) {
+			throw new ArgumentException ($"Malformed JNI signature '{jniSignature}': missing ')'");
+		}
+		int parameterSignatureLength = closeParen + 1;
+		foreach (var constructor in publicConstructors) {
+			if (constructor.JniParameterSignature.Length != parameterSignatureLength ||
+			    string.CompareOrdinal (jniSignature, 0, constructor.JniParameterSignature, 0, parameterSignatureLength) != 0) {
 				continue;
 			}
 			// If multiple overloads with the same JNI-compatible signature exist, match
 			// the first public constructor in metadata order, like TypeManager.Activate.
-			return [.. sig.ParameterTypes];
+			return [.. constructor.ParameterTypes];
 		}
 		return null;
-	}
-
-	bool ManagedConstructorParametersMatchJniSignature (IReadOnlyList<TypeRefData> managedParams, IReadOnlyList<JniParameterInfo> jniParams)
-	{
-		if (managedParams.Count != jniParams.Count) {
-			return false;
-		}
-
-		for (int i = 0; i < managedParams.Count; i++) {
-			var managedDescriptor = ManagedTypeToJniDescriptor (managedParams [i]);
-			if (!string.Equals (managedDescriptor, jniParams [i].JniType, StringComparison.Ordinal)) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	/// <summary>
@@ -2570,7 +2610,7 @@ public sealed class JavaPeerScanner : IDisposable
 	{
 		foreach (var caHandle in methodDef.GetCustomAttributes ()) {
 			var ca = index.Reader.GetCustomAttribute (caHandle);
-			var attrName = AssemblyIndex.GetCustomAttributeName (ca, index.Reader);
+			var attrName = index.GetCustomAttributeName (ca);
 
 			if (attrName != "ExportFieldAttribute") {
 				continue;
@@ -2587,8 +2627,8 @@ public sealed class JavaPeerScanner : IDisposable
 			}
 
 			var managedName = index.Reader.GetString (methodDef.Name);
-			var sig = methodDef.DecodeSignature (TypeRefSignatureTypeProvider.Instance, index);
-			var jniSig = BuildJniSignatureFromManaged (sig, CreateDefaultExportKinds (sig.ParameterTypes.Length), ExportParameterKindInfo.Unspecified);
+			var sig = methodDef.DecodeSignature (index.TypeRefSignatureProvider, index);
+			var jniSig = BuildJniSignatureFromManaged (sig, GetDefaultExportKinds (sig.ParameterTypes.Length), ExportParameterKindInfo.Unspecified);
 			var jniReturnType = JniSignatureHelper.ParseReturnTypeString (jniSig);
 			var javaReturnType = JniSignatureHelper.JniTypeToJava (jniReturnType);
 			var access = GetJavaAccess (methodDef.Attributes & MethodAttributes.MemberAccessMask);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/SignatureTypeProvider.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/SignatureTypeProvider.cs
@@ -68,18 +68,64 @@ sealed class SignatureTypeProvider : ISignatureTypeProvider<string, object?>
 
 sealed class TypeRefSignatureTypeProvider : ISignatureTypeProvider<TypeRefData, AssemblyIndex>
 {
-	public static readonly TypeRefSignatureTypeProvider Instance = new ();
+	static readonly TypeRefData VoidType = CreatePrimitiveType ("System.Void");
+	static readonly TypeRefData BooleanType = CreatePrimitiveType ("System.Boolean");
+	static readonly TypeRefData CharType = CreatePrimitiveType ("System.Char");
+	static readonly TypeRefData SByteType = CreatePrimitiveType ("System.SByte");
+	static readonly TypeRefData ByteType = CreatePrimitiveType ("System.Byte");
+	static readonly TypeRefData Int16Type = CreatePrimitiveType ("System.Int16");
+	static readonly TypeRefData UInt16Type = CreatePrimitiveType ("System.UInt16");
+	static readonly TypeRefData Int32Type = CreatePrimitiveType ("System.Int32");
+	static readonly TypeRefData UInt32Type = CreatePrimitiveType ("System.UInt32");
+	static readonly TypeRefData Int64Type = CreatePrimitiveType ("System.Int64");
+	static readonly TypeRefData UInt64Type = CreatePrimitiveType ("System.UInt64");
+	static readonly TypeRefData SingleType = CreatePrimitiveType ("System.Single");
+	static readonly TypeRefData DoubleType = CreatePrimitiveType ("System.Double");
+	static readonly TypeRefData StringType = CreatePrimitiveType ("System.String");
+	static readonly TypeRefData ObjectType = CreatePrimitiveType ("System.Object");
+	static readonly TypeRefData IntPtrType = CreatePrimitiveType ("System.IntPtr");
+	static readonly TypeRefData UIntPtrType = CreatePrimitiveType ("System.UIntPtr");
+	static readonly TypeRefData TypedReferenceType = CreatePrimitiveType ("System.TypedReference");
+	readonly AssemblyIndex index;
 
-	public TypeRefData GetPrimitiveType (PrimitiveTypeCode typeCode) => new () {
-		ManagedTypeName = SignatureTypeProvider.Instance.GetPrimitiveType (typeCode),
+	internal TypeRefSignatureTypeProvider (AssemblyIndex index)
+	{
+		this.index = index;
+	}
+
+	public TypeRefData GetPrimitiveType (PrimitiveTypeCode typeCode) => typeCode switch {
+		PrimitiveTypeCode.Void => VoidType,
+		PrimitiveTypeCode.Boolean => BooleanType,
+		PrimitiveTypeCode.Char => CharType,
+		PrimitiveTypeCode.SByte => SByteType,
+		PrimitiveTypeCode.Byte => ByteType,
+		PrimitiveTypeCode.Int16 => Int16Type,
+		PrimitiveTypeCode.UInt16 => UInt16Type,
+		PrimitiveTypeCode.Int32 => Int32Type,
+		PrimitiveTypeCode.UInt32 => UInt32Type,
+		PrimitiveTypeCode.Int64 => Int64Type,
+		PrimitiveTypeCode.UInt64 => UInt64Type,
+		PrimitiveTypeCode.Single => SingleType,
+		PrimitiveTypeCode.Double => DoubleType,
+		PrimitiveTypeCode.String => StringType,
+		PrimitiveTypeCode.Object => ObjectType,
+		PrimitiveTypeCode.IntPtr => IntPtrType,
+		PrimitiveTypeCode.UIntPtr => UIntPtrType,
+		PrimitiveTypeCode.TypedReference => TypedReferenceType,
+		_ => CreatePrimitiveType (typeCode.ToString ()),
+	};
+
+	static TypeRefData CreatePrimitiveType (string managedTypeName) => new () {
+		ManagedTypeName = managedTypeName,
 		AssemblyName = "System.Runtime",
 	};
 
+	// Each provider is owned by the AssemblyIndex for the MetadataReader being decoded.
 	public TypeRefData GetTypeFromDefinition (MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
-		=> MetadataTypeNameResolver.GetTypeRefFromDefinition (reader, handle, reader.GetString (reader.GetAssemblyDefinition ().Name), rawTypeKind);
+		=> index.GetTypeRef (handle, rawTypeKind);
 
 	public TypeRefData GetTypeFromReference (MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
-		=> MetadataTypeNameResolver.GetTypeRefFromReference (reader, handle, reader.GetString (reader.GetAssemblyDefinition ().Name), rawTypeKind);
+		=> index.GetTypeRef (handle, rawTypeKind);
 
 	public TypeRefData GetTypeFromSpecification (MetadataReader reader, AssemblyIndex genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
 	{

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -26,6 +26,10 @@ public class TrimmableTypeMapGenerator
 	/// assemblies, generate JCW Java sources, and optionally generate a merged manifest.
 	/// No file IO is performed — all results are returned in memory.
 	/// </summary>
+	/// <param name="collectMarshalMethodsForNonAcw">
+	/// Set to <see langword="false"/> when callers do not consume method metadata for types
+	/// that cannot generate Java callable wrappers.
+	/// </param>
 	public TrimmableTypeMapResult Execute (
 		IReadOnlyList<AssemblyInput> assemblies,
 		Version systemRuntimeVersion,
@@ -35,12 +39,18 @@ public class TrimmableTypeMapGenerator
 		XDocument? manifestTemplate = null,
 		string? packageNamingPolicy = null,
 		bool generateTypeMapAssemblies = true,
-		bool errorOnCustomJavaObject = true)
+		bool errorOnCustomJavaObject = true,
+		bool collectMarshalMethodsForNonAcw = true)
 	{
 		_ = assemblies ?? throw new ArgumentNullException (nameof (assemblies));
 		_ = systemRuntimeVersion ?? throw new ArgumentNullException (nameof (systemRuntimeVersion));
 		_ = frameworkAssemblyNames ?? throw new ArgumentNullException (nameof (frameworkAssemblyNames));
-		var (allPeers, assemblyManifestInfo) = ScanAssemblies (assemblies, packageNamingPolicy, frameworkAssemblyNames, errorOnCustomJavaObject);
+		var (allPeers, assemblyManifestInfo) = ScanAssemblies (
+			assemblies,
+			packageNamingPolicy,
+			frameworkAssemblyNames,
+			errorOnCustomJavaObject,
+			collectMarshalMethodsForNonAcw);
 		if (allPeers.Count == 0) {
 			logger.LogNoJavaPeerTypesFound ();
 			return new TrimmableTypeMapResult ([], [], allPeers);
@@ -250,9 +260,15 @@ public class TrimmableTypeMapGenerator
 		IReadOnlyList<AssemblyInput> assemblies,
 		string? packageNamingPolicy,
 		HashSet<string> frameworkAssemblyNames,
-		bool errorOnCustomJavaObject = true)
+		bool errorOnCustomJavaObject,
+		bool collectMarshalMethodsForNonAcw)
 	{
-		using var scanner = new JavaPeerScanner (packageNamingPolicy, logger, frameworkAssemblyNames, errorOnCustomJavaObject);
+		using var scanner = new JavaPeerScanner (
+			packageNamingPolicy,
+			logger,
+			frameworkAssemblyNames,
+			errorOnCustomJavaObject,
+			collectMarshalMethodsForNonAcw);
 		var peers = scanner.Scan (assemblies);
 		var manifestInfo = scanner.ScanAssemblyManifestInfo ();
 		logger.LogJavaPeerScanInfo (assemblies.Count, peers.Count);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -221,7 +221,8 @@ public class GenerateTrimmableTypeMap : AndroidTask
 				manifestTemplate: manifestTemplate,
 				packageNamingPolicy: PackageNamingPolicy,
 				generateTypeMapAssemblies: GenerateTypeMapAssemblies,
-				errorOnCustomJavaObject: ErrorOnCustomJavaObject);
+				errorOnCustomJavaObject: ErrorOnCustomJavaObject,
+				collectMarshalMethodsForNonAcw: false);
 			if (Log.HasLoggedErrors) {
 				return false;
 			}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -308,6 +308,37 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void Execute_CanSkipUnusedNonAcwMarshalMethods ()
+	{
+		using var fullReader = CreateTestFixturePEReader ();
+		using var optimizedReader = CreateTestFixturePEReader ();
+		var generator = CreateGenerator ();
+		var full = generator.Execute ([Input ("TestFixtures", fullReader)], new Version (11, 0), new HashSet<string> ());
+		var optimized = generator.Execute (
+			[Input ("TestFixtures", optimizedReader)],
+			new Version (11, 0),
+			new HashSet<string> (),
+			collectMarshalMethodsForNonAcw: false);
+
+		var fullActivity = Assert.Single (full.AllPeers, peer => peer.JavaName == "android/app/Activity");
+		var optimizedActivity = Assert.Single (optimized.AllPeers, peer => peer.JavaName == "android/app/Activity");
+		Assert.NotEmpty (fullActivity.MarshalMethods);
+		Assert.Empty (optimizedActivity.MarshalMethods);
+
+		var fullAcw = Assert.Single (full.AllPeers, peer => peer.JavaName == "my/app/MyHelper");
+		var optimizedAcw = Assert.Single (optimized.AllPeers, peer => peer.JavaName == "my/app/MyHelper");
+		Assert.Equal (
+			fullAcw.MarshalMethods.Select (method => (method.JniName, method.JniSignature, method.ManagedMethodName, method.CallManagedMethodDirectly)),
+			optimizedAcw.MarshalMethods.Select (method => (method.JniName, method.JniSignature, method.ManagedMethodName, method.CallManagedMethodDirectly)));
+		Assert.Equal (full.GeneratedJavaSources, optimized.GeneratedJavaSources);
+		Assert.Equal (full.GeneratedAssemblies.Count, optimized.GeneratedAssemblies.Count);
+		for (int i = 0; i < full.GeneratedAssemblies.Count; i++) {
+			Assert.Equal (full.GeneratedAssemblies [i].Name, optimized.GeneratedAssemblies [i].Name);
+			Assert.Equal (full.GeneratedAssemblies [i].Content.ToArray (), optimized.GeneratedAssemblies [i].Content.ToArray ());
+		}
+	}
+
+	[Fact]
 	public void Execute_CollectsDeferredRegistrationTypes_ForAllApplicationAndInstrumentationSubtypes ()
 	{
 		using var peReader = CreateTestFixturePEReader ();


### PR DESCRIPTION
## Summary

- skip unused marshal-method, property, and constructor scanning for non-ACW types in the MSBuild task path
- cache metadata names and type references and parse `RegisterAttribute` without generic decoder allocations
- reduce typemap emitter allocations from intermediate collections, delegates, and buffers
- preserve the public full-detail scanner behavior by default

## Performance

Measured with the 18 MiB `Microsoft.Android.Ref.36` `Mono.Android.dll` workload containing 8,820 Java peers:

| Metric | `main` | This PR |
| --- | ---: | ---: |
| Cold end-to-end | 624 ms | 285 ms |
| Cold scan | 457 ms | 128 ms |
| Warm scan | 251 ms | 48 ms |
| Total allocations | 299 MiB | 93 MiB |

Generated `_Java.Interop.TypeMap.dll`, `_Mono.Android.TypeMap.dll`, `_Microsoft.Android.TypeMaps.dll`, and all 313 Java sources are byte-identical to `main`.

## Tests

- `dotnet test tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj -c Release` (775 passed)
- full `Mono.Android.dll` generation and SHA-256 comparison against `main`