### PR TITLE
[ci] Fix MAUI R2R Helix submissions for fork PRs

### DIFF
--- a/build-tools/automation/scripts/ConfigureMauiR2RHelixEnvironment.Tests.ps1
+++ b/build-tools/automation/scripts/ConfigureMauiR2RHelixEnvironment.Tests.ps1
@@ -1,0 +1,39 @@
+$ErrorActionPreference = 'Stop'
+$environmentScript = Join-Path $PSScriptRoot 'ConfigureMauiR2RHelixEnvironment.ps1'
+$powerShellExe = (Get-Process -Id $PID).Path
+if (-not $powerShellExe) {
+	$powerShellExe = 'powershell.exe'
+}
+
+$childScript = Join-Path ([IO.Path]::GetTempPath()) "$([IO.Path]::GetRandomFileName()).ps1"
+try {
+	@'
+param (
+	[string] $ExpectAccessToken
+)
+
+$hasAccessToken = Test-Path Env:SYSTEM_ACCESSTOKEN
+if ($hasAccessToken -ne [Convert]::ToBoolean($ExpectAccessToken)) {
+	Write-Error "Expected inherited SYSTEM_ACCESSTOKEN presence to be '$ExpectAccessToken', but it was '$hasAccessToken'."
+	exit 1
+}
+'@ | Set-Content -LiteralPath $childScript -Encoding ASCII
+
+	$testCases = @(
+		@{ IsFork = 'True'; ExpectAccessToken = 'False' },
+		@{ IsFork = 'False'; ExpectAccessToken = 'True' }
+	)
+
+	foreach ($testCase in $testCases) {
+		$env:SYSTEM_PULLREQUEST_ISFORK = $testCase.IsFork
+		$env:SYSTEM_ACCESSTOKEN = 'test-token'
+		. $environmentScript
+
+		& $powerShellExe -NoLogo -NoProfile -File $childScript $testCase.ExpectAccessToken
+		if ($LASTEXITCODE -ne 0) {
+			throw "MAUI R2R Helix environment test failed for fork value '$($testCase.IsFork)'."
+		}
+	}
+} finally {
+	Remove-Item -LiteralPath $childScript -Force -ErrorAction Ignore
+}

--- a/build-tools/automation/scripts/ConfigureMauiR2RHelixEnvironment.ps1
+++ b/build-tools/automation/scripts/ConfigureMauiR2RHelixEnvironment.ps1
@@ -1,0 +1,4 @@
+if ($env:SYSTEM_PULLREQUEST_ISFORK -eq 'True') {
+	Write-Host 'Disabling Azure Pipelines test reporting for anonymous fork PR Helix submissions.'
+	Remove-Item Env:SYSTEM_ACCESSTOKEN -ErrorAction Ignore
+}

--- a/build-tools/automation/yaml-templates/run-maui-r2r-helix-matrix.yaml
+++ b/build-tools/automation/yaml-templates/run-maui-r2r-helix-matrix.yaml
@@ -255,7 +255,7 @@ steps:
 
     if ($env:SYSTEM_PULLREQUEST_ISFORK -eq 'True') {
       Write-Host 'Disabling Azure Pipelines test reporting for anonymous fork PR Helix submissions.'
-      $env:SYSTEM_ACCESSTOKEN = ''
+      Remove-Item Env:SYSTEM_ACCESSTOKEN -ErrorAction Ignore
     }
 
     if ([Environment]::OSVersion.Platform -eq "Unix") {

--- a/build-tools/automation/yaml-templates/run-maui-r2r-helix-matrix.yaml
+++ b/build-tools/automation/yaml-templates/run-maui-r2r-helix-matrix.yaml
@@ -253,6 +253,11 @@ steps:
     $payloadRootDirectory = '${{ parameters.payloadDirectory }}'
     New-Item -ItemType Directory -Force -Path $logsDirectory | Out-Null
 
+    if ($env:SYSTEM_PULLREQUEST_ISFORK -eq 'True') {
+      Write-Host 'Disabling Azure Pipelines test reporting for anonymous fork PR Helix submissions.'
+      $env:SYSTEM_ACCESSTOKEN = ''
+    }
+
     if ([Environment]::OSVersion.Platform -eq "Unix") {
       $dotnetRoot = Join-Path $xaSourcePath 'bin/$(XA.Build.Configuration)/dotnet'
       $dotnetPath = Join-Path $dotnetRoot 'dotnet'
@@ -366,3 +371,4 @@ steps:
   continueOnError: false
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    SYSTEM_PULLREQUEST_ISFORK: $(System.PullRequest.IsFork)

--- a/build-tools/automation/yaml-templates/run-maui-r2r-helix-matrix.yaml
+++ b/build-tools/automation/yaml-templates/run-maui-r2r-helix-matrix.yaml
@@ -247,16 +247,17 @@ steps:
     continueOnError: false
 
 - powershell: |
+    & '${{ parameters.xaSourcePath }}/build-tools/automation/scripts/ConfigureMauiR2RHelixEnvironment.Tests.ps1'
+  displayName: Test MAUI R2R Helix environment
+
+- powershell: |
     $ErrorActionPreference = 'Stop'
     $xaSourcePath = '${{ parameters.xaSourcePath }}'
     $logsDirectory = '${{ parameters.logsDirectory }}'
     $payloadRootDirectory = '${{ parameters.payloadDirectory }}'
     New-Item -ItemType Directory -Force -Path $logsDirectory | Out-Null
 
-    if ($env:SYSTEM_PULLREQUEST_ISFORK -eq 'True') {
-      Write-Host 'Disabling Azure Pipelines test reporting for anonymous fork PR Helix submissions.'
-      Remove-Item Env:SYSTEM_ACCESSTOKEN -ErrorAction Ignore
-    }
+    . (Join-Path $xaSourcePath 'build-tools/automation/scripts/ConfigureMauiR2RHelixEnvironment.ps1')
 
     if ([Environment]::OSVersion.Platform -eq "Unix") {
       $dotnetRoot = Join-Path $xaSourcePath 'bin/$(XA.Build.Configuration)/dotnet'


### PR DESCRIPTION
## Summary

- detect fork PR builds before starting MAUI R2R Helix submissions
- remove the unavailable `System.AccessToken` so the Helix SDK disables Azure Pipelines test reporting
- preserve anonymous Helix submission and test reporting for trusted builds
- verify fork and non-fork token inheritance in child PowerShell processes before running the submissions

## Context

Fork PR submissions were failing before reaching Helix because `AzurePipelines.MultiQueue.targets` attempted to start an Azure Pipelines test run with the restricted fork token and received HTTP 401.

Example failure: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1577851&view=logs&jobId=7ec14a57-4d0d-5c34-dfba-b9061d40ba04

## Behavior change

The MAUI R2R tests will still be submitted anonymously to Helix using an empty `HelixAccessToken` and the `Creator` identity. The submission task will continue waiting for Helix completion and will fail when a Helix work item fails.

For fork PRs, these runs will no longer create or update an Azure Pipelines test run, so their results will not appear in the Azure DevOps **Tests** tab. Removing `System.AccessToken` is scoped to the submission PowerShell process and its children; later pipeline tasks and non-fork builds are unchanged.

## Validation

- added executable coverage for both fork and non-fork environment inheritance
- ran the regression script under PowerShell
- parsed the updated YAML template
- ran `git diff --check`