### PR TITLE
[build] Mark AndroidSdk package as prerelease

### DIFF
--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -83,7 +83,6 @@ stages:
     steps:
     - checkout: self
       path: s/android
-      fetchDepth: 0
       submodules: recursive
       persistCredentials: false
 
@@ -117,7 +116,6 @@ stages:
     timeoutInMinutes: 240
     steps:
     - checkout: self
-      fetchDepth: 0
       submodules: recursive
       persistCredentials: false
 

--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -83,6 +83,7 @@ stages:
     steps:
     - checkout: self
       path: s/android
+      fetchDepth: 0
       submodules: recursive
       persistCredentials: false
 
@@ -116,6 +117,7 @@ stages:
     timeoutInMinutes: 240
     steps:
     - checkout: self
+      fetchDepth: 0
       submodules: recursive
       persistCredentials: false
 

--- a/build-tools/scripts/Xamarin.Android.Tools.Versioning.targets
+++ b/build-tools/scripts/Xamarin.Android.Tools.Versioning.targets
@@ -43,6 +43,7 @@
     <PropertyGroup>
       <Version>$([System.Text.RegularExpressions.Regex]::Match('$(AndroidPackVersion)', '^\d+\.\d+')).$(PackVersionCommitCount)</Version>
       <PackageVersion>$(Version)</PackageVersion>
+      <PackageVersion Condition=" '$(_AndroidToolsPackageVersionSuffix)' != '' ">$(AndroidPackVersion)-$(_AndroidToolsPackageVersionSuffix).$(PackVersionCommitCount)</PackageVersion>
     </PropertyGroup>
   </Target>
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -25,6 +25,7 @@
     <Copyright>Copyright © Xamarin 2011-2016</Copyright>
     <PackageTags>Xamarin;Xamarin.Android</PackageTags>
     <AssemblyName>$(VendorPrefix)Xamarin.Android.Tools.AndroidSdk$(VendorSuffix)</AssemblyName>
+    <_AndroidToolsPackageVersionSuffix>preview</_AndroidToolsPackageVersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [ ] Unit tests: N/A

The [Build Promotion Pipeline failure](https://dev.azure.com/devdiv/DevDiv/DevDiv%20Team/_build/results?buildId=15152005&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=74531eb2-9b39-5603-839e-94e3ba212b65&l=780) rejects `Xamarin.Android.Tools.AndroidSdk` because its stable-looking package version is targeted at the non-isolated .NET 11 transport feed:

```text
Package 'Xamarin.Android.Tools.AndroidSdk' has stable version '37.0.2353' but is targeted at a non-isolated feed 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json'
```

Give only the AndroidSdk package a `preview` suffix. The failing full-history build's `37.0.2353` therefore becomes `37.0.0-preview.2353`. The shared versioning target retains its existing default, so `Microsoft.Android.Build.BaseTasks` keeps its current versioning behavior.

The prerelease suffix applies only to `PackageVersion`; the numeric assembly `Version` remains distance-based. Consecutive full-history builds therefore remain distinct to .NET Framework as assembly versions such as `37.0.2361.0` and `37.0.2362.0`, while NuGet sees package versions `37.0.0-preview.2361` and `37.0.0-preview.2362`.

PR validation uses a shallow checkout, where the existing versioning fallback intentionally produces distance `0`. The downloaded PR artifact is therefore `37.0.0-preview.0`; release builds retain the real commit distance.