### PR TITLE
[r8-obfuscation] Enable R8 JNI name obfuscation for NativeAOT

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -472,11 +472,11 @@ This property is `False` by default.
 
 A boolean property that enables R8 obfuscation of Java type, method, and field names
 referenced by managed JNI metadata. The build uses an R8-generated mapping to rewrite
-managed assemblies before trimming, then applies the same
+managed assemblies before trimming or NativeAOT compilation, then applies the same
 mapping during the final R8 invocation.
 
 This property requires `AndroidLinkTool=r8`,
-`AndroidTypeMapImplementation=trimmable`, the CoreCLR runtime, and
+`AndroidTypeMapImplementation=trimmable`, and either NativeAOT or CoreCLR with
 `PublishTrimmed=true`.
 The default value is `False`.
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.NativeAOT.targets
@@ -19,7 +19,6 @@
     <_AndroidBuildRuntimeIdentifiersInParallel
         Condition=" ('$(_AndroidTrimmableTypemapTrimJavaCode)' == 'true' or '$(IlcGenerateDgmlFile)' == 'true') and '$(_AndroidBuildRuntimeIdentifiersInParallel)' == '' ">false</_AndroidBuildRuntimeIdentifiersInParallel>
     <_TrimmableRuntimeProviderJavaName Condition=" '$(_TrimmableRuntimeProviderJavaName)' == '' ">net.dot.jni.nativeaot.NativeAotRuntimeProvider</_TrimmableRuntimeProviderJavaName>
-    <AndroidLinkTool Condition=" '$(AndroidLinkTool)' == '' ">r8</AndroidLinkTool>
     <AndroidDexTool Condition=" '$(AndroidLinkTool)' == 'r8' ">d8</AndroidDexTool>
     <AndroidEnableProguard Condition=" '$(AndroidLinkTool)' != '' ">True</AndroidEnableProguard>
     <AndroidCreateProguardMappingFile Condition=" '$(AndroidCreateProguardMappingFile)' == '' and '$(AndroidLinkTool)' == 'r8' ">True</AndroidCreateProguardMappingFile>
@@ -70,6 +69,64 @@
           Condition=" '$(_AndroidTrimmableTypemapTrimJavaCode)' == 'true' and '$(AndroidLinkTool)' != '' and '$(IlcGenerateDgmlFile)' != 'true' and '$(Optimize)' != 'true' "
           Include="--dgmllog:$(NativeIntermediateOutputPath)$(TargetName).codegen.dgml.xml" />
       <UnmanagedEntryPointsAssembly Include="@(_TrimmableTypeMapUnmanagedEntryPointAssemblyNames)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_AndroidRewriteJniNamesBeforeIlcInputs"
+      Condition=" '$(_AndroidEnableR8JniNameRewriting)' == 'true' "
+      DependsOnTargets="_AndroidGenerateR8JniSeedMapping">
+    <PropertyGroup>
+      <_AndroidR8JniRewrittenAssemblyDirectory>$(IntermediateOutputPath)r8-jni-rewritten/</_AndroidR8JniRewrittenAssemblyDirectory>
+      <_AndroidR8JniRewriteStamp>$(_AndroidStampDirectory)_AndroidRewriteJniNamesBeforeIlc.stamp</_AndroidR8JniRewriteStamp>
+    </PropertyGroup>
+    <ItemGroup>
+      <_AndroidR8JniIlcAssembly Remove="@(_AndroidR8JniIlcAssembly)" />
+      <_AndroidR8JniHashedIlcAssembly Remove="@(_AndroidR8JniHashedIlcAssembly)" />
+      <_AndroidR8JniRewrittenIlcAssembly Remove="@(_AndroidR8JniRewrittenIlcAssembly)" />
+      <_AndroidR8JniExpectedRewriteOutput Remove="@(_AndroidR8JniExpectedRewriteOutput)" />
+      <_AndroidR8JniMissingRewriteOutput Remove="@(_AndroidR8JniMissingRewriteOutput)" />
+      <_AndroidR8JniIlcAssembly Include="@(ManagedBinary)">
+        <R8JniInputKind>ManagedBinary</R8JniInputKind>
+      </_AndroidR8JniIlcAssembly>
+      <_AndroidR8JniIlcAssembly Include="@(IlcReference)">
+        <R8JniInputKind>IlcReference</R8JniInputKind>
+      </_AndroidR8JniIlcAssembly>
+      <_AndroidR8JniIlcAssembly Remove="@(_AndroidR8JniIlcAssembly)" Condition=" '%(Extension)' != '.dll' " />
+    </ItemGroup>
+    <ComputeHash Source="@(_AndroidR8JniIlcAssembly)">
+      <Output TaskParameter="Output" ItemName="_AndroidR8JniHashedIlcAssembly" />
+    </ComputeHash>
+    <ItemGroup>
+      <_AndroidR8JniRewrittenIlcAssembly Include="@(_AndroidR8JniHashedIlcAssembly->'$(_AndroidR8JniRewrittenAssemblyDirectory)%(Hash)/%(Filename)%(Extension)')" />
+      <_AndroidR8JniExpectedRewriteOutput Include="@(_AndroidR8JniRewrittenIlcAssembly);$(_AndroidR8JniRewriteManifest)" />
+      <_AndroidR8JniMissingRewriteOutput Include="@(_AndroidR8JniExpectedRewriteOutput)" Condition="!Exists('%(Identity)')" />
+    </ItemGroup>
+    <Delete Files="$(_AndroidR8JniRewriteStamp)" Condition=" '@(_AndroidR8JniMissingRewriteOutput->Count())' != '0' " />
+  </Target>
+
+  <Target Name="_AndroidRewriteJniNamesBeforeIlc"
+      Condition=" '$(_AndroidEnableR8JniNameRewriting)' == 'true' "
+      BeforeTargets="WriteIlcRspFileForCompilation"
+      DependsOnTargets="_AndroidRewriteJniNamesBeforeIlcInputs"
+      Inputs="@(_AndroidR8JniHashedIlcAssembly);$(_AndroidR8JniSeedMapping)"
+      Outputs="$(_AndroidR8JniRewriteStamp)">
+    <RewriteJniNamesForR8
+        SourceFiles="@(_AndroidR8JniHashedIlcAssembly)"
+        DestinationFiles="@(_AndroidR8JniRewrittenIlcAssembly)"
+        MappingFile="$(_AndroidR8JniSeedMapping)"
+        RewriteManifestFile="$(_AndroidR8JniRewriteManifest)" />
+    <Touch Files="$(_AndroidR8JniRewriteStamp)" AlwaysCreate="true" />
+    <ItemGroup>
+      <ManagedBinary Remove="@(ManagedBinary)" />
+      <ManagedBinary Include="@(_AndroidR8JniRewrittenIlcAssembly)" Condition=" '%(R8JniInputKind)' == 'ManagedBinary' " />
+      <IlcCompileInput Remove="@(IlcCompileInput)" />
+      <IlcCompileInput Include="@(ManagedBinary)" />
+      <IlcReference Remove="@(IlcReference)" />
+      <IlcReference Include="@(_AndroidR8JniRewrittenIlcAssembly)" Condition=" '%(R8JniInputKind)' == 'IlcReference' " />
+      <FileWrites Include="@(_AndroidR8JniRewrittenIlcAssembly)" />
+      <FileWrites Include="$(_AndroidR8JniRewriteStamp)" />
+      <_AndroidR8JniExpectedRewriteOutput Remove="@(_AndroidR8JniExpectedRewriteOutput)" />
+      <_AndroidR8JniMissingRewriteOutput Remove="@(_AndroidR8JniMissingRewriteOutput)" />
     </ItemGroup>
   </Target>
 
