### PR TITLE
[xabt] Disable legacy assembly fixups for trimmable typemap

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -51,6 +51,12 @@ object collection.
 
 The default value is `True` for Release configuration builds.
 
+For untrimmed builds using the `trimmable` type map, `GC.KeepAlive()` calls are
+only inserted when
+[`$(AndroidEnableLegacyCompatibilityAssemblyFixups)`](#androidenablelegacycompatibilityassemblyfixups)
+is also `True`. Trimmed builds using the `trimmable` type map do not insert
+these calls.
+
 ## AndroidAotAdditionalArguments
 
 A string property that allows
@@ -398,7 +404,8 @@ assemblies to support legacy binding and resource designer behavior. These
 modifications include adding missing abstract interface methods, updating
 legacy resource designer references, and inserting `GC.KeepAlive()` calls into
 older Xamarin.Android binding assemblies. Trimmed builds using the `trimmable`
-type map do not run these compatibility fixups.
+type map do not run these compatibility fixups, and setting this property to
+`True` does not enable them for trimmed builds.
 
 The default value is `False` when
 [`$(AndroidTypeMapImplementation)`](#androidtypemapimplementation) is

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -391,6 +391,19 @@ Store checks: XA1004, XA1005 and XA1006. Disabling these checks is useful for
 developers who are not targeting the Google Play Store and do
 not wish to run those checks.
 
+## AndroidEnableLegacyCompatibilityAssemblyFixups
+
+A boolean property that controls whether untrimmed builds modify referenced
+assemblies to support legacy binding and resource designer behavior. These
+modifications include adding missing abstract interface methods, updating
+legacy resource designer references, and inserting `GC.KeepAlive()` calls into
+older Xamarin.Android binding assemblies. Trimmed builds using the `trimmable`
+type map do not run these compatibility fixups.
+
+The default value is `False` when
+[`$(AndroidTypeMapImplementation)`](#androidtypemapimplementation) is
+`trimmable`, and `True` otherwise.
+
 ## AndroidEnableMarshalMethods
 
 A bool property, that determines whether or not LLVM marshal methods are enabled.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -11,6 +11,7 @@
   <UsingTask TaskName="Xamarin.Android.Tasks.PreTrimmingFixLegacyDesigner" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
   <PropertyGroup>
+    <AndroidEnableLegacyCompatibilityAssemblyFixups Condition=" '$(AndroidEnableLegacyCompatibilityAssemblyFixups)' == '' ">true</AndroidEnableLegacyCompatibilityAssemblyFixups>
     <_RemoveRegisterFlag>$(MonoAndroidIntermediateAssemblyDir)shrunk\shrunk.flag</_RemoveRegisterFlag>
     <!-- Inject typemap-specific targets into build dependency chains -->
     <_BeforeAddStaticResources>$(_BeforeAddStaticResources);_GetMonoPlatformJarPath</_BeforeAddStaticResources>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -12,6 +12,7 @@
       Condition=" '$(_AndroidRuntime)' == 'NativeAOT' " />
 
   <PropertyGroup>
+    <AndroidEnableLegacyCompatibilityAssemblyFixups Condition=" '$(AndroidEnableLegacyCompatibilityAssemblyFixups)' == '' ">false</AndroidEnableLegacyCompatibilityAssemblyFixups>
     <_TypeMapAssemblyName>_Microsoft.Android.TypeMaps</_TypeMapAssemblyName>
     <_TrimmableTypeMapPackageNamingPolicy Condition=" '$(_AndroidPackageNamingPolicySetByUser)' == 'true' ">$(AndroidPackageNamingPolicy)</_TrimmableTypeMapPackageNamingPolicy>
     <_TrimmableTypeMapPackageNamingPolicy Condition=" '$(_TrimmableTypeMapPackageNamingPolicy)' == '' ">Crc64</_TrimmableTypeMapPackageNamingPolicy>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using Microsoft.Android.Build.Tasks;
 using MonoDroid.Tuner;
 
 namespace Xamarin.Android.Tasks
@@ -15,6 +16,7 @@ namespace Xamarin.Android.Tasks
 
 		public bool AddKeepAlives { get; set; }
 
+		// MSBuild supplies the typemap-specific default. Keep direct task callers backward compatible.
 		public bool EnableLegacyCompatibilityAssemblyFixups { get; set; } = true;
 
 		public bool UseDesignerAssembly { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -40,6 +40,8 @@ namespace Xamarin.Android.Tasks
 					addKeepAliveStep.Initialize (context);
 					pipeline.Steps.Add (addKeepAliveStep);
 				}
+			} else {
+				Log.LogDebugMessage ("Skipping legacy compatibility assembly fixups. Set `AndroidEnableLegacyCompatibilityAssemblyFixups` to `true` to enable them.");
 			}
 
 			// Ensure the <AssemblyModifierPipeline> task's steps are added

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -15,27 +15,31 @@ namespace Xamarin.Android.Tasks
 
 		public bool AddKeepAlives { get; set; }
 
+		public bool EnableLegacyCompatibilityAssemblyFixups { get; set; } = true;
+
 		public bool UseDesignerAssembly { get; set; }
 
 		protected override void BuildPipeline (AssemblyPipeline pipeline, MSBuildLinkContext context)
 		{
-			// FixAbstractMethodsStep
-			var fixAbstractMethodsStep = new FixAbstractMethodsStep ();
-			fixAbstractMethodsStep.Initialize (context);
-			pipeline.Steps.Add (fixAbstractMethodsStep);
+			if (EnableLegacyCompatibilityAssemblyFixups) {
+				// FixAbstractMethodsStep
+				var fixAbstractMethodsStep = new FixAbstractMethodsStep ();
+				fixAbstractMethodsStep.Initialize (context);
+				pipeline.Steps.Add (fixAbstractMethodsStep);
 
-			// FixLegacyResourceDesignerStep
-			if (UseDesignerAssembly) {
-				var fixLegacyResourceDesignerStep = new FixLegacyResourceDesignerStep ();
-				fixLegacyResourceDesignerStep.Initialize (context);
-				pipeline.Steps.Add (fixLegacyResourceDesignerStep);
-			}
+				// FixLegacyResourceDesignerStep
+				if (UseDesignerAssembly) {
+					var fixLegacyResourceDesignerStep = new FixLegacyResourceDesignerStep ();
+					fixLegacyResourceDesignerStep.Initialize (context);
+					pipeline.Steps.Add (fixLegacyResourceDesignerStep);
+				}
 
-			// AddKeepAlivesStep
-			if (AddKeepAlives) {
-				var addKeepAliveStep = new AddKeepAlivesStep ();
-				addKeepAliveStep.Initialize (context);
-				pipeline.Steps.Add (addKeepAliveStep);
+				// AddKeepAlivesStep
+				if (AddKeepAlives) {
+					var addKeepAliveStep = new AddKeepAlivesStep ();
+					addKeepAliveStep.Initialize (context);
+					pipeline.Steps.Add (addKeepAliveStep);
+				}
 			}
 
 			// Ensure the <AssemblyModifierPipeline> task's steps are added

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -22,6 +22,33 @@ namespace Xamarin.Android.Build.Tests
 		void Logger (TraceLevel level, string message) =>
 			TestContext.WriteLine ($"{level}: {message}");
 
+		[TestCase (false)]
+		[TestCase (true)]
+		public void LinkAssembliesNoShrinkLegacyCompatibilityFixups (bool enabled)
+		{
+			var task = new TestableLinkAssembliesNoShrink {
+				AddKeepAlives = true,
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				EnableLegacyCompatibilityAssemblyFixups = enabled,
+				UseDesignerAssembly = true,
+			};
+			var resolver = new DirectoryAssemblyResolver (Logger, false);
+			using var pipeline = new AssemblyPipeline (resolver);
+			var context = new MSBuildLinkContext (resolver, task.Log);
+
+			task.BuildPipelineForTest (pipeline, context);
+
+			Assert.AreEqual (enabled, pipeline.Steps.Any (step => step is FixAbstractMethodsStep));
+			Assert.AreEqual (enabled, pipeline.Steps.Any (step => step is FixLegacyResourceDesignerStep));
+			Assert.AreEqual (enabled, pipeline.Steps.Any (step => step is AddKeepAlivesStep));
+		}
+
+		sealed class TestableLinkAssembliesNoShrink : LinkAssembliesNoShrink
+		{
+			public void BuildPipelineForTest (AssemblyPipeline pipeline, MSBuildLinkContext context) =>
+				BuildPipeline (pipeline, context);
+		}
+
 		[Test]
 		public void FixAbstractMethodsStep_SkipDimMembers ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -38,9 +38,15 @@ namespace Xamarin.Android.Build.Tests
 
 			task.BuildPipelineForTest (pipeline, context);
 
-			Assert.AreEqual (enabled, pipeline.Steps.Any (step => step is FixAbstractMethodsStep));
-			Assert.AreEqual (enabled, pipeline.Steps.Any (step => step is FixLegacyResourceDesignerStep));
-			Assert.AreEqual (enabled, pipeline.Steps.Any (step => step is AddKeepAlivesStep));
+			Assert.AreEqual (enabled, pipeline.Steps.Any (step => step is FixAbstractMethodsStep),
+				$"{nameof (FixAbstractMethodsStep)} presence should match the compatibility fixup setting.");
+			Assert.AreEqual (enabled, pipeline.Steps.Any (step => step is FixLegacyResourceDesignerStep),
+				$"{nameof (FixLegacyResourceDesignerStep)} presence should match the compatibility fixup setting.");
+			Assert.AreEqual (enabled, pipeline.Steps.Any (step => step is AddKeepAlivesStep),
+				$"{nameof (AddKeepAlivesStep)} presence should match the compatibility fixup setting.");
+			Assert.IsTrue (pipeline.Steps.Any (step => step is FindJavaObjectsStep), $"{nameof (FindJavaObjectsStep)} should always run.");
+			Assert.IsTrue (pipeline.Steps.Any (step => step is SaveChangedAssemblyStep), $"{nameof (SaveChangedAssemblyStep)} should always run.");
+			Assert.IsTrue (pipeline.Steps.Any (step => step is FindTypeMapObjectsStep), $"{nameof (FindTypeMapObjectsStep)} should always run.");
 		}
 
 		sealed class TestableLinkAssembliesNoShrink : LinkAssembliesNoShrink
@@ -400,23 +406,35 @@ $@"			var myButton = new AttributedButtonStub (this);
 				AddTestData (isRelease: true,  setAndroidAddKeepAlivesTrue: false, setLinkModeNone: true,  shouldAddKeepAlives: true,  runtime);
 			}
 
+			AddTestData (isRelease: false, setAndroidAddKeepAlivesTrue: true, setLinkModeNone: false,
+				shouldAddKeepAlives: false, AndroidRuntime.CoreCLR, typeMapImplementation: "trimmable");
+			AddTestData (isRelease: false, setAndroidAddKeepAlivesTrue: true, setLinkModeNone: false,
+				shouldAddKeepAlives: true, AndroidRuntime.CoreCLR, typeMapImplementation: "trimmable",
+				enableLegacyCompatibilityAssemblyFixups: true);
+
 			return ret;
 
-			void AddTestData (bool isRelease, bool setAndroidAddKeepAlivesTrue, bool setLinkModeNone, bool shouldAddKeepAlives, AndroidRuntime runtime)
+			void AddTestData (bool isRelease, bool setAndroidAddKeepAlivesTrue, bool setLinkModeNone,
+				bool shouldAddKeepAlives, AndroidRuntime runtime, string? typeMapImplementation = null,
+				bool enableLegacyCompatibilityAssemblyFixups = false)
 			{
 				ret.Add (new object[] {
 					isRelease,
 					setAndroidAddKeepAlivesTrue,
 					setLinkModeNone,
 					shouldAddKeepAlives,
-					runtime
+					runtime,
+					typeMapImplementation,
+					enableLegacyCompatibilityAssemblyFixups,
 				});
 			}
 		}
 
 		[Test]
 		[TestCaseSource (nameof (Get_AndroidAddKeepAlivesData))]
-		public void AndroidAddKeepAlives (bool isRelease, bool setAndroidAddKeepAlivesTrue, bool setLinkModeNone, bool shouldAddKeepAlives, AndroidRuntime runtime)
+		public void AndroidAddKeepAlives (bool isRelease, bool setAndroidAddKeepAlivesTrue, bool setLinkModeNone,
+			bool shouldAddKeepAlives, AndroidRuntime runtime, string? typeMapImplementation,
+			bool enableLegacyCompatibilityAssemblyFixups)
 		{
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
@@ -473,6 +491,8 @@ namespace UnnamedProject {
 
 			proj.SetRuntime (runtime);
 			proj.SetProperty ("AllowUnsafeBlocks", "True");
+			if (!typeMapImplementation.IsNullOrEmpty ())
+				proj.SetProperty ("AndroidTypeMapImplementation", typeMapImplementation);
 
 			// We don't want `[TargetPlatform ("android35")]` to get set because we don't do AddKeepAlives on .NET for Android assemblies
 			proj.SetProperty ("GenerateAssemblyInfo", "False");
@@ -482,6 +502,9 @@ namespace UnnamedProject {
 
 			if (setLinkModeNone)
 				proj.SetProperty (isRelease ? proj.ReleaseProperties : proj.DebugProperties, "AndroidLinkMode", "None");
+
+			if (enableLegacyCompatibilityAssemblyFixups)
+				proj.SetProperty ("AndroidEnableLegacyCompatibilityAssemblyFixups", "True");
 
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Building a project should have succeded.");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -969,6 +969,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidAddKeepAlives=$(AndroidAddKeepAlives)" />
 		<_PropertyCacheItems Include="AndroidAotMode=$(AndroidAotMode)" />
 		<_PropertyCacheItems Include="AndroidEmbedProfilers=$(AndroidEmbedProfilers)" />
+		<_PropertyCacheItems Include="AndroidEnableLegacyCompatibilityAssemblyFixups=$(AndroidEnableLegacyCompatibilityAssemblyFixups)" />
 		<_PropertyCacheItems Include="AndroidEnableProfiledAot=$(AndroidEnableProfiledAot)" />
 		<_PropertyCacheItems Include="AndroidDexTool=$(AndroidDexTool)" />
 		<_PropertyCacheItems Include="AndroidLinkTool=$(AndroidLinkTool)" />
@@ -1468,6 +1469,7 @@ because xbuild doesn't support framework reference assemblies.
       ResolvedUserAssemblies="@(ResolvedUserAssemblies)"
       SourceFiles="@(ResolvedAssemblies)"
       DestinationFiles="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"
+      EnableLegacyCompatibilityAssemblyFixups="$(AndroidEnableLegacyCompatibilityAssemblyFixups)"
       TargetName="$(TargetName)"
       AddKeepAlives="$(AndroidAddKeepAlives)"
       UseDesignerAssembly="$(AndroidUseDesignerAssembly)"


### PR DESCRIPTION
## Summary

- add `AndroidEnableLegacyCompatibilityAssemblyFixups`
- default it to `false` for the trimmable typemap and `true` for LLVM-IR
- gate the untrimmed `FixAbstractMethodsStep`, `FixLegacyResourceDesignerStep`, and `AddKeepAlivesStep` passes behind the property
- preserve the existing non-compatibility `LinkAssembliesNoShrink` scanning and staging behavior
- document the untrimmed-only opt-in semantics and log when the compatibility passes are skipped
- cover both pipeline composition and the actual trimmable default/explicit opt-in MSBuild wiring

Trimmed trimmable builds already exclude these compatibility rewriters, so this closes the remaining untrimmed path by default while retaining an escape hatch for older binding/resource-designer binaries in untrimmed builds.

Follow-up to #10842.

## Validation

- target XML validation
- MSBuild property evaluation: trimmable defaults to `false`, LLVM-IR defaults to `true`, and an explicit trimmable opt-in remains `true`
- focused pipeline unit coverage for enabled and disabled compatibility passes
- full-build `AndroidAddKeepAlives` cases for trimmable default-off and explicit opt-in added for CI
- local full-build execution unavailable because this worktree has no prepared local Android SDK or JDK