### PR TITLE
[tests] Add Android interop benchmarks and reduce JNI overhead

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -768,7 +768,7 @@ namespace Android.Runtime {
 				} },
 				{ typeof (Array), (type, source, index) => {
 					IntPtr  elem      = GetObjectArrayElement (source, index);
-					return GetArray (elem, JniHandleOwnership.TransferLocalRef, type);
+					return GetArray (elem, JniHandleOwnership.TransferLocalRef, type?.GetElementType ());
 				} },
 			};
 		}

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -313,6 +313,14 @@ namespace Android.Runtime {
 			return global_ref;
 		}
 
+		static IntPtr FindClass (ReadOnlySpan<byte> classname)
+		{
+			JniObjectReference local_ref = JniEnvironment.Types.FindClass (classname);
+			IntPtr global_ref = NewGlobalRef (local_ref.Handle);
+			JniObjectReference.Dispose (ref local_ref);
+			return global_ref;
+		}
+
 		public static IntPtr FindClass (string className, ref IntPtr cachedJniClassHandle)
 		{
 			if (cachedJniClassHandle != IntPtr.Zero)
@@ -564,58 +572,92 @@ namespace Android.Runtime {
 
 		static void AssertCompatibleArrayTypes (Type srcElementType, IntPtr destArray)
 		{
-			IntPtr grefSource = FindArrayClassByElementType (srcElementType);
-			IntPtr lrefDest   = GetObjectClass (destArray);
+			JniObjectReference sourceClass = FindArrayClassByElementType (srcElementType);
+			JniObjectReference destClass   = JniEnvironment.Types.GetObjectClass (new JniObjectReference (destArray));
 			try {
-				if (!IsAssignableFrom (grefSource, lrefDest)) {
+				if (!JniEnvironment.Types.IsAssignableFrom (sourceClass, destClass)) {
 					throw new InvalidCastException (FormattableString.Invariant (
-						$"Unable to cast from '{JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (grefSource))}' to '{JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (lrefDest))}'."));
+						$"Unable to cast from '{JniEnvironment.Types.GetJniTypeNameFromClass (sourceClass)}' to '{JniEnvironment.Types.GetJniTypeNameFromClass (destClass)}'."));
 				}
 			} finally {
-				DeleteGlobalRef (grefSource);
-				DeleteLocalRef (lrefDest);
+				JniObjectReference.Dispose (ref sourceClass);
+				JniObjectReference.Dispose (ref destClass);
 			}
 		}
 
 		static void AssertCompatibleArrayTypes (IntPtr sourceArray, Type destElementType)
 		{
-			IntPtr grefDest   = FindArrayClassByElementType (destElementType);
-			IntPtr lrefSource = GetObjectClass (sourceArray);
+			JniObjectReference destClass = FindArrayClassByElementType (destElementType);
 			try {
-				if (!IsAssignableFrom (lrefSource, grefDest)) {
+				var sourceReference = new JniObjectReference (sourceArray);
+				if (JniEnvironment.Types.IsInstanceOf (sourceReference, destClass))
+					return;
+
+				JniObjectReference sourceClass = JniEnvironment.Types.GetObjectClass (sourceReference);
+				try {
 					throw new InvalidCastException (FormattableString.Invariant (
-						$"Unable to cast from '{JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (lrefSource))}' to '{JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (grefDest))}'."));
+						$"Unable to cast from '{JniEnvironment.Types.GetJniTypeNameFromClass (sourceClass)}' to '{JniEnvironment.Types.GetJniTypeNameFromClass (destClass)}'."));
+				} finally {
+					JniObjectReference.Dispose (ref sourceClass);
 				}
 			} finally {
-				DeleteGlobalRef (grefDest);
-				DeleteLocalRef (lrefSource);
+				JniObjectReference.Dispose (ref destClass);
 			}
 		}
 
-		static IntPtr FindArrayClassByElementType (Type elementType)
+		static JniObjectReference FindArrayClassByElementType (Type elementType)
 		{
-			var boxedPrimitiveJniClassName = GetBoxedPrimitiveJniClassName (elementType);
-			if (boxedPrimitiveJniClassName != null) {
-				return FindClass ("[L" + boxedPrimitiveJniClassName + ";");
-			}
+			var builtInArrayJniClassName = GetBuiltInArrayJniClassNameUtf8 (elementType);
+			if (!builtInArrayJniClassName.IsEmpty)
+				return JniEnvironment.Types.FindClass (builtInArrayJniClassName);
 
 			int rank = JavaNativeTypeManager.GetArrayInfo (elementType, out elementType) + 1;
 			var typeSignature = JniRuntime.CurrentRuntime.TypeManager.GetTypeSignature (elementType).AddArrayRank (rank);
-			return FindClass (typeSignature.Name);
+			return JniEnvironment.Types.FindClass (typeSignature.Name);
 		}
 
