### PR TITLE
[build] Error on marshal methods with ReadyToRun

### DIFF
--- a/Documentation/docs-mobile/TOC.yml
+++ b/Documentation/docs-mobile/TOC.yml
@@ -270,6 +270,8 @@
         href: messages/xa1043.md
       - name: XA1048
         href: messages/xa1048.md
+      - name: XA1049
+        href: messages/xa1049.md
     - name: "XA2xxx: Linker"
       items:
       - name: "XA2xxx: Linker"

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -399,6 +399,9 @@ for Java `native` method registration.
 
 This property is False by default.
 
+This property cannot be set to `true` when
+[`$(PublishReadyToRun)`](#publishreadytorun) is `true`.
+
 Added in .NET 8.
 
 ## AndroidEnableMultiDex

--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -158,6 +158,7 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 + [XA1046](xa1046.md): Attribute '{0}' in element '{1}' has value '{2}' that cannot be parsed as boolean; {3} line {4}.
 + [XA1047](xa1047.md): Required attribute '{0}' missing from element '{1}'; {2} line {3}.
 + [XA1048](xa1048.md): '{0}' does not contain an &lt;instrumentation&gt; element.
++ [XA1049](xa1049.md): The 'AndroidEnableMarshalMethods' and 'PublishReadyToRun' MSBuild properties cannot both be set to 'true'.
 
 ## XA2xxx: Linker
 

--- a/Documentation/docs-mobile/messages/xa1049.md
+++ b/Documentation/docs-mobile/messages/xa1049.md
@@ -1,0 +1,41 @@
+---
+title: .NET for Android error XA1049
+description: XA1049 error code
+ms.date: 08/31/2026
+f1_keywords:
+  - "XA1049"
+---
+
+# .NET for Android error XA1049
+
+## Example messages
+
+```dotnetcli
+error XA1049: The 'AndroidEnableMarshalMethods' and 'PublishReadyToRun' MSBuild properties cannot both be set to 'true'. Set one property to 'false'.
+```
+
+## Issue
+
+[`$(AndroidEnableMarshalMethods)`](../building-apps/build-properties.md#androidenablemarshalmethods)
+rewrites managed assemblies after trimming, while
+[`$(PublishReadyToRun)`](../building-apps/build-properties.md#publishreadytorun)
+adds native code to those assemblies. The marshal methods rewriter cannot modify
+ReadyToRun assemblies.
+
+## Solution
+
+Disable marshal methods or ReadyToRun in the project file:
+
+```xml
+<PropertyGroup>
+  <AndroidEnableMarshalMethods>false</AndroidEnableMarshalMethods>
+</PropertyGroup>
+```
+
+Alternatively:
+
+```xml
+<PropertyGroup>
+  <PublishReadyToRun>false</PublishReadyToRun>
+</PropertyGroup>
+```

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1015,6 +1015,15 @@ namespace Xamarin.Android.Tasks.Properties {
                 return ResourceManager.GetString("XA1048", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;AndroidEnableMarshalMethods&apos; and &apos;PublishReadyToRun&apos; MSBuild properties cannot both be set to &apos;true&apos;. Set one property to &apos;false&apos;..
+        /// </summary>
+        public static string XA1049 {
+            get {
+                return ResourceManager.GetString("XA1049", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 and higher will only support a single AppDomain, so this API will no longer be available in .NET for Android once .NET 6 is released..

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1128,6 +1128,10 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {0} - The path to the AndroidManifest.xml file.
 </comment>
   </data>
+  <data name="XA1049" xml:space="preserve">
+    <value>The 'AndroidEnableMarshalMethods' and 'PublishReadyToRun' MSBuild properties cannot both be set to 'true'. Set one property to 'false'.</value>
+    <comment>The following are literal names and should not be translated: AndroidEnableMarshalMethods, PublishReadyToRun, MSBuild, true, false.</comment>
+  </data>
   <data name="XA4241" xml:space="preserve">
     <value>Java dependency '{0}' is not satisfied.</value>
     <comment>The following are literal names and should not be translated: Java.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -117,6 +117,7 @@ namespace Xamarin.Android.Build.Tests
 			StringAssertEx.Contains ("error XA1049", b.LastBuildOutput);
 			StringAssertEx.Contains ("AndroidEnableMarshalMethods", b.LastBuildOutput);
 			StringAssertEx.Contains ("PublishReadyToRun", b.LastBuildOutput);
+			StringAssertEx.DoesNotContain ("XARMM7015", b.LastBuildOutput, "Build should fail before rewriting ReadyToRun assemblies.");
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -102,6 +102,24 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void AndroidEnableMarshalMethodsWithReadyToRunFailsBuild ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+				EnableMarshalMethods = true,
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("PublishReadyToRun", "true");
+
+			using var b = CreateApkBuilder ();
+			b.ThrowOnBuildFailure = false;
+			Assert.IsFalse (b.Build (proj), "Build should have failed.");
+			StringAssertEx.Contains ("error XA1049", b.LastBuildOutput);
+			StringAssertEx.Contains ("AndroidEnableMarshalMethods", b.LastBuildOutput);
+			StringAssertEx.Contains ("PublishReadyToRun", b.LastBuildOutput);
+		}
+
+		[Test]
 		public void BasicApplicationPublishReadyToRunCustomConfiguration ([Values] bool isComposite, [Values ("android-x64", "android-arm64")] string rid)
 		{
 			// Use a non-standard release configuration name to validate PublishReadyToRun

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -532,6 +532,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ResourceName="XA0119_ReadyToRunWithoutTrimming"
       Condition=" '$(_AndroidReadyToRunWithoutTrimming)' == 'true' "
   />
+  <AndroidError Code="XA1049"
+      ResourceName="XA1049"
+      Condition=" '$(AndroidEnableMarshalMethods)' == 'true' and '$(PublishReadyToRun)' == 'true' "
+  />
   <AndroidWarning Code="XA1027"
       ResourceName="XA1027"
       Condition=" $(_AndroidXA1027) == 'true' "

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -534,7 +534,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   />
   <AndroidError Code="XA1049"
       ResourceName="XA1049"
-      Condition=" '$(AndroidEnableMarshalMethods)' == 'true' and '$(PublishReadyToRun)' == 'true' "
+      Condition=" '$(AndroidEnableMarshalMethods)' == 'True' And '$(PublishReadyToRun)' == 'True' "
   />
   <AndroidWarning Code="XA1027"
       ResourceName="XA1027"


### PR DESCRIPTION
## Description

Fail early with `XA1049` when `AndroidEnableMarshalMethods` and `PublishReadyToRun` are both enabled.

Without this validation, ReadyToRun compilation completes before the marshal-methods rewriter attempts to modify the mixed-mode assemblies and fails with the implementation-level error `XARMM7015: Writing mixed-mode assemblies is not supported`.

This also documents the incompatibility and adds the new diagnostic to the error-code reference.

## Testing

- `AndroidEnableMarshalMethodsWithReadyToRunFailsBuild`
- `BasicApplicationPublishReadyToRun` (all four composite/RID cases)