### PR TITLE
[tests] Cover AppCompat Java alias casts

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1751,6 +1751,241 @@ namespace Styleable.Library {
 			Assert.IsTrue (didStart, "Activity should have started.");
 		}
 
+		[TestCase ("llvm-ir", AndroidRuntime.CoreCLR)]
+		[TestCase ("trimmable", AndroidRuntime.CoreCLR)]
+		[TestCase ("trimmable", AndroidRuntime.NativeAOT)]
+		public void AppCompatJavaAliasCastsAndInflation (
+			string typemapImplementation,
+			AndroidRuntime runtime)
+		{
+			const string expectedLogcatOutput = "APPCOMPAT_ALIAS_CASTS_PASS";
+
+			if (IgnoreUnsupportedConfiguration (runtime, release: true)) {
+				return;
+			}
+
+			var packageSuffix = $"appcompataliascasts{typemapImplementation.Replace ("-", "")}";
+			var proj = new XamarinAndroidApplicationProject (
+				packageName: PackageUtils.MakePackageName (runtime, packageSuffix)) {
+				IsRelease = true,
+			};
+			proj.SetRuntime (runtime);
+			proj.SetRuntimeIdentifiers (new [] { DeviceAbi });
+			proj.SetProperty ("AndroidTypeMapImplementation", typemapImplementation);
+			proj.SetDefaultTargetDevice ();
+			proj.PackageReferences.Add (new Package {
+				Id = "Xamarin.AndroidX.AppCompat",
+				Version = "1.7.1.3",
+			});
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\styles.xml") {
+				TextContent = () => """
+					<?xml version="1.0" encoding="utf-8"?>
+					<resources>
+						<style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar" />
+					</resources>
+					""",
+			});
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\alias_casts.xml") {
+				TextContent = () => """
+					<?xml version="1.0" encoding="utf-8"?>
+					<LinearLayout
+						xmlns:android="http://schemas.android.com/apk/res/android"
+						android:layout_width="match_parent"
+						android:layout_height="match_parent"
+						android:orientation="vertical">
+						<androidx.appcompat.widget.Toolbar
+							android:id="@+id/toolbar"
+							android:layout_width="match_parent"
+							android:layout_height="wrap_content" />
+						<androidx.appcompat.widget.AppCompatImageButton
+							android:id="@+id/image_button"
+							android:layout_width="wrap_content"
+							android:layout_height="wrap_content"
+							android:src="@android:drawable/ic_menu_add" />
+					</LinearLayout>
+					""",
+			});
+			proj.MainActivity = """
+				using System;
+
+				using Android.App;
+				using Android.Content;
+				using Android.OS;
+				using Android.Runtime;
+				using Android.Util;
+				using Android.Views;
+
+				using AndroidX.AppCompat.App;
+				using AndroidX.AppCompat.Widget;
+				using AndroidX.Core.View;
+
+				using Java.Interop;
+
+				namespace UnnamedProject
+				{
+					[Activity (
+						Label = "AppCompat alias casts",
+						MainLauncher = true,
+						Theme = "@style/AppTheme")]
+					public class MainActivity : AppCompatActivity
+					{
+						public MainActivity ()
+						{
+						}
+
+						protected MainActivity (IntPtr handle, JniHandleOwnership transfer)
+							: base (handle, transfer)
+						{
+						}
+
+						protected override void OnCreate (Bundle savedInstanceState)
+						{
+							base.OnCreate (savedInstanceState);
+							SetContentView (Resource.Layout.alias_casts);
+
+							VerifyInflatedViews ();
+							VerifyManagedCreatedViews ();
+							VerifyCallerDirectedGenericWrapper ();
+
+							Log.Info ("JavaAliasCasts", "APPCOMPAT_ALIAS_CASTS_PASS");
+						}
+
+						void VerifyInflatedViews ()
+						{
+							var toolbarView = FindViewById (Resource.Id.toolbar);
+							Require (toolbarView != null, "Inflated Toolbar was not found.");
+							Require (
+								toolbarView.GetType () == typeof (AndroidX.AppCompat.Widget.Toolbar),
+								$"Expected most-derived Toolbar binding; {Describe (toolbarView)}.");
+
+							var toolbar = JavaObjectExtensions.JavaCast<AndroidX.AppCompat.Widget.Toolbar> (toolbarView);
+							var toolbarAs = JavaPeerableExtensions.JavaAs<AndroidX.AppCompat.Widget.Toolbar> (toolbarView);
+							Require (ReferenceEquals (toolbarView, toolbar), "JavaCast<Toolbar> did not preserve the existing peer.");
+							Require (ReferenceEquals (toolbarView, toolbarAs), "JavaAs<Toolbar> did not preserve the existing peer.");
+							Require (
+								ReferenceEquals (toolbarView, FindViewById (Resource.Id.toolbar)),
+								"Repeated Toolbar lookup did not preserve peer identity.");
+
+							var imageView = FindViewById (Resource.Id.image_button);
+							Require (imageView != null, "Inflated AppCompatImageButton was not found.");
+							Require (
+								imageView.GetType () == typeof (AppCompatImageButton),
+								$"Expected most-derived AppCompatImageButton binding; {Describe (imageView)}.");
+							Require (
+								ReferenceEquals (imageView, FindViewById (Resource.Id.image_button)),
+								"Repeated AppCompatImageButton lookup did not preserve peer identity.");
+
+							using var untypedImage = new Java.Lang.Object (
+								imageView.Handle,
+								JniHandleOwnership.DoNotTransfer | JniHandleOwnership.DoNotRegister);
+							using var alias = JavaObjectExtensions.JavaCast<AppCompatImageButtonAlias> (untypedImage);
+							var aliasAs = JavaPeerableExtensions.JavaAs<AppCompatImageButtonAlias> (alias);
+							Require (alias != null, "JavaCast did not select the concrete AppCompatImageButton alias.");
+							Require (ReferenceEquals (alias, aliasAs), "JavaAs did not preserve the selected alias peer.");
+							Require (
+								JNIEnv.IsSameObject (imageView.Handle, alias.Handle),
+								"Concrete alias did not retain the inflated Java object.");
+							Require (
+								AppCompatImageButtonAlias.HandleConstructorCalls == 1,
+								"Concrete alias did not use its explicit handle constructor exactly once.");
+
+							using var tintable = JavaObjectExtensions.JavaCast<ITintableBackgroundView> (untypedImage);
+							using var tintableAs = JavaPeerableExtensions.JavaAs<ITintableBackgroundView> (untypedImage);
+							Require (tintable != null, "JavaCast did not resolve the AppCompat interface.");
+							Require (tintableAs != null, "JavaAs did not resolve the AppCompat interface.");
+							Require (
+								JNIEnv.IsSameObject (imageView.Handle, tintable.Handle),
+								"Interface cast did not retain the inflated Java object.");
+							Require (
+								JNIEnv.IsSameObject (imageView.Handle, tintableAs.PeerReference.Handle),
+								"Interface JavaAs did not retain the inflated Java object.");
+						}
+
+						void VerifyManagedCreatedViews ()
+						{
+							using var image = new AppCompatImageButton (this);
+							using var untypedImage = new Java.Lang.Object (
+								image.Handle,
+								JniHandleOwnership.DoNotTransfer | JniHandleOwnership.DoNotRegister);
+							var castImage = JavaObjectExtensions.JavaCast<AppCompatImageButton> (untypedImage);
+							var imageAs = JavaPeerableExtensions.JavaAs<AppCompatImageButton> (image);
+							Require (ReferenceEquals (image, castImage), "Managed-created JavaCast did not preserve peer identity.");
+							Require (ReferenceEquals (image, imageAs), "Managed-created JavaAs did not preserve peer identity.");
+
+							using var alias = new AppCompatImageButtonAlias (this);
+							using var untypedAlias = new Java.Lang.Object (
+								alias.Handle,
+								JniHandleOwnership.DoNotTransfer | JniHandleOwnership.DoNotRegister);
+							var castAlias = JavaObjectExtensions.JavaCast<AppCompatImageButtonAlias> (untypedAlias);
+							var aliasAs = JavaPeerableExtensions.JavaAs<AppCompatImageButtonAlias> (alias);
+							Require (ReferenceEquals (alias, castAlias), "Managed-created alias JavaCast did not preserve peer identity.");
+							Require (ReferenceEquals (alias, aliasAs), "Managed-created alias JavaAs did not preserve peer identity.");
+						}
+
+						static void VerifyCallerDirectedGenericWrapper ()
+						{
+							using var list = new JavaList ();
+							using var untyped = new Java.Lang.Object (
+								list.Handle,
+								JniHandleOwnership.DoNotTransfer | JniHandleOwnership.DoNotRegister);
+							using var generic = JavaObjectExtensions.JavaCast<JavaList<string>> (untyped);
+							var genericAs = JavaPeerableExtensions.JavaAs<JavaList<string>> (generic);
+							generic.Add ("alias");
+							Require (generic [0] == "alias", "Caller-directed generic wrapper did not round trip its value.");
+							Require (ReferenceEquals (generic, genericAs), "Generic JavaAs did not preserve peer identity.");
+						}
+
+						static string Describe (Java.Lang.Object value)
+						{
+							return $"managed={value.GetType ().FullName}, java={JNIEnv.GetClassNameFromInstance (value.Handle)}";
+						}
+
+						static void Require (bool condition, string message)
+						{
+							if (!condition) {
+								throw new InvalidOperationException (message);
+							}
+						}
+					}
+
+					[Register ("androidx/appcompat/widget/AppCompatImageButton", DoNotGenerateAcw = true)]
+					public sealed class AppCompatImageButtonAlias : AppCompatImageButton
+					{
+						public static int HandleConstructorCalls;
+
+						public AppCompatImageButtonAlias (Context context)
+							: base (context)
+						{
+						}
+
+						public AppCompatImageButtonAlias (Context context, IAttributeSet attrs)
+							: base (context, attrs)
+						{
+						}
+
+						public AppCompatImageButtonAlias (Context context, IAttributeSet attrs, int style)
+							: base (context, attrs, style)
+						{
+						}
+
+						public AppCompatImageButtonAlias (IntPtr handle, JniHandleOwnership transfer)
+							: base (handle, transfer)
+						{
+							HandleConstructorCalls++;
+						}
+					}
+				}
+				""";
+			using var builder = CreateApkBuilder ();
+			Assert.True (builder.Install (proj), "Project should have installed.");
+			RunProjectAndAssert (proj, builder, doNotCleanupOnUpdate: true);
+			Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity",
+				Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), ActivityStartTimeoutInSeconds), "Activity should have started.");
+			Assert.True (MonitorAdbLogcat (line => line.Contains (expectedLogcatOutput),
+				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"), 45), $"Output did not contain {expectedLogcatOutput}.");
+			Assert.True (builder.Uninstall (proj), "Project should have uninstalled.");
+		}
+
 		[Test]
 		public void CheckXamarinFormsAppDeploysAndAButtonWorks ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 		{

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1951,10 +1951,17 @@ namespace Styleable.Library {
 								list.Handle,
 								JniHandleOwnership.DoNotTransfer | JniHandleOwnership.DoNotRegister);
 							using var generic = JavaObjectExtensions.JavaCast<JavaList<string>> (untyped);
-							var genericAs = JavaPeerableExtensions.JavaAs<JavaList<string>> (generic);
+							using var genericAs = JavaPeerableExtensions.JavaAs<JavaList<string>> (untyped);
+							Require (generic != null, "JavaCast did not create the caller-directed generic wrapper.");
+							Require (genericAs != null, "JavaAs did not create the caller-directed generic wrapper.");
+							Require (
+								JNIEnv.IsSameObject (generic.Handle, genericAs.Handle),
+								"Caller-directed generic wrappers did not retain the same Java object.");
 							generic.Add ("alias");
-							Require (generic [0] == "alias", "Caller-directed generic wrapper did not round trip its value.");
-							Require (ReferenceEquals (generic, genericAs), "Generic JavaAs did not preserve peer identity.");
+							Require (genericAs [0] == "alias", "Caller-directed generic wrappers did not round trip their value.");
+							Require (
+								ReferenceEquals (generic, JavaPeerableExtensions.JavaAs<JavaList<string>> (generic)),
+								"Generic JavaAs did not preserve the typed peer.");
 						}
 
 						static string Describe (Java.Lang.Object value)
@@ -2005,6 +2012,7 @@ namespace Styleable.Library {
 			RunAdbCommand ($"uninstall {proj.PackageName}");
 			try {
 				Assert.True (builder.Install (proj), "Project should have installed.");
+				ClearAdbLogcat ();
 				RunProjectAndAssert (proj, builder, doNotCleanupOnUpdate: true);
 				Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity",
 					Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), ActivityStartTimeoutInSeconds), "Activity should have started.");

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1882,33 +1882,45 @@ namespace Styleable.Library {
 							using var untypedImage = new Java.Lang.Object (
 								imageView.Handle,
 								JniHandleOwnership.DoNotTransfer | JniHandleOwnership.DoNotRegister);
-							using var alias = JavaObjectExtensions.JavaCast<AppCompatImageButtonAlias> (untypedImage);
-							using var aliasAs = JavaPeerableExtensions.JavaAs<AppCompatImageButtonAlias> (untypedImage);
-							Require (alias != null, "JavaCast did not select the concrete AppCompatImageButton alias.");
-							Require (aliasAs != null, "JavaAs did not select the concrete AppCompatImageButton alias.");
-							Require (
-								JNIEnv.IsSameObject (imageView.Handle, alias.Handle),
-								"Concrete alias did not retain the inflated Java object.");
-							Require (
-								JNIEnv.IsSameObject (imageView.Handle, aliasAs.Handle),
-								"Concrete alias JavaAs did not retain the inflated Java object.");
-							if (imageView is AppCompatImageButtonAlias) {
-								Require (ReferenceEquals (imageView, alias), "JavaCast did not preserve the inflated alias peer.");
-							}
-							Require (
-								AppCompatImageButtonAlias.HandleConstructorCalls == 2,
-								"Inflation and concrete alias casts did not use the expected handle constructors.");
+							var alias = JavaObjectExtensions.JavaCast<AppCompatImageButtonAlias> (untypedImage);
+							try {
+								using var aliasAs = JavaPeerableExtensions.JavaAs<AppCompatImageButtonAlias> (untypedImage);
+								Require (alias != null, "JavaCast did not select the concrete AppCompatImageButton alias.");
+								Require (aliasAs != null, "JavaAs did not select the concrete AppCompatImageButton alias.");
+								Require (
+									JNIEnv.IsSameObject (imageView.Handle, alias.Handle),
+									"Concrete alias did not retain the inflated Java object.");
+								Require (
+									JNIEnv.IsSameObject (imageView.Handle, aliasAs.Handle),
+									"Concrete alias JavaAs did not retain the inflated Java object.");
+								if (imageView is AppCompatImageButtonAlias) {
+									Require (ReferenceEquals (imageView, alias), "JavaCast did not preserve the inflated alias peer.");
+								}
+								Require (
+									AppCompatImageButtonAlias.HandleConstructorCalls == 2,
+									"Inflation and concrete alias casts did not use the expected handle constructors.");
 
-							using var tintable = JavaObjectExtensions.JavaCast<ITintableBackgroundView> (untypedImage);
-							using var tintableAs = JavaPeerableExtensions.JavaAs<ITintableBackgroundView> (untypedImage);
-							Require (tintable != null, "JavaCast did not resolve the AppCompat interface.");
-							Require (tintableAs != null, "JavaAs did not resolve the AppCompat interface.");
-							Require (
-								JNIEnv.IsSameObject (imageView.Handle, tintable.Handle),
-								"Interface cast did not retain the inflated Java object.");
-							Require (
-								JNIEnv.IsSameObject (imageView.Handle, tintableAs.PeerReference.Handle),
-								"Interface JavaAs did not retain the inflated Java object.");
+								var tintable = JavaObjectExtensions.JavaCast<ITintableBackgroundView> (untypedImage);
+								try {
+									using var tintableAs = JavaPeerableExtensions.JavaAs<ITintableBackgroundView> (untypedImage);
+									Require (tintable != null, "JavaCast did not resolve the AppCompat interface.");
+									Require (tintableAs != null, "JavaAs did not resolve the AppCompat interface.");
+									Require (
+										JNIEnv.IsSameObject (imageView.Handle, tintable.Handle),
+										"Interface cast did not retain the inflated Java object.");
+									Require (
+										JNIEnv.IsSameObject (imageView.Handle, tintableAs.PeerReference.Handle),
+										"Interface JavaAs did not retain the inflated Java object.");
+								} finally {
+									if (tintable != null && !ReferenceEquals (tintable, imageView)) {
+										tintable.Dispose ();
+									}
+								}
+							} finally {
+								if (alias != null && !ReferenceEquals (alias, imageView)) {
+									alias.Dispose ();
+								}
+							}
 						}
 
 						void VerifyManagedCreatedViews ()