-		static string? GetBoxedPrimitiveJniClassName (Type type)
+		static ReadOnlySpan<byte> GetBuiltInArrayJniClassNameUtf8 (Type type)
 		{
-			if (type == typeof (bool?))   return "java/lang/Boolean";
-			if (type == typeof (byte?))   return "java/lang/Byte";
-			if (type == typeof (sbyte?))  return "java/lang/Byte";
-			if (type == typeof (char?))   return "java/lang/Character";
-			if (type == typeof (short?))  return "java/lang/Short";
-			if (type == typeof (int?))    return "java/lang/Integer";
-			if (type == typeof (long?))   return "java/lang/Long";
-			if (type == typeof (float?))  return "java/lang/Float";
-			if (type == typeof (double?)) return "java/lang/Double";
-			return null;
+			// Formatting JniTypeSignature.Name allocates for array ranks; use static UTF-8 data for hot built-in cases.
+			if (type.IsEnum)
+				type = Enum.GetUnderlyingType (type);
+
+			if (type == typeof (bool))    return "[Z"u8;
+			if (type == typeof (byte))    return "[B"u8;
+			if (type == typeof (sbyte))   return "[B"u8;
+			if (type == typeof (char))    return "[C"u8;
+			if (type == typeof (short))   return "[S"u8;
+			if (type == typeof (ushort))  return "[S"u8;
+			if (type == typeof (int))     return "[I"u8;
+			if (type == typeof (uint))    return "[I"u8;
+			if (type == typeof (long))    return "[J"u8;
+			if (type == typeof (ulong))   return "[J"u8;
+			if (type == typeof (float))   return "[F"u8;
+			if (type == typeof (double))  return "[D"u8;
+			if (type == typeof (bool?))   return "[Ljava/lang/Boolean;"u8;
+			if (type == typeof (byte?))   return "[Ljava/lang/Byte;"u8;
+			if (type == typeof (sbyte?))  return "[Ljava/lang/Byte;"u8;
+			if (type == typeof (char?))   return "[Ljava/lang/Character;"u8;
+			if (type == typeof (short?))  return "[Ljava/lang/Short;"u8;
+			if (type == typeof (int?))    return "[Ljava/lang/Integer;"u8;
+			if (type == typeof (long?))   return "[Ljava/lang/Long;"u8;
+			if (type == typeof (float?))  return "[Ljava/lang/Float;"u8;
+			if (type == typeof (double?)) return "[Ljava/lang/Double;"u8;
+			return [];
+		}
+
+		static ReadOnlySpan<byte> GetBoxedPrimitiveJniClassNameUtf8 (Type type)
+		{
+			if (type == typeof (bool?))   return "java/lang/Boolean"u8;
+			if (type == typeof (byte?))   return "java/lang/Byte"u8;
+			if (type == typeof (sbyte?))  return "java/lang/Byte"u8;
+			if (type == typeof (char?))   return "java/lang/Character"u8;
+			if (type == typeof (short?))  return "java/lang/Short"u8;
+			if (type == typeof (int?))    return "java/lang/Integer"u8;
+			if (type == typeof (long?))   return "java/lang/Long"u8;
+			if (type == typeof (float?))  return "java/lang/Float"u8;
+			if (type == typeof (double?)) return "java/lang/Double"u8;
+			return [];
 		}
 
 		public static void CopyArray (IntPtr src, bool[] dest)
