### PR TITLE
Reduce typemap signature encoder allocations

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
@@ -162,8 +162,11 @@ sealed class PEAssemblyBuilder
 	{
 		_sigBlob.Clear ();
 		encodeSig (new BlobEncoder (_sigBlob));
-		return Metadata.AddMemberReference (parent, Metadata.GetOrAddString (name), Metadata.GetOrAddBlob (_sigBlob));
+		return AddMemberRef (parent, name, Metadata.GetOrAddBlob (_sigBlob));
 	}
+
+	public MemberReferenceHandle AddMemberRef (EntityHandle parent, string name, BlobHandle signature)
+		=> Metadata.AddMemberReference (parent, Metadata.GetOrAddString (name), signature);
 
 	/// <summary>
 	/// Resolves a <see cref="TypeRefData"/> to a TypeReference/TypeSpecification handle, with caching.
@@ -382,6 +385,15 @@ sealed class PEAssemblyBuilder
 		Action<BlobEncoder> encodeSig, Action<TrackedInstructionEncoder> emitIL)
 		=> EmitBody (name, attrs, encodeSig, emitIL, encodeLocals: null, useBranches: false);
 
+	public MethodDefinitionHandle EmitBody (string name, MethodAttributes attrs,
+		BlobHandle signature, Action<TrackedInstructionEncoder> emitIL)
+		=> EmitBody (name, attrs, signature, emitIL, encodeLocals: null, useBranches: false);
+
+	public MethodDefinitionHandle EmitBody (string name, MethodAttributes attrs,
+		BlobHandle signature, Action<TrackedInstructionEncoder> emitIL,
+		Action<BlobBuilder>? encodeLocals)
+		=> EmitBody (name, attrs, signature, emitIL, encodeLocals, useBranches: false);
+
 	/// <summary>
 	/// Emits a method body and definition with optional local variable declarations.
 	/// </summary>
@@ -408,7 +420,13 @@ sealed class PEAssemblyBuilder
 		encodeSig (new BlobEncoder (_sigBlob));
 		// Capture the sig blob handle before emitIL, because emitIL callbacks
 		// may call AddMemberRef which clears and repopulates _sigBlob.
-		var sigBlobHandle = Metadata.GetOrAddBlob (_sigBlob);
+		return EmitBody (name, attrs, Metadata.GetOrAddBlob (_sigBlob), emitIL, encodeLocals, useBranches);
+	}
+
+	MethodDefinitionHandle EmitBody (string name, MethodAttributes attrs,
+		BlobHandle signature, Action<TrackedInstructionEncoder> emitIL,
+		Action<BlobBuilder>? encodeLocals, bool useBranches)
+	{
 
 		StandaloneSignatureHandle localSigHandle = default;
 		if (encodeLocals != null) {
@@ -433,7 +451,7 @@ sealed class PEAssemblyBuilder
 		return Metadata.AddMethodDefinition (
 			attrs, MethodImplAttributes.IL,
 			Metadata.GetOrAddString (name),
-			sigBlobHandle,
+			signature,
 			bodyOffset, MetadataTokens.ParameterHandle (Metadata.GetRowCount (TableIndex.Param) + 1));
 	}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
@@ -159,14 +159,17 @@ sealed class PEAssemblyBuilder
 	/// Adds a member reference using the reusable signature blob builder.
 	/// </summary>
 	public MemberReferenceHandle AddMemberRef (EntityHandle parent, string name, Action<BlobEncoder> encodeSig)
-	{
-		_sigBlob.Clear ();
-		encodeSig (new BlobEncoder (_sigBlob));
-		return AddMemberRef (parent, name, Metadata.GetOrAddBlob (_sigBlob));
-	}
+		=> AddMemberRef (parent, name, GetOrAddSignature (encodeSig));
 
 	public MemberReferenceHandle AddMemberRef (EntityHandle parent, string name, BlobHandle signature)
 		=> Metadata.AddMemberReference (parent, Metadata.GetOrAddString (name), signature);
+
+	public BlobHandle GetOrAddSignature (Action<BlobEncoder> encodeSig)
+	{
+		_sigBlob.Clear ();
+		encodeSig (new BlobEncoder (_sigBlob));
+		return Metadata.GetOrAddBlob (_sigBlob);
+	}
 
 	/// <summary>
 	/// Resolves a <see cref="TypeRefData"/> to a TypeReference/TypeSpecification handle, with caching.
@@ -416,11 +419,9 @@ sealed class PEAssemblyBuilder
 		Action<BlobEncoder> encodeSig, Action<TrackedInstructionEncoder> emitIL,
 		Action<BlobBuilder>? encodeLocals, bool useBranches)
 	{
-		_sigBlob.Clear ();
-		encodeSig (new BlobEncoder (_sigBlob));
 		// Capture the sig blob handle before emitIL, because emitIL callbacks
 		// may call AddMemberRef which clears and repopulates _sigBlob.
-		return EmitBody (name, attrs, Metadata.GetOrAddBlob (_sigBlob), emitIL, encodeLocals, useBranches);
+		return EmitBody (name, attrs, GetOrAddSignature (encodeSig), emitIL, encodeLocals, useBranches);
 	}
 
 	MethodDefinitionHandle EmitBody (string name, MethodAttributes attrs,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -137,6 +137,9 @@ sealed class TypeMapAssemblyEmitter
 	MemberReferenceHandle _jniEnvTypesRegisterNativesRef;
 	MemberReferenceHandle _readOnlySpanOfJniNativeMethodCtorRef;
 
+	BlobHandle _activationCtorSignature;
+	BlobHandle _createInstanceSignature;
+
 	EntityHandle _anchorTypeHandle;
 
 	ExportMethodDispatchEmitter? _exportMethodDispatchEmitter;
@@ -950,12 +953,7 @@ sealed class TypeMapAssemblyEmitter
 	{
 		_pe.EmitBody ("CreateInstance",
 			MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
-				rt => rt.Type ().Type (_iJavaPeerableRef, false),
-				p => {
-					p.AddParameter ().Type ().IntPtr ();
-					p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
-				}),
+			GetCreateInstanceSignature (),
 			emitIL);
 	}
 