@@ -2000,7 +2012,7 @@ namespace Styleable.Library {
 					Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"), 45), $"Output did not contain {expectedLogcatOutput}.");
 			} finally {
 				RunAdbCommand ($"shell am force-stop --user all {proj.PackageName}");
-				builder.Uninstall (proj);
+				RunAdbCommand ($"uninstall {proj.PackageName}");
 			}
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1853,6 +1853,8 @@ namespace Styleable.Library {
 
 						void VerifyInflatedViews ()
 						{
+							const bool allowRegisteredAliasInflation = __ALLOW_REGISTERED_ALIAS_INFLATION__;
+
 							var toolbarView = FindViewById (Resource.Id.toolbar);
 							Require (toolbarView != null, "Inflated Toolbar was not found.");
 							Require (
@@ -1871,8 +1873,8 @@ namespace Styleable.Library {
 							Require (imageView != null, "Inflated AppCompatImageButton was not found.");
 							Require (
 								imageView.GetType () == typeof (AppCompatImageButton) ||
-									imageView.GetType () == typeof (AppCompatImageButtonAlias),
-								$"Expected an AppCompatImageButton binding or its registered alias; {Describe (imageView)}.");
+									(allowRegisteredAliasInflation && imageView.GetType () == typeof (AppCompatImageButtonAlias)),
+								$"Expected the canonical AppCompatImageButton binding; {Describe (imageView)}.");
 							Require (
 								ReferenceEquals (imageView, FindViewById (Resource.Id.image_button)),
 								"Repeated AppCompatImageButton lookup did not preserve peer identity.");
@@ -1983,7 +1985,9 @@ namespace Styleable.Library {
 						}
 					}
 				}
-				""";
+				""".Replace (
+					"__ALLOW_REGISTERED_ALIAS_INFLATION__",
+					typemapImplementation == "llvm-ir" ? "true" : "false");
 			using var builder = CreateApkBuilder (packageName: packageName);
 			Assert.AreEqual (proj.PackageName, TestPackageNames [packageName], "Teardown should track the installed package.");
 			RunAdbCommand ($"uninstall {proj.PackageName}");

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1870,8 +1870,9 @@ namespace Styleable.Library {
 							var imageView = FindViewById (Resource.Id.image_button);
 							Require (imageView != null, "Inflated AppCompatImageButton was not found.");
 							Require (
-								imageView.GetType () == typeof (AppCompatImageButton),
-								$"Expected most-derived AppCompatImageButton binding; {Describe (imageView)}.");
+								imageView.GetType () == typeof (AppCompatImageButton) ||
+									imageView.GetType () == typeof (AppCompatImageButtonAlias),
+								$"Expected an AppCompatImageButton binding or its registered alias; {Describe (imageView)}.");
 							Require (
 								ReferenceEquals (imageView, FindViewById (Resource.Id.image_button)),
 								"Repeated AppCompatImageButton lookup did not preserve peer identity.");
@@ -1889,9 +1890,12 @@ namespace Styleable.Library {
 							Require (
 								JNIEnv.IsSameObject (imageView.Handle, aliasAs.Handle),
 								"Concrete alias JavaAs did not retain the inflated Java object.");
+							if (imageView is AppCompatImageButtonAlias) {
+								Require (ReferenceEquals (imageView, alias), "JavaCast did not preserve the inflated alias peer.");
+							}
 							Require (
 								AppCompatImageButtonAlias.HandleConstructorCalls == 2,
-								"Concrete alias casts did not use the explicit handle constructor.");
+								"Inflation and concrete alias casts did not use the expected handle constructors.");
 
 							using var tintable = JavaObjectExtensions.JavaCast<ITintableBackgroundView> (untypedImage);
 							using var tintableAs = JavaPeerableExtensions.JavaAs<ITintableBackgroundView> (untypedImage);

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -1765,8 +1765,9 @@ namespace Styleable.Library {
 			}
 
 			var packageSuffix = $"appcompataliascasts{typemapImplementation.Replace ("-", "")}";
+			var packageName = PackageUtils.MakePackageName (runtime, packageSuffix);
 			var proj = new XamarinAndroidApplicationProject (
-				packageName: PackageUtils.MakePackageName (runtime, packageSuffix)) {
+				packageName: packageName) {
 				IsRelease = true,
 			};
 			proj.SetRuntime (runtime);
@@ -1879,15 +1880,18 @@ namespace Styleable.Library {
 								imageView.Handle,
 								JniHandleOwnership.DoNotTransfer | JniHandleOwnership.DoNotRegister);
 							using var alias = JavaObjectExtensions.JavaCast<AppCompatImageButtonAlias> (untypedImage);
-							var aliasAs = JavaPeerableExtensions.JavaAs<AppCompatImageButtonAlias> (alias);
+							using var aliasAs = JavaPeerableExtensions.JavaAs<AppCompatImageButtonAlias> (untypedImage);
 							Require (alias != null, "JavaCast did not select the concrete AppCompatImageButton alias.");
-							Require (ReferenceEquals (alias, aliasAs), "JavaAs did not preserve the selected alias peer.");
+							Require (aliasAs != null, "JavaAs did not select the concrete AppCompatImageButton alias.");
 							Require (
 								JNIEnv.IsSameObject (imageView.Handle, alias.Handle),
 								"Concrete alias did not retain the inflated Java object.");
 							Require (
-								AppCompatImageButtonAlias.HandleConstructorCalls == 1,
-								"Concrete alias did not use its explicit handle constructor exactly once.");
+								JNIEnv.IsSameObject (imageView.Handle, aliasAs.Handle),
+								"Concrete alias JavaAs did not retain the inflated Java object.");
+							Require (
+								AppCompatImageButtonAlias.HandleConstructorCalls == 2,
+								"Concrete alias casts did not use the explicit handle constructor.");
 
 							using var tintable = JavaObjectExtensions.JavaCast<ITintableBackgroundView> (untypedImage);
 							using var tintableAs = JavaPeerableExtensions.JavaAs<ITintableBackgroundView> (untypedImage);