@@ -746,6 +788,8 @@ namespace Android.Runtime {
 					elementType = Enum.GetUnderlyingType (elementType);
 				if (dict.TryGetValue (elementType, out converter))
 					return converter;
+				if (elementType.IsArray)
+					return dict [typeof (Array)];
 			}
 
 			if (array != IntPtr.Zero) {
@@ -771,9 +815,6 @@ namespace Android.Runtime {
 				if (type == "[Ljava/lang/String;")
 					return dict [typeof (string)];
 			}
-
-			if (elementType != null && elementType.IsArray)
-				return dict [typeof (Array)];
 
 			AssertIsJavaObject (elementType);
 			return dict [typeof (IJavaObject)];
@@ -1437,8 +1478,8 @@ namespace Android.Runtime {
 
 		static IntPtr FindObjectArrayElementClass (Type elementType)
 		{
-			var boxedPrimitiveJniClassName = GetBoxedPrimitiveJniClassName (elementType);
-			if (boxedPrimitiveJniClassName != null) {
+			var boxedPrimitiveJniClassName = GetBoxedPrimitiveJniClassNameUtf8 (elementType);
+			if (!boxedPrimitiveJniClassName.IsEmpty) {
 				return FindClass (boxedPrimitiveJniClassName);
 			}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -195,8 +195,45 @@ public class TrimmableTypeMap
 			return null;
 		}
 
+		if (TryResolveProxyFromSealedTargetType (handle, targetType, out var proxy)) {
+			return proxy;
+		}
+
 		return TryGetProxyFromHierarchy (handle, targetType) ??
 			TryGetProxyFromTargetType (handle, targetType);
+	}
+
+	bool TryResolveProxyFromSealedTargetType (
+		IntPtr handle,
+		Type? targetType,
+		out JavaPeerProxy? proxy)
+	{
+		proxy = null;
+		// App peers can use class loaders which differ from the runtime fallback loader.
+		if (targetType is null ||
+				!targetType.IsSealed ||
+				targetType.Assembly != typeof (Java.Lang.Object).Assembly) {
+			return false;
+		}
+
+		var targetProxy = GetProxyForManagedType (targetType);
+		if (targetProxy is null) {
+			return false;
+		}
+
+		var targetClass = default (JniObjectReference);
+		try {
+			targetClass = JniEnvironment.Types.FindClass (targetProxy.JniName);
+			var reference = new JniObjectReference (handle);
+			if (JniEnvironment.Types.IsInstanceOf (reference, targetClass)) {
+				proxy = targetProxy;
+			}
+			return true;
+		} catch (Java.Lang.ClassNotFoundException) {
+			return false;
+		} finally {
+			JniObjectReference.Dispose (ref targetClass);
+		}
 	}
 
 	JavaPeerProxy? TryGetProxyFromHierarchy (IntPtr handle, Type? targetType)

--- a/tests/Android.Benchmarks/Android.Benchmarks.csproj
+++ b/tests/Android.Benchmarks/Android.Benchmarks.csproj
@@ -12,6 +12,8 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <RootNamespace>Xamarin.Android.Benchmarks</RootNamespace>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
+    <UseMonoRuntime>false</UseMonoRuntime>
+    <AndroidTypeMapImplementation>trimmable</AndroidTypeMapImplementation>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Android.Benchmarks/AndroidApiBenchmarks.cs
+++ b/tests/Android.Benchmarks/AndroidApiBenchmarks.cs
@@ -1,0 +1,128 @@
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.Graphics;
+using Android.OS;
+using Android.Views;
+using BenchmarkDotNet.Attributes;
+
+namespace Xamarin.Android.Benchmarks;
+
+[MemoryDiagnoser]
+public class AndroidApiBenchmarks
+{
+	const string BundleKey = "value";
+	const int BundleValue = 42;
+
+	readonly Context context;
+	readonly PackageManager packageManager;
+	readonly global::Android.Content.Res.Resources resources;
+	readonly Bundle bundle;
+	readonly Rect rect;
+	readonly View view;
+	Java.Lang.Object? powerManager;
+
+	public AndroidApiBenchmarks ()
+	{
+		context = Application.Context;
+		packageManager = context.PackageManager ?? throw new InvalidOperationException ("PackageManager is unavailable.");
+		resources = context.Resources ?? throw new InvalidOperationException ("Resources are unavailable.");
+		bundle = new Bundle ();
+		bundle.PutInt (BundleKey, BundleValue);
+		rect = new Rect (0, 0, 100, 100);
+		view = new View (context);
+	}
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		powerManager = GetPowerManager ();
+		if (GetBundleInt () != BundleValue)
+			throw new InvalidOperationException ("Bundle value was not preserved.");
+		if (!RectContainsPoint ())
+			throw new InvalidOperationException ("The benchmark point is outside the rectangle.");
+		if (GetSystemResourceString ().Length == 0)
+			throw new InvalidOperationException ("The system resource string is empty.");
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		powerManager?.Dispose ();
+		view.Dispose ();
+		rect.Dispose ();
+		bundle.Dispose ();
+	}
+
+	[Benchmark]
+	public long GetElapsedRealtime ()
+	{
+		return SystemClock.ElapsedRealtime ();
+	}
+
+	[Benchmark]
+	public bool RectContainsPoint ()
+	{
+		return rect.Contains (50, 50);
+	}
+
+	[Benchmark]
+	public int GetBundleInt ()
+	{
+		return bundle.GetInt (BundleKey);
+	}
+
+	[Benchmark]
+	public bool HasCameraFeature ()
+	{
+		return packageManager.HasSystemFeature (PackageManager.FeatureCamera);
+	}
+
+	[Benchmark]
+	public Java.Lang.Object? GetPowerManager ()
+	{
+		return context.GetSystemService (Context.PowerService);
+	}
+
+	[Benchmark]
+	public Context? GetApplicationContext ()
+	{
+		return context.ApplicationContext;
+	}
+
+	[Benchmark]
+	public ContentResolver? GetContentResolver ()
+	{
+		return context.ContentResolver;
+	}
+
+	[Benchmark]
+	public global::Android.Content.Res.Configuration? GetConfiguration ()
+	{
+		return resources.Configuration;
+	}
+
+	[Benchmark]
+	public global::Android.Util.DisplayMetrics? GetDisplayMetrics ()
+	{
+		return resources.DisplayMetrics;
+	}
+
+	[Benchmark]
+	public View? GetRootView ()
+	{
+		return view.RootView;
+	}
+
+	[Benchmark]
+	public string GetSystemResourceString ()
+	{
+		return resources.GetString (global::Android.Resource.String.Ok);
+	}
+
+	[Benchmark]
+	public void SetViewPadding ()
+	{
+		view.SetPadding (1, 2, 3, 4);
+	}
+}

--- a/tests/Android.Benchmarks/AndroidArrayMarshallingBenchmarks.cs
+++ b/tests/Android.Benchmarks/AndroidArrayMarshallingBenchmarks.cs
@@ -1,0 +1,181 @@
+using Android.App;
+using Android.App.AppSearch;
+using Android.Content;
+using Android.Graphics;
+using Android.OS;
+using Android.Util;
+using BenchmarkDotNet.Attributes;
+using Java.Security;
+using System.Runtime.Versioning;
+
+namespace Xamarin.Android.Benchmarks;
+
+[MemoryDiagnoser]
+[SupportedOSPlatform ("android31.0")]
+public class AndroidArrayMarshallingBenchmarks
+{
+	const int Base64ByteCount = 344;
+	const int ByteCount = 256;
+	const string BytesProperty = "bytes";
+	const string BytesArrayProperty = "bytesArray";
+	const int DigestByteCount = 32;
+
+	readonly byte [] bytes = new byte [ByteCount];
+	readonly byte [] encodedBytes;
+	readonly Bitmap bitmap;
+	readonly Context context;
+	readonly GenericDocument document;
+	readonly MessageDigest messageDigest;
+	readonly Parcel parcel;
+	readonly int [] pixels = new int [64];
+	readonly IntPtr preparedByteArray;
+	readonly IntPtr preparedJaggedByteArray;
+
+	public AndroidArrayMarshallingBenchmarks ()
+	{
+		context = Application.Context;
+		encodedBytes = Base64.Encode (bytes, Base64Flags.NoWrap)
+			?? throw new InvalidOperationException ("Could not Base64-encode the benchmark input.");
+		Bitmap.Config bitmapConfig = Bitmap.Config.Argb8888
+			?? throw new InvalidOperationException ("Could not obtain the ARGB_8888 bitmap configuration.");
+		bitmap = Bitmap.CreateBitmap (8, 8, bitmapConfig);
+		messageDigest = MessageDigest.GetInstance ("SHA-256")
+			?? throw new InvalidOperationException ("Could not obtain SHA-256.");
+		parcel = Parcel.Obtain ();
+		parcel.WriteByteArray (bytes);
+		IntPtr localByteArray = global::Android.Runtime.JNIEnv.NewArray (bytes);
+		try {
+			preparedByteArray = global::Android.Runtime.JNIEnv.NewGlobalRef (localByteArray);
+		} finally {
+			global::Android.Runtime.JNIEnv.DeleteLocalRef (localByteArray);
+		}
+		IntPtr localJaggedByteArray = global::Android.Runtime.JNIEnv.NewArray<byte []> ([bytes, bytes, bytes, bytes]);
+		try {
+			preparedJaggedByteArray = global::Android.Runtime.JNIEnv.NewGlobalRef (localJaggedByteArray);
+		} finally {
+			global::Android.Runtime.JNIEnv.DeleteLocalRef (localJaggedByteArray);
+		}
+
+		using var builder = new GenericDocument.Builder ("benchmark", "1", "ByteDocument");
+		builder.SetPropertyBytes (BytesProperty, [bytes]);
+		builder.SetPropertyBytes (BytesArrayProperty, [bytes, bytes, bytes, bytes]);
+		document = builder.Build ();
+	}
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		byte []? byteArray = GetByteArray ();
+		if (byteArray is null || byteArray.Length != bytes.Length)
+			throw new InvalidOperationException ("GenericDocument byte array length is incorrect.");
+		byte [] []? jaggedByteArray = GetJaggedByteArray ();
+		if (jaggedByteArray is null || jaggedByteArray.Length != 4)
+			throw new InvalidOperationException ("GenericDocument jagged byte array length is incorrect.");
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		document.Dispose ();
+		messageDigest.Dispose ();
+		bitmap.Dispose ();
+		parcel.Dispose ();
+		global::Android.Runtime.JNIEnv.DeleteGlobalRef (preparedByteArray);
+		global::Android.Runtime.JNIEnv.DeleteGlobalRef (preparedJaggedByteArray);
+	}
+
+	[Benchmark]
+	public byte []? EncodeByteArray ()
+	{
+		return Base64.Encode (bytes, Base64Flags.NoWrap);
+	}
+
+	[Benchmark]
+	public byte []? DecodeByteArray ()
+	{
+		return Base64.Decode (encodedBytes, Base64Flags.NoWrap);
+	}
+
+	[Benchmark]
+	public byte []? MarshallParcel ()
+	{
+		return parcel.Marshall ();
+	}
+
+	[Benchmark]
+	public byte []? DigestByteArray ()
+	{
+		return messageDigest.Digest (bytes);
+	}
+
+	[Benchmark]
+	public void GetBitmapPixels ()
+	{
+		bitmap.GetPixels (pixels, 0, 8, 0, 0, 8, 8);
+	}
+
+	[Benchmark]
+	public string []? GetPackagesForUid ()
+	{
+		return context.PackageManager?.GetPackagesForUid (global::Android.OS.Process.MyUid ());
+	}
+
+	[Benchmark]
+	public byte []? GetByteArray ()
+	{
+		return document.GetPropertyBytes (BytesProperty);
+	}
+
+	[Benchmark]
+	public byte [] []? GetJaggedByteArray ()
+	{
+		return document.GetPropertyBytesArray (BytesArrayProperty);
+	}
+
+	[Benchmark]
+	public byte []? ConvertPreparedByteArray ()
+	{
+		return (byte []?) global::Android.Runtime.JNIEnv.GetArray (
+			preparedByteArray,
+			global::Android.Runtime.JniHandleOwnership.DoNotTransfer,
+			typeof (byte));
+	}
+
+	[Benchmark]
+	public byte [] []? ConvertPreparedJaggedByteArray ()
+	{
+		return (byte [] []?) global::Android.Runtime.JNIEnv.GetArray (
+			preparedJaggedByteArray,
+			global::Android.Runtime.JniHandleOwnership.DoNotTransfer,
+			typeof (byte []));
+	}
+
+	[Benchmark]
+	public byte [] AllocateDigestSizedByteArray ()
+	{
+		return new byte [DigestByteCount];
+	}
+
+	[Benchmark]
+	public byte [] AllocateByteArray ()
+	{
+		return new byte [ByteCount];
+	}
+
+	[Benchmark]
+	public byte [] AllocateBase64SizedByteArray ()
+	{
+		return new byte [Base64ByteCount];
+	}
+
+	[Benchmark]
+	public byte [] [] AllocateJaggedByteArray ()
+	{
+		return [
+			new byte [ByteCount],
+			new byte [ByteCount],
+			new byte [ByteCount],
+			new byte [ByteCount],
+		];
+	}
+}