@@ -963,25 +961,45 @@ sealed class TypeMapAssemblyEmitter
 	{
 		_pe.EmitBody ("CreateInstance",
 			MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
-				rt => rt.Type ().Type (_iJavaPeerableRef, false),
-				p => {
-					p.AddParameter ().Type ().IntPtr ();
-					p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
-				}),
+			GetCreateInstanceSignature (),
 			emitIL,
 			encodeLocals);
 	}
 
 	MemberReferenceHandle AddActivationCtorRef (EntityHandle declaringTypeRef)
 	{
-		return _pe.AddMemberRef (declaringTypeRef, ".ctor",
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
-				rt => rt.Void (),
-				p => {
-					p.AddParameter ().Type ().IntPtr ();
-					p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
-				}));
+		return _pe.AddMemberRef (declaringTypeRef, ".ctor", GetActivationCtorSignature ());
+	}
+
+	BlobHandle GetActivationCtorSignature ()
+	{
+		if (_activationCtorSignature.IsNil) {
+			var blob = new BlobBuilder (8);
+			blob.WriteByte ((byte) SignatureAttributes.Instance);
+			blob.WriteCompressedInteger (2);
+			blob.WriteByte ((byte) SignatureTypeCode.Void);
+			blob.WriteByte ((byte) SignatureTypeCode.IntPtr);
+			blob.WriteByte ((byte) SignatureTypeKind.ValueType);
+			blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_jniHandleOwnershipRef));
+			_activationCtorSignature = _pe.Metadata.GetOrAddBlob (blob);
+		}
+		return _activationCtorSignature;
+	}
+
+	BlobHandle GetCreateInstanceSignature ()
+	{
+		if (_createInstanceSignature.IsNil) {
+			var blob = new BlobBuilder (8);
+			blob.WriteByte ((byte) SignatureAttributes.Instance);
+			blob.WriteCompressedInteger (2);
+			blob.WriteByte ((byte) SignatureTypeKind.Class);
+			blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_iJavaPeerableRef));
+			blob.WriteByte ((byte) SignatureTypeCode.IntPtr);
+			blob.WriteByte ((byte) SignatureTypeKind.ValueType);
+			blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_jniHandleOwnershipRef));
+			_createInstanceSignature = _pe.Metadata.GetOrAddBlob (blob);
+		}
+		return _createInstanceSignature;
 	}
 
 	MemberReferenceHandle AddManagedCtorRef (EntityHandle declaringTypeRef, IReadOnlyList<TypeRefData> parameterTypes)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -974,14 +974,13 @@ sealed class TypeMapAssemblyEmitter
 	BlobHandle GetActivationCtorSignature ()
 	{
 		if (_activationCtorSignature.IsNil) {
-			var blob = new BlobBuilder (8);
-			blob.WriteByte ((byte) SignatureAttributes.Instance);
-			blob.WriteCompressedInteger (2);
-			blob.WriteByte ((byte) SignatureTypeCode.Void);
-			blob.WriteByte ((byte) SignatureTypeCode.IntPtr);
-			blob.WriteByte ((byte) SignatureTypeKind.ValueType);
-			blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_jniHandleOwnershipRef));
-			_activationCtorSignature = _pe.Metadata.GetOrAddBlob (blob);
+			_activationCtorSignature = _pe.GetOrAddSignature (
+				sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
+					rt => rt.Void (),
+					p => {
+						p.AddParameter ().Type ().IntPtr ();
+						p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
+					}));
 		}
 		return _activationCtorSignature;
 	}
