### PR TITLE
[ci] Enable CFSClean network isolation

### DIFF
--- a/build-tools/automation/azure-pipelines-internal.yaml
+++ b/build-tools/automation/azure-pipelines-internal.yaml
@@ -91,6 +91,8 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     pool:
       name: $(NetCoreInternalPoolName)
       image: $(WindowsPoolImageNetCoreInternal)

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -85,7 +85,7 @@ extends:
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
     settings:
-      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
+      networkIsolationPolicy: Permissive,CFSClean
       skipBuildTagsForGitHubPullRequests: true
     stages:
     - template: /build-tools/automation/yaml-templates/build-macos.yaml@self

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -58,6 +58,8 @@ extends:
   ${{ else }}:
     template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@1esPipelines
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       ${{ if eq('${{ parameters.Skip1ESComplianceTasks }}', 'true') }}:
         enableAllTools: false

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -58,8 +58,6 @@ extends:
   ${{ else }}:
     template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@1esPipelines
   parameters:
-    settings:
-      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       ${{ if eq('${{ parameters.Skip1ESComplianceTasks }}', 'true') }}:
         enableAllTools: false
@@ -87,6 +85,7 @@ extends:
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
     settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
       skipBuildTagsForGitHubPullRequests: true
     stages:
     - template: /build-tools/automation/yaml-templates/build-macos.yaml@self

--- a/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.Packages.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.Packages.cs
@@ -91,7 +91,7 @@ public partial class SdkManager
 			var trimmed = line.Trim ();
 
 			// Match section headers case-insensitively: the classic sdkmanager emits
-			// "Available Packages:" (capital P) while the newer Android CLI replacement
+			// "Available Packages:" (uppercase P) while the newer Android CLI replacement
 			// (cmdline-tools 23+) emits "Available packages:" (lowercase p).
 			var foundSection = false;
 			foreach (var section in PackageSections) {


### PR DESCRIPTION
## Summary

- set `networkIsolationPolicy: Permissive,CFSClean` in the shared DevDiv production/PR pipeline entry point
- set the same policy in the separate dnceng/internal production pipeline entry point
- retain `Permissive` so Android SDK/NDK traffic remains available
- rely on centrally required `CFSClean2` and `CFSClean3` instead of listing them in repository YAML
- replace `capital P` with `uppercase P` in an sdkmanager parsing comment to avoid a PoliCheck geopolitical false positive without changing behavior

## Pipeline coverage

| Definition | YAML entry point | 1ES template path |
| --- | --- | --- |
| DevDiv `11410` — Xamarin.Android | `build-tools/automation/azure-pipelines.yaml` | Official |
| DevDiv `12278` — Xamarin.Android-PR | `build-tools/automation/azure-pipelines.yaml` | Unofficial |
| dnceng/internal `1644` — dotnet-android-internal | `build-tools/automation/azure-pipelines-internal.yaml` | Official |

The dnceng/internal definition is independent of the DevDiv definitions, so both YAML entry points require an explicit setting. `dotnet-android-tools-official` (`1596`) belongs to the separate `dotnet-android-tools` repository and is not in scope. Public, nightly, API-docs, and Renovate definitions are also unchanged.

This PR is opened from a branch in the main `dotnet/android` repository so trusted/full definitions can validate the submitted commit. The earlier fork PR was closed.

## SFI / CFS rationale

S360 tracks Xamarin.Android (`devdiv/11410`) and Xamarin.Android-PR (`devdiv/12278`). Direct `api.nuget.org` access is classified as a `CFSClean` violation. This change applies the policy without weakening it or adding a public-NuGet allowlist.

## Validation evidence

Final commit: `b63ae9fd6`.

The pipeline validation builds below ran against implementation commit `2cc30f604c5742141d9cccff57311614362e99c2`; the final commit changes only comment wording to resolve the resulting PoliCheck false positive.

- [Xamarin.Android build 15184305](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=15184305&view=results): `Permissive` and `CFSClean` came from `PipelineArguments`; `CFSClean2` and `CFSClean3` came from `PerPipelineRequiredConfig`. Windows Android preparation succeeded. The run reached a 20-minute Mac .NET timeout after its build/tests had otherwise succeeded; its PoliCheck failure is addressed by the final comment-only commit.
- [Xamarin.Android-PR build 15184306](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=15184306&view=results): the same policy/source composition was applied. `Prepare Solution` downloaded 15 Android archives from `dl.google.com`, including `android-ndk-r28c-windows.zip`, and completed successfully with no network-isolation block. Its PoliCheck failure is addressed by the final comment-only commit.
- [dotnet-android-internal build 3064262](https://dev.azure.com/dnceng/internal/_build/results?buildId=3064262&view=results): the same policy/source composition was applied. Its Linux Android archive cache restored successfully, and `make jenkins` actively built native Android targets with the cached SDK CMake and NDK Clang toolchain with no network-isolation or acquisition errors.

Expanded `Start Network Isolation` logs for all three definitions report:

`Policies=[(Permissive:PipelineArguments), (CFSClean:PipelineArguments), ... (CFSClean2:PerPipelineRequiredConfig), (CFSClean3:PerPipelineRequiredConfig)]`

The policy composition and required Android dependency acquisition checks pass; the final comment-only fix removes the observed PoliCheck false positive.