--- a/tests/Android.Benchmarks/AndroidObjectCreationBenchmarks.cs
+++ b/tests/Android.Benchmarks/AndroidObjectCreationBenchmarks.cs
@@ -1,0 +1,124 @@
+using Android.Content;
+using Android.Content.PM;
+using Android.Graphics;
+using BenchmarkDotNet.Attributes;
+
+namespace Xamarin.Android.Benchmarks;
+
+[MemoryDiagnoser]
+[InvocationCount (OperationsPerIteration)]
+public class AndroidObjectCreationBenchmarks
+{
+	const int OperationsPerIteration = 256;
+
+	readonly global::Android.Net.Uri baseUri;
+	readonly int [] colors = new int [64];
+	readonly global::Android.Net.Uri? [] appendedUris = new global::Android.Net.Uri? [OperationsPerIteration];
+	readonly Intent? [] chooserIntents = new Intent? [OperationsPerIteration];
+	readonly ApplicationInfo? [] applicationInfos = new ApplicationInfo? [OperationsPerIteration];
+	readonly Bitmap? [] threeArgumentBitmaps = new Bitmap? [OperationsPerIteration];
+	readonly Bitmap? [] fourArgumentBitmaps = new Bitmap? [OperationsPerIteration];
+	readonly Bitmap.Config bitmapConfig;
+	readonly PackageManager packageManager;
+	readonly string packageName;
+	readonly Intent intent;
+	int appendedUriIndex;
+	int chooserIntentIndex;
+	int applicationInfoIndex;
+	int threeArgumentBitmapIndex;
+	int fourArgumentBitmapIndex;
+
+	public AndroidObjectCreationBenchmarks ()
+	{
+		baseUri = global::Android.Net.Uri.Parse ("https://example.com/benchmark")
+			?? throw new InvalidOperationException ("Could not parse the base URI.");
+		Context context = Application.Context;
+		packageManager = context.PackageManager ?? throw new InvalidOperationException ("PackageManager is unavailable.");
+		packageName = context.PackageName ?? throw new InvalidOperationException ("Package name is unavailable.");
+		bitmapConfig = Bitmap.Config.Argb8888
+			?? throw new InvalidOperationException ("Could not obtain the ARGB_8888 bitmap configuration.");
+		intent = new Intent (Intent.ActionView, baseUri);
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		CleanupAppendedUris ();
+		CleanupChooserIntents ();
+		CleanupApplicationInfos ();
+		CleanupThreeArgumentBitmaps ();
+		CleanupFourArgumentBitmaps ();
+		intent.Dispose ();
+		baseUri.Dispose ();
+	}
+
+	[IterationSetup (Target = nameof (WithAppendedPathTwoArguments))]
+	public void SetupAppendedUris () => appendedUriIndex = 0;
+
+	[IterationCleanup (Target = nameof (WithAppendedPathTwoArguments))]
+	public void CleanupAppendedUris () => DisposeAll (appendedUris);
+
+	[Benchmark]
+	public global::Android.Net.Uri? WithAppendedPathTwoArguments ()
+	{
+		return appendedUris [appendedUriIndex++] = global::Android.Net.Uri.WithAppendedPath (baseUri, "child");
+	}
+
+	[IterationSetup (Target = nameof (CreateChooserTwoArguments))]
+	public void SetupChooserIntents () => chooserIntentIndex = 0;
+
+	[IterationCleanup (Target = nameof (CreateChooserTwoArguments))]
+	public void CleanupChooserIntents () => DisposeAll (chooserIntents);
+
+	[Benchmark]
+	public Intent? CreateChooserTwoArguments ()
+	{
+		return chooserIntents [chooserIntentIndex++] = Intent.CreateChooser (intent, "benchmark");
+	}
+
+	[IterationSetup (Target = nameof (GetApplicationInfoTwoArguments))]
+	public void SetupApplicationInfos () => applicationInfoIndex = 0;
+
+	[IterationCleanup (Target = nameof (GetApplicationInfoTwoArguments))]
+	public void CleanupApplicationInfos () => DisposeAll (applicationInfos);
+
+	[Benchmark]
+	public ApplicationInfo? GetApplicationInfoTwoArguments ()
+	{
+		return applicationInfos [applicationInfoIndex++] =
+			packageManager.GetApplicationInfo (packageName, PackageInfoFlags.MetaData);
+	}
+
+	[IterationSetup (Target = nameof (CreateBitmapThreeArguments))]
+	public void SetupThreeArgumentBitmaps () => threeArgumentBitmapIndex = 0;
+
+	[IterationCleanup (Target = nameof (CreateBitmapThreeArguments))]
+	public void CleanupThreeArgumentBitmaps () => DisposeAll (threeArgumentBitmaps);
+
+	[Benchmark]
+	public Bitmap? CreateBitmapThreeArguments ()
+	{
+		return threeArgumentBitmaps [threeArgumentBitmapIndex++] = Bitmap.CreateBitmap (8, 8, bitmapConfig);
+	}
+
+	[IterationSetup (Target = nameof (CreateBitmapFourArguments))]
+	public void SetupFourArgumentBitmaps () => fourArgumentBitmapIndex = 0;
+
+	[IterationCleanup (Target = nameof (CreateBitmapFourArguments))]
+	public void CleanupFourArgumentBitmaps () => DisposeAll (fourArgumentBitmaps);
+
+	[Benchmark]
+	public Bitmap? CreateBitmapFourArguments ()
+	{
+		return fourArgumentBitmaps [fourArgumentBitmapIndex++] = Bitmap.CreateBitmap (colors, 8, 8, bitmapConfig);
+	}
+
+	static void DisposeAll<T> (T? [] values)
+		where T : Java.Lang.Object
+	{
+		for (int i = 0; i < values.Length; i++) {
+			values [i]?.Dispose ();
+			values [i] = null;
+		}
+	}
+}