@@ -989,15 +988,13 @@ sealed class TypeMapAssemblyEmitter
 	BlobHandle GetCreateInstanceSignature ()
 	{
 		if (_createInstanceSignature.IsNil) {
-			var blob = new BlobBuilder (8);
-			blob.WriteByte ((byte) SignatureAttributes.Instance);
-			blob.WriteCompressedInteger (2);
-			blob.WriteByte ((byte) SignatureTypeKind.Class);
-			blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_iJavaPeerableRef));
-			blob.WriteByte ((byte) SignatureTypeCode.IntPtr);
-			blob.WriteByte ((byte) SignatureTypeKind.ValueType);
-			blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_jniHandleOwnershipRef));
-			_createInstanceSignature = _pe.Metadata.GetOrAddBlob (blob);
+			_createInstanceSignature = _pe.GetOrAddSignature (
+				sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
+					rt => rt.Type ().Type (_iJavaPeerableRef, false),
+					p => {
+						p.AddParameter ().Type ().IntPtr ();
+						p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
+					}));
 		}
 		return _createInstanceSignature;
 	}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -394,6 +394,49 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void EmitBody_PreencodedSignature_PreservesMethodSignature ()
+	{
+		var pe = new PEAssemblyBuilder (new Version (11, 0, 0, 0));
+		pe.EmitPreamble ("PreencodedSigTest", "PreencodedSigTest.dll");
+		var objectRef = pe.Metadata.AddTypeReference (pe.SystemRuntimeRef,
+			pe.Metadata.GetOrAddString ("System"), pe.Metadata.GetOrAddString ("Object"));
+		pe.Metadata.AddTypeDefinition (
+			TypeAttributes.Public | TypeAttributes.Class,
+			pe.Metadata.GetOrAddString ("Test"),
+			pe.Metadata.GetOrAddString ("MyType"),
+			objectRef,
+			MetadataTokens.FieldDefinitionHandle (pe.Metadata.GetRowCount (TableIndex.Field) + 1),
+			MetadataTokens.MethodDefinitionHandle (pe.Metadata.GetRowCount (TableIndex.MethodDef) + 1));
+		var signature = new BlobBuilder ();
+		signature.WriteByte ((byte) SignatureAttributes.Instance);
+		signature.WriteCompressedInteger (1);
+		signature.WriteByte ((byte) SignatureTypeCode.String);
+		signature.WriteByte ((byte) SignatureTypeCode.Int32);
+
+		pe.EmitBody (
+			"PreencodedMethod",
+			MethodAttributes.Public,
+			pe.Metadata.GetOrAddBlob (signature),
+			encoder => {
+				encoder.OpCode (ILOpCode.Ldnull);
+				encoder.Return (returnsValue: true);
+			});
+		using var stream = new MemoryStream ();
+		pe.WritePE (stream);
+		stream.Position = 0;
+		using var peReader = new PEReader (stream);
+		var reader = peReader.GetMetadataReader ();
+		var method = reader.TypeDefinitions
+			.SelectMany (handle => reader.GetTypeDefinition (handle).GetMethods ())
+			.Select (handle => reader.GetMethodDefinition (handle))
+			.Single (method => reader.GetString (method.Name) == "PreencodedMethod");
+		var decoded = method.DecodeSignature (SignatureTypeProvider.Instance, null);
+
+		Assert.Equal ("System.String", decoded.ReturnType);
+		Assert.Equal ("System.Int32", Assert.Single (decoded.ParameterTypes));
+	}
+
+	[Fact]
 	public void Generate_JiStyleInvoker_FirstParamIsByRef ()
 	{
 		var peer = MakeInterfacePeer ("test/IJiInvoker", "Test.IJiInvoker", "TestAsm", "Test.IJiInvokerInvoker") with {


### PR DESCRIPTION
## Summary

Cache the two fixed signatures repeated for every emitted peer (`CreateInstance` and the activation constructor), and let `PEAssemblyBuilder` accept a pre-encoded `BlobHandle`. This avoids rebuilding nested SRM signature callbacks while retaining the existing encoder and IL/max-stack paths.

This is the third PR in #12598 -> #12599 -> this PR and must remain based on `simonrozsival-incremental-typemap-emission`.

## Measurements

Release `net11.0` harness, three warmups per process. The primary comparison used 21 alternating parent/final pairs for Microsoft.Android.Ref.36 `Mono.Android.dll` (18 MiB, 8,820 peers) and 31 pairs for `TestFixtures.dll`.

| Input / case | Parent wall median | Final wall median | Parent allocations | Final allocations |
|---|---:|---:|---:|---:|
| Mono.Android, changed | 167.382 ms | 170.434 ms | 92.616 MiB | 90.754 MiB (-2.0%) |
| Mono.Android, unchanged | 112.035 ms | 112.723 ms | 61.196 MiB | 61.196 MiB |
| TestFixtures, changed | 2.913 ms | 2.963 ms | 2.573 MiB | 2.542 MiB (-1.2%) |
| TestFixtures, unchanged | 1.763 ms | 1.796 ms | 1.575 MiB | 1.575 MiB |

The small wall deltas are within observed process noise: the unchanged path does not execute the changed emission code but shows the same-sized delta. A separate 102-iteration in-process real-input comparison measured changed emission at 102.618 ms parent vs 102.632 ms final (effectively neutral), with allocations at 89.927 MiB vs 89.458 MiB.

Allocation traces over three changed real-input iterations showed sampled `Action<ParametersEncoder>` allocations falling from 9.46 MiB to 2.54 MiB and `Action<BlobEncoder>` from 7.91 MiB to 4.45 MiB. CPU traces showed no attributable wall-time regression.

## Rejected experiments

- **Direct task-owned file streaming:** reduced managed allocations by about 4.8 MiB, but repeated task-equivalent comparisons regressed wall time by roughly 9-19%. A 64 KiB `BufferedStream` did not recover the regression. Reverted, including staging/atomic-replacement code.
- **Combined incremental/content fingerprint serialization:** reduced allocations, but computing both fingerprints before the unchanged decision regressed paired unchanged wall time by about 13% on Mono.Android and 19% on TestFixtures. Reverted to the parent serialization and MVID path.
- **Base-constructor signature cache:** a CPU trace attributed 2.47% inclusive time to `CollectBaseConstructorChain`, but the generic-context-safe cache produced no consistent real-input scan improvement and added about 0.012 MiB scan allocations. Reverted.
- **`PEStreamOptions.PrefetchMetadata`:** real changed median regressed from 249.055 ms to 264.390 ms; unchanged regressed from 128.780 ms to 227.844 ms, with effectively unchanged allocations. Reverted.
- **Broader IL callback/state rewrite:** not retained; traces supported the narrower fixed-signature cache without requiring a broad emitter rewrite.

## Output identity

Parent and final aggregate SHA-256 hashes match:

| Input | Typemap assemblies | Java sources |
|---|---|---|
| Mono.Android.dll | `D991AC653F162B8E7B461BE66CCB1643A6B0354452718CFE91222E6EA3B47D42` | `E4D683D59AEF99603D8BAD51248A693168A7E71894556F3DD4493BAFA62726A7` |
| TestFixtures.dll | `1EA6E805D6375F0C5C726A3281CE085D26679CBE3F467ACE9517F7EE1B43F6A1` | `D4A4A1CF9D4C4848CD97D9CCE1E2996DD8CAF1EF82E084E28FA9C4A83F621E41` |

## Validation

- `dotnet test tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj -c Release -v minimal`: **780 passed**
- Added focused coverage for the pre-encoded signature path.
- Full-build `TrimmableTypeMap.IntegrationTests` were not run because neither `bin/Debug/dotnet/dotnet` nor `bin/Release/dotnet/dotnet` exists in this workspace.