### PR TITLE
Fix reference file logging to avoid logcat output

### DIFF
--- a/src/native/clr/host/os-bridge.cc
+++ b/src/native/clr/host/os-bridge.cc
@@ -180,7 +180,7 @@ void OSBridge::log_it (LogCategories category, std::string_view const& line, FIL
 		log_writef (category, LogLevel::Info, "%.*s", static_cast<int>(line.length ()), line.data ());
 	}
 
-	// We skip logcat here when logging to file is enabled because _write_stack_trace will output to logcat as well, if enabled
+	// Without a file, only full reference logging (gref+/lref+) writes the stack trace to logcat.
 	if (to == nullptr) {
 		if (logcat_enabled) {
 			_write_stack_trace (nullptr, from, category);

--- a/src/native/clr/host/os-bridge.cc
+++ b/src/native/clr/host/os-bridge.cc
@@ -164,7 +164,9 @@ void OSBridge::_monodroid_gref_logf (const char *format, ...) noexcept
 [[gnu::always_inline, gnu::flatten]]
 void OSBridge::log_it (LogCategories category, std::string_view const& line, FILE *to, const char *const from, bool logcat_enabled) noexcept
 {
-	log_writef (category, LogLevel::Info, "%.*s", static_cast<int>(line.length ()), line.data ());
+	if (to == nullptr || logcat_enabled) {
+		log_writef (category, LogLevel::Info, "%.*s", static_cast<int>(line.length ()), line.data ());
+	}
 
 	// We skip logcat here when logging to file is enabled because _write_stack_trace will output to logcat as well, if enabled
 	if (to == nullptr) {

--- a/src/native/clr/host/os-bridge.cc
+++ b/src/native/clr/host/os-bridge.cc
@@ -9,6 +9,18 @@
 
 using namespace xamarin::android;
 
+namespace {
+	constexpr auto should_log_message_to_logcat (bool file_logging_enabled, bool logcat_enabled) noexcept -> bool
+	{
+		return !file_logging_enabled || logcat_enabled;
+	}
+
+	static_assert (should_log_message_to_logcat (false, false));
+	static_assert (should_log_message_to_logcat (false, true));
+	static_assert (!should_log_message_to_logcat (true, false));
+	static_assert (should_log_message_to_logcat (true, true));
+}
+
 void OSBridge::initialize_on_onload (JavaVM *vm, JNIEnv *env) noexcept
 {
 	abort_if_invalid_pointer_argument (env, "env");
@@ -164,7 +176,7 @@ void OSBridge::_monodroid_gref_logf (const char *format, ...) noexcept
 [[gnu::always_inline, gnu::flatten]]
 void OSBridge::log_it (LogCategories category, std::string_view const& line, FILE *to, const char *const from, bool logcat_enabled) noexcept
 {
-	if (to == nullptr || logcat_enabled) {
+	if (should_log_message_to_logcat (to != nullptr, logcat_enabled)) {
 		log_writef (category, LogLevel::Info, "%.*s", static_cast<int>(line.length ()), line.data ());
 	}
 


### PR DESCRIPTION
## Description

`OSBridge::log_it()` unconditionally wrote reference log lines to logcat even when `gref=<file>` or `lref=<file>` selected file output without the `+` logcat option. Large GC-bridge diagnostics consequently flooded logcat and caused messages to be dropped.

Only write the line to logcat when no file is available or logcat output was explicitly requested. File output remains unchanged. The shared CLR host source covers CoreCLR and NativeAOT.

## Validation

- Built `src/native/native-clr.csproj` for all configured Android ABIs.
- Built `src/native/native-nativeaot.csproj` for all configured Android ABIs.
- Validated on an arm64 Android emulator with `gc,gref=<file>`: reference traffic was written to the file, while logcat contained only the file-open diagnostic. All 780 weak-reference creations and promotions were preserved in the file.