--- a/tests/Android.Benchmarks/ExportRoundtripBenchmarks.cs
+++ b/tests/Android.Benchmarks/ExportRoundtripBenchmarks.cs
@@ -1,0 +1,89 @@
+using System.Runtime.CompilerServices;
+using Android.Runtime;
+using BenchmarkDotNet.Attributes;
+using Java.Interop;
+
+namespace Xamarin.Android.Benchmarks;
+
+[MemoryDiagnoser]
+public unsafe class ExportRoundtripBenchmarks
+{
+	const int Value = 42;
+	const long State = 0x123456789;
+	const string TextValue = "benchmark";
+	const string PrimitiveRoundtripSignature = "(IJ)J";
+	const string StringRoundtripSignature = "(IJLjava/lang/String;)J";
+
+	readonly ExportRoundtripPeer peer = new ();
+	readonly Java.Lang.String text = new (TextValue);
+	IntPtr primitiveRoundtripMethod;
+	IntPtr stringRoundtripMethod;
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		IntPtr peerClass = JNIEnv.GetObjectClass (peer.Handle);
+		try {
+			primitiveRoundtripMethod = JNIEnv.GetMethodID (peerClass, "primitiveRoundtrip", PrimitiveRoundtripSignature);
+			stringRoundtripMethod = JNIEnv.GetMethodID (peerClass, "stringRoundtrip", StringRoundtripSignature);
+		} finally {
+			JNIEnv.DeleteLocalRef (peerClass);
+		}
+
+		long expected = DirectManagedCall ();
+		long primitiveResult = JniPrimitiveRoundtrip ();
+		long stringResult = JniStringRoundtrip ();
+		if (primitiveResult != State + Value)
+			throw new InvalidOperationException ($"Expected primitive roundtrip result {State + Value}, but received {primitiveResult}.");
+		if (stringResult != expected)
+			throw new InvalidOperationException ($"Expected string roundtrip result {expected}, but received {stringResult}.");
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		text.Dispose ();
+		peer.Dispose ();
+	}
+
+	long DirectManagedCall ()
+	{
+		return peer.Roundtrip (Value, State, TextValue);
+	}
+
+	[Benchmark]
+	public long JniPrimitiveRoundtrip ()
+	{
+		JValue* arguments = stackalloc JValue [2];
+		arguments [0] = new JValue (Value);
+		arguments [1] = new JValue (State);
+		return JNIEnv.CallLongMethod (peer.Handle, primitiveRoundtripMethod, arguments);
+	}
+
+	[Benchmark]
+	public long JniStringRoundtrip ()
+	{
+		JValue* arguments = stackalloc JValue [3];
+		arguments [0] = new JValue (Value);
+		arguments [1] = new JValue (State);
+		arguments [2] = new JValue (text);
+		return JNIEnv.CallLongMethod (peer.Handle, stringRoundtripMethod, arguments);
+	}
+}
+
+class ExportRoundtripPeer : Java.Lang.Object
+{
+	[Export ("primitiveRoundtrip")]
+	[MethodImpl (MethodImplOptions.NoInlining)]
+	public long PrimitiveRoundtrip (int value, long state)
+	{
+		return state + value;
+	}
+
+	[Export ("stringRoundtrip")]
+	[MethodImpl (MethodImplOptions.NoInlining)]
+	public long Roundtrip (int value, long state, string text)
+	{
+		return state + value + text.Length;
+	}
+}

