### PR TITLE
[build] Fix assembly architecture mismatch message

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
@@ -92,7 +92,7 @@ public class AssemblyModifierPipeline : AndroidTask
 			AndroidTargetArch destinationArch = MonoAndroidHelper.GetRequiredValidArchitecture (destination);
 
 			if (sourceArch != destinationArch) {
-				throw new InvalidOperationException ($"Internal error: assembly '{sourceArch}' targets architecture '{sourceArch}', while destination assembly '{destination}' targets '{destinationArch}' instead");
+				throw new InvalidOperationException ($"Internal error: assembly '{source.ItemSpec}' targets architecture '{sourceArch}', while destination assembly '{destination.ItemSpec}' targets '{destinationArch}' instead");
 			}
 
 			// Each architecture must have a different set of context classes, or otherwise only the first instance of the assembly may be rewritten.


### PR DESCRIPTION
## Summary

- include the source assembly path in architecture-mismatch exceptions
- render the destination assembly path instead of the MSBuild task item object
- preserve both source and destination architecture values

Addresses https://github.com/dotnet/android/pull/12616#discussion_r3902635029

## Validation

- `dotnet build build-tools\xa-prep-tasks\xa-prep-tasks.csproj --nologo --verbosity:minimal`
- Product build blocked locally because the installed .NET SDK is 10.0.400 and `main` targets .NET 11