### PR TITLE
[TrimmableTypeMap] Generate app value container roots

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
@@ -210,11 +210,18 @@ sealed class PEAssemblyBuilder
 
 	public void WriteTypeSignature (BlobBuilder blob, TypeRefData typeRef)
 	{
-		if (typeRef.ManagedTypeName.EndsWith ("[]", StringComparison.Ordinal)) {
-			blob.WriteByte ((byte) SignatureTypeCode.SZArray);
-			WriteTypeSignature (blob, typeRef with {
-				ManagedTypeName = typeRef.ManagedTypeName.Substring (0, typeRef.ManagedTypeName.Length - 2),
-			});
+		if (TryGetArraySuffix (typeRef.ManagedTypeName, out var elementTypeName, out var rank)) {
+			if (rank == 1) {
+				blob.WriteByte ((byte) SignatureTypeCode.SZArray);
+			} else {
+				blob.WriteByte ((byte) SignatureTypeCode.Array);
+			}
+			WriteTypeSignature (blob, typeRef with { ManagedTypeName = elementTypeName });
+			if (rank > 1) {
+				blob.WriteCompressedInteger (rank);
+				blob.WriteCompressedInteger (0);
+				blob.WriteCompressedInteger (0);
+			}
 			return;
 		}
 
@@ -234,6 +241,7 @@ sealed class PEAssemblyBuilder
 		case "System.String":  blob.WriteByte ((byte) SignatureTypeCode.String);  return;
 		case "System.Object":  blob.WriteByte ((byte) SignatureTypeCode.Object);  return;
 		case "System.IntPtr":  blob.WriteByte ((byte) SignatureTypeCode.IntPtr);  return;
+		case "System.UIntPtr": blob.WriteByte ((byte) SignatureTypeCode.UIntPtr);  return;
 		}
 
 		if (typeRef.GenericArguments.Count > 0) {
@@ -257,6 +265,31 @@ sealed class PEAssemblyBuilder
 		var typeHandle = ResolveTypeRef (typeRef);
 		blob.WriteByte ((byte) (typeRef.EncodeAsValueType ? SignatureTypeKind.ValueType : SignatureTypeKind.Class));
 		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (typeHandle));
+	}
+
+	static bool TryGetArraySuffix (string typeName, out string elementTypeName, out int rank)
+	{
+		if (!typeName.EndsWith ("]", StringComparison.Ordinal)) {
+			elementTypeName = "";
+			rank = 0;
+			return false;
+		}
+		int openBracket = typeName.LastIndexOf ('[');
+		if (openBracket < 0) {
+			elementTypeName = "";
+			rank = 0;
+			return false;
+		}
+		for (int i = openBracket + 1; i < typeName.Length - 1; i++) {
+			if (typeName [i] != ',') {
+				elementTypeName = "";
+				rank = 0;
+				return false;
+			}
+		}
+		elementTypeName = typeName.Substring (0, openBracket);
+		rank = typeName.Length - openBracket - 1;
+		return true;
 	}
 
 	TypeReferenceHandle MakeTypeRefForManagedName (EntityHandle scope, string managedTypeName)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/RootTypeMapAssemblyGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/RootTypeMapAssemblyGenerator.cs
@@ -75,12 +75,24 @@ public sealed class RootTypeMapAssemblyGenerator
 	/// <param name="assemblyName">Optional assembly name (defaults to _Microsoft.Android.TypeMaps).</param>
 	/// <param name="moduleName">Optional module name for the PE metadata.</param>
 	public void Generate (IReadOnlyList<string> perAssemblyTypeMapNames, bool useSharedTypemapUniverse, Stream stream, string? assemblyName = null, string? moduleName = null)
+		=> Generate (perAssemblyTypeMapNames, [], useSharedTypemapUniverse, stream, assemblyName, moduleName);
+
+	internal void Generate (
+		IReadOnlyList<string> perAssemblyTypeMapNames,
+		IReadOnlyList<ValueTypeContainerRoot> valueTypeContainerRoots,
+		bool useSharedTypemapUniverse,
+		Stream stream,
+		string? assemblyName = null,
+		string? moduleName = null)
 	{
 		if (perAssemblyTypeMapNames is null) {
 			throw new ArgumentNullException (nameof (perAssemblyTypeMapNames));
 		}
 		if (stream is null) {
 			throw new ArgumentNullException (nameof (stream));
+		}
+		if (valueTypeContainerRoots is null) {
+			throw new ArgumentNullException (nameof (valueTypeContainerRoots));
 		}
 
 		assemblyName ??= DefaultAssemblyName;
@@ -125,10 +137,15 @@ public sealed class RootTypeMapAssemblyGenerator
 		if (!useSharedTypemapUniverse) {
 			accessTargets.AddRange (perAssemblyTypeMapNames);
 		}
+		foreach (var root in valueTypeContainerRoots) {
+			foreach (var argument in root.TypeArguments) {
+				AddTypeAssemblyAccessTargets (argument, accessTargets);
+			}
+		}
 		pe.EmitIgnoresAccessChecksToAttribute (accessTargets);
 
 		// Emit TypeMapLoader class with Initialize() method
-		EmitTypeMapLoader (pe, anchorTypeHandle, perAssemblyTypeMapNames, useSharedTypemapUniverse, assemblyName);
+		EmitTypeMapLoader (pe, anchorTypeHandle, perAssemblyTypeMapNames, valueTypeContainerRoots, useSharedTypemapUniverse, assemblyName);
 
 		pe.WritePE (stream);
 	}
@@ -176,7 +193,13 @@ public sealed class RootTypeMapAssemblyGenerator
 		pe.Metadata.AddCustomAttribute (EntityHandle.AssemblyDefinition, ctorRef, blobHandle);
 	}
 
-	static void EmitTypeMapLoader (PEAssemblyBuilder pe, EntityHandle anchorTypeHandle, IReadOnlyList<string> perAssemblyTypeMapNames, bool useSharedTypemapUniverse, string assemblyName)
+	static void EmitTypeMapLoader (
+		PEAssemblyBuilder pe,
+		EntityHandle anchorTypeHandle,
+		IReadOnlyList<string> perAssemblyTypeMapNames,
+		IReadOnlyList<ValueTypeContainerRoot> valueTypeContainerRoots,
+		bool useSharedTypemapUniverse,
+		string assemblyName)
 	{
 		var metadata = pe.Metadata;
 
@@ -212,15 +235,23 @@ public sealed class RootTypeMapAssemblyGenerator
 			MetadataTokens.MethodDefinitionHandle (metadata.GetRowCount (TableIndex.MethodDef) + 1));
 
 		var externalDictTypeSpec = MakeIReadOnlyDictTypeSpec (pe, iReadOnlyDictOpenRef, systemTypeRef, keyIsString: true);
+		var valueTypeRegistrationSpecs = MakeValueTypeRegistrationSpecs (pe, valueTypeContainerRoots);
 
 		if (useSharedTypemapUniverse) {
 			var initializeRef = AddInitializeSingleNoArraysRef (pe, trimmableTypeMapRef, iReadOnlyDictOpenRef, systemTypeRef);
-			EmitInitializeWithSingleTypeMapNoArrays (pe, anchorTypeHandle, getExternalMemberRef, getProxyMemberRef, initializeRef, assemblyName);
+			EmitInitializeWithSingleTypeMapNoArrays (
+				pe,
+				anchorTypeHandle,
+				getExternalMemberRef,
+				getProxyMemberRef,
+				initializeRef,
+				valueTypeRegistrationSpecs,
+				assemblyName);
 		} else {
 			var proxyDictTypeSpec = MakeIReadOnlyDictTypeSpec (pe, iReadOnlyDictOpenRef, systemTypeRef, keyIsString: false);
 			var initializeRef = AddInitializeAggregateNoArraysRef (pe, trimmableTypeMapRef, iReadOnlyDictOpenRef, systemTypeRef);
 			EmitInitializeWithAggregateTypeMapNoArrays (pe, perAssemblyTypeMapNames, getExternalMemberRef, getProxyMemberRef,
-				initializeRef, externalDictTypeSpec, proxyDictTypeSpec, iReadOnlyDictOpenRef, systemTypeRef, assemblyName);
+				initializeRef, valueTypeRegistrationSpecs, externalDictTypeSpec, proxyDictTypeSpec, iReadOnlyDictOpenRef, systemTypeRef, assemblyName);
 		}
 	}
 
@@ -249,6 +280,7 @@ public sealed class RootTypeMapAssemblyGenerator
 		IReadOnlyList<string> perAssemblyTypeMapNames,
 		MemberReferenceHandle getExternalMemberRef, MemberReferenceHandle getProxyMemberRef,
 		MemberReferenceHandle initializeRef,
+		IReadOnlyList<MethodSpecificationHandle> valueTypeRegistrationSpecs,
 		TypeSpecificationHandle externalDictTypeSpec, TypeSpecificationHandle proxyDictTypeSpec,
 		TypeReferenceHandle iReadOnlyDictOpenRef, TypeReferenceHandle systemTypeRef,
 		string assemblyName)