@@ -231,15 +288,19 @@
   <Target Name="_GenerateTrimmableTypeMapProguardConfiguration"
       DependsOnTargets="_WriteTrimmableNativeAotProguardConfigurationInputs;_CollectTrimmableNativeAotDgmlFiles"
       Condition=" '$(PublishTrimmed)' == 'true' and '$(_ProguardProjectConfiguration)' != '' "
-      Inputs="$(_TrimmableNativeAotProguardConfigurationInputsStamp);@(_TrimmableNativeAotDgmlFiles);$(IntermediateOutputPath)acw-map.txt"
-      Outputs="$(_ProguardProjectConfiguration)">
+      Inputs="$(_TrimmableNativeAotProguardConfigurationInputsStamp);@(_TrimmableNativeAotDgmlFiles);$(IntermediateOutputPath)acw-map.txt;$(_AndroidR8JniSeedMapping);$(_AndroidR8JniRewriteManifest)"
+      Outputs="$(_ProguardProjectConfiguration);$(_AndroidR8JniReachabilityManifest)">
     <GenerateNativeAotProguardConfiguration
         NativeAotDgmlFiles="@(_TrimmableNativeAotDgmlFiles)"
         AcwMapFile="$(IntermediateOutputPath)acw-map.txt"
         TrimJavaCallableWrappers="$(_AndroidTrimmableTypemapTrimJavaCode)"
-        OutputFile="$(_ProguardProjectConfiguration)" />
+        OutputFile="$(_ProguardProjectConfiguration)"
+        R8MappingFile="$(_AndroidR8JniSeedMapping)"
+        R8RewriteManifestFile="$(_AndroidR8JniRewriteManifest)"
+        R8ReachabilityManifestFile="$(_AndroidR8JniReachabilityManifest)" />
     <ItemGroup>
       <FileWrites Include="$(_ProguardProjectConfiguration)" />
+      <FileWrites Include="$(_AndroidR8JniReachabilityManifest)" Condition=" '$(_AndroidR8JniReachabilityManifest)' != '' " />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_trimmable_nativeaot.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_trimmable_nativeaot.cfg
@@ -4,6 +4,8 @@
 
 -keep class net.dot.jni.** { *; <init>(...); }
 -keep class net.dot.android.crypto.** { *; <init>(...); }
+# The prebuilt native runtime resolves this class and its fields by JNI name.
+-keep class mono.android.Runtime { *; }
 # NativeAOT resolves these interface methods through JNI during startup.
 -keep class mono.android.IGCUserPeer { *; }
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeAotProguardConfiguration.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeAotProguardConfiguration.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Xml;
 using Microsoft.Build.Framework;
 using Microsoft.Android.Build.Tasks;
