### PR TITLE
Use debug.dotnet properties for CoreCLR and NativeAOT

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-targets.md
+++ b/Documentation/docs-mobile/building-apps/build-targets.md
@@ -201,7 +201,7 @@ of the logcat file with the logged messages.
 
 Properties which affect how the target works:
 
-  * `/p:RunLogVerbose=true` enables even more verbose logging from MonoVM
+  * `/p:RunLogVerbose=true` enables even more verbose runtime logging
   * `/p:RunLogDelayInMS=X` where `X` should be replaced with time in milliseconds to wait before writing the
     log output to file.  Defaults to `1000`.
 

--- a/Documentation/workflow/SystemProperties.md
+++ b/Documentation/workflow/SystemProperties.md
@@ -4,6 +4,10 @@
 - [Custom Android system properties used by .NET for Android](#custom-android-system-properties-used-by-xamarinandroid)
     - [Introduction](#introduction)
     - [Known properties](#known-properties)
+        - [debug.dotnet.log](#debugdotnetlog)
+        - [debug.dotnet.max_grefc](#debugdotnetmax_grefc)
+        - [debug.dotnet.profile](#debugdotnetprofile)
+        - [debug.dotnet.timing](#debugdotnettiming)
         - [debug.mono.connect](#debugmonoconnect)
         - [debug.mono.debug](#debugmonodebug)
         - [debug.mono.env](#debugmonoenv)
@@ -39,6 +43,33 @@ $ adb shell setprop property_name "''"
 ```
 
 ## Known properties
+
+Properties under `debug.dotnet` are available to CoreCLR and NativeAOT as
+described below. Properties under `debug.mono` apply to MonoVM. CoreCLR and
+NativeAOT continue to accept the corresponding `debug.mono` property when a
+`debug.dotnet` value is not set.
+
+### debug.dotnet.log
+
+CoreCLR and NativeAOT equivalent of [`debug.mono.log`](#debugmonolog).
+NativeAOT also uses the `gref`, `gref=FILE`, `lref`, `lref=FILE`, and `all`
+values to configure managed JNI reference logging.
+
+### debug.dotnet.max_grefc
+
+CoreCLR and NativeAOT equivalent of
+[`debug.mono.max_grefc`](#debugmonomax_grefc).
+
+### debug.dotnet.profile
+
+CoreCLR uses the presence of this property when deciding whether runtime
+diagnostic output directories are required. `debug.mono.profile` is accepted
+as a fallback.
+
+### debug.dotnet.timing
+
+Configures CoreCLR fast timing output. Supported comma-separated values are
+`to-file`, `filename=FILE`, and `duration=MILLISECONDS`.
 
 ### debug.mono.connect
 

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -94,6 +94,13 @@
         Timeout="60000"
     />
     <Xamarin.Android.Tools.BootstrapTasks.Adb
+        Arguments="$(_AdbTarget) shell setprop debug.dotnet.log default,assembly,timing=bare"
+        IgnoreExitCode="True"
+        ToolExe="$(AdbToolExe)"
+        ToolPath="$(AdbToolPath)"
+        Timeout="60000"
+    />
+    <Xamarin.Android.Tools.BootstrapTasks.Adb
         Arguments="$(_AdbTarget) logcat -G 256M"
         IgnoreExitCode="True"
         ToolExe="$(AdbToolExe)"

--- a/samples/NativeAOT/run.sh
+++ b/samples/NativeAOT/run.sh
@@ -19,7 +19,7 @@ fi
 
 adb uninstall "${PACKAGE}" || true
 adb install -r -d --no-streaming --no-fastdeploy "${APK}"
-adb shell setprop debug.mono.log default,assembly,timing=bare
+adb shell setprop debug.dotnet.log default,assembly,timing=bare
 adb logcat -G 128M
 adb logcat -c
 adb shell am start -S --user "0" -a "android.intent.action.MAIN" -c "android.intent.category.LAUNCHER" -n "${PACKAGE}/${ACTIVITY}" -W

--- a/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/DiagnosticSettings.cs
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Android.Runtime.NativeAOT/DiagnosticSettings.cs
@@ -65,7 +65,8 @@ struct DiagnosticSettings {
 	public void AddDebugDotnetLog ()
 	{
 		Span<byte>  value   = stackalloc byte [RuntimeNativeMethods.PROP_VALUE_MAX];
-		if (!RuntimeNativeMethods.TryGetSystemProperty ("debug.dotnet.log"u8, ref value)) {
+		if (!RuntimeNativeMethods.TryGetSystemProperty ("debug.dotnet.log"u8, ref value) &&
+		    !RuntimeNativeMethods.TryGetSystemProperty ("debug.mono.log"u8, ref value)) {
 			return;
 		}
 		AddParse (value);

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -166,19 +166,22 @@ This file contains targets specific for Android application projects.
     </GetAndroidActivityName>
 
     <PropertyGroup>
-      <_MonoLog>default,assembly,timing=bare</_MonoLog>
-      <_MonoLog Condition=" '$(RunLogVerbose)' != 'false' ">$(_MonoLog),mono_log_level=debug,mono_log_mask=all</_MonoLog>
+      <_AndroidRuntimeLogProperty Condition=" '$(_AndroidRuntime)' == 'MonoVM' ">debug.mono.log</_AndroidRuntimeLogProperty>
+      <_AndroidRuntimeLogProperty Condition=" '$(_AndroidRuntime)' != 'MonoVM' ">debug.dotnet.log</_AndroidRuntimeLogProperty>
+      <_AndroidRuntimeLog>default,assembly,timing=bare</_AndroidRuntimeLog>
+      <_AndroidRuntimeLog Condition=" '$(RunLogVerbose)' != 'false' and '$(_AndroidRuntime)' == 'MonoVM' ">$(_AndroidRuntimeLog),mono_log_level=debug,mono_log_mask=all</_AndroidRuntimeLog>
+      <_AndroidRuntimeLog Condition=" '$(RunLogVerbose)' != 'false' and '$(_AndroidRuntime)' != 'MonoVM' ">all</_AndroidRuntimeLog>
       <RunLogDelayInMS>1000</RunLogDelayInMS> <!-- milliseconds -->
     </PropertyGroup>
 
     <Message Text="Preparing application to log more information" Importance="High" />
-    <Message Text="Setting the debug.mono.log property to: $(_MonoLog)" Importance="High" />
+    <Message Text="Setting the $(_AndroidRuntimeLogProperty) property to: $(_AndroidRuntimeLog)" Importance="High" />
     <AndroidAdb
       ToolExe="$(AdbToolExe)"
       ToolPath="$(AdbToolPath)"
       AdbTarget="$(AdbTarget)"
       Command="shell"
-      Arguments="setprop debug.mono.log $(_MonoLog)"
+      Arguments="setprop $(_AndroidRuntimeLogProperty) $(_AndroidRuntimeLog)"
     />
     <AndroidAdb
       ToolExe="$(AdbToolExe)"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
@@ -13,7 +13,7 @@ See: https://github.com/dotnet/runtime/blob/b13715b6984889a709ba29ea8a1961db469f
   <PropertyGroup>
     <_BinaryRuntimeConfigPath>$(IntermediateOutputPath)$(ProjectRuntimeConfigFileName).bin</_BinaryRuntimeConfigPath>
     <!-- Internal switch for tests/diagnostics. On trimmed builds, keep it false unless explicitly re-enabled so the logging code can be removed.
-         On non-trimmed (Debug) builds, default to true so that debug.mono.log=gref continues to work as expected. -->
+         On non-trimmed (Debug) builds, default to true so that runtime object reference logging continues to work as expected. -->
     <_AndroidEnableObjectReferenceLogging Condition=" '$(_AndroidEnableObjectReferenceLogging)' == '' And '$(PublishTrimmed)' == 'true' ">false</_AndroidEnableObjectReferenceLogging>
     <_AndroidEnableObjectReferenceLogging Condition=" '$(_AndroidEnableObjectReferenceLogging)' == '' And '$(PublishTrimmed)' != 'true' ">true</_AndroidEnableObjectReferenceLogging>
     <!-- Enable .NET runtime crash reporting before Android's signal chaining takes place.

--- a/src/native/clr/include/constants.hh
+++ b/src/native/clr/include/constants.hh
@@ -49,19 +49,9 @@ namespace xamarin::android {
 		static constexpr std::string_view RUNTIME_CONFIG_BLOB_NAME            { RUNTIME_CONFIG_BLOB_NAME_ARRAY.data () };
 		static constexpr std::string_view OVERRIDE_DIRECTORY_NAME             { ".__override__" };
 
-		static inline constexpr std::string_view DEBUG_DOTNET_CONNECT_PROPERTY      { "debug.dotnet.connect" };
-		static inline constexpr std::string_view DEBUG_DOTNET_DEBUG_PROPERTY        { "debug.dotnet.debug" };
-		static inline constexpr std::string_view DEBUG_DOTNET_ENV_PROPERTY          { "debug.dotnet.env" };
-		static inline constexpr std::string_view DEBUG_DOTNET_EXTRA_PROPERTY        { "debug.dotnet.extra" };
-		static inline constexpr std::string_view DEBUG_DOTNET_GC_PROPERTY           { "debug.dotnet.gc" };
-		static inline constexpr std::string_view DEBUG_DOTNET_GDB_PROPERTY          { "debug.dotnet.gdb" };
 		static inline constexpr std::string_view DEBUG_DOTNET_LOG_PROPERTY          { "debug.dotnet.log" };
 		static inline constexpr std::string_view DEBUG_DOTNET_MAX_GREFC             { "debug.dotnet.max_grefc" };
 		static inline constexpr std::string_view DEBUG_DOTNET_PROFILE_PROPERTY      { "debug.dotnet.profile" };
-		static inline constexpr std::string_view DEBUG_DOTNET_RUNTIME_ARGS_PROPERTY { "debug.dotnet.runtime_args" };
-		static inline constexpr std::string_view DEBUG_DOTNET_SOFT_BREAKPOINTS      { "debug.dotnet.soft_breakpoints" };
-		static inline constexpr std::string_view DEBUG_DOTNET_TRACE_PROPERTY        { "debug.dotnet.trace" };
-		static inline constexpr std::string_view DEBUG_DOTNET_WREF_PROPERTY         { "debug.dotnet.wref" };
 		static constexpr std::string_view DEBUG_DOTNET_TIMING                       { "debug.dotnet.timing" };
 
 		static inline constexpr std::string_view LEGACY_DEBUG_MONO_LOG_PROPERTY     { "debug.mono.log" };

--- a/src/native/clr/include/constants.hh
+++ b/src/native/clr/include/constants.hh
@@ -49,21 +49,25 @@ namespace xamarin::android {
 		static constexpr std::string_view RUNTIME_CONFIG_BLOB_NAME            { RUNTIME_CONFIG_BLOB_NAME_ARRAY.data () };
 		static constexpr std::string_view OVERRIDE_DIRECTORY_NAME             { ".__override__" };
 
-		/* Android property containing connection information, set by XS */
-		static inline constexpr std::string_view DEBUG_MONO_CONNECT_PROPERTY      { "debug.mono.connect" };
-		static inline constexpr std::string_view DEBUG_MONO_DEBUG_PROPERTY        { "debug.mono.debug" };
-		static inline constexpr std::string_view DEBUG_MONO_ENV_PROPERTY          { "debug.mono.env" };
-		static inline constexpr std::string_view DEBUG_MONO_EXTRA_PROPERTY        { "debug.mono.extra" };
-		static inline constexpr std::string_view DEBUG_MONO_GC_PROPERTY           { "debug.mono.gc" };
-		static inline constexpr std::string_view DEBUG_MONO_GDB_PROPERTY          { "debug.mono.gdb" };
-		static inline constexpr std::string_view DEBUG_MONO_LOG_PROPERTY          { "debug.mono.log" };
-		static inline constexpr std::string_view DEBUG_MONO_MAX_GREFC             { "debug.mono.max_grefc" };
-		static inline constexpr std::string_view DEBUG_MONO_PROFILE_PROPERTY      { "debug.mono.profile" };
-		static inline constexpr std::string_view DEBUG_MONO_RUNTIME_ARGS_PROPERTY { "debug.mono.runtime_args" };
-		static inline constexpr std::string_view DEBUG_MONO_SOFT_BREAKPOINTS      { "debug.mono.soft_breakpoints" };
-		static inline constexpr std::string_view DEBUG_MONO_TRACE_PROPERTY        { "debug.mono.trace" };
-		static inline constexpr std::string_view DEBUG_MONO_WREF_PROPERTY         { "debug.mono.wref" };
-		static constexpr std::string_view DEBUG_MONO_TIMING                       { "debug.mono.timing" };
+		static inline constexpr std::string_view DEBUG_DOTNET_CONNECT_PROPERTY      { "debug.dotnet.connect" };
+		static inline constexpr std::string_view DEBUG_DOTNET_DEBUG_PROPERTY        { "debug.dotnet.debug" };
+		static inline constexpr std::string_view DEBUG_DOTNET_ENV_PROPERTY          { "debug.dotnet.env" };
+		static inline constexpr std::string_view DEBUG_DOTNET_EXTRA_PROPERTY        { "debug.dotnet.extra" };
+		static inline constexpr std::string_view DEBUG_DOTNET_GC_PROPERTY           { "debug.dotnet.gc" };
+		static inline constexpr std::string_view DEBUG_DOTNET_GDB_PROPERTY          { "debug.dotnet.gdb" };
+		static inline constexpr std::string_view DEBUG_DOTNET_LOG_PROPERTY          { "debug.dotnet.log" };
+		static inline constexpr std::string_view DEBUG_DOTNET_MAX_GREFC             { "debug.dotnet.max_grefc" };
+		static inline constexpr std::string_view DEBUG_DOTNET_PROFILE_PROPERTY      { "debug.dotnet.profile" };
+		static inline constexpr std::string_view DEBUG_DOTNET_RUNTIME_ARGS_PROPERTY { "debug.dotnet.runtime_args" };
+		static inline constexpr std::string_view DEBUG_DOTNET_SOFT_BREAKPOINTS      { "debug.dotnet.soft_breakpoints" };
+		static inline constexpr std::string_view DEBUG_DOTNET_TRACE_PROPERTY        { "debug.dotnet.trace" };
+		static inline constexpr std::string_view DEBUG_DOTNET_WREF_PROPERTY         { "debug.dotnet.wref" };
+		static constexpr std::string_view DEBUG_DOTNET_TIMING                       { "debug.dotnet.timing" };
+
+		static inline constexpr std::string_view LEGACY_DEBUG_MONO_LOG_PROPERTY     { "debug.mono.log" };
+		static inline constexpr std::string_view LEGACY_DEBUG_MONO_MAX_GREFC         { "debug.mono.max_grefc" };
+		static inline constexpr std::string_view LEGACY_DEBUG_MONO_PROFILE_PROPERTY { "debug.mono.profile" };
+		static constexpr std::string_view LEGACY_DEBUG_MONO_TIMING                  { "debug.mono.timing" };
 
 		static constexpr std::string_view LOG_CATEGORY_NAME_NONE                  { "*none*" };
 		static constexpr std::string_view LOG_CATEGORY_NAME_MONODROID             { "monodroid" };

--- a/src/native/clr/include/runtime-base/android-system.hh
+++ b/src/native/clr/include/runtime-base/android-system.hh
@@ -112,7 +112,9 @@ namespace xamarin::android {
 				 * pre-loaded apps!), we need the .__override__ directory...
 				 */
 				char value[Constants::PROPERTY_VALUE_BUFFER_LEN];
-				if (log_categories == 0 && monodroid_get_system_property (Constants::DEBUG_MONO_PROFILE_PROPERTY.data (), value, sizeof (value)) == nullptr) [[likely]] {
+				if (log_categories == 0 &&
+				    monodroid_get_system_property (Constants::DEBUG_DOTNET_PROFILE_PROPERTY.data (), value, sizeof (value)) == nullptr &&
+				    monodroid_get_system_property (Constants::LEGACY_DEBUG_MONO_PROFILE_PROPERTY.data (), value, sizeof (value)) == nullptr) [[likely]] {
 					return;
 				}
 			}

--- a/src/native/clr/runtime-base/android-system-shared.cc
+++ b/src/native/clr/runtime-base/android-system-shared.cc
@@ -59,7 +59,12 @@ AndroidSystem::get_max_gref_count_from_system () noexcept -> long
 	}
 
 	char override[Constants::PROPERTY_VALUE_BUFFER_LEN];
-	const char *grefc = monodroid_get_system_property (Constants::DEBUG_MONO_MAX_GREFC.data (), override, sizeof (override));
+	std::string_view property_name = Constants::DEBUG_DOTNET_MAX_GREFC;
+	const char *grefc = monodroid_get_system_property (property_name.data (), override, sizeof (override));
+	if (grefc == nullptr) {
+		property_name = Constants::LEGACY_DEBUG_MONO_MAX_GREFC;
+		grefc = monodroid_get_system_property (property_name.data (), override, sizeof (override));
+	}
 	if (grefc != nullptr) {
 		char *e;
 		max = strtol (grefc, &e, 10);
@@ -82,7 +87,7 @@ AndroidSystem::get_max_gref_count_from_system () noexcept -> long
 			log_warnf (
 				LOG_GC,
 				"Unsupported '%s' value '%s'.",
-				Constants::DEBUG_MONO_MAX_GREFC.data (),
+				property_name.data (),
 				grefc
 			);
 		}

--- a/src/native/clr/runtime-base/logger.cc
+++ b/src/native/clr/runtime-base/logger.cc
@@ -144,7 +144,10 @@ Logger::init_logging_categories () noexcept
 	_log_timing_categories = LogTimingCategories::Default;
 
 	char value[Constants::PROPERTY_VALUE_BUFFER_LEN];
-	const char *categories = AndroidSystem::monodroid_get_system_property (Constants::DEBUG_MONO_LOG_PROPERTY.data (), value, sizeof (value));
+	const char *categories = AndroidSystem::monodroid_get_system_property (Constants::DEBUG_DOTNET_LOG_PROPERTY.data (), value, sizeof (value));
+	if (categories == nullptr) {
+		categories = AndroidSystem::monodroid_get_system_property (Constants::LEGACY_DEBUG_MONO_LOG_PROPERTY.data (), value, sizeof (value));
+	}
 	if (categories == nullptr) {
 		return;
 	}

--- a/src/native/common/include/runtime-base/timing-internal.hh
+++ b/src/native/common/include/runtime-base/timing-internal.hh
@@ -90,7 +90,7 @@ namespace xamarin::android {
 		static constexpr size_t default_duration_milliseconds = 1500;
 		static constexpr std::string_view default_timing_file_name { "timing.txt" };
 
-		// Parameters for the `debug.mono.timing` property
+		// Parameters for the runtime timing property
 		static constexpr std::string_view OPT_DURATION      { "duration=" };
 		static constexpr std::string_view OPT_FILE_NAME     { "filename=" };
 		static constexpr std::string_view OPT_TO_FILE       { "to-file" };

--- a/src/native/common/runtime-base/timing-internal.cc
+++ b/src/native/common/runtime-base/timing-internal.cc
@@ -24,13 +24,20 @@ void FastTiming::really_initialize (bool log_immediately) noexcept
 	open_sequences.push (0);
 	open_sequences.pop ();
 
-	// Options in `debug.mono.timing` are relevant only when immediate logging is disabled
+	// Timing property options are relevant only when immediate logging is disabled
 	if (immediate_logging) {
 		return;
 	}
 
 	char value [Constants::PROPERTY_VALUE_BUFFER_LEN];
+#if defined(XA_HOST_MONOVM)
 	const char *options = AndroidSystem::monodroid_get_system_property (Constants::DEBUG_MONO_TIMING.data (), value, sizeof (value));
+#else
+	const char *options = AndroidSystem::monodroid_get_system_property (Constants::DEBUG_DOTNET_TIMING.data (), value, sizeof (value));
+	if (options == nullptr) {
+		options = AndroidSystem::monodroid_get_system_property (Constants::LEGACY_DEBUG_MONO_TIMING.data (), value, sizeof (value));
+	}
+#endif
 	if (options != nullptr) {
 		internal_timing.parse_options (options);
 	}

--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -237,6 +237,10 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(CMakeRuntimeFlavor)' == 'NativeAOT' ">
+      <_RuntimeSources Include="clr\include\constants.hh" />
+      <_RuntimeSources Include="clr\include\runtime-base\android-system.hh" />
+      <_RuntimeSources Include="clr\runtime-base\android-system-shared.cc" />
+      <_RuntimeSources Include="clr\runtime-base\logger.cc" />
       <_RuntimeSources Include="nativeaot\include\**\*.hh" />
       <_RuntimeSources Include="nativeaot\host\*.cc" />
     </ItemGroup>

--- a/tests/MSBuildDeviceIntegration/Tests/FastTimingTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastTimingTests.cs
@@ -47,11 +47,11 @@ public class FastTimingTests : DeviceTest
 		using var builder = CreateApkBuilder (packageName: packageName);
 		Assert.IsTrue (builder.Install (proj), "Project should have installed.");
 
-		string previousMonoLog = RunAdbCommand ("shell getprop debug.mono.log").Trim ();
-		string previousMonoTiming = RunAdbCommand ("shell getprop debug.mono.timing").Trim ();
+		string previousDotnetLog = RunAdbCommand ("shell getprop debug.dotnet.log").Trim ();
+		string previousDotnetTiming = RunAdbCommand ("shell getprop debug.dotnet.timing").Trim ();
 		try {
-			RunAdbCommand ("shell setprop debug.mono.log timing=fast-bare");
-			RunAdbCommand ($"shell setprop debug.mono.timing to-file,filename={timingFileName}");
+			RunAdbCommand ("shell setprop debug.dotnet.log timing=fast-bare");
+			RunAdbCommand ($"shell setprop debug.dotnet.timing to-file,filename={timingFileName}");
 			ClearAdbLogcat ();
 
 			bool sawBufferGrowth = false;
@@ -79,10 +79,10 @@ public class FastTimingTests : DeviceTest
 		} finally {
 			RunAdbCommand ($"shell am force-stop {proj.PackageName}");
 			RunAdbCommand ($"shell run-as {proj.PackageName} rm -f cache/{timingFileName}");
-			string monoLogValue = previousMonoLog.Length == 0 ? "\"\"" : $"\"{previousMonoLog}\"";
-			RunAdbCommand ($"shell setprop debug.mono.log {monoLogValue}");
-			string monoTimingValue = previousMonoTiming.Length == 0 ? "\"\"" : $"\"{previousMonoTiming}\"";
-			RunAdbCommand ($"shell setprop debug.mono.timing {monoTimingValue}");
+			string dotnetLogValue = previousDotnetLog.Length == 0 ? "\"\"" : $"\"{previousDotnetLog}\"";
+			RunAdbCommand ($"shell setprop debug.dotnet.log {dotnetLogValue}");
+			string dotnetTimingValue = previousDotnetTiming.Length == 0 ? "\"\"" : $"\"{previousDotnetTiming}\"";
+			RunAdbCommand ($"shell setprop debug.dotnet.timing {dotnetTimingValue}");
 		}
 	}
 }


### PR DESCRIPTION
CoreCLR and NativeAOT currently expose runtime diagnostics through legacy `debug.mono.*` Android system properties. Use the runtime-neutral `debug.dotnet.*` prefix so these settings no longer appear Mono-specific.

- Prefer `debug.dotnet.log`, `debug.dotnet.max_grefc`, `debug.dotnet.profile`, and `debug.dotnet.timing` where supported, while retaining `debug.mono.*` compatibility fallbacks.
- Keep MonoVM on `debug.mono.*` and make `RunWithLogging` select the property and verbose options for the active runtime.
- Update NativeAOT diagnostics, shared test tooling, samples, device tests, documentation, and NativeAOT incremental native inputs.

Validation:
- Built `Microsoft.Android.Runtime.NativeAOT.csproj`.
- Built the CoreCLR native runtime.
- Built the NativeAOT native runtime.