### PR TITLE
[release/10.0.1xx] Bump R8 to 9.4.17

### DIFF
--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -10,7 +10,7 @@ java {
 }
 
 dependencies {
-    implementation 'com.android.tools:r8:8.13.19'
+    implementation 'com.android.tools:r8:9.0.32'
 }
 
 jar {

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -10,7 +10,7 @@ java {
 }
 
 dependencies {
-    implementation 'com.android.tools:r8:9.0.32'
+    implementation 'com.android.tools:r8:9.1.31'
 }
 
 jar {

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -10,7 +10,7 @@ java {
 }
 
 dependencies {
-    implementation 'com.android.tools:r8:8.13.17'
+    implementation 'com.android.tools:r8:8.13.19'
 }
 
 jar {

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -10,7 +10,7 @@ java {
 }
 
 dependencies {
-    implementation 'com.android.tools:r8:9.1.31'
+    implementation 'com.android.tools:r8:9.4.14'
 }
 
 jar {

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -10,7 +10,7 @@ java {
 }
 
 dependencies {
-    implementation 'com.android.tools:r8:8.11.18'
+    implementation 'com.android.tools:r8:8.13.17'
 }
 
 jar {

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -10,7 +10,7 @@ java {
 }
 
 dependencies {
-    implementation 'com.android.tools:r8:9.4.14'
+    implementation 'com.android.tools:r8:9.4.17'
 }
 
 jar {


### PR DESCRIPTION
## Summary

Backports the following R8 dependency updates from `main` onto `release/10.0.1xx`:

- [`ccefa0d4c`](https://github.com/dotnet/android/commit/ccefa0d4cfcf6bcd2b0c2a3b12a79a2890172e0c) — Bump R8 from 8.11.18 to 8.13.17
- [`51a138dee`](https://github.com/dotnet/android/commit/51a138deee3f08083a571f803d72dcb8bdb45f70) — Bump R8 from 8.13.17 to 8.13.19
- [`74499fddf`](https://github.com/dotnet/android/commit/74499fddf0f6cf89d640ec5f2afff59a1685bb5a) — Bump R8 from 8.13.19 to 9.0.32
- [`ebae46e53`](https://github.com/dotnet/android/commit/ebae46e53f1649b55d05454d2c39b64ea760316e) — Bump R8 from 9.0.32 to 9.1.31
- [`bc9b4dd51`](https://github.com/dotnet/android/commit/bc9b4dd519c1275cb269f2128b5a63f1099a39ac) — Bump R8 from 9.1.31 to 9.4.14
- [`68c63c0d5`](https://github.com/dotnet/android/commit/68c63c0d5b430d44578d6ec5c576c864f982cb60) — Bump R8 from 9.4.14 to 9.4.17

The resulting release-branch diff changes only `src/r8/build.gradle`.

## Testing

- Built the R8 jar with Gradle and JDK 17 successfully.