### PR TITLE
[release/10.1xx] Backport CFSClean network isolation fixes

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -83,6 +83,7 @@ extends:
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
     settings:
+      networkIsolationPolicy: Permissive,CFSClean
       skipBuildTagsForGitHubPullRequests: true
     stages:
     - template: /build-tools/automation/yaml-templates/build-macos.yaml@self

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -80,6 +80,9 @@ variables:
   value: true
 - name: DOTNET_GENERATE_ASPNET_CERTIFICATE
   value: false
+# XBD Google Maven mirror support: https://github.com/dotnet/android-libraries/commit/4fe06d57f3ef7905fab0257d7246c97464d29e74
+- name: XamarinBuildDownloadGoogleMavenRepository
+  value: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1
 # Fix network isolation requirements
 # See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
 - name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Microsoft.Android.Sdk.Analysis.Tests.csproj
@@ -20,6 +20,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Android.Sdk.Analysis.csproj" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\..\NuGet.config" Link="NuGet.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="..\..\..\build-tools\scripts\NUnitReferences.projitems" />
   <ItemGroup>

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -16,6 +16,8 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
 		public List<DiagnosticAnalyzer> Analyzers => analyzers;
 		public Test ()
 		{
+			ReferenceAssemblies = CSharpVerifierHelper.DefaultReferenceAssemblies;
+
 			SolutionTransforms.Add ((solution, projectId) => {
 				var project = solution.GetProject (projectId);
 				var compilationOptions = project.CompilationOptions;

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpCodeFixVerifier`2+Test.cs
@@ -11,6 +11,8 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 	{
 		public Test ()
 		{
+			ReferenceAssemblies = CSharpVerifierHelper.DefaultReferenceAssemblies;
+
 			SolutionTransforms.Add ((solution, projectId) => {
 				var compilationOptions = solution.GetProject (projectId).CompilationOptions;
 				compilationOptions = compilationOptions.WithSpecificDiagnosticOptions (
@@ -22,4 +24,3 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 		}
 	}
 }
-

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -8,6 +8,8 @@ public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
 	{
 		public Test ()
 		{
+			ReferenceAssemblies = CSharpVerifierHelper.DefaultReferenceAssemblies;
+
 			SolutionTransforms.Add ((solution, projectId) => {
 				var compilationOptions = solution.GetProject (projectId).CompilationOptions;
 				compilationOptions = compilationOptions.WithSpecificDiagnosticOptions (

--- a/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpVerifierHelper.cs
+++ b/src/Microsoft.Android.Sdk.Analysis/Tests/Verifiers/CSharpVerifierHelper.cs
@@ -1,10 +1,15 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
 using System;
 using System.Collections.Immutable;
+using System.IO;
 
 internal static class CSharpVerifierHelper
 {
+	internal static ReferenceAssemblies DefaultReferenceAssemblies { get; } =
+		ReferenceAssemblies.Default.WithNuGetConfigFilePath (Path.Combine (AppContext.BaseDirectory, "NuGet.config"));
+
 	/// <summary>
 	/// By default, the compiler reports diagnostics for nullable reference types at
 	/// <see cref="DiagnosticSeverity.Warning"/>, and the analyzer test framework defaults to only validating

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -658,6 +658,7 @@ class MemTest {
 					new Package { Id = "Xamarin.GooglePlayServices.Base", Version = "118.2.0.5" },
 					new Package { Id = "Xamarin.GooglePlayServices.Basement", Version = "118.2.0.5" },
 					new Package { Id = "Xamarin.GooglePlayServices.Tasks", Version = "118.0.2.6" },
+					KnownPackages.Xamarin_Build_Download,
 				}
 			};
 			using (var b = CreateApkBuilder ()) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -127,7 +127,7 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package Xamarin_Build_Download = new Package {
 			Id = "Xamarin.Build.Download",
-			Version = "0.11.4",
+			Version = "0.11.6",
 		};
 		public static Package NuGet_Build_Packaging = new Package {
 			Id = "NuGet.Build.Packaging",


### PR DESCRIPTION
## Summary

Backports the complete CFSClean/network-isolation set needed by `release/10.0.1xx`:

- #10803 / `1e4bbd9c501098d18c2306d74c2117b725553f8b` — update `mono/debugger-libs` to remove its nested `api.nuget.org` override and use the approved `dotnet-tools` feed
- #12520 / `7c7d207aa8b73eb8e733a9269c5d7e131587096b` — route Roslyn analyzer test reference acquisition through the repository `NuGet.config`
- #12643 / `8eac8ed475d33470319e8ced1040e866c9f01467` — enable `networkIsolationPolicy: Permissive,CFSClean` in the shared DevDiv production/PR pipeline
- #12544 / `adb7d10d80907604727cd415fbb184a33fd0e3d2` — route Xamarin.Build.Download Google Maven requests through `dotnet-public-maven`, update XBD to 0.11.6, and directly pin the transitive test consumer

The commits remain separate and in dependency order.

## Release compatibility

The #12643 cherry-pick produced modify/delete conflicts for two main-only files that do not exist on this release branch:

- `build-tools/automation/azure-pipelines-internal.yaml`
- `src/Xamarin.Android.Tools.AndroidSdk/SdkManager.Packages.cs`

Both paths remain absent. The first would invent dnceng/internal topology not used by this release branch; the second upstream change was comment-only. The release-applicable shared `build-tools/automation/azure-pipelines.yaml` policy change was retained unchanged.

`CFSClean2` and `CFSClean3` are intentionally not listed because they are supplied centrally by `PerPipelineRequiredConfig`. Retaining `Permissive` allows required Android SDK/NDK traffic; DefaultDeny Google SDK/NDK telemetry is not a failure for this change.

## Validation

- `Microsoft.Android.Sdk.Analysis.Tests`: 16 passed, 1 skipped
- `git diff --check origin/release/10.0.1xx...HEAD`
- DevDiv 12278 (`Xamarin.Android-PR`): [build 15200544](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=15200544&view=results) — queued on PR merge ref `refs/pull/12665/merge`
- DevDiv 11410 (`Xamarin.Android`): [build 15200531](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=15200531&view=results) — queued on trusted branch `jonathanpeppers-release-cfsclean-audit`

Azure results and network-isolation evidence will be updated when both runs complete.