### PR TITLE
[ci] Enable CFSClean network isolation

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -58,6 +58,8 @@ extends:
   ${{ else }}:
     template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@1esPipelines
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       ${{ if eq('${{ parameters.Skip1ESComplianceTasks }}', 'true') }}:
         enableAllTools: false

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -58,8 +58,6 @@ extends:
   ${{ else }}:
     template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@1esPipelines
   parameters:
-    settings:
-      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       ${{ if eq('${{ parameters.Skip1ESComplianceTasks }}', 'true') }}:
         enableAllTools: false
@@ -87,6 +85,7 @@ extends:
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
     settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
       skipBuildTagsForGitHubPullRequests: true
     stages:
     - template: /build-tools/automation/yaml-templates/build-macos.yaml@self


### PR DESCRIPTION
## Summary

- explicitly configure the shared Xamarin.Android production/PR 1ES pipeline with `Permissive,CFSClean,CFSClean2,CFSClean3`
- retain `Permissive` so Android SDK/NDK traffic such as `dl.google.com` and `dl-ssl.google.com` remains available
- retain the existing required `CFSClean2` and `CFSClean3` policies while adding the SFI-required `CFSClean` policy

## SFI / CFS rationale

S360 tracks Xamarin.Android (`devdiv/11410`) and Xamarin.Android-PR (`devdiv/12278`). Direct `api.nuget.org` access is classified as a `CFSClean` violation. The fix intentionally applies the policy rather than weakening it or adding a public-NuGet allowlist.

Both Azure DevOps definitions map to `build-tools/automation/azure-pipelines.yaml`, so one explicit 1ES `settings.networkIsolationPolicy` value covers the official production template and unofficial PR template selected by that entry point. Unrelated public, nightly, API-docs, internal-mirror, and Renovate definitions are unchanged.

## Evidence

Before this change, `Start Network Isolation` logs for both definitions selected `Permissive`, `CFSClean2`, and `CFSClean3`, but not `CFSClean`:

- Xamarin.Android build `15174775`: `Policies=[(Permissive:PerPipelineConfig), (CFSClean3:PerPipelineRequiredConfig), (CFSClean2:PerPipelineRequiredConfig)]`
- Xamarin.Android-PR build `15122095`: `Policies=[(Permissive:PerPipelineConfig), (CFSClean3:PerPipelineRequiredConfig), (CFSClean2:PerPipelineRequiredConfig)]`

Post-change validation queued both definitions against commit `8ff97062d963e3f451d0079951f8a509440c4cca`:

- [Xamarin.Android build 15183926](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=15183926&view=results): `Start Network Isolation` selected `Permissive`, `CFSClean`, `CFSClean2`, and `CFSClean3`, all from `PipelineArguments`. The Windows Android archive cache restored successfully and `Prepare Solution` succeeded.
- [Xamarin.Android-PR build 15183927](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=15183927&view=results): `Start Network Isolation` selected the same four policies from `PipelineArguments`. `Prepare Solution` downloaded 15 archives from `dl.google.com`, including `android-ndk-r28c-windows.zip`, then succeeded with no network-isolation block.

The relevant network-isolation and Android SDK/NDK acquisition checks passed. The full validation runs remain in progress and both contain an unrelated 1ES PoliCheck post-analysis failure (`Guardian` exit code 8); this one-line pipeline-policy change does not touch scanned source content.