### PR TITLE
[ci] Remove BuildSummary phase

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -495,18 +495,3 @@ extends:
         policheckPtbScanFolder: $(Build.SourcesDirectory)\Localize\loc\pt-BR
         policheckRusScanFolder: $(Build.SourcesDirectory)\Localize\loc\ru
         policheckTrkScanFolder: $(Build.SourcesDirectory)\Localize\loc\tr
-
-    - ${{ if eq(variables['Build.DefinitionName'], 'Xamarin.Android-PR') }}:
-      - stage: BuildSummary
-        dependsOn:
-        - mac_build
-        - win_build_test
-        - linux_build
-        - smoke_tests
-        - linux_tests
-        - msbuild_dotnet
-        - msbuilddevice_tests
-        - maui_tests
-        condition: failed()
-        jobs:
-        - template: build-summary/v1.yml@yaml-templates


### PR DESCRIPTION
## Changes

- Remove the `BuildSummary` stage from the `Xamarin.Android-PR` pipeline.

This stage only ran after failures and has no downstream dependencies.