+using Xamarin.Android.Tasks.JniRemapping;
 
 namespace Xamarin.Android.Tasks;
 
@@ -22,6 +23,12 @@ public class GenerateNativeAotProguardConfiguration : AndroidTask
 
 	[Required]
 	public string OutputFile { get; set; } = "";
+
+	public string? R8MappingFile { get; set; }
+
+	public string? R8RewriteManifestFile { get; set; }
+
+	public string? R8ReachabilityManifestFile { get; set; }
 
 	// When false, the ILC DGML is not consulted (it may not have been generated at all) and a
 	// -keep rule is emitted for every Java type in the ACW map, so R8 keeps them all instead of
@@ -56,15 +63,73 @@ public class GenerateNativeAotProguardConfiguration : AndroidTask
 			retainedTypeKeys = LoadRetainedTypeKeysFromDgml ();
 		}
 
+		var allJavaTypes = LoadJavaTypesFromAcwMap (null);
 		// A null retainedTypeKeys means "keep every Java type in the ACW map" (Java trimming disabled).
-		var javaTypes = LoadJavaTypesFromAcwMap (retainedTypeKeys);
+		var javaTypes = retainedTypeKeys == null ? allJavaTypes : LoadJavaTypesFromAcwMap (retainedTypeKeys);
+		var reachableR8Entries = new HashSet<string> (StringComparer.Ordinal);
+		R8Mapping? mapping = null;
+		if (!R8MappingFile.IsNullOrEmpty ()) {
+			if (!File.Exists (R8MappingFile)) {
+				LogR8JniMappingError (string.Format (Properties.Resources.XA4327_SeedMappingNotFound, R8MappingFile));
+				return false;
+			}
+			if (R8RewriteManifestFile.IsNullOrEmpty () || !File.Exists (R8RewriteManifestFile)) {
+				LogR8JniMappingError (string.Format (Properties.Resources.XA4327_RewriteManifestNotFound, R8RewriteManifestFile));
+				return false;
+			}
+			try {
+				mapping = R8Mapping.Load (R8MappingFile);
+				var rewriteEntries = File.ReadAllLines (R8RewriteManifestFile);
+				// Comparing the seed mapping to itself validates every manifest entry and verifies
+				// that it identifies an entry in the seed mapping.
+				foreach (string conflict in mapping.GetReachabilityConflicts (mapping, rewriteEntries)) {
+					throw new FormatException (conflict);
+				}
+
+				var allAcwTypes = new HashSet<string> (StringComparer.Ordinal);
+				foreach (string javaTypeName in allJavaTypes) {
+					allAcwTypes.Add (javaTypeName.Replace ('.', '/'));
+				}
+				var retainedAcwTypes = new HashSet<string> (StringComparer.Ordinal);
+				foreach (string javaTypeName in javaTypes) {
+					string jniTypeName = javaTypeName.Replace ('.', '/');
+					retainedAcwTypes.Add (jniTypeName);
+					if (mapping.TryGetRenamedClass (jniTypeName, out _)) {
+						reachableR8Entries.Add (R8Mapping.BuildClassEntry (jniTypeName));
+					}
+				}
+				foreach (string entry in rewriteEntries) {
+					string [] parts = entry.Split ('\t');
+					string owningType = parts [1];
+					if (!allAcwTypes.Contains (owningType) || retainedAcwTypes.Contains (owningType)) {
+						reachableR8Entries.Add (entry);
+					}
+				}
+			} catch (FormatException ex) {
+				LogR8JniMappingError (string.Format (Properties.Resources.XA4327_MappingDataFailure, ex.Message));
+				return false;
+			} catch (IOException ex) {
+				LogR8JniMappingError (string.Format (Properties.Resources.XA4327_MappingDataFailure, ex.Message));
+				return false;
+			} catch (UnauthorizedAccessException ex) {
+				LogR8JniMappingError (string.Format (Properties.Resources.XA4327_MappingDataFailure, ex.Message));
+				return false;
+			}
+		}
 
 		using var writer = new StringWriter ();
 		writer.WriteLine ("# ACWs retained by NativeAOT ILC");
-		foreach (var javaTypeName in javaTypes) {
-			writer.WriteLine ($"-keep class {javaTypeName} {{ *; }}");
+		if (mapping == null) {
+			foreach (var javaTypeName in javaTypes) {
+				writer.WriteLine ($"-keep class {javaTypeName} {{ *; }}");
+			}
+		} else {
+			GenerateProguardConfiguration.WriteMappedRules (writer, reachableR8Entries);
 		}
-		Files.CopyIfStringChanged (writer.ToString (), OutputFile);
+		File.WriteAllText (OutputFile, writer.ToString ());
+		if (!R8ReachabilityManifestFile.IsNullOrEmpty ()) {
+			WriteReachabilityManifest (R8ReachabilityManifestFile, reachableR8Entries);
+		}
 
 		if (TrimJavaCallableWrappers) {
 			Log.LogMessage (MessageImportance.Low, "Generated {0} NativeAOT trimmable typemap ProGuard rules from {1} DGML file(s).", javaTypes.Count, NativeAotDgmlFiles.Length);
@@ -72,6 +137,18 @@ public class GenerateNativeAotProguardConfiguration : AndroidTask
 			Log.LogMessage (MessageImportance.Low, "Generated {0} NativeAOT ProGuard rules keeping every Java type in the ACW map (Java trimming is disabled).", javaTypes.Count);
 		}
 		return !Log.HasLoggedErrors;
+	}
+
+	void LogR8JniMappingError (string detail)
+		=> Log.LogCodedError ("XA4327", Properties.Resources.XA4327, detail);
+
+	static void WriteReachabilityManifest (string path, IEnumerable<string> entries)
+	{
+		string? directory = Path.GetDirectoryName (path);
+		if (!directory.IsNullOrEmpty ()) {
+			Directory.CreateDirectory (directory);
+		}
+		File.WriteAllText (path, R8Mapping.CreateManifestContent (entries));
 	}
 
 	List<string> LoadJavaTypesFromAcwMap (HashSet<string>? retainedTypeKeys)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateProguardConfiguration.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateProguardConfiguration.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Android.Tasks
 				foreach (var assembly in LinkedAssemblies) {
 					ScanRewrittenAssembly (assembly.ItemSpec, mapping);
 				}