@@ -1976,14 +1980,20 @@ namespace Styleable.Library {
 					}
 				}
 				""";
-			using var builder = CreateApkBuilder ();
-			Assert.True (builder.Install (proj), "Project should have installed.");
-			RunProjectAndAssert (proj, builder, doNotCleanupOnUpdate: true);
-			Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity",
-				Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), ActivityStartTimeoutInSeconds), "Activity should have started.");
-			Assert.True (MonitorAdbLogcat (line => line.Contains (expectedLogcatOutput),
-				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"), 45), $"Output did not contain {expectedLogcatOutput}.");
-			Assert.True (builder.Uninstall (proj), "Project should have uninstalled.");
+			using var builder = CreateApkBuilder (packageName: packageName);
+			Assert.AreEqual (proj.PackageName, TestPackageNames [packageName], "Teardown should track the installed package.");
+			RunAdbCommand ($"uninstall {proj.PackageName}");
+			try {
+				Assert.True (builder.Install (proj), "Project should have installed.");
+				RunProjectAndAssert (proj, builder, doNotCleanupOnUpdate: true);
+				Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity",
+					Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), ActivityStartTimeoutInSeconds), "Activity should have started.");
+				Assert.True (MonitorAdbLogcat (line => line.Contains (expectedLogcatOutput),
+					Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"), 45), $"Output did not contain {expectedLogcatOutput}.");
+			} finally {
+				RunAdbCommand ($"shell am force-stop --user all {proj.PackageName}");
+				builder.Uninstall (proj);
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
## Summary

- add a focused `MSBuildDeviceIntegration` AppCompat app for Java alias/cast parity
- inflate real `Toolbar` and `AppCompatImageButton` views from XML, then verify most-derived binding selection and repeated peer identity
- cover `JavaCast<T>` and `JavaAs<T>` for a concrete same-JNI-name alias, an AppCompat Java interface, managed-created peers, and a caller-directed closed generic `JavaList<string>` wrapper
- run the same Release fixture with llvm-ir/CoreCLR, trimmable/CoreCLR, and trimmable/NativeAOT

No production change is included: the unchanged focused fixture is green in all three configurations.

## Investigation

The existing NativeAOT skips all record the same historical startup failure:

- `InstallAndRunTests.CheckXamarinFormsAppDeploysAndAButtonWorks`
- `BundleToolNoAbiSplitTests.InstallAndRun`
- `DebuggingTest.ApplicationRunsWithoutDebugger`

The reported exception converts `AndroidX.AppCompat.Widget.AppCompatImageButton` to `AndroidX.AppCompat.Widget.Toolbar` inside `Xamarin.Forms.Platform.Android.FormsAppCompatActivity.OnCreate`. The BundleTool/Debugging skips were introduced by `b58d4606e6` (#10632); the InstallAndRun skip was added when that test gained NativeAOT coverage in `847c5fe161` (#10635).

The mismatch is stale/not reproducible for the current AppCompat binding and focused view-inflation path. The three broad Xamarin.Forms 5.0 skips remain unchanged: that exact legacy package is not present in the required offline package cache, and those tests also combine unrelated Forms, bundle-tool, and debugger behavior. They remain separate follow-up validation rather than being removed without executing the original fixtures.

## Artifact evidence

For trimmable NativeAOT:

- `_UnnamedProject.TypeMap.dll` contains an `AppCompatImageButton` alias holder with `[0]` targeting `AndroidX.AppCompat.Widget.AppCompatImageButton` and `[1]` targeting `UnnamedProject.AppCompatImageButtonAlias`
- `acw-map.txt` maps both managed types to `androidx.appcompat.widget.AppCompatImageButton`
- DEX contains the real `androidx/appcompat/widget/AppCompatImageButton`, `androidx/appcompat/widget/Toolbar`, and generated `MainActivity`
- startup logs contain `APPCOMPAT_ALIAS_CASTS_PASS`

## Test plan

- llvm-ir / CoreCLR baseline: passed
- trimmable / CoreCLR: passed
- trimmable / NativeAOT: passed
- final combined focused matrix: 3 passed
- `git diff --check`