@@ -270,6 +302,7 @@ public sealed class RootTypeMapAssemblyGenerator
 			sig => sig.MethodSignature ().Parameters (0, rt => rt.Void (), p => { }),
 			encoder => {
 				EmitSetTypeMappingEntryAssembly (pe, encoder, assemblyName);
+				EmitValueTypeContainerRegistrations (encoder, valueTypeRegistrationSpecs);
 				EmitNewArrayLocal (encoder, count, externalDictTypeSpec, slot: 0);
 				EmitFillArrayLocal (encoder, count, getExternalSpecs, slot: 0);
 
@@ -314,6 +347,7 @@ public sealed class RootTypeMapAssemblyGenerator
 	static void EmitInitializeWithSingleTypeMapNoArrays (PEAssemblyBuilder pe, EntityHandle anchorTypeHandle,
 		MemberReferenceHandle getExternalMemberRef, MemberReferenceHandle getProxyMemberRef,
 		MemberReferenceHandle initializeRef,
+		IReadOnlyList<MethodSpecificationHandle> valueTypeRegistrationSpecs,
 		string assemblyName)
 	{
 		var getExternalSpec = MakeGenericMethodSpec (pe, getExternalMemberRef, anchorTypeHandle);
@@ -324,6 +358,7 @@ public sealed class RootTypeMapAssemblyGenerator
 			sig => sig.MethodSignature ().Parameters (0, rt => rt.Void (), p => { }),
 			encoder => {
 				EmitSetTypeMappingEntryAssembly (pe, encoder, assemblyName);
+				EmitValueTypeContainerRegistrations (encoder, valueTypeRegistrationSpecs);
 				encoder.Call (getExternalSpec, parameterCount: 0, returnsValue: true);
 				encoder.Call (getProxySpec, parameterCount: 0, returnsValue: true);
 				encoder.Call (initializeRef, parameterCount: 2);
@@ -372,6 +407,83 @@ public sealed class RootTypeMapAssemblyGenerator
 		blob.WriteByte ((byte) SignatureTypeKind.Class);
 		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (typeArg));
 		return pe.Metadata.AddMethodSpecification (openMethodRef, pe.Metadata.GetOrAddBlob (blob));
+	}
+
+	static List<MethodSpecificationHandle> MakeValueTypeRegistrationSpecs (
+		PEAssemblyBuilder pe,
+		IReadOnlyList<ValueTypeContainerRoot> roots)
+	{
+		var factoryRef = pe.Metadata.AddTypeReference (
+			pe.MonoAndroidRef,
+			pe.Metadata.GetOrAddString ("Java.Interop"),
+			pe.Metadata.GetOrAddString ("SafeJavaCollectionFactory"));
+		var memberRefs = new Dictionary<ValueTypeContainerKind, MemberReferenceHandle> ();
+		var specs = new List<MethodSpecificationHandle> (roots.Count);
+		foreach (var root in roots) {
+			if (!memberRefs.TryGetValue (root.Kind, out var memberRef)) {
+				string methodName = root.Kind switch {
+					ValueTypeContainerKind.List => "RegisterValueTypeList",
+					ValueTypeContainerKind.Collection => "RegisterValueTypeCollection",
+					ValueTypeContainerKind.Dictionary => "RegisterValueTypeDictionary",
+					_ => throw new InvalidOperationException ($"Unsupported value-type container kind '{root.Kind}'."),
+				};
+				memberRef = AddGenericRegistrationMethodRef (pe, factoryRef, methodName, root.TypeArguments.Count);
+				memberRefs.Add (root.Kind, memberRef);
+			}
+			specs.Add (MakeGenericMethodSpec (pe, memberRef, root.TypeArguments));
+		}
+		return specs;
+	}
+
+	static MemberReferenceHandle AddGenericRegistrationMethodRef (
+		PEAssemblyBuilder pe,
+		EntityHandle factoryRef,
+		string methodName,
+		int genericArity)
+	{
+		var blob = new BlobBuilder (8);
+		blob.WriteByte ((byte) SignatureAttributes.Generic);
+		blob.WriteCompressedInteger (genericArity);
+		blob.WriteCompressedInteger (0);
+		blob.WriteByte ((byte) SignatureTypeCode.Void);
+		return pe.Metadata.AddMemberReference (
+			factoryRef,
+			pe.Metadata.GetOrAddString (methodName),
+			pe.Metadata.GetOrAddBlob (blob));
+	}
+
+	static MethodSpecificationHandle MakeGenericMethodSpec (
+		PEAssemblyBuilder pe,
+		MemberReferenceHandle openMethodRef,
+		IReadOnlyList<TypeRefData> typeArguments)
+	{
+		var blob = new BlobBuilder (32);
+		blob.WriteByte ((byte) SignatureKind.MethodSpecification);
+		blob.WriteCompressedInteger (typeArguments.Count);
+		foreach (var argument in typeArguments) {
+			pe.WriteTypeSignature (blob, argument);
+		}
+		return pe.Metadata.AddMethodSpecification (openMethodRef, pe.Metadata.GetOrAddBlob (blob));
+	}
+
+	static void EmitValueTypeContainerRegistrations (
+		TrackedInstructionEncoder encoder,
+		IReadOnlyList<MethodSpecificationHandle> registrationSpecs)
+	{
+		foreach (var registrationSpec in registrationSpecs) {
+			encoder.Call (registrationSpec, parameterCount: 0);
+		}
+	}
+
+	static void AddTypeAssemblyAccessTargets (TypeRefData type, List<string> accessTargets)
+	{
+		if (!string.Equals (type.AssemblyName, "System.Runtime", StringComparison.Ordinal) &&
+				!accessTargets.Exists (name => string.Equals (name, type.AssemblyName, StringComparison.Ordinal))) {
+			accessTargets.Add (type.AssemblyName);
+		}
+		foreach (var argument in type.GenericArguments) {
+			AddTypeAssemblyAccessTargets (argument, accessTargets);
+		}
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -33,6 +33,8 @@ sealed class AssemblyIndex : IDisposable
 	public string AssemblyPath { get; }
 	internal TypeRefSignatureTypeProvider TypeRefSignatureProvider { get; }
 
+	internal MethodBodyBlock GetMethodBody (int relativeVirtualAddress) => peReader.GetMethodBody (relativeVirtualAddress);
+
 	/// <summary>
 	/// Maps full managed type name (e.g., "Android.App.Activity") to its TypeDefinitionHandle.
 	/// </summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/ValueTypeContainerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/ValueTypeContainerScanner.cs
@@ -1,0 +1,665 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+enum ValueTypeContainerKind
+{
+	List,
+	Collection,
+	Dictionary,
+}
+
+sealed record ValueTypeContainerRoot
+{
+	public required ValueTypeContainerKind Kind { get; init; }
+	public required IReadOnlyList<TypeRefData> TypeArguments { get; init; }
+
+	public string DisplayName => $"{Kind}<{string.Join (",", TypeArguments.Select (t => t.DisplayName))}>";
+}
+
+sealed class MethodScanTraversal
+{
+	public HashSet<string> ActiveDefinitions { get; } = new (StringComparer.Ordinal);
+	public HashSet<string> ScannedInstances { get; } = new (StringComparer.Ordinal);
+}
+
+static class ValueTypeContainerScanner
+{
+	static readonly Dictionary<ushort, OperandType> OperandTypes = CreateOperandTypes ();
+
+	public static List<ValueTypeContainerRoot> Scan (
+		IReadOnlyList<AssemblyInput> assemblies,
+		HashSet<string> frameworkAssemblyNames)
+	{
+		var roots = new SortedDictionary<string, ValueTypeContainerRoot> (StringComparer.Ordinal);
+		var indexes = new List<AssemblyIndex> ();
+		var indexesByAssembly = new Dictionary<string, AssemblyIndex> (StringComparer.OrdinalIgnoreCase);
+		foreach (var assembly in assemblies) {
+			if (frameworkAssemblyNames.Contains (assembly.Name)) {
+				continue;
+			}
+
+			var index = AssemblyIndex.Create (assembly.Reader, assembly.Name, assembly.Path);
+			indexes.Add (index);
+			indexesByAssembly [assembly.Name] = index;
+		}
+		var traversal = new MethodScanTraversal ();
+		try {
+			foreach (var index in indexes) {
+				ScanAssembly (index, indexesByAssembly, roots, traversal);
+			}
+		} finally {
+			foreach (var index in indexes) {
+				index.Dispose ();
+			}
+		}
+		return roots.Values.ToList ();
+	}
+
+	static void ScanAssembly (
+		AssemblyIndex index,
+		IReadOnlyDictionary<string, AssemblyIndex> indexesByAssembly,
+		SortedDictionary<string, ValueTypeContainerRoot> roots,
+		MethodScanTraversal traversal)
+	{
+		var reader = index.Reader;
+		foreach (var typeHandle in reader.TypeDefinitions) {
+			var type = reader.GetTypeDefinition (typeHandle);
+			foreach (var fieldHandle in type.GetFields ()) {
+				AddType (reader.GetFieldDefinition (fieldHandle).DecodeSignature (index.TypeRefSignatureProvider, index), roots);
+			}
+			foreach (var methodHandle in type.GetMethods ()) {
+				AddMethodDefinition (methodHandle, index, indexesByAssembly, roots, [], [], traversal);
+			}
+			foreach (var propertyHandle in type.GetProperties ()) {
+				var signature = reader.GetPropertyDefinition (propertyHandle).DecodeSignature (index.TypeRefSignatureProvider, index);
+				AddMethodSignature (signature, roots, [], []);
+			}
+		}
+
+		int memberReferenceCount = reader.GetTableRowCount (TableIndex.MemberRef);
+		for (int row = 1; row <= memberReferenceCount; row++) {
+			AddMemberReference (
+				reader.GetMemberReference (MetadataTokens.MemberReferenceHandle (row)),
+				index,
+				indexesByAssembly,
+				roots,
+				[],
+				[],
+				[],
+				traversal);
+		}
+
+		int methodSpecificationCount = reader.GetTableRowCount (TableIndex.MethodSpec);
+		for (int row = 1; row <= methodSpecificationCount; row++) {
+			AddMethodSpecification (
+				reader.GetMethodSpecification (MetadataTokens.MethodSpecificationHandle (row)),
+				index,
+				indexesByAssembly,
+				roots,
+				[],
+				[],
+				traversal);
+		}
+	}
+
+	static void AddMethodDefinition (
+		MethodDefinitionHandle methodHandle,
+		AssemblyIndex index,
+		IReadOnlyDictionary<string, AssemblyIndex> indexesByAssembly,
+		SortedDictionary<string, ValueTypeContainerRoot> roots,
+		IReadOnlyList<TypeRefData> typeArguments,
+		IReadOnlyList<TypeRefData> methodArguments,
+		MethodScanTraversal traversal)
+	{
+		var instanceKey = GetMethodInstanceKey (index, methodHandle, typeArguments, methodArguments);
+		if (!traversal.ScannedInstances.Add (instanceKey)) {
+			return;
+		}
+		var method = index.Reader.GetMethodDefinition (methodHandle);
+		AddMethodSignature (
+			method.DecodeSignature (index.TypeRefSignatureProvider, index),
+			roots,
+			typeArguments,
+			methodArguments);
+		var definitionKey = $"{index.AssemblyName}:{MetadataTokens.GetRowNumber (methodHandle)}";
+		if (!traversal.ActiveDefinitions.Add (definitionKey)) {
+			AddMethodBody (
+				method,
+				index,
+				indexesByAssembly,
+				roots,
+				typeArguments,
+				methodArguments,
+				traversal,
+				followMethodCalls: false);
+			return;
+		}
+		try {
+			AddMethodBody (
+				method,
+				index,
+				indexesByAssembly,
+				roots,
+				typeArguments,
+				methodArguments,
+				traversal,
+				followMethodCalls: true);
+		} finally {
+			traversal.ActiveDefinitions.Remove (definitionKey);
+		}
+	}
+
+	static void AddMethodBody (
+		MethodDefinition method,
+		AssemblyIndex index,
+		IReadOnlyDictionary<string, AssemblyIndex> indexesByAssembly,
+		SortedDictionary<string, ValueTypeContainerRoot> roots,
+		IReadOnlyList<TypeRefData> typeArguments,
+		IReadOnlyList<TypeRefData> methodArguments,
+		MethodScanTraversal traversal,
+		bool followMethodCalls)
+	{
+		if (method.RelativeVirtualAddress == 0 ||
+				(method.ImplAttributes & MethodImplAttributes.CodeTypeMask) != MethodImplAttributes.IL) {
+			return;
+		}
+
+		var body = index.GetMethodBody (method.RelativeVirtualAddress);
+		if (!body.LocalSignature.IsNil) {
+			var locals = index.Reader.GetStandaloneSignature (body.LocalSignature)
+				.DecodeLocalSignature (index.TypeRefSignatureProvider, index);
+			foreach (var local in locals) {
+				AddType (SubstituteGenericParameters (local, typeArguments, methodArguments), roots);
+			}
+		}
+		var il = body.GetILBytes ();
+		if (il is not null) {
+			AddIlUsages (il, index, indexesByAssembly, roots, typeArguments, methodArguments, traversal, followMethodCalls);
+		}
+	}
+
+	static void AddMemberReference (
+		MemberReference memberReference,
+		AssemblyIndex index,
+		IReadOnlyDictionary<string, AssemblyIndex> indexesByAssembly,
+		SortedDictionary<string, ValueTypeContainerRoot> roots,
+		IReadOnlyList<TypeRefData> callerTypeArguments,
+		IReadOnlyList<TypeRefData> callerMethodArguments,
+		IReadOnlyList<TypeRefData> referencedMethodArguments,
+		MethodScanTraversal traversal)
+	{
+		IReadOnlyList<TypeRefData> referencedTypeArguments = callerTypeArguments;
+		if (memberReference.Parent.Kind == HandleKind.TypeSpecification) {
+			var parent = index.Reader.GetTypeSpecification ((TypeSpecificationHandle) memberReference.Parent)
+				.DecodeSignature (index.TypeRefSignatureProvider, index);
+			parent = SubstituteGenericParameters (parent, callerTypeArguments, callerMethodArguments);
+			referencedTypeArguments = parent.GenericArguments;
+		}
+
+		if (memberReference.GetKind () == MemberReferenceKind.Field) {
+			var fieldType = memberReference.DecodeFieldSignature (index.TypeRefSignatureProvider, index);
+			AddType (SubstituteGenericParameters (fieldType, referencedTypeArguments, referencedMethodArguments), roots);
+			return;
+		}
+
+		var signature = memberReference.DecodeMethodSignature (index.TypeRefSignatureProvider, index);
+		AddMethodSignature (
+			signature,
+			roots,
+			referencedTypeArguments,
+			referencedMethodArguments);
+		AddLocalMemberReferenceBodies (
+			memberReference,
+			signature,
+			index,
+			indexesByAssembly,
+			roots,
+			referencedTypeArguments,
+			referencedMethodArguments,
+			traversal);
+	}
+
+	static void AddMethodSpecification (
+		MethodSpecification specification,
+		AssemblyIndex index,
+		IReadOnlyDictionary<string, AssemblyIndex> indexesByAssembly,
+		SortedDictionary<string, ValueTypeContainerRoot> roots,
+		IReadOnlyList<TypeRefData> callerTypeArguments,
+		IReadOnlyList<TypeRefData> callerMethodArguments,
+		MethodScanTraversal traversal)
+	{
+		var methodArguments = specification.DecodeSignature (index.TypeRefSignatureProvider, index)
+			.Select (argument => SubstituteGenericParameters (argument, callerTypeArguments, callerMethodArguments))
+			.ToArray ();
+		foreach (var argument in methodArguments) {
+			AddType (argument, roots);
+		}
+
+		if (specification.Method.Kind == HandleKind.MethodDefinition) {
+			AddMethodDefinition (
+				(MethodDefinitionHandle) specification.Method,
+				index,
+				indexesByAssembly,
+				roots,
+				callerTypeArguments,
+				methodArguments,
+				traversal);
+		} else if (specification.Method.Kind == HandleKind.MemberReference) {
+			AddMemberReference (
+				index.Reader.GetMemberReference ((MemberReferenceHandle) specification.Method),
+				index,
+				indexesByAssembly,
+				roots,
+				callerTypeArguments,
+				callerMethodArguments,
+				methodArguments,
+				traversal);
+		}
+	}
+
+	static void AddLocalMemberReferenceBodies (
+		MemberReference memberReference,
+		MethodSignature<TypeRefData> memberSignature,
+		AssemblyIndex index,
+		IReadOnlyDictionary<string, AssemblyIndex> indexesByAssembly,
+		SortedDictionary<string, ValueTypeContainerRoot> roots,
+		IReadOnlyList<TypeRefData> typeArguments,
+		IReadOnlyList<TypeRefData> methodArguments,
+		MethodScanTraversal traversal)
+	{
+		if (!TryGetDeclaringType (
+				memberReference.Parent,
+				index,
+				indexesByAssembly,
+				out var declaringIndex,
+				out var declaringTypeHandle)) {
+			return;
+		}
+
+		var methodName = index.Reader.GetString (memberReference.Name);
+		var declaringType = declaringIndex.Reader.GetTypeDefinition (declaringTypeHandle);
+		foreach (var methodHandle in declaringType.GetMethods ()) {
+			var method = declaringIndex.Reader.GetMethodDefinition (methodHandle);
+			if (declaringIndex.Reader.GetString (method.Name) == ".cctor") {
+				AddMethodDefinition (
+					methodHandle,
+					declaringIndex,
+					indexesByAssembly,
+					roots,
+					typeArguments,
+					[],
+					traversal);
+			}
+		}
+		foreach (var methodHandle in declaringType.GetMethods ()) {
+			var method = declaringIndex.Reader.GetMethodDefinition (methodHandle);
+			if (declaringIndex.Reader.GetString (method.Name) != methodName ||
+					method.GetGenericParameters ().Count != memberSignature.GenericParameterCount) {
+				continue;
+			}
+			var signature = method.DecodeSignature (declaringIndex.TypeRefSignatureProvider, declaringIndex);
+			if (!HaveSameClosedSignature (memberSignature, signature, typeArguments, methodArguments)) {
+				continue;
+			}
+			AddMethodDefinition (
+				methodHandle,
+				declaringIndex,
+				indexesByAssembly,
+				roots,
+				typeArguments,
+				methodArguments,
+				traversal);
+		}
+	}
+
+	static bool HaveSameClosedSignature (
+		MethodSignature<TypeRefData> memberSignature,
+		MethodSignature<TypeRefData> definitionSignature,
+		IReadOnlyList<TypeRefData> typeArguments,
+		IReadOnlyList<TypeRefData> methodArguments)
+	{
+		if (memberSignature.ParameterTypes.Length != definitionSignature.ParameterTypes.Length ||
+				!SubstituteGenericParameters (memberSignature.ReturnType, typeArguments, methodArguments).Equals (
+					SubstituteGenericParameters (definitionSignature.ReturnType, typeArguments, methodArguments))) {
+			return false;
+		}
+		for (int i = 0; i < memberSignature.ParameterTypes.Length; i++) {
+			if (!SubstituteGenericParameters (memberSignature.ParameterTypes [i], typeArguments, methodArguments).Equals (
+					SubstituteGenericParameters (definitionSignature.ParameterTypes [i], typeArguments, methodArguments))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	static bool TryGetDeclaringType (
+		EntityHandle parentHandle,
+		AssemblyIndex index,
+		IReadOnlyDictionary<string, AssemblyIndex> indexesByAssembly,
+		out AssemblyIndex declaringIndex,
+		out TypeDefinitionHandle declaringTypeHandle)
+	{
+		if (parentHandle.Kind == HandleKind.TypeDefinition) {
+			declaringIndex = index;
+			declaringTypeHandle = (TypeDefinitionHandle) parentHandle;
+			return true;
+		}
+
+		TypeRefData? parent = null;
+		if (parentHandle.Kind == HandleKind.TypeReference) {
+			parent = index.GetTypeRef ((TypeReferenceHandle) parentHandle, rawTypeKind: 0);
+		} else if (parentHandle.Kind == HandleKind.TypeSpecification) {
+			parent = index.Reader.GetTypeSpecification ((TypeSpecificationHandle) parentHandle)
+				.DecodeSignature (index.TypeRefSignatureProvider, index);
+		}
+		if (parent is not null &&
+				indexesByAssembly.TryGetValue (parent.AssemblyName, out declaringIndex) &&
+				declaringIndex.TypesByFullName.TryGetValue (parent.ManagedTypeName, out declaringTypeHandle)) {
+			return true;
+		}
+		declaringIndex = index;
+		declaringTypeHandle = default;
+		return false;
+	}
+
+	static void AddMethodSignature (
+		MethodSignature<TypeRefData> signature,
+		SortedDictionary<string, ValueTypeContainerRoot> roots,
+		IReadOnlyList<TypeRefData> typeArguments,
+		IReadOnlyList<TypeRefData> methodArguments)
+	{
+		AddType (SubstituteGenericParameters (signature.ReturnType, typeArguments, methodArguments), roots);
+		foreach (var parameter in signature.ParameterTypes) {
+			AddType (SubstituteGenericParameters (parameter, typeArguments, methodArguments), roots);
+		}
+	}
+
+	static void AddIlUsages (
+		byte[] il,
+		AssemblyIndex index,
+		IReadOnlyDictionary<string, AssemblyIndex> indexesByAssembly,
+		SortedDictionary<string, ValueTypeContainerRoot> roots,
+		IReadOnlyList<TypeRefData> typeArguments,
+		IReadOnlyList<TypeRefData> methodArguments,
+		MethodScanTraversal traversal,
+		bool followMethodCalls)
+	{
+		for (int offset = 0; offset < il.Length;) {
+			ushort value = il [offset++];
+			if (value == 0xfe) {
+				EnsureRemainingBytes (il, offset, 1);
+				value = (ushort) (0xfe00 | il [offset++]);
+			}
+			if (!OperandTypes.TryGetValue (value, out var operandType)) {
+				throw new BadImageFormatException ($"Unknown IL opcode 0x{value:x4}.");
+			}
+
+			int operandSize = GetOperandSize (operandType, il, offset);
+			EnsureRemainingBytes (il, offset, operandSize);
+			if (operandType == OperandType.InlineType || value == (ushort) OpCodes.Ldtoken.Value) {
+				var handle = MetadataTokens.EntityHandle (BitConverter.ToInt32 (il, offset));
+				if (handle.Kind == HandleKind.TypeSpecification) {
+					var specification = index.Reader.GetTypeSpecification ((TypeSpecificationHandle) handle);
+					var type = specification.DecodeSignature (index.TypeRefSignatureProvider, index);
+					AddType (SubstituteGenericParameters (type, typeArguments, methodArguments), roots);
+				}
+			}
+			if (followMethodCalls && operandType == OperandType.InlineMethod) {
+				var handle = MetadataTokens.EntityHandle (BitConverter.ToInt32 (il, offset));
+				if (handle.Kind == HandleKind.MethodDefinition) {
+					AddMethodDefinition (
+						(MethodDefinitionHandle) handle,
+						index,
+						indexesByAssembly,
+						roots,
+						typeArguments,
+						[],
+						traversal);
+				} else if (handle.Kind == HandleKind.MemberReference) {
+					AddMemberReference (
+						index.Reader.GetMemberReference ((MemberReferenceHandle) handle),
+						index,
+						indexesByAssembly,
+						roots,
+						typeArguments,
+						methodArguments,
+						[],
+						traversal);
+				} else if (handle.Kind == HandleKind.MethodSpecification) {
+					AddMethodSpecification (
+						index.Reader.GetMethodSpecification ((MethodSpecificationHandle) handle),
+						index,
+						indexesByAssembly,
+						roots,
+						typeArguments,
+						methodArguments,
+						traversal);
+				}
+			}
+			offset += operandSize;
+		}
+	}
+
+	static TypeRefData SubstituteGenericParameters (
+		TypeRefData type,
+		IReadOnlyList<TypeRefData> typeArguments,
+		IReadOnlyList<TypeRefData> methodArguments)
+	{
+		if (TryGetArraySuffix (type.ManagedTypeName, out var elementTypeName, out var suffix)) {
+			var elementType = SubstituteGenericParameters (
+				type with { ManagedTypeName = elementTypeName },
+				typeArguments,
+				methodArguments);
+			return elementType with { ManagedTypeName = elementType.ManagedTypeName + suffix };
+		}
+		if (TryGetGenericParameterIndex (type.ManagedTypeName, "!!", out var methodIndex) &&
+				methodIndex < methodArguments.Count) {
+			return methodArguments [methodIndex];
+		}
+		if (TryGetGenericParameterIndex (type.ManagedTypeName, "!", out var typeIndex) &&
+				typeIndex < typeArguments.Count) {
+			return typeArguments [typeIndex];
+		}
+		if (type.GenericArguments.Count == 0) {
+			return type;
+		}
+		return type with {
+			GenericArguments = type.GenericArguments
+				.Select (argument => SubstituteGenericParameters (argument, typeArguments, methodArguments))
+				.ToArray (),
+		};
+	}
+
+	static bool TryGetGenericParameterIndex (string typeName, string prefix, out int index)
+	{
+		if (typeName.StartsWith (prefix, StringComparison.Ordinal) &&
+				int.TryParse (typeName.Substring (prefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out index)) {
+			return true;
+		}
+		index = 0;
+		return false;
+	}
+
+	static int GetOperandSize (OperandType operandType, byte[] il, int operandOffset)
+	{
+		switch (operandType) {
+		case OperandType.InlineNone:
+			return 0;
+		case OperandType.ShortInlineBrTarget:
+		case OperandType.ShortInlineI:
+		case OperandType.ShortInlineVar:
+			return 1;
+		case OperandType.InlineVar:
+			return 2;
+		case OperandType.InlineBrTarget:
+		case OperandType.InlineField:
+		case OperandType.InlineI:
+		case OperandType.InlineMethod:
+		case OperandType.InlineSig:
+		case OperandType.InlineString:
+		case OperandType.InlineTok:
+		case OperandType.InlineType:
+		case OperandType.ShortInlineR:
+			return 4;
+		case OperandType.InlineI8:
+		case OperandType.InlineR:
+			return 8;
+		case OperandType.InlineSwitch:
+			EnsureRemainingBytes (il, operandOffset, 4);
+			int count = BitConverter.ToInt32 (il, operandOffset);
+			if (count < 0 || count > (il.Length - operandOffset - 4) / 4) {
+				throw new BadImageFormatException ("Invalid IL switch operand.");
+			}
+			return 4 + count * 4;
+		default:
+			throw new BadImageFormatException ($"Unsupported IL operand type '{operandType}'.");
+		}
+	}
+
+	static void EnsureRemainingBytes (byte[] il, int offset, int count)
+	{
+		if (offset < 0 || count < 0 || offset > il.Length - count) {
+			throw new BadImageFormatException ("Unexpected end of IL stream.");
+		}
+	}
+
+	static Dictionary<ushort, OperandType> CreateOperandTypes ()
+	{
+		var result = new Dictionary<ushort, OperandType> ();
+		foreach (var field in typeof (OpCodes).GetFields (BindingFlags.Public | BindingFlags.Static)) {
+			if (field.GetValue (null) is OpCode opCode) {
+				result [(ushort) opCode.Value] = opCode.OperandType;
+			}
+		}
+		return result;
+	}
+
+	static string GetMethodInstanceKey (
+		AssemblyIndex index,
+		MethodDefinitionHandle methodHandle,
+		IReadOnlyList<TypeRefData> typeArguments,
+		IReadOnlyList<TypeRefData> methodArguments)
+		=> $"{index.AssemblyName}:{MetadataTokens.GetRowNumber (methodHandle)}:" +
+			$"{string.Join (",", typeArguments.Select (GetTypeKey))}:" +
+			$"{string.Join (",", methodArguments.Select (GetTypeKey))}";
+
+	static void AddType (TypeRefData type, SortedDictionary<string, ValueTypeContainerRoot> roots)
+	{
+		if (TryGetContainerKind (type, out var kind) &&
+				type.GenericArguments.All (IsClosedType) &&
+				type.GenericArguments.Any (IsValueType)) {
+			var root = new ValueTypeContainerRoot {
+				Kind = kind,
+				TypeArguments = type.GenericArguments,
+			};
+			roots [GetRootKey (root)] = root;
+		}
+
+		foreach (var argument in type.GenericArguments) {
+			AddType (argument, roots);
+		}
+	}
+
+	static bool TryGetContainerKind (TypeRefData type, out ValueTypeContainerKind kind)
+	{
+		var managedTypeName = type.ManagedTypeName;
+		while (TryGetArraySuffix (managedTypeName, out var elementTypeName, out _)) {
+			managedTypeName = elementTypeName;
+		}
+		switch (managedTypeName) {
+		case "System.Collections.Generic.IList`1":
+		case "Android.Runtime.JavaList`1":
+			kind = ValueTypeContainerKind.List;
+			return type.GenericArguments.Count == 1;
+		case "System.Collections.Generic.ICollection`1":
+		case "Android.Runtime.JavaCollection`1":
+			kind = ValueTypeContainerKind.Collection;
+			return type.GenericArguments.Count == 1;
+		case "System.Collections.Generic.IDictionary`2":
+		case "Android.Runtime.JavaDictionary`2":
+			kind = ValueTypeContainerKind.Dictionary;
+			return type.GenericArguments.Count == 2;
+		default:
+			kind = default;
+			return false;
+		}
+	}
+
+	static bool IsClosedType (TypeRefData type)
+	{
+		if (type.ManagedTypeName.StartsWith ("!", StringComparison.Ordinal)) {
+			return false;
+		}
+		return type.GenericArguments.All (IsClosedType);
+	}
+
+	static bool IsValueType (TypeRefData type)
+	{
+		if (TryGetArraySuffix (type.ManagedTypeName, out _, out _)) {
+			return false;
+		}
+		if (type.EncodeAsValueType) {
+			return true;
+		}
+		return type.ManagedTypeName switch {
+			"System.Boolean" or
+			"System.Byte" or
+			"System.Char" or
+			"System.Decimal" or
+			"System.Double" or
+			"System.Half" or
+			"System.Int16" or
+			"System.Int32" or
+			"System.Int64" or
+			"System.Int128" or
+			"System.IntPtr" or
+			"System.SByte" or
+			"System.Single" or
+			"System.UInt16" or
+			"System.UInt32" or
+			"System.UInt64" or
+			"System.UInt128" or
+			"System.UIntPtr" => true,
+			_ => false,
+		};
+	}
+
+	static bool TryGetArraySuffix (string typeName, out string elementTypeName, out string suffix)
+	{
+		if (!typeName.EndsWith ("]", StringComparison.Ordinal)) {
+			elementTypeName = "";
+			suffix = "";
+			return false;
+		}
+		int openBracket = typeName.LastIndexOf ('[');
+		if (openBracket < 0) {
+			elementTypeName = "";
+			suffix = "";
+			return false;
+		}
+		for (int i = openBracket + 1; i < typeName.Length - 1; i++) {
+			if (typeName [i] != ',') {
+				elementTypeName = "";
+				suffix = "";
+				return false;
+			}
+		}
+		elementTypeName = typeName.Substring (0, openBracket);
+		suffix = typeName.Substring (openBracket);
+		return true;
+	}
+
+	static string GetRootKey (ValueTypeContainerRoot root)
+		=> $"{root.Kind}:{string.Join ("|", root.TypeArguments.Select (GetTypeKey))}";
+
+	static string GetTypeKey (TypeRefData type)
+		=> $"{type.AssemblyName}:{type.ManagedTypeName}:{type.EncodeAsValueType}<{string.Join (",", type.GenericArguments.Select (GetTypeKey))}>";
+}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -51,6 +51,7 @@ public class TrimmableTypeMapGenerator
 			frameworkAssemblyNames,
 			errorOnCustomJavaObject,
 			collectMarshalMethodsForNonAcw);
+		var valueTypeContainerRoots = ValueTypeContainerScanner.Scan (assemblies, frameworkAssemblyNames);
 		if (allPeers.Count == 0) {
 			logger.LogNoJavaPeerTypesFound ();
 			return new TrimmableTypeMapResult ([], [], allPeers);
@@ -65,7 +66,7 @@ public class TrimmableTypeMapGenerator
 		}
 
 		var generatedAssemblies = generateTypeMapAssemblies
-			? GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion, useSharedTypemapUniverse)
+			? GenerateTypeMapAssemblies (allPeers, valueTypeContainerRoots, systemRuntimeVersion, useSharedTypemapUniverse)
 			: [];
 		var jcwPeers = allPeers.Where (ShouldGenerateJcw).ToList ();
 		logger.LogGeneratingJcwFilesInfo (jcwPeers.Count, allPeers.Count);
@@ -286,6 +287,7 @@ public class TrimmableTypeMapGenerator
 
 	List<GeneratedAssembly> GenerateTypeMapAssemblies (
 		List<JavaPeerInfo> allPeers,
+		IReadOnlyList<ValueTypeContainerRoot> valueTypeContainerRoots,
 		Version systemRuntimeVersion,
 		bool useSharedTypemapUniverse)
 	{
@@ -323,7 +325,7 @@ public class TrimmableTypeMapGenerator
 		}
 		var rootStream = new MemoryStream ();
 		var rootGenerator = new RootTypeMapAssemblyGenerator (systemRuntimeVersion);
-		rootGenerator.Generate (perAssemblyNames, useSharedTypemapUniverse, rootStream);
+		rootGenerator.Generate (perAssemblyNames, valueTypeContainerRoots, useSharedTypemapUniverse, rootStream);
 		rootStream.Position = 0;
 		generatedAssemblies.Add (new GeneratedAssembly ("_Microsoft.Android.TypeMaps", rootStream));
 		logger.LogGeneratedRootTypeMapInfo (perAssemblyNames.Count);

--- a/src/Mono.Android/Java.Interop/SafeArrayFactory.cs
+++ b/src/Mono.Android/Java.Interop/SafeArrayFactory.cs
@@ -12,8 +12,8 @@ static class SafeArrayFactory
 	// and StandardCanonicalizationAlgorithm canonicalizes reference DefTypes and arrays to __Canon.
 	//
 	// Value-type element arrays are different: value types do not collapse to __Canon, so an exact
-	// vector EEType/template must be available. ValueTypeFactory roots typeof(T[]), new T[length],
-	// and the matching Java collection wrapper instantiations in one shared primitive map.
+	// vector EEType/template must be available. ValueTypeFactory roots typeof(T[]) and new T[length]
+	// for the fixed primitive array set. Collection wrappers use generated exact-shape registrations.
 
 	internal static bool TryGetArrayType (Type elementType, int rank, [NotNullWhen (true)] out Type? arrayType)
 	{
@@ -54,7 +54,7 @@ static class SafeArrayFactory
 		if (elementType == null)
 			throw new ArgumentNullException (nameof (elementType));
 
-		if (rank == 1 && ValueTypeFactory.PrimitiveTypeFactories.TryGetValue (elementType, out var factory)) {
+		if (rank == 1 && ValueTypeFactory.PrimitiveArrayFactories.TryGetValue (elementType, out var factory)) {
 			array = factory.CreateArray (length);
 			return true;
 		}
@@ -76,7 +76,7 @@ static class SafeArrayFactory
 	static bool TryGetVectorType (Type elementType, [NotNullWhen (true)] out Type? vectorType)
 	{
 		if (elementType.IsValueType) {
-			if (ValueTypeFactory.PrimitiveTypeFactories.TryGetValue (elementType, out var factory)) {
+			if (ValueTypeFactory.PrimitiveArrayFactories.TryGetValue (elementType, out var factory)) {
 				vectorType = factory.ArrayType;
 				return true;
 			}

--- a/src/Mono.Android/Java.Interop/SafeJavaCollectionFactory.cs
+++ b/src/Mono.Android/Java.Interop/SafeJavaCollectionFactory.cs
@@ -29,14 +29,16 @@ namespace Java.Interop;
 /// <item><description>reference element arguments ride the <c>__Canon</c> template: the wrapper definition is
 /// reflectively closed and its activation constructor invoked, kept alive by a concrete-literal
 /// <c>IJavaPeerable</c> rooting branch in the same method;</description></item>
-/// <item><description>primitive/nullable value-type arguments go through <see cref="ValueTypeFactory"/>,
-/// which roots the exact instantiation with a direct <c>new</c>;</description></item>
-/// <item><description>other value types use the corresponding untyped collection wrapper because
-/// their exact generic instantiations are not rooted.</description></item>
+/// <item><description>closed value-type container uses discovered in application assemblies are registered
+/// by the generated root typemap assembly, which roots and constructs only those exact instantiations;</description></item>
+/// <item><description>unregistered value-type shapes use the corresponding untyped collection wrapper because
+/// NativeAOT cannot construct an exact instantiation that was not present at build time.</description></item>
 /// </list>
 /// </remarks>
 static class SafeJavaCollectionFactory
 {
+	static readonly Dictionary<Type, Func<IntPtr, JniHandleOwnership, object?>> RegisteredValueTypeConverters = new ();
+
 	internal const DynamicallyAccessedMemberTypes Constructors =
 		DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
@@ -57,6 +59,10 @@ static class SafeJavaCollectionFactory
 			return false;
 		}
 
+		if (RegisteredValueTypeConverters.TryGetValue (targetType, out converter)) {
+			return true;
+		}
+
 		if (targetType.IsGenericType && !targetType.IsGenericTypeDefinition) {
 			var genericDefinition = targetType.GetGenericTypeDefinition ();
 			if (IsKnownContainerDefinition (genericDefinition)) {
@@ -66,11 +72,7 @@ static class SafeJavaCollectionFactory
 				if (genericDefinition == typeof (IList<>) || genericDefinition == typeof (JavaList<>)) {
 					var elementType = arguments [0];
 					if (elementType.IsValueType) {
-						if (!ValueTypeFactory.PrimitiveTypeFactories.TryGetValue (elementType, out var listFactory)) {
-							converter = GetUntypedFromJniHandleConverter (genericDefinition);
-							return true;
-						}
-						converter = (handle, transfer) => handle == IntPtr.Zero ? null : listFactory.CreateList (handle, transfer);
+						converter = GetUntypedFromJniHandleConverter (genericDefinition);
 						return true;
 					}
 					converter = (handle, transfer) => CreateReferenceListFromJniHandle (elementType, handle, transfer);
@@ -80,11 +82,7 @@ static class SafeJavaCollectionFactory
 				if (genericDefinition == typeof (ICollection<>) || genericDefinition == typeof (JavaCollection<>)) {
 					var elementType = arguments [0];
 					if (elementType.IsValueType) {
-						if (!ValueTypeFactory.PrimitiveTypeFactories.TryGetValue (elementType, out var collectionFactory)) {
-							converter = GetUntypedFromJniHandleConverter (genericDefinition);
-							return true;
-						}
-						converter = (handle, transfer) => handle == IntPtr.Zero ? null : collectionFactory.CreateCollection (handle, transfer);
+						converter = GetUntypedFromJniHandleConverter (genericDefinition);
 						return true;
 					}
 					converter = (handle, transfer) => CreateReferenceCollectionFromJniHandle (elementType, handle, transfer);
@@ -93,21 +91,8 @@ static class SafeJavaCollectionFactory
 
 				var keyType = arguments [0];
 				var valueType = arguments [1];
-				ValueTypeFactory? keyFactory = null;
-				ValueTypeFactory? valueFactory = null;
-				if ((keyType.IsValueType && !ValueTypeFactory.PrimitiveTypeFactories.TryGetValue (keyType, out keyFactory))
-						|| (valueType.IsValueType && !ValueTypeFactory.PrimitiveTypeFactories.TryGetValue (valueType, out valueFactory))) {
+				if (keyType.IsValueType || valueType.IsValueType) {
 					converter = GetUntypedFromJniHandleConverter (genericDefinition);
-					return true;
-				}
-				if (keyFactory != null) {
-					converter = valueFactory != null
-						? (handle, transfer) => handle == IntPtr.Zero ? null : keyFactory.CreateDictionary (valueFactory, handle, transfer)
-						: (handle, transfer) => handle == IntPtr.Zero ? null : keyFactory.CreateDictionaryWithReferenceValue (valueType, handle, transfer);
-					return true;
-				}
-				if (valueFactory != null) {
-					converter = (handle, transfer) => handle == IntPtr.Zero ? null : valueFactory.CreateDictionaryWithReferenceKey (keyType, handle, transfer);
 					return true;
 				}
 				converter = (handle, transfer) => CreateReferenceDictionaryFromJniHandle (keyType, valueType, handle, transfer);
@@ -118,6 +103,37 @@ static class SafeJavaCollectionFactory
 		converter = null;
 		return false;
 	}
+
+	internal static void RegisterValueTypeList<[DynamicallyAccessedMembers (Constructors)] T> ()
+	{
+		RegisteredValueTypeConverters [typeof (IList<T>)] = CreateValueTypeList<T>;
+		RegisteredValueTypeConverters [typeof (JavaList<T>)] = CreateValueTypeList<T>;
+	}
+
+	internal static void RegisterValueTypeCollection<[DynamicallyAccessedMembers (Constructors)] T> ()
+	{
+		RegisteredValueTypeConverters [typeof (ICollection<T>)] = CreateValueTypeCollection<T>;
+		RegisteredValueTypeConverters [typeof (JavaCollection<T>)] = CreateValueTypeCollection<T>;
+	}
+
+	internal static void RegisterValueTypeDictionary<
+		[DynamicallyAccessedMembers (Constructors)] TKey,
+		[DynamicallyAccessedMembers (Constructors)] TValue> ()
+	{
+		RegisteredValueTypeConverters [typeof (IDictionary<TKey, TValue>)] = CreateValueTypeDictionary<TKey, TValue>;
+		RegisteredValueTypeConverters [typeof (JavaDictionary<TKey, TValue>)] = CreateValueTypeDictionary<TKey, TValue>;
+	}
+
+	static object? CreateValueTypeList<[DynamicallyAccessedMembers (Constructors)] T> (IntPtr handle, JniHandleOwnership transfer)
+		=> handle == IntPtr.Zero ? null : new JavaList<T> (handle, transfer);
+
+	static object? CreateValueTypeCollection<[DynamicallyAccessedMembers (Constructors)] T> (IntPtr handle, JniHandleOwnership transfer)
+		=> handle == IntPtr.Zero ? null : new JavaCollection<T> (handle, transfer);
+
+	static object? CreateValueTypeDictionary<
+		[DynamicallyAccessedMembers (Constructors)] TKey,
+		[DynamicallyAccessedMembers (Constructors)] TValue> (IntPtr handle, JniHandleOwnership transfer)
+		=> handle == IntPtr.Zero ? null : new JavaDictionary<TKey, TValue> (handle, transfer);
 
 	static bool IsKnownContainerDefinition (Type genericDefinition)
 		=> genericDefinition == typeof (IList<>) || genericDefinition == typeof (JavaList<>)
@@ -209,7 +225,8 @@ static class SafeJavaCollectionFactory
 		Justification = "IL2071 fires because MakeGenericType () cannot statically prove the runtime keyType/valueType satisfy the DynamicallyAccessedMembers(Constructors) " +
 			"requirement that JavaDictionary<[DAM(Constructors)] TKey, [DAM(Constructors)] TValue> places on its element parameters. That requirement exists only for the " +
 			"dynamic-code path, where the wrapper reflectively activates key/value peers from their constructors. On the trimmable typemap path the wrapper never activates its " +
-			"elements — element peer creation goes through JavaConvert and the typemap's registered activation constructors — so the unsatisfied element requirement is never exercised.")]
+			"elements — element peer creation goes through JavaConvert and the typemap's registered activation constructors — so the unsatisfied element requirement is never " +
+			"exercised.")]
 	[UnconditionalSuppressMessage ("Trimming", "IL2072:UnrecognizedReflectionPattern",
 		Justification = "The dynamically constructed JavaDictionary<keyType,valueType> rides the JavaDictionary<IJavaPeerable,IJavaPeerable> canonical template whose activation " +
 			"constructor is rooted by the concrete-literal branch. Only the known JavaDictionary<TKey,TValue> activation constructor is invoked here.")]

--- a/src/Mono.Android/Java.Interop/ValueTypeFactory.cs
+++ b/src/Mono.Android/Java.Interop/ValueTypeFactory.cs
@@ -1,13 +1,6 @@
 #nullable enable
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Reflection;
-
-using Android.Runtime;
 
 namespace Java.Interop;
 
@@ -15,11 +8,11 @@ abstract class ValueTypeFactory
 {
 	// NativeAOT's MakeGenericType() and MakeArrayType() paths use canonical templates.
 	// Reference types collapse to __Canon, but value types stay value-specific. This map
-	// intentionally roots each primitive/nullable value shape through direct typeof(T), typeof(T[]),
-	// new T[length], and Java collection wrapper constructor references.
+	// intentionally roots each primitive/nullable array shape through direct typeof(T), typeof(T[]),
+	// and new T[length]. Collection wrappers are rooted separately from generated app-specific usage.
 	// `byte` is included alongside `sbyte` (both marshal to java.lang.Byte bitwise) so that
 	// byte-element collections keep working on the trimmable path, matching the reflection paths.
-	internal static readonly Dictionary<Type, ValueTypeFactory> PrimitiveTypeFactories = new () {
+	internal static readonly Dictionary<Type, ValueTypeFactory> PrimitiveArrayFactories = new () {
 		{ typeof (bool),    new ValueTypeFactory<bool> () },
 		{ typeof (byte),    new ValueTypeFactory<byte> () },
 		{ typeof (sbyte),   new ValueTypeFactory<sbyte> () },
@@ -45,24 +38,9 @@ abstract class ValueTypeFactory
 	public abstract Type ArrayType { get; }
 
 	public abstract Array CreateArray (int length);
-
-	internal abstract IList CreateList (IntPtr handle, JniHandleOwnership transfer);
-
-	internal abstract ICollection CreateCollection (IntPtr handle, JniHandleOwnership transfer);
-
-	internal abstract IDictionary CreateDictionary (ValueTypeFactory valueFactory, IntPtr handle, JniHandleOwnership transfer);
-
-	internal abstract IDictionary CreateDictionaryWithReferenceKey (Type keyType, IntPtr handle, JniHandleOwnership transfer);
-
-	internal abstract IDictionary CreateDictionaryWithReferenceValue (Type valueType, IntPtr handle, JniHandleOwnership transfer);
-
-	internal abstract IDictionary CreateDictionaryWithKey<[DynamicallyAccessedMembers (SafeJavaCollectionFactory.Constructors)] TKey> (
-		ValueTypeFactory<TKey> keyFactory,
-		IntPtr handle,
-		JniHandleOwnership transfer);
 }
 
-sealed class ValueTypeFactory<[DynamicallyAccessedMembers (SafeJavaCollectionFactory.Constructors)] T> : ValueTypeFactory
+sealed class ValueTypeFactory<T> : ValueTypeFactory
 {
 	internal ValueTypeFactory ()
 	{
@@ -75,95 +53,5 @@ sealed class ValueTypeFactory<[DynamicallyAccessedMembers (SafeJavaCollectionFac
 	public override Array CreateArray (int length)
 	{
 		return new T [length];
-	}
-
-	internal override IList CreateList (IntPtr handle, JniHandleOwnership transfer)
-	{
-		return new JavaList<T> (handle, transfer);
-	}
-
-	internal override ICollection CreateCollection (IntPtr handle, JniHandleOwnership transfer)
-	{
-		return new JavaCollection<T> (handle, transfer);
-	}
-
-	internal override IDictionary CreateDictionary (ValueTypeFactory valueFactory, IntPtr handle, JniHandleOwnership transfer)
-	{
-		return valueFactory.CreateDictionaryWithKey (this, handle, transfer);
-	}
-
-	internal override IDictionary CreateDictionaryWithReferenceKey (Type keyType, IntPtr handle, JniHandleOwnership transfer)
-	{
-		// JavaDictionary<keyType, T> canonicalizes like JavaDictionary<__Canon, T>; the
-		// JavaDictionary<IJavaPeerable, T> exemplar roots that template with its constructors.
-		return CreateReferenceMixedDictionary<JavaDictionary<IJavaPeerable, T>> ([keyType, typeof (T)], handle, transfer);
-	}
-
-	internal override IDictionary CreateDictionaryWithReferenceValue (Type valueType, IntPtr handle, JniHandleOwnership transfer)
-	{
-		// JavaDictionary<T, valueType> canonicalizes like JavaDictionary<T, __Canon>; the
-		// JavaDictionary<T, IJavaPeerable> exemplar roots that template with its constructors.
-		return CreateReferenceMixedDictionary<JavaDictionary<T, IJavaPeerable>> ([typeof (T), valueType], handle, transfer);
-	}
-
-	/// <summary>
-	/// Builds a mixed reference/value <see cref="JavaDictionary{K,V}"/> whose reference argument rides the
-	/// <c>__Canon</c> template rooted by the <typeparamref name="TExemplar"/> instantiation.
-	/// </summary>
-	/// <typeparam name="TExemplar">
-	/// The <c>JavaDictionary&lt;IJavaPeerable, T&gt;</c> / <c>JavaDictionary&lt;T, IJavaPeerable&gt;</c> exemplar.
-	/// Its <see cref="DynamicallyAccessedMembersAttribute"/> roots the constructors of the canonical
-	/// template that <paramref name="arguments"/> resolves to (the exact-value argument stays value-specific).
-	/// </typeparam>
-	/// <param name="arguments">The <c>[key, value]</c> generic arguments, exactly one of which is a reference type.</param>
-	[UnconditionalSuppressMessage ("AOT", "IL3050:RequiresDynamicCode",
-		Justification = "NativeAOT's Type.MakeGenericType() and Activator.CreateInstance() are annotated because arbitrary constructed generics can lack a runtime template. " +
-			"This helper only closes JavaDictionary<,> over one reference argument and the mapped value type T. " +
-			"The reference argument canonicalizes to __Canon and T stays value-specific, so the result shares the JavaDictionary<IJavaPeerable, T> / JavaDictionary<T, IJavaPeerable> " +
-			"template that TExemplar already roots.")]
-	[UnconditionalSuppressMessage ("Trimming", "IL2055:MakeGenericType",
-		Justification = "IL2055 is raised because the runtime key/value arguments cannot be statically proven to satisfy the DynamicallyAccessedMembers(Constructors) " +
-			"requirement that JavaDictionary<[DAM(Constructors)] TKey, [DAM(Constructors)] TValue> places on its element type parameters. That requirement exists for the " +
-			"dynamic-code path, where the wrapper reflectively activates key/value peers from their constructors. On the trimmable typemap path taken here the wrapper never " +
-			"activates its elements: element peer creation goes through JavaConvert and the typemap's registered activation constructors, so the unmet element requirement is " +
-			"never exercised. The wrapper's own constructor is separately rooted by the DynamicallyAccessedMembers(Constructors) annotation on TExemplar.")]
-	[UnconditionalSuppressMessage ("Trimming", "IL2072:UnrecognizedReflectionPattern",
-		Justification = "The constructed dictionary type rides the TExemplar canonical template whose constructors are rooted by DynamicallyAccessedMembers(Constructors). " +
-			"Only the known JavaDictionary<TKey,TValue> constructor is invoked here.")]
-	static IDictionary CreateReferenceMixedDictionary<[DynamicallyAccessedMembers (SafeJavaCollectionFactory.Constructors)] TExemplar> (
-		Type[] arguments,
-		IntPtr handle,
-		JniHandleOwnership transfer)
-	{
-		var exemplarType = typeof (TExemplar);
-		Debug.Assert (exemplarType.IsGenericType && !exemplarType.IsGenericTypeDefinition);
-
-		var definition = exemplarType.GetGenericTypeDefinition ();
-		var dictionaryType = definition.MakeGenericType (arguments);
-		var instance = Activator.CreateInstance (
-			dictionaryType,
-			SafeJavaCollectionFactory.ActivationConstructorBinding,
-			binder: null,
-			args: [handle, transfer],
-			culture: CultureInfo.InvariantCulture);
-		if (instance == null) {
-			throw new InvalidOperationException ($"Unable to create an instance of collection type '{dictionaryType}'.");
-		}
-		return (IDictionary) instance;
-	}
-
-	internal override IDictionary CreateDictionaryWithKey<[DynamicallyAccessedMembers (SafeJavaCollectionFactory.Constructors)] TKey> (
-		ValueTypeFactory<TKey> keyFactory,
-		IntPtr handle,
-		JniHandleOwnership transfer)
-	{
-		// Value/value dictionaries need no dedicated rooting token (unlike the mixed reference/value
-		// cases): the full JavaDictionary<TKey, T> cross-product is statically rooted by NativeAOT.
-		// Every ValueTypeFactory<X> is constructed in PrimitiveTypeFactories, CreateDictionary is a
-		// virtual call reachable for all of them (so CreateDictionaryWithKey<X> is instantiated for
-		// every key type X), and this override is a generic virtual method — so NativeAOT's GVM
-		// dependency analysis emits ValueTypeFactory<Y>.CreateDictionaryWithKey<X> (hence
-		// new JavaDictionary<X, Y>()) for every (X, Y) pair in the fixed primitive/nullable set.
-		return new JavaDictionary<TKey, T> (handle, transfer);
 	}
 }

--- a/tests/MSBuildDeviceIntegration/Resources/ValueTypeContainerApp/MainActivity.cs
+++ b/tests/MSBuildDeviceIntegration/Resources/ValueTypeContainerApp/MainActivity.cs
@@ -1,0 +1,554 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+using Android.App;
+using Android.OS;
+using Android.Runtime;
+using Android.Util;
+
+using Java.Interop;
+
+namespace ${ROOT_NAMESPACE}
+{
+	[Register ("${JAVA_PACKAGENAME}.MainActivity"), Activity (Label = "${PROJECT_NAME}", MainLauncher = true)]
+	public class MainActivity : Activity
+	{
+		const string ResultPrefix = "VALUE_TYPE_CONTAINER_RESULT";
+		const string Tag = "ValueTypeContainers";
+
+		public MainActivity ()
+		{
+		}
+
+		public MainActivity (IntPtr handle, JniHandleOwnership ownership)
+			: base (handle, ownership)
+		{
+		}
+
+		protected override void OnCreate (Bundle savedInstanceState)
+		{
+			base.OnCreate (savedInstanceState);
+
+			int passed = 0;
+			try {
+				JavaList_NullablePrimitivePreservesNullAndDefault ();
+				passed++;
+				JavaList_UserStructSupportsOperationsAndRoundTrip ();
+				passed++;
+				JavaCollection_NonIntEnumSupportsOperationsAndRoundTrip ();
+				passed++;
+				JavaList_NullableEnumPreservesNullAndDefault ();
+				passed++;
+				JavaObjectArray_NullableUserStructPreservesNullAndDefault ();
+				passed++;
+				JavaDictionary_UserStructKeysSupportOperationsAndRoundTrip ();
+				passed++;
+				JavaDictionary_EnumValuesSupportOperationsAndRoundTrip ();
+				passed++;
+				JavaDictionary_UserStructKeysAndEnumValuesSupportOperationsAndRoundTrip ();
+				passed++;
+				JavaDictionary_NullableValueTypesPreserveNullAndDefault ();
+				passed++;
+				Log.Info (Tag, $"{ResultPrefix} PASS {passed}/9");
+			} catch (Exception e) {
+				Log.Error (Tag, $"{ResultPrefix} FAIL {passed}/9: {e}");
+			} finally {
+				Finish ();
+			}
+		}
+
+		static void JavaList_NullablePrimitivePreservesNullAndDefault ()
+		{
+			using var holder = new RawValueTypeContainerHolder ();
+			var list = holder.CreateNullableIntList ();
+			try {
+				AssertWrapperType (list, typeof (JavaList<>), typeof (int?));
+				list.Add (17);
+				list.Add (0);
+				list.Add (null);
+				AssertEqual (3, list.Count, "nullable primitive list count");
+				AssertEqual ((int?) 17, list [0], "nullable primitive value");
+				AssertEqual ((int?) 0, list [1], "nullable primitive default");
+				AssertNull (list [2], "nullable primitive null");
+				AssertTrue (list.Contains (null), "nullable primitive list contains null");
+				AssertTrue (list.Remove (0), "nullable primitive list removes default");
+
+				var roundTrip = holder.RoundTripNullableIntList (list);
+				try {
+					AssertWrapperType (roundTrip, typeof (JavaList<>), typeof (int?));
+					AssertSameJavaObject (list, roundTrip);
+					AssertEqual ((int?) 17, roundTrip [0], "round-tripped nullable primitive");
+				} finally {
+					DisposeIfDistinct (list, roundTrip);
+				}
+			} finally {
+				DisposeJavaObject (list);
+			}
+		}
+
+		static void JavaList_UserStructSupportsOperationsAndRoundTrip ()
+		{
+			using var holder = new RawValueTypeContainerHolder ();
+			var list = holder.CreateStructList ();
+			try {
+				AssertWrapperType (list, typeof (JavaList<>), typeof (AppValue));
+				var first = new AppValue (11, 111);
+				var second = new AppValue (22, 222);
+				list.Add (first);
+				list.Add (default);
+				list.Add (second);
+				AssertEqual (3, list.Count, "struct list count");
+				AssertEqual (first, list [0], "struct list first");
+				AssertEqual (default (AppValue), list [1], "struct list default");
+				AssertSequence ([first, default, second], list, "struct list enumeration");
+
+				var roundTrip = holder.RoundTripStructList (list);
+				try {
+					AssertWrapperType (roundTrip, typeof (JavaList<>), typeof (AppValue));
+					AssertSameJavaObject (list, roundTrip);
+					AssertEqual (second, roundTrip [2], "round-tripped struct");
+				} finally {
+					DisposeIfDistinct (list, roundTrip);
+				}
+
+				// Value proxies are distinct Java objects in the llvm-ir contract, so equality-based
+				// Contains/Remove cannot find a separately boxed struct. Index-based removal is supported.
+				list.RemoveAt (0);
+				AssertSequence ([default, second], list, "struct list after indexed remove");
+			} finally {
+				DisposeJavaObject (list);
+			}
+		}
+
+		static void JavaCollection_NonIntEnumSupportsOperationsAndRoundTrip ()
+		{
+			using var holder = new RawValueTypeContainerHolder ();
+			var collection = holder.CreateEnumCollection ();
+			try {
+				AssertWrapperType (collection, typeof (JavaCollection<>), typeof (AppState));
+				collection.Add (AppState.Ready);
+				collection.Add (default);
+				AssertEqual (2, collection.Count, "enum collection count");
+				AssertSequence ([AppState.Ready, default], collection, "enum collection enumeration");
+
+				var roundTrip = holder.RoundTripEnumCollection (collection);
+				try {
+					AssertWrapperType (roundTrip, typeof (JavaCollection<>), typeof (AppState));
+					AssertSameJavaObject (collection, roundTrip);
+					AssertSequence ([AppState.Ready, default], roundTrip, "round-tripped enum collection");
+				} finally {
+					DisposeIfDistinct (collection, roundTrip);
+				}
+
+				collection.Clear ();
+				AssertEqual (0, collection.Count, "enum collection count after clear");
+			} finally {
+				DisposeJavaObject (collection);
+			}
+		}
+
+		static void JavaList_NullableEnumPreservesNullAndDefault ()
+		{
+			using var holder = new RawValueTypeContainerHolder ();
+			var list = holder.CreateNullableEnumList ();
+			try {
+				AssertWrapperType (list, typeof (JavaList<>), typeof (AppState?));
+				list.Add (AppState.Busy);
+				list.Add (default (AppState));
+				list.Add (null);
+				AssertEqual ((AppState?) AppState.Busy, list [0], "nullable enum value");
+				AssertEqual ((AppState?) AppState.None, list [1], "nullable enum default");
+				AssertNull (list [2], "nullable enum null");
+				AssertTrue (list.Contains (null), "nullable enum list contains null");
+				AssertSequence ([AppState.Busy, AppState.None, null], list, "nullable enum enumeration");
+			} finally {
+				DisposeJavaObject (list);
+			}
+		}
+
+		static void JavaObjectArray_NullableUserStructPreservesNullAndDefault ()
+		{
+			using var holder = new RawValueTypeContainerHolder ();
+			using var array = holder.CreateNullableStructArray (3);
+			var value = new AppValue (31, 331);
+			array [0] = value;
+			array [1] = default (AppValue);
+			array [2] = null;
+
+			AssertWrapperType (array, typeof (JavaObjectArray<>), typeof (AppValue?));
+			AssertEqual ((AppValue?) value, array [0], "nullable struct array value");
+			AssertEqual ((AppValue?) default (AppValue), array [1], "nullable struct array default");
+			AssertNull (array [2], "nullable struct array null");
+			AssertSequence ([value, (AppValue?) default (AppValue), null], array, "nullable struct array enumeration");
+
+			using var roundTrip = holder.RoundTripNullableStructArray (array);
+			AssertWrapperType (roundTrip, typeof (JavaObjectArray<>), typeof (AppValue?));
+			AssertSameJavaObject (array, roundTrip);
+			AssertEqual ((AppValue?) value, roundTrip [0], "round-tripped nullable struct array");
+		}
+
+		static void JavaDictionary_UserStructKeysSupportOperationsAndRoundTrip ()
+		{
+			using var holder = new RawValueTypeContainerHolder ();
+			var dictionary = holder.CreateStructKeyDictionary ();
+			try {
+				AssertWrapperType (dictionary, typeof (JavaDictionary<,>), typeof (AppValue), typeof (string));
+				var first = new AppValue (41, 441);
+				dictionary.Add (first, "first");
+				dictionary.Add (default, "default");
+				AssertEqual (2, dictionary.Count, "struct-key dictionary count");
+				AssertFalse (dictionary.ContainsKey (first), "struct-key lookup uses Java proxy identity");
+				AssertThrows<KeyNotFoundException> (() => _ = dictionary [first], "struct-key indexer");
+
+				var roundTrip = holder.RoundTripStructKeyDictionary (dictionary);
+				try {
+					AssertWrapperType (roundTrip, typeof (JavaDictionary<,>), typeof (AppValue), typeof (string));
+					AssertSameJavaObject (dictionary, roundTrip);
+					AssertEqual (2, roundTrip.Count, "round-tripped struct-key dictionary count");
+				} finally {
+					DisposeIfDistinct (dictionary, roundTrip);
+				}
+
+				// The llvm-ir value proxy uses Java identity for separately boxed struct keys. Key
+				// lookup, removal, and enumeration are therefore outside the parity contract.
+				dictionary.Clear ();
+				AssertEqual (0, dictionary.Count, "struct-key dictionary count after clear");
+			} finally {
+				DisposeJavaObject (dictionary);
+			}
+		}
+
+		static void JavaDictionary_EnumValuesSupportOperationsAndRoundTrip ()
+		{
+			using var holder = new RawValueTypeContainerHolder ();
+			var dictionary = holder.CreateEnumValueDictionary ();
+			try {
+				AssertWrapperType (dictionary, typeof (JavaDictionary<,>), typeof (string), typeof (AppState));
+				dictionary.Add ("ready", AppState.Ready);
+				dictionary.Add ("default", default);
+				AssertEqual (AppState.Ready, dictionary ["ready"], "enum-value dictionary ready");
+				AssertEqual (AppState.None, dictionary ["default"], "enum-value dictionary default");
+				AssertTrue (ContainsValue (dictionary, AppState.Ready), "enum-value dictionary enumeration");
+
+				var roundTrip = holder.RoundTripEnumValueDictionary (dictionary);
+				try {
+					AssertWrapperType (roundTrip, typeof (JavaDictionary<,>), typeof (string), typeof (AppState));
+					AssertSameJavaObject (dictionary, roundTrip);
+					AssertEqual (AppState.Ready, roundTrip ["ready"], "round-tripped enum value");
+				} finally {
+					DisposeIfDistinct (dictionary, roundTrip);
+				}
+
+				AssertTrue (dictionary.Remove ("ready"), "enum-value dictionary removes ready");
+			} finally {
+				DisposeJavaObject (dictionary);
+			}
+		}
+
+		static void JavaDictionary_UserStructKeysAndEnumValuesSupportOperationsAndRoundTrip ()
+		{
+			using var holder = new RawValueTypeContainerHolder ();
+			var dictionary = holder.CreateStructEnumDictionary ();
+			try {
+				AssertWrapperType (dictionary, typeof (JavaDictionary<,>), typeof (AppValue), typeof (AppState));
+				var key = new AppValue (51, 551);
+				dictionary.Add (key, AppState.Busy);
+				AssertFalse (dictionary.ContainsKey (key), "value/value lookup uses Java proxy identity");
+				AssertThrows<KeyNotFoundException> (() => _ = dictionary [key], "value/value indexer");
+
+				var roundTrip = holder.RoundTripStructEnumDictionary (dictionary);
+				try {
+					AssertWrapperType (roundTrip, typeof (JavaDictionary<,>), typeof (AppValue), typeof (AppState));
+					AssertSameJavaObject (dictionary, roundTrip);
+					AssertEqual (1, roundTrip.Count, "round-tripped value/value dictionary count");
+				} finally {
+					DisposeIfDistinct (dictionary, roundTrip);
+				}
+			} finally {
+				DisposeJavaObject (dictionary);
+			}
+		}
+
+		static void JavaDictionary_NullableValueTypesPreserveNullAndDefault ()
+		{
+			using var holder = new RawValueTypeContainerHolder ();
+			var dictionary = holder.CreateNullableDictionary ();
+			try {
+				AssertWrapperType (dictionary, typeof (JavaDictionary<,>), typeof (AppValue?), typeof (AppState?));
+				var key = new AppValue (61, 661);
+				dictionary.Add (key, AppState.Ready);
+				dictionary.Add (default (AppValue), default (AppState));
+				dictionary.Add (null, null);
+				AssertFalse (dictionary.ContainsKey (key), "nullable non-null key uses Java proxy identity");
+				AssertNull (dictionary [null], "nullable dictionary null");
+				AssertTrue (dictionary.ContainsKey (null), "nullable dictionary contains null key");
+				AssertTrue (dictionary.Remove (null), "nullable dictionary removes null key");
+			} finally {
+				DisposeJavaObject (dictionary);
+			}
+		}
+
+		static bool ContainsValue<TKey, TValue> (IDictionary<TKey, TValue> dictionary, TValue expected)
+		{
+			foreach (var pair in dictionary) {
+				if (EqualityComparer<TValue>.Default.Equals (expected, pair.Value)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		static void AssertSequence<T> (T [] expected, IEnumerable<T> actual, string message)
+		{
+			int index = 0;
+			foreach (var item in actual) {
+				if (index >= expected.Length) {
+					throw new InvalidOperationException ($"Assertion failed: {message}; too many elements.");
+				}
+				AssertEqual (expected [index], item, $"{message} element {index}");
+				index++;
+			}
+			AssertEqual (expected.Length, index, $"{message} length");
+		}
+
+		static void AssertWrapperType (object wrapper, Type expectedGenericDefinition, params Type [] expectedArguments)
+		{
+			var wrapperType = wrapper.GetType ();
+			AssertTrue (wrapperType.IsGenericType, "wrapper must be generic");
+			AssertEqual (expectedGenericDefinition, wrapperType.GetGenericTypeDefinition (), "wrapper generic definition");
+			AssertEqual (expectedArguments.Length, wrapperType.GenericTypeArguments.Length, "wrapper generic argument count");
+			for (int i = 0; i < expectedArguments.Length; i++) {
+				AssertEqual (expectedArguments [i], wrapperType.GenericTypeArguments [i], $"wrapper generic argument {i}");
+			}
+		}
+
+		[DynamicDependency ("FromJniHandle", "Java.Interop.JavaConvert", "Mono.Android")]
+		static object InvokeJavaConvertFromJniHandle (Type targetType, IntPtr handle)
+		{
+			var javaConvert = typeof (Java.Lang.Object).Assembly.GetType ("Java.Interop.JavaConvert");
+			if (javaConvert == null) {
+				throw new InvalidOperationException ("JavaConvert type was not found.");
+			}
+
+			var method = javaConvert.GetMethod (
+				"FromJniHandle",
+				BindingFlags.Public | BindingFlags.Static,
+				binder: null,
+				types: [typeof (IntPtr), typeof (JniHandleOwnership), typeof (Type)],
+				modifiers: null);
+			if (method == null) {
+				throw new InvalidOperationException ("JavaConvert.FromJniHandle method was not found.");
+			}
+
+			var value = method.Invoke (null, [handle, JniHandleOwnership.TransferLocalRef, targetType]);
+			if (value == null) {
+				throw new InvalidOperationException ($"JavaConvert returned null for target type '{targetType}'.");
+			}
+			return value;
+		}
+
+		static void AssertSameJavaObject (object expected, object actual)
+		{
+			var expectedPeer = (IJavaPeerable) expected;
+			var actualPeer = (IJavaPeerable) actual;
+			AssertTrue (
+				JNIEnv.IsSameObject (expectedPeer.PeerReference.Handle, actualPeer.PeerReference.Handle),
+				"expected identical Java peers");
+		}
+
+		static void AssertTrue (bool value, string message)
+		{
+			if (!value) {
+				throw new InvalidOperationException ($"Assertion failed: {message}.");
+			}
+		}
+
+		static void AssertFalse (bool value, string message)
+		{
+			AssertTrue (!value, message);
+		}
+
+		static void AssertThrows<TException> (Action action, string message)
+			where TException : Exception
+		{
+			try {
+				action ();
+			} catch (TException) {
+				return;
+			}
+			throw new InvalidOperationException ($"Assertion failed: {message}; expected {typeof (TException)}.");
+		}
+
+		static void AssertNull<T> (T? value, string message)
+			where T : struct
+		{
+			if (value.HasValue) {
+				throw new InvalidOperationException ($"Assertion failed: {message}; expected null, found '{value}'.");
+			}
+		}
+
+		static void AssertEqual<T> (T expected, T actual, string message)
+		{
+			if (!EqualityComparer<T>.Default.Equals (expected, actual)) {
+				throw new InvalidOperationException ($"Assertion failed: {message}; expected '{expected}', found '{actual}'.");
+			}
+		}
+
+		static void DisposeIfDistinct (object owner, object value)
+		{
+			if (!ReferenceEquals (owner, value)) {
+				DisposeJavaObject (value);
+			}
+		}
+
+		static void DisposeJavaObject (object value)
+		{
+			if (value is IDisposable disposable) {
+				disposable.Dispose ();
+			}
+		}
+
+		readonly struct AppValue : IEquatable<AppValue>
+		{
+			public AppValue (int first, int second)
+			{
+				First = first;
+				Second = second;
+			}
+
+			public int First { get; }
+			public int Second { get; }
+
+			public bool Equals (AppValue other) => First == other.First && Second == other.Second;
+
+			public override bool Equals (object value) => value is AppValue other && Equals (other);
+
+			public override int GetHashCode () => HashCode.Combine (First, Second);
+
+			public override string ToString () => $"{First}:{Second}";
+		}
+
+		enum AppState : short
+		{
+			None = 0,
+			Ready = 7,
+			Busy = 300,
+		}
+
+		sealed class RawValueTypeContainerHolder : IDisposable
+		{
+			const string ArraySignature = "()[Ljava/lang/Object;";
+			const string CollectionSignature = "()Ljava/util/Collection;";
+			const string DictionarySignature = "()Ljava/util/Map;";
+			const string JniName = "net/dot/android/test/ValueTypeContainerFixture";
+			const string ListSignature = "()Ljava/util/List;";
+			const string RoundTripArraySignature = "([Ljava/lang/Object;)[Ljava/lang/Object;";
+			const string RoundTripCollectionSignature = "(Ljava/util/Collection;)Ljava/util/Collection;";
+			const string RoundTripDictionarySignature = "(Ljava/util/Map;)Ljava/util/Map;";
+			const string RoundTripListSignature = "(Ljava/util/List;)Ljava/util/List;";
+
+			readonly Java.Lang.Object holder;
+
+			public RawValueTypeContainerHolder ()
+			{
+				var holderClass = JniEnvironment.Types.FindClass (JniName);
+				try {
+					var constructor = JNIEnv.GetMethodID (holderClass.Handle, "<init>", "()V");
+					var handle = JNIEnv.NewObject (holderClass.Handle, constructor);
+					holder = new Java.Lang.Object (handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+					JniObjectReference.Dispose (ref holderClass);
+				}
+			}
+
+			public IList<int?> CreateNullableIntList () => ConvertContainer<IList<int?>> (Call ("createList", ListSignature));
+
+			public IList<int?> RoundTripNullableIntList (IList<int?> value) =>
+				ConvertContainer<IList<int?>> (Call ("roundTripList", RoundTripListSignature, value));
+
+			public IList<AppValue> CreateStructList () => ConvertContainer<IList<AppValue>> (Call ("createList", ListSignature));
+
+			public IList<AppValue> RoundTripStructList (IList<AppValue> value) =>
+				ConvertContainer<IList<AppValue>> (Call ("roundTripList", RoundTripListSignature, value));
+
+			public ICollection<AppState> CreateEnumCollection () =>
+				ConvertContainer<ICollection<AppState>> (Call ("createCollection", CollectionSignature));
+
+			public ICollection<AppState> RoundTripEnumCollection (ICollection<AppState> value) =>
+				ConvertContainer<ICollection<AppState>> (Call ("roundTripCollection", RoundTripCollectionSignature, value));
+
+			public IList<AppState?> CreateNullableEnumList () =>
+				ConvertContainer<IList<AppState?>> (Call ("createList", ListSignature));
+
+			public JavaObjectArray<AppValue?> CreateNullableStructArray (int length) =>
+				WrapNullableStructArray (Call ("createArray", $"(I){ArraySignature.Substring (2)}", length));
+
+			public JavaObjectArray<AppValue?> RoundTripNullableStructArray (JavaObjectArray<AppValue?> value) =>
+				WrapNullableStructArray (Call ("roundTripArray", RoundTripArraySignature, value));
+
+			public IDictionary<AppValue, string> CreateStructKeyDictionary () =>
+				ConvertContainer<IDictionary<AppValue, string>> (Call ("createDictionary", DictionarySignature));
+
+			public IDictionary<AppValue, string> RoundTripStructKeyDictionary (IDictionary<AppValue, string> value) =>
+				ConvertContainer<IDictionary<AppValue, string>> (Call ("roundTripDictionary", RoundTripDictionarySignature, value));
+
+			public IDictionary<string, AppState> CreateEnumValueDictionary () =>
+				ConvertContainer<IDictionary<string, AppState>> (Call ("createDictionary", DictionarySignature));
+
+			public IDictionary<string, AppState> RoundTripEnumValueDictionary (IDictionary<string, AppState> value) =>
+				ConvertContainer<IDictionary<string, AppState>> (Call ("roundTripDictionary", RoundTripDictionarySignature, value));
+
+			public IDictionary<AppValue, AppState> CreateStructEnumDictionary () =>
+				ConvertContainer<IDictionary<AppValue, AppState>> (Call ("createDictionary", DictionarySignature));
+
+			public IDictionary<AppValue, AppState> RoundTripStructEnumDictionary (IDictionary<AppValue, AppState> value) =>
+				ConvertContainer<IDictionary<AppValue, AppState>> (Call ("roundTripDictionary", RoundTripDictionarySignature, value));
+
+			public IDictionary<AppValue?, AppState?> CreateNullableDictionary () =>
+				ConvertContainer<IDictionary<AppValue?, AppState?>> (Call ("createDictionary", DictionarySignature));
+
+			public void Dispose ()
+			{
+				holder.Dispose ();
+			}
+
+			static T ConvertContainer<T> (IntPtr handle) => (T) InvokeJavaConvertFromJniHandle (typeof (T), handle);
+
+			static JavaObjectArray<AppValue?> WrapNullableStructArray (IntPtr handle)
+			{
+				var reference = new JniObjectReference (handle, JniObjectReferenceType.Local);
+				return new JavaObjectArray<AppValue?> (ref reference, JniObjectReferenceOptions.CopyAndDispose);
+			}
+
+			IntPtr Call (string methodName, string signature, object value = null)
+			{
+				var holderClass = JniEnvironment.Types.GetObjectClass (holder.PeerReference);
+				try {
+					var method = JNIEnv.GetMethodID (holderClass.Handle, methodName, signature);
+					if (value == null) {
+						return JNIEnv.CallObjectMethod (holder.Handle, method);
+					}
+					var peer = (IJavaPeerable) value;
+					var result = JNIEnv.CallObjectMethod (holder.Handle, method, new JValue (peer.PeerReference.Handle));
+					GC.KeepAlive (value);
+					return result;
+				} finally {
+					JniObjectReference.Dispose (ref holderClass);
+				}
+			}
+
+			IntPtr Call (string methodName, string signature, int value)
+			{
+				var holderClass = JniEnvironment.Types.GetObjectClass (holder.PeerReference);
+				try {
+					var method = JNIEnv.GetMethodID (holderClass.Handle, methodName, signature);
+					return JNIEnv.CallObjectMethod (holder.Handle, method, new JValue (value));
+				} finally {
+					JniObjectReference.Dispose (ref holderClass);
+				}
+			}
+		}
+	}
+}

--- a/tests/MSBuildDeviceIntegration/Resources/ValueTypeContainerApp/ValueTypeContainerFixture.java
+++ b/tests/MSBuildDeviceIntegration/Resources/ValueTypeContainerApp/ValueTypeContainerFixture.java
@@ -1,0 +1,44 @@
+package net.dot.android.test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class ValueTypeContainerFixture {
+	public ValueTypeContainerFixture() {
+	}
+
+	public Object[] createArray(int length) {
+		return new Object[length];
+	}
+
+	public Object[] roundTripArray(Object[] value) {
+		return value;
+	}
+
+	public List<Object> createList() {
+		return new ArrayList<>();
+	}
+
+	public List<Object> roundTripList(List<Object> value) {
+		return value;
+	}
+
+	public Collection<Object> createCollection() {
+		return new ArrayList<>();
+	}
+
+	public Collection<Object> roundTripCollection(Collection<Object> value) {
+		return value;
+	}
+
+	public Map<Object, Object> createDictionary() {
+		return new LinkedHashMap<>();
+	}
+
+	public Map<Object, Object> roundTripDictionary(Map<Object, Object> value) {
+		return value;
+	}
+}

--- a/tests/MSBuildDeviceIntegration/Resources/ValueTypeContainerApp/proguard.cfg
+++ b/tests/MSBuildDeviceIntegration/Resources/ValueTypeContainerApp/proguard.cfg
@@ -1,0 +1,3 @@
+-keep class net.dot.android.test.ValueTypeContainerFixture {
+    *;
+}

--- a/tests/MSBuildDeviceIntegration/Tests/ValueTypeContainerTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/ValueTypeContainerTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using System.Text;
+
+using NUnit.Framework;
+
+using Xamarin.Android.Tasks;
+using Xamarin.Android.Tools;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	[Category ("UsesDevice")]
+	public class ValueTypeContainerTests : DeviceTest
+	{
+		const string ResultPrefix = "VALUE_TYPE_CONTAINER_RESULT";
+
+		[TestCase ("llvm-ir", AndroidRuntime.CoreCLR)]
+		[TestCase ("trimmable", AndroidRuntime.CoreCLR)]
+		[TestCase ("trimmable", AndroidRuntime.NativeAOT)]
+		public void ApplicationValueTypesInJavaContainers (string typemapImplementation, AndroidRuntime runtime)
+		{
+			var suffix = $"valuecontainers{typemapImplementation.Replace ("-", "")}{runtime}".ToLowerInvariant ();
+			var proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (runtime, suffix)) {
+				IsRelease = true,
+			};
+			proj.SetRuntime (runtime);
+			proj.SetRuntimeIdentifiers ([DeviceAbi]);
+			proj.SetProperty ("AndroidTypeMapImplementation", typemapImplementation);
+			proj.SetProperty ("AndroidSdkDirectory", AndroidSdkResolver.GetAndroidSdkPath ());
+			var javaSdkDirectory = AndroidSdkResolver.GetJavaSdkPath ();
+			proj.SetProperty ("JavaSdkDirectory", javaSdkDirectory);
+			proj.SetProperty ("JavaCPath", Path.Combine (javaSdkDirectory, "bin", "javac"));
+			proj.SetProperty ("JarPath", Path.Combine (javaSdkDirectory, "bin", "jar"));
+			proj.SetDefaultTargetDevice ();
+			if (runtime == AndroidRuntime.NativeAOT) {
+				proj.SetProperty ("IlcGenerateDgmlFile", "true");
+			}
+			proj.MainActivity = proj.ProcessSourceTemplate (ReadFixture ("MainActivity.cs"));
+			proj.AndroidJavaSources.Add (new AndroidItem.AndroidJavaSource (
+				Path.Combine ("java", "net", "dot", "android", "test", "ValueTypeContainerFixture.java")) {
+				Encoding = Encoding.ASCII,
+				TextContent = () => ReadFixture ("ValueTypeContainerFixture.java"),
+				Metadata = {
+					{ "Bind", bool.FalseString },
+				},
+			});
+			proj.OtherBuildItems.Add (new AndroidItem.ProguardConfiguration ("proguard.cfg") {
+				TextContent = () => ReadFixture ("proguard.cfg"),
+			});
+
+			var testDirectory = Path.Combine ("temp", $"{nameof (ApplicationValueTypesInJavaContainers)}-{typemapImplementation}-{runtime}");
+			using var builder = CreateApkBuilder (testDirectory);
+			try {
+				Assert.IsTrue (builder.Install (proj), "The focused value-type container app should install.");
+				AssertRawJavaHolderHasNoManagedBinding (builder);
+
+				ClearAdbLogcat ();
+				string resultLine = "";
+				var logcatPath = Path.Combine (Root, builder.ProjectDirectory, "value-type-containers-logcat.log");
+				Assert.IsTrue (
+					MonitorAdbLogcat (
+						line => {
+							if (!line.Contains (ResultPrefix, StringComparison.Ordinal)) {
+								return false;
+							}
+							resultLine = line;
+							return true;
+						},
+						logcatPath,
+						timeout: 90,
+						onMonitoringStarted: () => StartActivityAndAssert (proj)),
+					$"The focused app did not report a result. See '{logcatPath}'.");
+				StringAssert.Contains ($"{ResultPrefix} PASS 9/9", resultLine);
+			} finally {
+				RunAdbCommand ($"uninstall {proj.PackageName}");
+			}
+		}
+
+		void AssertRawJavaHolderHasNoManagedBinding (ProjectBuilder builder)
+		{
+			var projectDirectory = Path.Combine (Root, builder.ProjectDirectory);
+			Assert.IsEmpty (
+				Directory.GetFiles (projectDirectory, "*ValueTypeContainerFixture*.cs", SearchOption.AllDirectories),
+				"The raw JNI holder must not produce a managed binding that can root closed collection wrappers.");
+		}
+
+		static string ReadFixture (string fileName)
+		{
+			return File.ReadAllText (
+				Path.Combine (
+					XABuildPaths.TopDirectory,
+					"tests",
+					"MSBuildDeviceIntegration",
+					"Resources",
+					"ValueTypeContainerApp",
+					fileName));
+		}
+	}
+}

--- a/tests/MSBuildDeviceIntegration/Tests/ValueTypeContainerTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/ValueTypeContainerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -73,9 +74,103 @@ namespace Xamarin.Android.Build.Tests
 						onMonitoringStarted: () => StartActivityAndAssert (proj)),
 					$"The focused app did not report a result. See '{logcatPath}'.");
 				StringAssert.Contains ($"{ResultPrefix} PASS 9/9", resultLine);
+				if (runtime == AndroidRuntime.NativeAOT) {
+					var projectDirectory = Path.Combine (Root, builder.ProjectDirectory);
+					var dgmlFiles = Directory.GetFiles (
+						projectDirectory,
+						$"{proj.ProjectName}.scan.dgml.xml",
+						SearchOption.AllDirectories);
+					Assert.AreEqual (1, dgmlFiles.Length, "The focused NativeAOT app should produce one scan dependency graph.");
+					AssertGeneratedValueTypeRootsAreExclusive (dgmlFiles [0]);
+				}
 			} finally {
 				RunAdbCommand ($"uninstall {proj.PackageName}");
 			}
+		}
+
+		static void AssertGeneratedValueTypeRootsAreExclusive (string dgmlFile)
+		{
+			string loaderId = "";
+			var registrationNodes = new Dictionary<string, string> (StringComparer.Ordinal);
+			var incomingLinks = new Dictionary<string, List<(string Source, string Reason)>> (StringComparer.Ordinal);
+			foreach (var line in File.ReadLines (dgmlFile)) {
+				if (line.Contains ("<Node ", StringComparison.Ordinal)) {
+					var id = GetAttribute (line, "Id");
+					var label = GetAttribute (line, "Label");
+					if (label == "_Microsoft_Android_TypeMaps_Microsoft_Android_Runtime_TypeMapLoader__Initialize") {
+						loaderId = id;
+					}
+					if (label.StartsWith (
+							"Mono_Android_Java_Interop_SafeJavaCollectionFactory__RegisterValueType",
+							StringComparison.Ordinal) ||
+							label.StartsWith (
+								"__GenericDict_Mono_Android_Java_Interop_SafeJavaCollectionFactory__RegisterValueType",
+								StringComparison.Ordinal)) {
+						registrationNodes.Add (id, label);
+					}
+				} else if (line.Contains ("<Link ", StringComparison.Ordinal)) {
+					var target = GetAttribute (line, "Target");
+					if (!incomingLinks.TryGetValue (target, out var links)) {
+						links = new List<(string Source, string Reason)> ();
+						incomingLinks.Add (target, links);
+					}
+					links.Add ((GetAttribute (line, "Source"), GetAttribute (line, "Reason")));
+				}
+			}
+
+			Assert.IsNotEmpty (loaderId, "The generated TypeMapLoader.Initialize node was not found.");
+			Assert.AreEqual (
+				10,
+				registrationNodes.Count,
+				"The eight selected shapes should emit ten call targets because each mixed dictionary has a generic dictionary and canonical method target.");
+			string[] expectedRegistrationPatterns = [
+				"RegisterValueTypeCollection&lt;UnnamedProject_UnnamedProject_MainActivity_AppState&gt;",
+				"RegisterValueTypeDictionary&lt;S_P_CoreLib_System_Nullable_1&lt;UnnamedProject_UnnamedProject_MainActivity_AppValue&gt;__" +
+					"S_P_CoreLib_System_Nullable_1&lt;UnnamedProject_UnnamedProject_MainActivity_AppState&gt;&gt;",
+				"RegisterValueTypeDictionary&lt;String__UnnamedProject_UnnamedProject_MainActivity_AppState&gt;",
+				"RegisterValueTypeDictionary&lt;System___Canon__UnnamedProject_UnnamedProject_MainActivity_AppState&gt;",
+				"RegisterValueTypeDictionary&lt;UnnamedProject_UnnamedProject_MainActivity_AppValue__String&gt;",
+				"RegisterValueTypeDictionary&lt;UnnamedProject_UnnamedProject_MainActivity_AppValue__System___Canon&gt;",
+				"RegisterValueTypeDictionary&lt;UnnamedProject_UnnamedProject_MainActivity_AppValue__" +
+					"UnnamedProject_UnnamedProject_MainActivity_AppState&gt;",
+				"RegisterValueTypeList&lt;S_P_CoreLib_System_Nullable_1&lt;Int32&gt;&gt;",
+				"RegisterValueTypeList&lt;S_P_CoreLib_System_Nullable_1&lt;UnnamedProject_UnnamedProject_MainActivity_AppState&gt;&gt;",
+				"RegisterValueTypeList&lt;UnnamedProject_UnnamedProject_MainActivity_AppValue&gt;",
+			];
+			foreach (var pattern in expectedRegistrationPatterns) {
+				Assert.IsTrue (
+					ContainsValue (registrationNodes, pattern),
+					$"Generated registration root '{pattern}' was not found.");
+			}
+
+			foreach (var (registrationId, label) in registrationNodes) {
+				Assert.IsTrue (incomingLinks.TryGetValue (registrationId, out var links), $"Registration '{label}' has no incoming dependency.");
+				Assert.AreEqual (1, links.Count, $"Registration '{label}' should have one exclusive incoming dependency.");
+				Assert.AreEqual (loaderId, links [0].Source, $"Registration '{label}' should be rooted by TypeMapLoader.Initialize.");
+				Assert.AreEqual ("call", links [0].Reason, $"Registration '{label}' should be reached by a direct call.");
+			}
+		}
+
+		static bool ContainsValue (Dictionary<string, string> values, string pattern)
+		{
+			foreach (var value in values.Values) {
+				if (value.Contains (pattern, StringComparison.Ordinal)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		static string GetAttribute (string line, string name)
+		{
+			var prefix = $"{name}=\"";
+			int start = line.IndexOf (prefix, StringComparison.Ordinal);
+			if (start < 0) {
+				return "";
+			}
+			start += prefix.Length;
+			int end = line.IndexOf ('"', start);
+			return end < 0 ? "" : line.Substring (start, end - start);
 		}
 
 		void AssertRawJavaHolderHasNoManagedBinding (ProjectBuilder builder)

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/RootTypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/RootTypeMapAssemblyGeneratorTests.cs
@@ -11,13 +11,107 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
 
 public class RootTypeMapAssemblyGeneratorTests : FixtureTestBase
 {
-	static MemoryStream GenerateRootAssembly (IReadOnlyList<string> perAssemblyNames, bool useSharedTypemapUniverse = false, string? assemblyName = null)
+	static MemoryStream GenerateRootAssembly (
+		IReadOnlyList<string> perAssemblyNames,
+		bool useSharedTypemapUniverse = false,
+		string? assemblyName = null,
+		IReadOnlyList<ValueTypeContainerRoot>? valueTypeContainerRoots = null)
 	{
 		var stream = new MemoryStream ();
 		var generator = new RootTypeMapAssemblyGenerator (new Version (11, 0, 0, 0));
-		generator.Generate (perAssemblyNames, useSharedTypemapUniverse, stream, assemblyName);
+		generator.Generate (perAssemblyNames, valueTypeContainerRoots ?? [], useSharedTypemapUniverse, stream, assemblyName);
 		stream.Position = 0;
 		return stream;
+	}
+
+	[Fact]
+	public void Generate_InitializeRegistersExactValueTypeContainerShapes ()
+	{
+		var userValue = new TypeRefData {
+			ManagedTypeName = "ValueTypeContainerFixtures.UserValue",
+			AssemblyName = "TestFixtures",
+			IsValueType = true,
+		};
+		var userState = new TypeRefData {
+			ManagedTypeName = "ValueTypeContainerFixtures.UserState",
+			AssemblyName = "TestFixtures",
+			IsValueType = true,
+		};
+		var nullableState = new TypeRefData {
+			ManagedTypeName = "System.Nullable`1",
+			AssemblyName = "System.Runtime",
+			IsValueType = true,
+			GenericArguments = [userState],
+		};
+		var unsignedPointer = new TypeRefData {
+			ManagedTypeName = "System.UIntPtr",
+			AssemblyName = "System.Runtime",
+		};
+		var rectangularUserValue = userValue with {
+			ManagedTypeName = userValue.ManagedTypeName + "[,]",
+		};
+		var int32 = new TypeRefData {
+			ManagedTypeName = "System.Int32",
+			AssemblyName = "System.Runtime",
+		};
+		ValueTypeContainerRoot[] roots = [
+			new () {
+				Kind = ValueTypeContainerKind.List,
+				TypeArguments = [userValue],
+			},
+			new () {
+				Kind = ValueTypeContainerKind.Collection,
+				TypeArguments = [nullableState],
+			},
+			new () {
+				Kind = ValueTypeContainerKind.Dictionary,
+				TypeArguments = [userValue, userState],
+			},
+			new () {
+				Kind = ValueTypeContainerKind.List,
+				TypeArguments = [unsignedPointer],
+			},
+			new () {
+				Kind = ValueTypeContainerKind.Dictionary,
+				TypeArguments = [rectangularUserValue, int32],
+			},
+		];
+
+		using var stream = GenerateRootAssembly (["_App.TypeMap"], valueTypeContainerRoots: roots);
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+		using var index = AssemblyIndex.Create (pe, "_Microsoft.Android.TypeMaps");
+		var registrations = new List<string> ();
+		var registrationTokens = new List<int> ();
+		int methodSpecificationCount = reader.GetTableRowCount (TableIndex.MethodSpec);
+		for (int row = 1; row <= methodSpecificationCount; row++) {
+			var handle = MetadataTokens.MethodSpecificationHandle (row);
+			var specification = reader.GetMethodSpecification (handle);
+			if (specification.Method.Kind != HandleKind.MemberReference) {
+				continue;
+			}
+			var memberReference = reader.GetMemberReference ((MemberReferenceHandle) specification.Method);
+			var methodName = reader.GetString (memberReference.Name);
+			if (!methodName.StartsWith ("RegisterValueType", StringComparison.Ordinal)) {
+				continue;
+			}
+			var arguments = specification.DecodeSignature (index.TypeRefSignatureProvider, index);
+			registrations.Add ($"{methodName}<{string.Join (",", arguments.Select (a => a.DisplayName))}>");
+			registrationTokens.Add (MetadataTokens.GetToken (handle));
+		}
+
+		Assert.Equal (new [] {
+			"RegisterValueTypeList<ValueTypeContainerFixtures.UserValue>",
+			"RegisterValueTypeCollection<System.Nullable`1<ValueTypeContainerFixtures.UserState>>",
+			"RegisterValueTypeDictionary<ValueTypeContainerFixtures.UserValue,ValueTypeContainerFixtures.UserState>",
+			"RegisterValueTypeList<System.UIntPtr>",
+			"RegisterValueTypeDictionary<ValueTypeContainerFixtures.UserValue[,],System.Int32>",
+		}, registrations);
+		var initialize = reader.GetMethodDefinition (FindMethodDefinition (reader, "Initialize"));
+		var il = pe.GetMethodBody (initialize.RelativeVirtualAddress).GetILBytes ();
+		Assert.NotNull (il);
+		Assert.All (registrationTokens, token => Assert.True (ILContainsCallToken (il, token)));
+		Assert.Contains ("TestFixtures", GetIgnoresAccessChecksToValues (reader));
 	}
 
 	static MethodDefinitionHandle FindMethodDefinition (MetadataReader reader, string methodName) =>

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ValueTypeContainerScannerTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ValueTypeContainerScannerTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+public class ValueTypeContainerScannerTests : FixtureTestBase
+{
+	[Fact]
+	public void Scan_CollectsOnlyClosedValueTypeContainerShapes ()
+	{
+		using var peReader = new PEReader (File.OpenRead (TestFixtureAssemblyPath));
+		var fixtureDirectory = Path.GetDirectoryName (TestFixtureAssemblyPath);
+		Assert.NotNull (fixtureDirectory);
+		var attributeFixturePath = Path.Combine (fixtureDirectory, "TestAttributeFixtures.dll");
+		using var attributePeReader = new PEReader (File.OpenRead (attributeFixturePath));
+		var roots = ValueTypeContainerScanner.Scan (
+			[
+				new AssemblyInput ("TestFixtures", TestFixtureAssemblyPath, peReader),
+				new AssemblyInput ("TestAttributeFixtures", attributeFixturePath, attributePeReader),
+			],
+			new HashSet<string> (StringComparer.Ordinal));
+		var fixtureRoots = roots
+			.Where (root => root.TypeArguments.Any (ContainsFixtureValueType))
+			.Select (root => root.DisplayName)
+			.ToList ();
+
+		Assert.Equal (new [] {
+			"Collection<ValueTypeContainerFixtures.UserState>",
+			"Dictionary<System.String,ValueTypeContainerFixtures.UserState>",
+			"Dictionary<ValueTypeContainerFixtures.GenericArrayValue[],System.Int32>",
+			"Dictionary<ValueTypeContainerFixtures.UserState,ValueTypeContainerFixtures.UserValue>",
+			"Dictionary<ValueTypeContainerFixtures.UserValue,System.String>",
+			"Dictionary<ValueTypeContainerFixtures.UserValue,ValueTypeContainerFixtures.UserState>",
+			"Dictionary<ValueTypeContainerFixtures.UserValue[,],System.Int32>",
+			"List<System.Nullable`1<ValueTypeContainerFixtures.UserState>>",
+			"List<ValueTypeContainerFixtures.ChainedMethodValue>",
+			"List<ValueTypeContainerFixtures.ExternalBodyValue>",
+			"List<ValueTypeContainerFixtures.GenericBodyValue>",
+			"List<ValueTypeContainerFixtures.GenericMethodValue>",
+			"List<ValueTypeContainerFixtures.GenericTypeBodyValue>",
+			"List<ValueTypeContainerFixtures.GenericTypeValue>",
+			"List<ValueTypeContainerFixtures.LocalOnlyValue>",
+			"List<ValueTypeContainerFixtures.StaticBodyValue>",
+			"List<ValueTypeContainerFixtures.UserValue>",
+		}, fixtureRoots);
+		Assert.Contains (roots, root => root.DisplayName == "List<System.Nullable`1<System.Int32>>");
+		Assert.Contains (roots, root => root.DisplayName == "List<System.UIntPtr>");
+		Assert.DoesNotContain (roots, root => root.DisplayName == "List<System.String>");
+		Assert.DoesNotContain (roots, root => root.DisplayName == "List<ValueTypeContainerFixtures.UserValue[,]>");
+		Assert.DoesNotContain (roots, root => root.TypeArguments.Any (ContainsOpenType));
+	}
+
+	static bool ContainsFixtureValueType (TypeRefData type)
+	{
+		if (type.AssemblyName == "TestFixtures" &&
+				type.ManagedTypeName.StartsWith ("ValueTypeContainerFixtures.", StringComparison.Ordinal)) {
+			return true;
+		}
+		return type.GenericArguments.Any (ContainsFixtureValueType);
+	}
+
+	static bool ContainsOpenType (TypeRefData type)
+	{
+		if (type.ManagedTypeName.StartsWith ("!", StringComparison.Ordinal)) {
+			return true;
+		}
+		return type.GenericArguments.Any (ContainsOpenType);
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestAttributeFixtures/GenericContainerSources.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestAttributeFixtures/GenericContainerSources.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace ValueTypeContainerFixtures.External;
+
+public static class GenericContainerSource
+{
+	public static IList<T> CreateList<T> () => throw new NotSupportedException ();
+}
+
+public sealed class GenericContainerSource<T>
+{
+	public IList<T> GetList () => throw new NotSupportedException ();
+}
+
+public sealed class GenericBodySource<T>
+{
+	public object GetValue (object value)
+	{
+		IList<T> result = (IList<T>) value;
+		return result;
+	}
+}
+
+public static class GenericStaticBodySource<T>
+{
+	static readonly Type ContainerType = typeof (IList<T>);
+
+	public static object GetValue () => ContainerType;
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/ValueTypeContainerUsage.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/ValueTypeContainerUsage.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+
+using ValueTypeContainerFixtures.External;
+
+namespace ValueTypeContainerFixtures;
+
+public readonly struct UserValue
+{
+	public UserValue (int value)
+	{
+		Value = value;
+	}
+
+	public int Value { get; }
+}
+
+public enum UserState : short
+{
+	None,
+	Ready,
+}
+
+public readonly struct GenericBodyValue
+{
+}
+
+public readonly struct ChainedMethodValue
+{
+}
+
+public readonly struct ExternalBodyValue
+{
+}
+
+public readonly struct GenericArrayValue
+{
+}
+
+public readonly struct GenericMethodValue
+{
+}
+
+public readonly struct GenericTypeValue
+{
+}
+
+public readonly struct GenericTypeBodyValue
+{
+}
+
+public readonly struct LocalOnlyValue
+{
+}
+
+public readonly struct StaticBodyValue
+{
+}
+
+public sealed class GenericBodyHolder<T>
+{
+	public object GetValue (object value)
+	{
+		IList<T> result = (IList<T>) value;
+		return result;
+	}
+}
+
+public sealed class ContainerUsage
+{
+	public IList<UserValue> GetStructList () => throw new NotSupportedException ();
+
+	public ICollection<UserState> GetEnumCollection () => throw new NotSupportedException ();
+
+	public IList<UserState?> GetNullableEnumList () => throw new NotSupportedException ();
+
+	public IList<int?> GetNullablePrimitiveList () => throw new NotSupportedException ();
+
+	public IDictionary<UserValue, string> GetStructKeyDictionary () => throw new NotSupportedException ();
+
+	public IDictionary<string, UserState> GetEnumValueDictionary () => throw new NotSupportedException ();
+
+	public IDictionary<UserValue, UserState> GetValueTypeDictionary () => throw new NotSupportedException ();
+
+	public Type GetTokenOnlyDictionary () => typeof (IDictionary<UserState, UserValue>);
+
+	public Type GetTokenOnlyUIntPtrList () => typeof (IList<UIntPtr>);
+
+	public IList<UserValue>[] GetArrayOfStructLists () => throw new NotSupportedException ();
+
+	public IList<UserValue[,]> GetRectangularStructArrayList () => throw new NotSupportedException ();
+
+	public IDictionary<UserValue[,], int> GetRectangularStructArrayDictionary () => throw new NotSupportedException ();
+
+	public object GetClosedGenericBodyOnly (object value) => GetGenericBodyOnly<GenericBodyValue> (value);
+
+	public object GetChainedGenericBodyOnly (object value) => ForwardGenericBody<ChainedMethodValue> (value);
+
+	public object GetExternalGenericBodyOnly (object value) => new GenericBodySource<ExternalBodyValue> ().GetValue (value);
+
+	public object GetExternalGenericStaticBodyOnly () => GenericStaticBodySource<StaticBodyValue>.GetValue ();
+
+	public object GetGenericArrayBodyOnly (object value) => GetGenericArrayBody<GenericArrayValue> (value);
+
+	public object GetGenericMethodCallOnly () => GenericContainerSource.CreateList<GenericMethodValue> ();
+
+	public object GetGenericTypeCallOnly () => new GenericContainerSource<GenericTypeValue> ().GetList ();
+
+	public object GetGenericTypeBodyOnly (object value) => new GenericBodyHolder<GenericTypeBodyValue> ().GetValue (value);
+
+	public object GetLocalOnly (object value)
+	{
+		IList<LocalOnlyValue> result = (IList<LocalOnlyValue>) value;
+		return result;
+	}
+
+	public IList<string> GetReferenceList () => throw new NotSupportedException ();
+
+	public IList<T> GetOpenList<T> () => throw new NotSupportedException ();
+
+	static object ForwardGenericBody<T> (object value) => GetGenericBodyOnly<T> (value);
+
+	static object GetGenericBodyOnly<T> (object value)
+	{
+		IList<T> result = (IList<T>) value;
+		return result;
+	}
+
+	static object GetGenericArrayBody<T> (object value)
+	{
+		IDictionary<T[], int> result = (IDictionary<T[], int>) value;
+		return result;
+	}
+
+	static void ExpandingRecursion<T> () => ExpandingRecursion<List<T>> ();
+}


### PR DESCRIPTION
## What

Replace the fixed NativeAOT collection-wrapper allowlist and value/value dictionary Cartesian product with exact registrations generated from closed value-type container uses found in application assemblies.

The scanner follows signatures, locals, type tokens, member references, generic method/type substitutions, static constructors, and cross-assembly generic call chains. `_Microsoft.Android.TypeMaps` calls the resulting `RegisterValueType*` instantiations during startup, so NativeAOT roots only the used `JavaList<T>`, `JavaCollection<T>`, and `JavaDictionary<TKey,TValue>` shapes. Primitive array factories remain unchanged.

## Runtime contract

The focused app covers app-defined structs, short-backed enums, nullable primitives/enums/structs, `JavaObjectArray`, list, collection, dictionary key-only/value-only/value-value shapes, mutation, get/remove/contains, enumeration, round-trip, default, and null behavior.

The llvm-ir baseline classifies equality lookup/removal for separately boxed custom-value proxies and non-null custom-value dictionary keys as unsupported legacy behavior; trimmable does not add behavior beyond that baseline. `JavaCollection<T>.Remove` remains excluded because its existing JNI descriptor is independently broken under llvm-ir.

## TDD evidence

Before production changes, the unchanged fixture:

- passed under llvm-ir/CoreCLR (`PASS 9/9`);
- failed under trimmable/CoreCLR after the nullable-primitive case with `InvalidCastException: Unable to cast Android.Runtime.JavaList to IList<AppValue>`;
- failed under trimmable/NativeAOT at the same boundary with `InvalidCastException`, while its scan DGML contained the app interface metadata but no closed app-value Java wrapper constructors.

After the fix, all three configurations pass. The NativeAOT assertion verifies that the eight selected shapes produce ten canonical/exact registration call targets and that every target has exactly one incoming edge, directly from generated `TypeMapLoader.Initialize`.

## Validation

- `Microsoft.Android.Sdk.TrimmableTypeMap.Tests`: 778 passed
- `Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests`: 24 passed
- focused device matrix on `emulator-5554`: llvm-ir/CoreCLR, trimmable/CoreCLR, trimmable/NativeAOT all passed
- `git diff --check`

Fixes #12169
Contributes to #12561