--- a/tests/Android.Benchmarks/PeerActivationComponentBenchmarks.cs
+++ b/tests/Android.Benchmarks/PeerActivationComponentBenchmarks.cs
@@ -1,0 +1,79 @@
+using Android.Runtime;
+using BenchmarkDotNet.Attributes;
+using Java.Interop;
+
+namespace Xamarin.Android.Benchmarks;
+
+[MemoryDiagnoser]
+public class PeerActivationComponentBenchmarks
+{
+	IntPtr objectClass;
+	IntPtr reference;
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		IntPtr localReference = JNIEnv.NewString ("benchmark");
+		try {
+			reference = JNIEnv.NewGlobalRef (localReference);
+		} finally {
+			JNIEnv.DeleteLocalRef (localReference);
+		}
+
+		IntPtr localClass = JNIEnv.GetObjectClass (reference);
+		try {
+			objectClass = JNIEnv.NewGlobalRef (localClass);
+		} finally {
+			JNIEnv.DeleteLocalRef (localClass);
+		}
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		DeleteGlobalReference (ref objectClass);
+		DeleteGlobalReference (ref reference);
+	}
+
+	[Benchmark]
+	public int GetObjectClass ()
+	{
+		JniObjectReference result = JniEnvironment.Types.GetObjectClass (new JniObjectReference (reference));
+		try {
+			return result.IsValid ? 1 : 0;
+		} finally {
+			JniObjectReference.Dispose (ref result);
+		}
+	}
+
+	[Benchmark]
+	public string? GetJniTypeName ()
+	{
+		return JniEnvironment.Types.GetJniTypeNameFromClass (new JniObjectReference (objectClass));
+	}
+
+	[Benchmark]
+	public int GetIdentityHashCode ()
+	{
+		return JniEnvironment.References.GetIdentityHashCode (new JniObjectReference (reference));
+	}
+
+	[Benchmark]
+	public int CreateGlobalReference ()
+	{
+		JniObjectReference result = new JniObjectReference (reference).NewGlobalRef ();
+		try {
+			return result.IsValid ? 1 : 0;
+		} finally {
+			JniObjectReference.Dispose (ref result);
+		}
+	}
+
+	static void DeleteGlobalReference (ref IntPtr value)
+	{
+		if (value == IntPtr.Zero)
+			return;
+		JNIEnv.DeleteGlobalRef (value);
+		value = IntPtr.Zero;
+	}
+}

--- a/tests/Android.Benchmarks/PeerActivationComponentBenchmarks.cs
+++ b/tests/Android.Benchmarks/PeerActivationComponentBenchmarks.cs
@@ -53,6 +53,17 @@ public class PeerActivationComponentBenchmarks
 	}
 
 	[Benchmark]
+	public bool ValidateKnownSealedType ()
+	{
+		JniObjectReference targetClass = JniEnvironment.Types.FindClass ("java/lang/String");
+		try {
+			return JniEnvironment.Types.IsInstanceOf (new JniObjectReference (reference), targetClass);
+		} finally {
+			JniObjectReference.Dispose (ref targetClass);
+		}
+	}
+
+	[Benchmark]
 	public int GetIdentityHashCode ()
 	{
 		return JniEnvironment.References.GetIdentityHashCode (new JniObjectReference (reference));

--- a/tests/Android.Benchmarks/PeerLookupBenchmarks.cs
+++ b/tests/Android.Benchmarks/PeerLookupBenchmarks.cs
@@ -1,0 +1,121 @@
+using Android.Runtime;
+using BenchmarkDotNet.Attributes;
+
+namespace Xamarin.Android.Benchmarks;
+
+[MemoryDiagnoser]
+[InvocationCount (OperationsPerIteration)]
+public class PeerLookupBenchmarks
+{
+	const int OperationsPerIteration = 4096;
+
+	readonly IntPtr [] uncachedReferences = new IntPtr [OperationsPerIteration];
+	readonly IntPtr [] newGlobalReferences = new IntPtr [OperationsPerIteration];
+	readonly Java.Lang.String? [] uncachedPeers = new Java.Lang.String? [OperationsPerIteration];
+	IntPtr cachedReference;
+	IntPtr cachedObjectReference;
+	Java.Lang.String? cachedPeer;
+	Java.Lang.String? cachedObjectPeer;
+	int uncachedIndex;
+	int newGlobalReferenceIndex;
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		cachedReference = CreateGlobalString ();
+		cachedObjectReference = CreateGlobalString ();
+
+		cachedPeer = Java.Lang.Object.GetObject<Java.Lang.String> (cachedReference, JniHandleOwnership.DoNotTransfer);
+		cachedObjectPeer = Java.Lang.Object.GetObject<Java.Lang.String> (cachedObjectReference, JniHandleOwnership.DoNotTransfer);
+		if (cachedPeer == null || cachedObjectPeer == null)
+			throw new InvalidOperationException ("Could not create the cached Java string peers.");
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		CleanupUncachedPeer ();
+		CleanupNewGlobalReference ();
+		cachedPeer?.Dispose ();
+		cachedObjectPeer?.Dispose ();
+		DeleteGlobalReference (ref cachedReference);
+		DeleteGlobalReference (ref cachedObjectReference);
+	}
+
+	[IterationSetup (Target = nameof (GetObjectUncached))]
+	public void SetupUncachedPeer ()
+	{
+		uncachedIndex = 0;
+		for (int i = 0; i < uncachedReferences.Length; i++)
+			uncachedReferences [i] = CreateGlobalString ();
+	}
+
+	[IterationCleanup (Target = nameof (GetObjectUncached))]
+	public void CleanupUncachedPeer ()
+	{
+		for (int i = 0; i < uncachedReferences.Length; i++) {
+			uncachedPeers [i]?.Dispose ();
+			uncachedPeers [i] = null;
+			DeleteGlobalReference (ref uncachedReferences [i]);
+		}
+	}
+
+	[Benchmark]
+	public Java.Lang.String? GetObjectUncached ()
+	{
+		int index = uncachedIndex++;
+		return uncachedPeers [index] = Java.Lang.Object.GetObject<Java.Lang.String> (
+			uncachedReferences [index],
+			JniHandleOwnership.DoNotTransfer);
+	}
+
+	[Benchmark]
+	public Java.Lang.String? GetObjectCached ()
+	{
+		return Java.Lang.Object.GetObject<Java.Lang.String> (
+			cachedReference,
+			JniHandleOwnership.DoNotTransfer);
+	}
+
+	[IterationSetup (Target = nameof (GetObjectCachedWithNewGlobalReference))]
+	public void SetupNewGlobalReference ()
+	{
+		newGlobalReferenceIndex = 0;
+		for (int i = 0; i < newGlobalReferences.Length; i++)
+			newGlobalReferences [i] = JNIEnv.NewGlobalRef (cachedObjectReference);
+	}
+
+	[IterationCleanup (Target = nameof (GetObjectCachedWithNewGlobalReference))]
+	public void CleanupNewGlobalReference ()
+	{
+		for (int i = 0; i < newGlobalReferences.Length; i++)
+			DeleteGlobalReference (ref newGlobalReferences [i]);
+	}
+
+	[Benchmark]
+	public Java.Lang.String? GetObjectCachedWithNewGlobalReference ()
+	{
+		int index = newGlobalReferenceIndex++;
+		return Java.Lang.Object.GetObject<Java.Lang.String> (
+			newGlobalReferences [index],
+			JniHandleOwnership.DoNotTransfer);
+	}
+
+	static IntPtr CreateGlobalString ()
+	{
+		IntPtr localReference = JNIEnv.NewString ("benchmark");
+		try {
+			return JNIEnv.NewGlobalRef (localReference);
+		} finally {
+			JNIEnv.DeleteLocalRef (localReference);
+		}
+	}
+
+	static void DeleteGlobalReference (ref IntPtr reference)
+	{
+		if (reference == IntPtr.Zero)
+			return;
+		JNIEnv.DeleteGlobalRef (reference);
+		reference = IntPtr.Zero;
+	}
+}

