### PR TITLE
[AndroidSdk] Avoid warnings for emulator diagnostics

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/EmulatorRunner.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/EmulatorRunner.cs
@@ -99,7 +99,7 @@ public class EmulatorRunner
 		};
 		process.ErrorDataReceived += (_, e) => {
 			if (e.Data != null)
-				logger.Invoke (TraceLevel.Warning, $"[emulator] {e.Data}");
+				logger.Invoke (TraceLevel.Verbose, $"[emulator] {e.Data}");
 		};
 
 		if (!process.Start ()) {


### PR DESCRIPTION
## Context

The Android emulator writes informational `netsimd` startup diagnostics to stderr. `EmulatorRunner` classified every stderr line as an MSBuild warning, causing a successful test run to report 35 warnings:

<details>
<summary>Original CLI output</summary>

```text
> dotnet test -f net11.0-android
csproj (0.2s)
 mauitest net11.0-android succeeded with 35 warning(s) (7.8s)
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] netsimd I 08-31 19:21:25.029 external/netsim+/rust/daemon/src\rust_main.rs:93 - netsim artifacts path: "D:\\temp\\netsimd"
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] netsimd I 08-31 19:21:25.029 external/netsim+/rust/daemon/src\rust_main.rs:96 - NetsimdArgs {
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] fd_startup_str: None,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] no_cli_ui: true,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] no_web_ui: true,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] pcap: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] disable_address_reuse: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] hci_port: None,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] connector_instance: None,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] instance: None,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] logtostderr: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] dev: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] forward_host_mdns: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] vsock: None,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] config: None,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] host_dns: Some(
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] "192.168.1.254",
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] ),
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] http_proxy: None,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] wifi_tap: None,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] wifi: None,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] test_beacons: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] no_test_beacons: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] no_shutdown: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] verbose: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] version: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] debug: DebugArgs {
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] debug_no_traffic: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] debug_no_network: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] debug_no_wmedium: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] debug_no_mdns_wmedium: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] debug_no_guest_to_host_mdns: false,
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] },
 D:\dotnet-sdk-11.0.100-rc.1.26425.128-win-x64\packs\Microsoft.Android.Sdk.Windows\37.0.0-rc.1.2253\targets\Microsoft.Android.Sdk.Application.targets(79,5): warning [emulator] rssi: None,
Running tests from bin\Debug\net11.0-android\mauitest.dll (net11.0|x64)
bin\Debug\net11.0-android\mauitest.dll (net11.0|x64) passed [✓1/x0/↓0] (1s 887ms)

Test run summary: Passed!
 total: 1
 failed: 0
 succeeded: 1
 skipped: 0
 duration: 2s 011ms
```

</details>

## Fix

Log redirected emulator stderr at `TraceLevel.Verbose` instead of `TraceLevel.Warning`. Actual launch and boot failures remain reported through the existing boot result handling.

- [x] Useful description of why the change is necessary
- [x] Links to issues fixed: N/A
- [x] Unit tests: existing Android SDK tools test suite passes