### PR TITLE
[native] Avoid redundant GC bridge type checks

### DIFF
--- a/src/native/clr/host/bridge-processing.cc
+++ b/src/native/clr/host/bridge-processing.cc
@@ -283,17 +283,17 @@ void BridgeProcessing::add_cross_reference (size_t source_index, size_t dest_ind
 	CrossReferenceTarget from = select_cross_reference_target (source_index, temporary_peers);
 	CrossReferenceTarget to = select_cross_reference_target (dest_index, temporary_peers);
 
-	if (add_reference (from.get_handle(), to.get_handle())) {
+	if (add_reference (from.get_handle(), to.get_handle(), from.is_gc_user_peer_known ())) {
 		from.mark_refs_added_if_needed ();
 	}
 }
 
-bool BridgeProcessing::add_reference (jobject from, jobject to) noexcept
+bool BridgeProcessing::add_reference (jobject from, jobject to, bool known_gc_user_peer) noexcept
 {
 	abort_if_invalid_pointer_argument (from, "from");
 	abort_if_invalid_pointer_argument (to, "to");
 
-	if (!env->IsInstanceOf (from, IGCUserPeer_class)) [[unlikely]] {
+	if (!known_gc_user_peer && !env->IsInstanceOf (from, IGCUserPeer_class)) [[unlikely]] {
 		jclass java_class = env->GetObjectClass (from);
 		log_missing_add_references_method (java_class);
 		env->DeleteLocalRef (java_class);
@@ -329,12 +329,10 @@ void BridgeProcessing::clear_references (jobject handle) noexcept
 {
 	abort_if_invalid_pointer_argument (handle, "handle");
 
-	if (!env->IsInstanceOf (handle, IGCUserPeer_class)) [[unlikely]] {
-		jclass java_class = env->GetObjectClass (handle);
-		log_missing_clear_references_method (java_class);
-		env->DeleteLocalRef (java_class);
-		return;
-	}
+	// refs_added is set only after add_reference verifies that the source implements IGCUserPeer.
+#if DEBUG
+	abort_unless (env->IsInstanceOf (handle, IGCUserPeer_class), "Object with added references must implement IGCUserPeer");
+#endif
 
 	env->CallVoidMethod (handle, IGCUserPeer_monodroidClearReferences);
 	abort_on_pending_java_exception ("A Java exception was thrown by monodroidClearReferences during GC bridge processing"sv);
@@ -449,6 +447,17 @@ jobject CrossReferenceTarget::get_handle () const noexcept
 	return context->control_block->handle;
 }
 
+bool CrossReferenceTarget::is_gc_user_peer_known () const noexcept
+{
+	if (is_temporary_peer) {
+		return true;
+	}
+
+	abort_unless (context != nullptr, "Context must not be null");
+	abort_unless (context->control_block != nullptr, "Control block must not be null");
+	return context->control_block->refs_added != 0;
+}
+
 void CrossReferenceTarget::mark_refs_added_if_needed () noexcept
 {
 	if (is_temporary_peer) {
@@ -472,22 +481,6 @@ void BridgeProcessing::log_missing_add_references_method ([[maybe_unused]] jclas
 
 	char *class_name = HostCommon::get_java_class_name_for_TypeManager (java_class);
 	log_errorf (LOG_GC, "Missing monodroidAddReferences method for object of class %s", optional_string (class_name));
-	free (class_name);
-#endif
-}
-
-[[gnu::always_inline]]
-void BridgeProcessing::log_missing_clear_references_method ([[maybe_unused]] jclass java_class) noexcept
-{
-	log_errorf (LOG_DEFAULT, "Failed to find monodroidClearReferences method");
-#if DEBUG
-	abort_if_invalid_pointer_argument (java_class, "java_class");
-	if (!Logger::gc_spew_enabled ()) [[likely]] {
-		return;
-	}
-
-	char *class_name = HostCommon::get_java_class_name_for_TypeManager (java_class);
-	log_errorf (LOG_GC, "Missing monodroidClearReferences method for object of class %s", optional_string (class_name));
 	free (class_name);
 #endif
 }

--- a/src/native/clr/include/host/bridge-processing.hh
+++ b/src/native/clr/include/host/bridge-processing.hh
@@ -18,6 +18,7 @@ struct CrossReferenceTarget
 	};
 
 	jobject get_handle () const noexcept;
+	bool is_gc_user_peer_known () const noexcept;
 	void mark_refs_added_if_needed () noexcept;
 };
 
@@ -83,7 +84,7 @@ private:
 	void add_circular_references (const StronglyConnectedComponent &scc) noexcept;
 	void add_cross_reference (size_t source_index, size_t dest_index, TemporaryPeerMap &temporary_peers) noexcept;
 	CrossReferenceTarget select_cross_reference_target (size_t scc_index, TemporaryPeerMap &temporary_peers) noexcept;
-	bool add_reference (jobject from, jobject to) noexcept;
+	bool add_reference (jobject from, jobject to, bool known_gc_user_peer = false) noexcept;
 
 	void cleanup_after_java_collection () noexcept;
 	void cleanup_scc_for_java_collection (const StronglyConnectedComponent &scc) noexcept;
@@ -99,7 +100,6 @@ private:
 	void abort_on_pending_java_exception (std::string_view message) noexcept;
 
 	void log_missing_add_references_method (jclass java_class) noexcept;
-	void log_missing_clear_references_method (jclass java_class) noexcept;
 	void log_weak_to_gref (jobject weak, jobject handle) noexcept;
 	void log_weak_ref_collected (jobject weak) noexcept;
 	void log_take_weak_global_ref (jobject handle) noexcept;


### PR DESCRIPTION
## Summary

Reduce JNI work in the shared CoreCLR/NativeAOT GC bridge without changing its reachability algorithm or reference lifecycle.

- Reuse a successful `IGCUserPeer` check for subsequent cross-references from the same source during a bridge round.
- Treat temporary `GCUserPeer` instances as already known implementations.
- Skip the redundant Release `IsInstanceOf` before `monodroidClearReferences`; retain a Debug assertion documenting and checking the invariant.
- Remove the now-unused missing-clear-method diagnostic path.

`refs_added` is set only after `add_reference` has verified that the source implements `IGCUserPeer`, and it is reset after references are cleared. It therefore also acts as per-round proof that later interface dispatch is valid.

## Observed workload

A .NET MAUI `--sample-content` startup capture contained 99 bridge cross-references. Fourteen discarded `PlatformGraphicsView` instances each had seven outgoing edges, so this change removes 84 repeated pre-GC `IsInstanceOf` calls; one surviving source also avoids its redundant post-GC check, for approximately 85 fewer JNI checks in that round.

## Physical-device startup A/B

Measured on a Samsung S23 (API 36, arm64, 60 Hz) using otherwise identical Release CoreCLR `dotnet new maui --sample-content` APKs. ReadyToRun was disabled in both arms because the exact preview SDK's Crossgen2 package was unavailable.

Method:

- 80 measured cold-process launches: 40 baseline and 40 optimized.
- Balanced A/B/B/A followed by B/A/A/B block order, 10 samples per block.
- `pm clear` and `cmd package compile -f -m speed` after every APK switch.
- Three warmups per block; `am start -W -S` `TotalTime` recorded.
- Device battery temperature recorded with every sample.

The final hot blocks reached 42.1 °C and produced asymmetric thermal outliers, so the thermally controlled subset (all 60 samples at or below 41.0 °C) is the useful comparison:

| Startup `TotalTime` | Baseline | Optimized | Delta |
|---|---:|---:|---:|
| Mean | 1,485.5 ms | 1,469.0 ms | **-16.4 ms (-1.1%)** |
| Median | 1,472.5 ms | 1,467.0 ms | **-5.5 ms (-0.4%)** |

A sample-level bootstrap gave a 95% interval of -31.1 to -3.7 ms for the mean and -25.0 to +0.5 ms for the median. This supports no startup regression and a modest favorable signal, but the effect is small relative to whole-app launch variance; the PR's direct claim remains the observed JNI-call reduction.

Raw measurements are preserved in the Copilot session artifact `maui-gc-benchmark/startup-results-s23-all.csv`.

## Validation

- CoreCLR native hosts compiled and linked for Android arm, arm64, and x64.
- NativeAOT arm64 Release host compiled and linked through its configured Ninja build.
- The MAUI sample-content app built and completed repeated cold launches on both an API-35 arm64 emulator and the physical API-36 S23, exercising the 99-edge bridge round.