--- a/tests/Android.Benchmarks/TypeMapLookupBenchmarks.cs
+++ b/tests/Android.Benchmarks/TypeMapLookupBenchmarks.cs
@@ -1,0 +1,67 @@
+using Android.Runtime;
+using BenchmarkDotNet.Attributes;
+using Java.Interop;
+
+namespace Xamarin.Android.Benchmarks;
+
+[MemoryDiagnoser]
+public class TypeMapLookupBenchmarks
+{
+	readonly JniRuntime.JniTypeManager typeManager = JniRuntime.CurrentRuntime.TypeManager;
+	readonly JniTypeSignature frameworkTypeSignature = new ("android/app/Activity");
+	readonly JniTypeSignature applicationTypeSignature = new ("net/dot/android/benchmarks/BenchmarkInstrumentation");
+	readonly JniTypeSignature missingTypeSignature = new ("net/dot/android/benchmarks/Missing");
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		if (GetFrameworkType () != typeof (global::Android.App.Activity))
+			throw new InvalidOperationException ("The framework typemap entry is unavailable.");
+		if (GetApplicationType () != typeof (BenchmarkInstrumentation))
+			throw new InvalidOperationException ("The application typemap entry is unavailable.");
+		if (GetMissingType () is not null)
+			throw new InvalidOperationException ("The missing typemap entry unexpectedly resolved.");
+		if (!GetFrameworkTypeSignature ().IsValid)
+			throw new InvalidOperationException ("The framework JNI signature is unavailable.");
+		if (!GetApplicationTypeSignature ().IsValid)
+			throw new InvalidOperationException ("The application JNI signature is unavailable.");
+		if (!GetClosedGenericTypeSignature ().IsValid)
+			throw new InvalidOperationException ("The closed generic JNI signature is unavailable.");
+	}
+
+	[Benchmark]
+	public Type? GetFrameworkType ()
+	{
+		return typeManager.GetType (frameworkTypeSignature);
+	}
+
+	[Benchmark]
+	public Type? GetApplicationType ()
+	{
+		return typeManager.GetType (applicationTypeSignature);
+	}
+
+	[Benchmark]
+	public Type? GetMissingType ()
+	{
+		return typeManager.GetType (missingTypeSignature);
+	}
+
+	[Benchmark]
+	public JniTypeSignature GetFrameworkTypeSignature ()
+	{
+		return typeManager.GetTypeSignature (typeof (global::Android.App.Activity));
+	}
+
+	[Benchmark]
+	public JniTypeSignature GetApplicationTypeSignature ()
+	{
+		return typeManager.GetTypeSignature (typeof (BenchmarkInstrumentation));
+	}
+
+	[Benchmark]
+	public JniTypeSignature GetClosedGenericTypeSignature ()
+	{
+		return typeManager.GetTypeSignature (typeof (JavaList<string>));
+	}
+}

