### PR TITLE
[tests] Copy installer runtime dependencies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -18,6 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" />
+    <PackageReference Include="Polly" Version="$(PollyVersion)" />
+    <PackageReference Include="SharpZipLib" Version="$(SharpZipLibVersion)" />
     <Reference Include="Xamarin.Android.Build.Debugging.Tasks" Condition="Exists('$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Build.Debugging.Tasks.dll')">
       <HintPath>$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Build.Debugging.Tasks.dll</HintPath>
     </Reference>


### PR DESCRIPTION
## Summary

- add direct `Polly` and `SharpZipLib` package references to `Xamarin.Android.Build.Tests`
- make the test assembly's runtime copy-local closure independent of shared pack output ordering

## Context

Azure DevOps build 1579349 failed `AndroidDependenciesTests.InstallAndroidDependenciesTest("GoogleV2", CoreCLR)` on Linux, macOS, and Windows because `test-assemblies/net10.0` omitted `ICSharpCode.SharpZipLib.dll` and `Polly.dll`. The failure surfaced as:

```
System.IO.FileNotFoundException: Could not load file or assembly 'ICSharpCode.SharpZipLib, Version=1.3.3.11'
```

`Xamarin.Installer.AndroidSDK` intentionally excludes/private-assets these runtime dependencies unless its legacy `PublicSharpZipLib` and `PublicPolly` switches are set. Since #12580 made `Xamarin.Android.Build.Tests` consume that project directly, the test had accidentally relied on `Xamarin.Installer.Build.Tasks` copying both packages into a shared output directory first. Parallel project builds made that ordering nondeterministic.

Direct package references follow the existing explicit-consumer pattern in `Xamarin.Installer.Build.Tasks` and ensure NuGet includes both assemblies in the test project's own copy-local set. Setting `AdditionalProperties` on the `ProjectReference` would only configure the referenced project build and would leave the consuming test project's restore/copy-local intent indirect.

## Validation

- restored `Xamarin.Android.Build.Tests` targeting .NET 10
- ran `ResolvePackageAssets` and confirmed both `Polly.dll` and `ICSharpCode.SharpZipLib.dll` are `RuntimeCopyLocalItems` with `CopyLocal=true`
- `git diff --check`