-				WriteMappedRules (writer, mapping);
+				WriteMappedRules (writer, mapping.AccessedEntries);
 			} else {
 				foreach (var assembly in LinkedAssemblies) {
 					ProcessAssembly (assembly.ItemSpec, writer);
@@ -110,18 +110,25 @@ namespace Xamarin.Android.Tasks
 		void LogR8JniMappingError (string detail)
 			=> Log.LogCodedError ("XA4327", Properties.Resources.XA4327, detail);
 
-		void WriteMappedRules (TextWriter writer, R8Mapping mapping)
+		internal static void WriteMappedRules (TextWriter writer, IEnumerable<string> entries)
 		{
 			var rules = new SortedDictionary<string, SortedSet<string>> (StringComparer.Ordinal);
-			foreach (string entry in mapping.AccessedEntries) {
+			foreach (string entry in entries) {
 				string [] parts = entry.Split ('\t');
-				if (parts.Length < 2) {
-					continue;
+				switch (parts.Length > 0 ? parts [0] : "") {
+				case "C" when parts.Length == 2:
+				break;
+				case "F" when parts.Length == 3:
+				break;
+				case "M" when parts.Length == 3:
+				break;
+				default:
+					throw new FormatException ($"Invalid R8 JNI reachability manifest entry '{entry}'.");
 				}
 				if (!rules.TryGetValue (parts [1], out var members)) {
 					rules [parts [1]] = members = new SortedSet<string> (StringComparer.Ordinal);
 				}
-				if (parts.Length != 3) {
+				if (parts [0] == "C") {
 					continue;
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
@@ -369,6 +369,9 @@ namespace Xamarin.Android.Build.Tests {
 			var path = Path.Combine (Root, "temp", TestName);
 			var dgmlFile = Path.Combine (path, "app.scan.dgml.xml");
 			var acwMapFile = Path.Combine (path, "acw-map.txt");
+			var mappingFile = Path.Combine (path, "mapping.txt");
+			var rewriteManifestFile = Path.Combine (path, "r8-jni-rewrite-manifest.txt");
+			var reachabilityManifestFile = Path.Combine (path, "r8-jni-reachability-manifest.txt");
 			var outputFile = Path.Combine (path, "proguard", "proguard_project_references.cfg");
 			Directory.CreateDirectory (path);
 			File.WriteAllText (dgmlFile, """
@@ -394,23 +397,96 @@ namespace Xamarin.Android.Build.Tests {
 				Duplicate.Type;wrong.Duplicate
 				Other.Type;other.Type
 				""");
+			File.WriteAllText (mappingFile, """
+				crc64a1.MainActivity -> a.a:
+				my.app.Duplicate -> a.b:
+				androidx.activity.result.contract.ActivityResultContracts$TakePicture -> a.c:
+				non.acw.Helper -> a.d:
+				    int value -> e
+				    void run() -> f
+				other.Type -> a.g:
+				    void removed() -> h:
+
+				""");
+			File.WriteAllText (rewriteManifestFile, """
+				C	crc64a1/MainActivity
+				C	non/acw/Helper
+				C	other/Type
+				F	non/acw/Helper	value
+				M	non/acw/Helper	run():void
+				M	other/Type	removed():void
+
+				""".ReplaceLineEndings ("\n"));
 
 			var task = new GenerateNativeAotProguardConfiguration {
 				BuildEngine = new MockBuildEngine (TestContext.Out),
 				NativeAotDgmlFiles = new [] { new TaskItem (dgmlFile) },
 				AcwMapFile = acwMapFile,
 				OutputFile = outputFile,
+				R8MappingFile = mappingFile,
+				R8RewriteManifestFile = rewriteManifestFile,
+				R8ReachabilityManifestFile = reachabilityManifestFile,
 				TrimJavaCallableWrappers = true,
 			};
 
 			Assert.IsTrue (task.Execute (), "Task should succeed.");
 			var proguard = File.ReadAllText (outputFile);
-			StringAssert.Contains ("-keep class crc64a1.MainActivity { *; }", proguard);
-			StringAssert.Contains ("-keep class android.app.Activity { *; }", proguard);
-			StringAssert.Contains ("-keep class my.app.Duplicate { *; }", proguard);
-			StringAssert.Contains ("-keep class androidx.activity.result.contract.ActivityResultContracts$TakePicture { *; }", proguard);
-			StringAssert.DoesNotContain ("wrong.Duplicate", proguard);
+			StringAssert.Contains ("-keep,allowobfuscation class crc64a1.MainActivity", proguard);
+			StringAssert.Contains ("-keep,allowobfuscation class my.app.Duplicate", proguard);
+			StringAssert.Contains ("-keep,allowobfuscation class androidx.activity.result.contract.ActivityResultContracts$TakePicture", proguard);
+			StringAssert.Contains ("-keep,allowobfuscation class non.acw.Helper", proguard);
+			StringAssert.Contains ("-keepclassmembers,allowobfuscation class non.acw.Helper", proguard);
+			StringAssert.Contains ("*** value;", proguard);
+			StringAssert.Contains ("*** run(...);", proguard);
+			StringAssert.DoesNotContain ("-keep class crc64a1.MainActivity", proguard);
 			StringAssert.DoesNotContain ("other.Type", proguard);
+			StringAssert.DoesNotContain ("wrong.Duplicate", proguard);
+			CollectionAssert.AreEqual (new [] {
+				"C\tandroidx/activity/result/contract/ActivityResultContracts$TakePicture",
+				"C\tcrc64a1/MainActivity",
+				"C\tmy/app/Duplicate",
+				"C\tnon/acw/Helper",
+				"F\tnon/acw/Helper\tvalue",
+				"M\tnon/acw/Helper\trun():void",
+			}, File.ReadAllLines (reachabilityManifestFile));
+			StringAssert.DoesNotContain ("\r", File.ReadAllText (reachabilityManifestFile), "R8 JNI manifests should use deterministic LF line endings.");
+		}
+
+		[TestCase ("missing-mapping")]
+		[TestCase ("malformed-mapping")]
+		[TestCase ("missing-rewrite-manifest")]
+		[TestCase ("malformed-rewrite-manifest")]
+		public void Execute_GenerateNativeAotProguardConfiguration_InvalidR8InputUsesXA4327 (string invalidInput)
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			var acwMapFile = Path.Combine (path, "acw-map.txt");
+			var mappingFile = Path.Combine (path, "mapping.txt");
+			var rewriteManifestFile = Path.Combine (path, "r8-jni-rewrite-manifest.txt");
+			Directory.CreateDirectory (path);
+			File.WriteAllText (acwMapFile, "Managed.Type;managed.Type\n");
+			if (invalidInput != "missing-mapping") {
+				File.WriteAllText (mappingFile, invalidInput == "malformed-mapping"
+					? "not a mapping\n"
+					: "managed.Type -> a:\n");
+			}
+			if (invalidInput != "missing-rewrite-manifest") {
+				File.WriteAllText (rewriteManifestFile, invalidInput == "malformed-rewrite-manifest"
+					? "not a manifest entry\n"
+					: "C\tmanaged/Type\n");
+			}
+			var errors = new List<BuildErrorEventArgs> ();
+			var task = new GenerateNativeAotProguardConfiguration {
+				BuildEngine = new MockBuildEngine (TestContext.Out, errors),
+				AcwMapFile = acwMapFile,
+				OutputFile = Path.Combine (path, "proguard.cfg"),
+				R8MappingFile = mappingFile,
+				R8RewriteManifestFile = rewriteManifestFile,
+				TrimJavaCallableWrappers = false,
+			};
+
+			Assert.IsFalse (task.Execute (), "Invalid R8 input should fail the task.");
+			Assert.That (errors, Has.Count.EqualTo (1));
+			Assert.AreEqual ("XA4327", errors [0].Code);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -203,9 +203,8 @@ namespace Xamarin.Android.Build.Tests {
 		}
 
 		[Test]
-		public void Build_WithR8JniNameRewriting_IsIncremental ()
+		public void Build_WithR8JniNameRewriting_IsIncremental ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 		{
-			const AndroidRuntime runtime = AndroidRuntime.CoreCLR;
 			const string originalJavaName = "com/example/R8JniPeer";
 			const string changedJavaName = "com/example/R8JniPeerChanged";
 			const string userJavaName = "com.example.UserJavaType";
@@ -273,6 +272,7 @@ public class R8JniPeer : Java.Lang.Object
 			StringAssert.Contains ($"C\t{originalJavaName}", File.ReadAllText (rewriteManifest));
 			Assert.That (new FileInfo (reachabilityManifest).Length, Is.GreaterThan (0), "The clean build should record post-link JNI reachability.");
 			Assert.That (new FileInfo (finalMapping).Length, Is.GreaterThan (0), "The final R8 pass should emit its applied mapping.");
+			AssertR8MappingRenamesClass (finalMapping, originalJavaName);
 			Assert.That (Directory.GetFiles (Path.Combine (projectDirectory, proj.OutputPath), "mapping.txt", SearchOption.AllDirectories), Is.Empty,
 				"Disabling public mapping output should not write mapping.txt under bin.");
 			var appBundle = FindSingleFile (Path.Combine (projectDirectory, proj.OutputPath), $"{proj.PackageName}-Signed.aab");
@@ -287,6 +287,11 @@ public class R8JniPeer : Java.Lang.Object
 				.Append (reachabilityManifest)
 				.Append (finalMapping)
 				.ToDictionary (path => path, File.GetLastWriteTimeUtc, StringComparer.Ordinal);
+			string? ilcRspFile = null;
+			if (runtime == AndroidRuntime.NativeAOT) {
+				ilcRspFile = FindSingleFile (projectDirectory, $"{proj.ProjectName}.ilc.rsp");
+				StringAssert.Contains ("r8-jni-rewritten", File.ReadAllText (ilcRspFile), "ILC should compile the rewritten managed inputs.");
+			}
 
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "No-op R8 JNI name-rewriting build should have succeeded.");
 			builder.Output.AssertTargetIsSkipped ("_AndroidCompileR8JniSeedJava");
@@ -297,6 +302,15 @@ public class R8JniPeer : Java.Lang.Object
 			builder.Output.AssertTargetIsSkipped ("_CompileToDalvik");
 			foreach (var pair in outputTimestamps) {
 				Assert.AreEqual (pair.Value, File.GetLastWriteTimeUtc (pair.Key), $"No-op build should preserve {pair.Key}.");
+			}
+
+			if (runtime == AndroidRuntime.NativeAOT) {
+				File.Delete (ilcRspFile);
+				Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "ILC response-file regeneration build should have succeeded.");
+				builder.Output.AssertTargetIsSkipped ("_AndroidRewriteJniNamesBeforeIlc");
+				builder.Output.AssertTargetIsNotSkipped ("WriteIlcRspFileForCompilation");
+				FileAssert.Exists (ilcRspFile);
+				StringAssert.Contains ("r8-jni-rewritten", File.ReadAllText (ilcRspFile), "A regenerated ILC response file should retain rewritten managed inputs when the rewrite target is skipped.");
 			}
 
 			System.Threading.Thread.Sleep (1100);
@@ -330,6 +344,7 @@ public class R8JniPeer : Java.Lang.Object
 			StringAssert.Contains ($"{changedJavaName.Replace ('/', '.')} ->", File.ReadAllText (seedMapping));
 			AssertR8MappingRenamesClass (seedMapping, changedJavaName);
 			AssertR8MappingKeepsClassName (seedMapping, $"{proj.PackageName}/MainActivity");
+			AssertR8MappingRenamesClass (finalMapping, changedJavaName);
 			StringAssert.Contains ($"C\t{changedJavaName}", File.ReadAllText (rewriteManifest));
 
 			proj.SetProperty ("AndroidEnableR8JniNameObfuscation", "false");
@@ -343,9 +358,8 @@ public class R8JniPeer : Java.Lang.Object
 		}
 
 		[Test]
-		public void Build_WithR8JniNameRewriting_SupportsMultipleRuntimeIdentifiers ()
+		public void Build_WithR8JniNameRewriting_SupportsMultipleRuntimeIdentifiers ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 		{
-			const AndroidRuntime runtime = AndroidRuntime.CoreCLR;
 			const string javaName = "com/example/R8JniMultiAbiPeer";
 			if (IgnoreUnsupportedConfiguration (runtime, release: true)) {
 				return;
@@ -403,9 +417,8 @@ public class R8JniMultiAbiPeer : Java.Lang.Object
 		}
 
 		[Test]
-		public void Build_WithR8JniNameRewriting_SupportsProjectReferencesAndCustomRules ()
+		public void Build_WithR8JniNameRewriting_SupportsProjectReferencesAndCustomRules ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 		{
-			const AndroidRuntime runtime = AndroidRuntime.CoreCLR;
 			const string libraryJavaName = "com/example/R8JniLibraryPeer";
 			if (IgnoreUnsupportedConfiguration (runtime, release: true)) {
 				return;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -281,17 +281,20 @@ public class R8JniPeer : Java.Lang.Object
 					"Disabling public mapping output should omit the ProGuard mapping from app-bundle metadata.");
 			}
 
-			var outputTimestamps = rewrittenAssemblies
+			IEnumerable<string> outputFiles = rewrittenAssemblies
 				.Append (seedMapping)
 				.Append (rewriteManifest)
 				.Append (reachabilityManifest)
-				.Append (finalMapping)
-				.ToDictionary (path => path, File.GetLastWriteTimeUtc, StringComparer.Ordinal);
+				.Append (finalMapping);
 			string? ilcRspFile = null;
+			string? ilcRspContent = null;
 			if (runtime == AndroidRuntime.NativeAOT) {
 				ilcRspFile = FindSingleFile (projectDirectory, $"{proj.ProjectName}.ilc.rsp");
-				StringAssert.Contains ("r8-jni-rewritten", File.ReadAllText (ilcRspFile), "ILC should compile the rewritten managed inputs.");
+				ilcRspContent = File.ReadAllText (ilcRspFile);
+				StringAssert.Contains ("r8-jni-rewritten", ilcRspContent, "ILC should compile the rewritten managed inputs.");
+				outputFiles = outputFiles.Append (ilcRspFile);
 			}
+			var outputTimestamps = outputFiles.ToDictionary (path => path, File.GetLastWriteTimeUtc, StringComparer.Ordinal);
 
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "No-op R8 JNI name-rewriting build should have succeeded.");
 			builder.Output.AssertTargetIsSkipped ("_AndroidCompileR8JniSeedJava");
@@ -299,18 +302,17 @@ public class R8JniPeer : Java.Lang.Object
 			builder.Output.AssertTargetIsSkipped (runtime == AndroidRuntime.CoreCLR
 				? "_AndroidRewriteJniNamesBeforeILLink"
 				: "_AndroidRewriteJniNamesBeforeIlc");
+			if (runtime == AndroidRuntime.NativeAOT) {
+				builder.Output.AssertTargetIsNotSkipped ("WriteIlcRspFileForCompilation");
+				FileAssert.Exists (ilcRspFile);
+				string actualIlcRspContent = File.ReadAllText (ilcRspFile);
+				StringAssert.Contains ("r8-jni-rewritten", actualIlcRspContent, "ILC response-file recomputation should retain rewritten managed inputs when the rewrite target is skipped.");
+				Assert.AreEqual (ilcRspContent, actualIlcRspContent, "ILC response-file recomputation should preserve rewritten managed inputs when the rewrite target is skipped.");
+				Assert.AreEqual (outputTimestamps [ilcRspFile], File.GetLastWriteTimeUtc (ilcRspFile), "An unchanged ILC response file should preserve its timestamp.");
+			}
 			builder.Output.AssertTargetIsSkipped ("_CompileToDalvik");
 			foreach (var pair in outputTimestamps) {
 				Assert.AreEqual (pair.Value, File.GetLastWriteTimeUtc (pair.Key), $"No-op build should preserve {pair.Key}.");
-			}
-
-			if (runtime == AndroidRuntime.NativeAOT) {
-				File.Delete (ilcRspFile);
-				Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "ILC response-file regeneration build should have succeeded.");
-				builder.Output.AssertTargetIsSkipped ("_AndroidRewriteJniNamesBeforeIlc");
-				builder.Output.AssertTargetIsNotSkipped ("WriteIlcRspFileForCompilation");
-				FileAssert.Exists (ilcRspFile);
-				StringAssert.Contains ("r8-jni-rewritten", File.ReadAllText (ilcRspFile), "A regenerated ILC response file should retain rewritten managed inputs when the rewrite target is skipped.");
 			}
 
 			System.Threading.Thread.Sleep (1100);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -459,6 +459,9 @@ public class R8JniLibraryPeer : Java.Lang.Object
 				IsRelease = true,
 				LinkTool = "r8",
 			};
+			app.MainActivity = app.DefaultMainActivity.Replace (
+				"//${AFTER_ONCREATE}",
+				"_ = new R8JniLibrary.R8JniLibraryPeer ();");
 			app.SetRuntime (runtime);
 			app.SetProperty (KnownProperties.RuntimeIdentifier, "android-arm64");
 			app.SetProperty ("AndroidPackageFormat", "apk");
@@ -530,6 +533,7 @@ public class R8JniLibraryPeer : Java.Lang.Object
 			var seedMapping = FindSingleFile (projectDirectory, "mapping.txt", path => path.Contains ("r8-jni-seed", StringComparison.Ordinal));
 			var finalMapping = FindSingleFile (projectDirectory, "mapping.txt", path => !path.Contains ("r8-jni-seed", StringComparison.Ordinal));
 			var rewriteManifest = FindSingleFile (projectDirectory, "r8-jni-rewrite-manifest.txt");
+			var reachabilityManifest = FindSingleFile (projectDirectory, "r8-jni-reachability-manifest.txt");
 			var seedConfigurationItems = File.ReadAllLines (FindSingleFile (projectDirectory, "configuration-items.txt"));
 			var seedConfigurationPaths = seedConfigurationItems.Select (item => item.Split ('|') [0]).ToArray ();
 			var finalConfigurationItems = File.ReadAllLines (FindSingleFile (projectDirectory, "final-configuration-items.txt"));
@@ -548,6 +552,7 @@ public class R8JniLibraryPeer : Java.Lang.Object
 			AssertR8MappingContainsMember (finalMapping, libraryJavaName, "nctor_0");
 			AssertR8MappingContainsMember (finalMapping, $"{app.PackageName}/MainActivity", "n_OnCreate_Landroid_os_Bundle_");
 			StringAssert.Contains ($"C\t{libraryJavaName}", File.ReadAllText (rewriteManifest));
+			StringAssert.Contains ($"C\t{libraryJavaName}", File.ReadAllText (reachabilityManifest), "The build should record the referenced library peer as reachable before asserting its final R8 mapping.");
 			Assert.That (seedConfigurationPaths, Has.Some.EndsWith ("r8-jni-rules.pro"), "Seed R8 should receive user-authored rules.");
 			Assert.That (seedConfigurationPaths, Has.Some.EndsWith ("proguard.txt"), "Seed R8 should receive AAR consumer rules.");
 			Assert.That (seedConfigurationItems, Has.Some.EndsWith ("manifest_rules.txt|true||true"),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -232,6 +232,9 @@ public class R8JniPeer : Java.Lang.Object
 					peerSource,
 				},
 			};
+			proj.MainActivity = proj.DefaultMainActivity.Replace (
+				"//${AFTER_ONCREATE}",
+				"_ = new R8JniPeer ();");
 			if (runtime == AndroidRuntime.CoreCLR) {
 				proj.LinkTool = "r8";
 			}
@@ -270,7 +273,7 @@ public class R8JniPeer : Java.Lang.Object
 			AssertR8MappingKeepsClassName (finalMapping, $"{proj.PackageName}/MainActivity");
 			StringAssert.DoesNotContain ($"{userJavaName} ->", File.ReadAllText (seedMapping), "User Java sources are kept by final R8 and should not receive seed-only names.");
 			StringAssert.Contains ($"C\t{originalJavaName}", File.ReadAllText (rewriteManifest));
-			Assert.That (new FileInfo (reachabilityManifest).Length, Is.GreaterThan (0), "The clean build should record post-link JNI reachability.");
+			StringAssert.Contains ($"C\t{originalJavaName}", File.ReadAllText (reachabilityManifest), "The clean build should record the peer as reachable before asserting its final R8 mapping.");
 			Assert.That (new FileInfo (finalMapping).Length, Is.GreaterThan (0), "The final R8 pass should emit its applied mapping.");
 			AssertR8MappingRenamesClass (finalMapping, originalJavaName);
 			Assert.That (Directory.GetFiles (Path.Combine (projectDirectory, proj.OutputPath), "mapping.txt", SearchOption.AllDirectories), Is.Empty,
@@ -348,6 +351,7 @@ public class R8JniPeer : Java.Lang.Object
 			AssertR8MappingKeepsClassName (seedMapping, $"{proj.PackageName}/MainActivity");
 			AssertR8MappingRenamesClass (finalMapping, changedJavaName);
 			StringAssert.Contains ($"C\t{changedJavaName}", File.ReadAllText (rewriteManifest));
+			StringAssert.Contains ($"C\t{changedJavaName}", File.ReadAllText (reachabilityManifest), "The JNI-name change rebuild should preserve the peer's NativeAOT reachability.");
 
 			proj.SetProperty ("AndroidEnableR8JniNameObfuscation", "false");
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true), "Disabling R8 JNI name rewriting should invalidate the existing build outputs.");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3107,8 +3107,9 @@ because xbuild doesn't support framework reference assemblies.
            Text="Invalid value for AndroidTypeMapImplementation: '$(AndroidTypeMapImplementation)'. Valid values are: llvm-ir, trimmable." />
   </Target>
   <PropertyGroup>
+    <AndroidLinkTool Condition=" '$(AndroidLinkTool)' == '' and '$(AndroidTypeMapImplementation)' == 'trimmable' and '$(_AndroidRuntime)' == 'NativeAOT' ">r8</AndroidLinkTool>
     <_AndroidEnableR8JniNameRewriting
-        Condition=" '$(_AndroidEnableR8JniNameRewriting)' == '' and '$(AndroidLinkTool)' == 'r8' and '$(AndroidTypeMapImplementation)' == 'trimmable' and '$(_AndroidRuntime)' == 'CoreCLR' and '$(PublishTrimmed)' == 'true' and '$(AndroidEnableR8JniNameObfuscation)' == 'true' ">true</_AndroidEnableR8JniNameRewriting>
+        Condition=" '$(_AndroidEnableR8JniNameRewriting)' == '' and '$(AndroidLinkTool)' == 'r8' and '$(AndroidTypeMapImplementation)' == 'trimmable' and ('$(_AndroidRuntime)' == 'NativeAOT' or ('$(_AndroidRuntime)' == 'CoreCLR' and '$(PublishTrimmed)' == 'true')) and '$(AndroidEnableR8JniNameObfuscation)' == 'true' ">true</_AndroidEnableR8JniNameRewriting>
     <_AndroidEnableR8JniNameRewriting Condition=" '$(_AndroidEnableR8JniNameRewriting)' == '' ">false</_AndroidEnableR8JniNameRewriting>
   </PropertyGroup>
 


### PR DESCRIPTION
Related to https://github.com/dotnet/android/issues/12535

Depends on https://github.com/dotnet/android/pull/12632

Layer 6 of 6 and the top of the replacement stack for draft PR #12575. Extends the shared two-pass R8 JNI name-obfuscation pipeline to NativeAOT, including incremental pre-ILC assembly rewriting, conservative JNI class/member reachability, seed-compatible final keep rules, and prebuilt runtime JNI startup keeps.

Testing:
- Modified target XML parses successfully.
- `Xamarin.Android.Build.Tasks.csproj` builds successfully.
- Complete `Xamarin.Android.Build.Tests.csproj` builds successfully.
- NativeAOT and direct-manifest generator tests: 28/28 passed.
- Cumulative focused R8/JNI unit suites: 165/165 passed.
- `TypeMapAssemblyGeneratorTests`: 121/121 passed, including owner-specific JNI method-name FieldRVA coverage.
- Independent Opus 5 correctness review found no remaining high-confidence issues and separately confirmed skipped incremental targets still evaluate item redirection.
- All three NativeAOT R8/JNI integration variants were attempted, but the local SDK stops before project code with `NETSDK1147: To build this project, the following workloads must be installed: android`; no unrelated workload was installed.