--- a/tests/Android.Benchmarks/UriParseAllocationBenchmarks.cs
+++ b/tests/Android.Benchmarks/UriParseAllocationBenchmarks.cs
@@ -1,0 +1,137 @@
+using Android.Runtime;
+using BenchmarkDotNet.Attributes;
+using Java.Interop;
+
+namespace Xamarin.Android.Benchmarks;
+
+[MemoryDiagnoser]
+[InvocationCount (OperationsPerIteration)]
+public unsafe class UriParseAllocationBenchmarks
+{
+	const int OperationsPerIteration = 512;
+	const string UriValue = "https://example.com/benchmark?q=android";
+
+	readonly global::Android.Net.Uri? [] boundResults = new global::Android.Net.Uri? [OperationsPerIteration];
+	readonly global::Android.Net.Uri? [] activatedResults = new global::Android.Net.Uri? [OperationsPerIteration];
+	readonly IntPtr [] parsedReferences = new IntPtr [OperationsPerIteration];
+	IntPtr uriClass;
+	IntPtr uriString;
+	JniMethodInfo? parseMethodInfo;
+	int boundIndex;
+	int activationIndex;
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		uriClass = JNIEnv.FindClass ("android/net/Uri");
+		IntPtr localString = JNIEnv.NewString (UriValue);
+		try {
+			uriString = JNIEnv.NewGlobalRef (localString);
+		} finally {
+			JNIEnv.DeleteLocalRef (localString);
+		}
+		IntPtr parseMethod = JNIEnv.GetStaticMethodID (uriClass, "parse", "(Ljava/lang/String;)Landroid/net/Uri;");
+		parseMethodInfo = new JniMethodInfo (parseMethod, isStatic: true);
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		CleanupBoundParse ();
+		CleanupActivation ();
+		DeleteGlobalReference (ref uriString);
+		DeleteGlobalReference (ref uriClass);
+	}
+
+	[IterationSetup (Target = nameof (BoundParse))]
+	public void SetupBoundParse () => boundIndex = 0;
+
+	[IterationCleanup (Target = nameof (BoundParse))]
+	public void CleanupBoundParse () => DisposeAll (boundResults);
+
+	[Benchmark]
+	public global::Android.Net.Uri? BoundParse ()
+	{
+		return boundResults [boundIndex++] = global::Android.Net.Uri.Parse (UriValue);
+	}
+
+	[Benchmark]
+	public int RawJniParseWithCachedString ()
+	{
+		IntPtr result = ParseUri (uriString);
+		JNIEnv.DeleteLocalRef (result);
+		return result == IntPtr.Zero ? 0 : 1;
+	}
+
+	[Benchmark]
+	public int RawJniParseWithNewString ()
+	{
+		IntPtr localString = JNIEnv.NewString (UriValue);
+		IntPtr result = IntPtr.Zero;
+		try {
+			result = ParseUri (localString);
+			return result == IntPtr.Zero ? 0 : 1;
+		} finally {
+			JNIEnv.DeleteLocalRef (result);
+			JNIEnv.DeleteLocalRef (localString);
+		}
+	}
+
+	[IterationSetup (Target = nameof (ActivateParsedUri))]
+	public void SetupActivation ()
+	{
+		activationIndex = 0;
+		for (int i = 0; i < parsedReferences.Length; i++) {
+			IntPtr localReference = ParseUri (uriString);
+			try {
+				parsedReferences [i] = JNIEnv.NewGlobalRef (localReference);
+			} finally {
+				JNIEnv.DeleteLocalRef (localReference);
+			}
+		}
+	}
+
+	[IterationCleanup (Target = nameof (ActivateParsedUri))]
+	public void CleanupActivation ()
+	{
+		DisposeAll (activatedResults);
+		for (int i = 0; i < parsedReferences.Length; i++)
+			DeleteGlobalReference (ref parsedReferences [i]);
+	}
+
+	[Benchmark]
+	public global::Android.Net.Uri? ActivateParsedUri ()
+	{
+		int index = activationIndex++;
+		return activatedResults [index] = Java.Lang.Object.GetObject<global::Android.Net.Uri> (
+			parsedReferences [index],
+			JniHandleOwnership.DoNotTransfer);
+	}
+
+	IntPtr ParseUri (IntPtr stringReference)
+	{
+		JniMethodInfo methodInfo = parseMethodInfo
+			?? throw new InvalidOperationException ("The URI parse method is unavailable.");
+		JniArgumentValue argument = new JniArgumentValue (stringReference);
+		return JniEnvironment.StaticMethods.CallStaticObjectMethod (
+			new JniObjectReference (uriClass),
+			methodInfo,
+			&argument).Handle;
+	}
+
+	static void DisposeAll (global::Android.Net.Uri? [] values)
+	{
+		for (int i = 0; i < values.Length; i++) {
+			values [i]?.Dispose ();
+			values [i] = null;
+		}
+	}
+
+	static void DeleteGlobalReference (ref IntPtr reference)
+	{
+		if (reference == IntPtr.Zero)
+			return;
+		JNIEnv.DeleteGlobalRef (reference);
+		reference = IntPtr.Zero;
+	}
+}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
@@ -125,6 +125,48 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		public void GetProxyForJavaObject_SealedTarget_ReturnsProxy ()
+		{
+			AssumeTrimmableTypeMapEnabled ();
+
+			using var value = new Java.Lang.String ("value");
+			var proxy = TrimmableTypeMap.Instance.GetProxyForJavaObject (value.Handle, typeof (Java.Lang.String));
+
+			if (proxy is null) {
+				Assert.Fail ("Expected a proxy for Java.Lang.String.");
+				return;
+			}
+			Assert.AreEqual (typeof (Java.Lang.String), proxy.TargetType);
+		}
+
+		[Test]
+		public void GetProxyForJavaObject_IncompatibleSealedTarget_ReturnsNull ()
+		{
+			AssumeTrimmableTypeMapEnabled ();
+
+			using var value = new Java.Lang.Integer (42);
+			var proxy = TrimmableTypeMap.Instance.GetProxyForJavaObject (value.Handle, typeof (Java.Lang.String));
+
+			Assert.IsNull (proxy);
+		}
+
+		[Test]
+		public void CreateInstance_SealedClosedGenericTarget_ReturnsClosedPeer ()
+		{
+			AssumeTrimmableTypeMapEnabled ();
+
+			using var value = new Java.Util.ArrayList ();
+			var peer = TrimmableTypeMap.Instance.CreateInstance (value.Handle, typeof (JavaCollection<int>));
+			if (peer is not JavaCollection<int> collection) {
+				peer?.Dispose ();
+				Assert.Fail ($"Expected {typeof (JavaCollection<int>)}, got {peer?.GetType ()}.");
+				return;
+			}
+
+			collection.Dispose ();
+		}
+
+		[Test]
 		public void RegisteredPeer_Dispose_InvokesDisposing ()
 		{
 			AssumeTrimmableTypeMapEnabled ();


### PR DESCRIPTION
## Summary

- add focused BenchmarkDotNet coverage for trimmable typemap lookups, peer activation/cache behavior, JNI-to-Java-to-UCO roundtrips, Android APIs, object returns, and primitive/jagged arrays
- decompose `Uri.Parse()` into Java execution, string creation, and managed peer activation
- eliminate transient JNI array-signature allocations by using UTF-8 literals for built-in array classes
- avoid redundant class-name discovery for known jagged-array element types and use `IsInstanceOf()` for Java-to-managed validation
- resolve sealed framework peer proxies from the requested managed type instead of materializing the runtime Java class name
- cache raw-JNI benchmark method metadata outside the measured operation

## Samsung S23 results

| Benchmark | Before | After | Allocation before | Allocation after |
|---|---:|---:|---:|---:|
| `byte[256]` conversion | 956.9 ns | 515.2 ns | 336 B | 280 B |
| four-element `byte[256][]` conversion | 6.010 µs | 2.940 µs | 1,432 B | 1,176 B |

The remaining allocations are exactly the required managed array representations: 280 B for `byte[256]`, and 1,176 B for the outer array plus four inner arrays. The raw JNI URI controls now allocate 0 B.

For sealed framework peer activation, the existing runtime class discovery components cost 471.8 ns and 112 B (`GetObjectClass` plus `GetJniTypeName`). Validating the already-known target class directly costs 384.9 ns and 0 B, removing the class-name allocation and reducing this lookup stage by about 18%.

## Validation

- built and ran the targeted benchmark filters on a Samsung S23 (SM-S911B)
- built the complete Android benchmark project in Release with CoreCLR and the trimmable typemap
- built `Mono.Android` with the sealed-peer optimization
- added compatible, incompatible, and sealed closed-generic peer activation coverage
- existing enum, nullable primitive, byte, sbyte, and jagged-array coverage exercises the changed conversion paths