### PR TITLE
[xabt] Default Java (JDWP) debugging to disabled

### DIFF
--- a/src/Xamarin.Android.Build.Debugging.Tasks/Xamarin.Android.Common.Debugging.targets
+++ b/src/Xamarin.Android.Build.Debugging.Tasks/Xamarin.Android.Common.Debugging.targets
@@ -211,7 +211,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
 		<AndroidAttachDebugger Condition="'$(AndroidAttachDebugger)' == ''">False</AndroidAttachDebugger>
 		<AndroidDebuggerServer Condition="'$(AndroidDebuggerServer)' == ''">True</AndroidDebuggerServer>
 		<_AndroidRunForceStop Condition="'$(_AndroidRunForceStop)' == ''">True</_AndroidRunForceStop>
-		<_AndroidAllowJavaDebugging Condition="'$(_AndroidAllowJavaDebugging)' == ''">True</_AndroidAllowJavaDebugging>
+		<_AndroidAllowJavaDebugging Condition="'$(_AndroidAllowJavaDebugging)' == ''">False</_AndroidAllowJavaDebugging>
 	</PropertyGroup>
 	<Exec Command="&quot;$(_AndroidPlatformToolsDirectory)adb&quot; $(AdbTarget) forward tcp:$(AndroidSdbTargetPort) tcp:$(AndroidSdbHostPort)"
 		Condition="'$(AndroidAttachDebugger)' == 'True' And '$(AndroidDebuggerServer)' == 'True'" />


### PR DESCRIPTION
## Why

This is a smaller alternative to #12589 for the pre-runtime **Waiting For Debugger** race seen in the VS Code MAUI F5 path. The extension launches Android apps through `dotnet build -t:Run` with `AndroidAttachDebugger=true`. Today, `_Run` defaults Java debugging on, which adds `am start -D`, opens a temporary JDWP connection through `ConnectJdwpAsync()`, and relies on the `Android.Debug.waitForDebugger()` gate. That JDWP startup sequence can race before the managed runtime is ready.

VS Code only needs managed debugging for this scenario. Defaulting `$(_AndroidAllowJavaDebugging)` to `False` bypasses the JDWP connection and wait gate entirely, while preserving `$(_AndroidAllowJavaDebugging)=True` as an explicit opt-in.

The JDWP path appears to have originated as a workaround for Windows Subsystem for Android, which is now retired. Rather than add more JDWP readiness protocol handling to .NET 11, this keeps the .NET 11 change minimal ahead of removing the obsolete path in .NET 12.

This addresses the pre-runtime wait race only; it does not address the separate post-runtime RemoteCoreCLR EventStream race.

## Testing

- validated `Xamarin.Android.Common.Debugging.targets` as XML