### PR TITLE
[release/10.0.1xx] Backport CI build fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -132,6 +132,7 @@ C# code uses tabs (not spaces) and Mono style (`.editorconfig`):
 - Preserve existing formatting and comments
 - Space before `(` and `[`: `Foo ()`, `array [0]`
 - Use `""` not `string.Empty`, `[]` not `Array.Empty<T>()`
+- Prefer C# raw string literals (`"""`) for multi-line strings instead of `@""` with escaped quotes
 - Minimal diffs - don't leave random empty lines
 
 ```csharp

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ src/native/clr/pinvoke-override/pinvoke-tables.include.generated
 src/native/mono/pinvoke-override/generate-pinvoke-tables
 src/native/mono/pinvoke-override/pinvoke-tables.include.generated
 dotnet-install.ps1
+*.gdn.sarif

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -22,7 +22,7 @@ resources:
   - repository: maui
     type: github
     name: dotnet/maui
-    ref: net10.0
+    ref: refs/tags/10.0.100
     endpoint: xamarin
 
 parameters:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -22,6 +22,7 @@ resources:
   - repository: maui
     type: github
     name: dotnet/maui
+    ref: net10.0
     endpoint: xamarin
 
 parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -25,7 +25,7 @@ resources:
   - repository: maui
     type: github
     name: dotnet/maui
-    ref: net10.0
+    ref: refs/tags/10.0.100
     endpoint: xamarin
 
 parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -25,7 +25,7 @@ resources:
   - repository: maui
     type: github
     name: dotnet/maui
-    ref: refs/heads/main
+    ref: net10.0
     endpoint: xamarin
 
 parameters:

--- a/build-tools/automation/yaml-templates/fail-on-dirty-tree.yaml
+++ b/build-tools/automation/yaml-templates/fail-on-dirty-tree.yaml
@@ -7,10 +7,10 @@ parameters:
 steps:
 - powershell: |
     # Run this to log the output for the user
-    git status
+    git status --ignore-submodules
 
     # Run this to error the build if modified/untracked files exist
-    $process= git status --porcelain
+    $process= git status --porcelain --ignore-submodules
 
     if ($process)
     {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -29,6 +29,13 @@ namespace Xamarin.ProjectTools
 	/// <seealso cref="XamarinAndroidBindingProject"/>
 	public class XamarinAndroidApplicationProject : XamarinAndroidCommonProject
 	{
+		// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
+		protected override string ExtraDirectoryBuildTargetsContent => """
+			<PropertyGroup>
+				<VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
+			</PropertyGroup>
+		""";
+
 		const string default_strings_xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
 	<string name=""hello"">Hello World, Click Me!</string>
@@ -73,16 +80,6 @@ namespace Xamarin.ProjectTools
 			SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True");
 			SetProperty ("_FastDeploymentDiagnosticLogging", "True");
 			SupportedOSPlatformVersion = "21.0";
-
-			// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
-			Imports.Add (new Import (() => "Directory.Build.targets") {
-				TextContent = () =>
-					@"<Project>
-						<PropertyGroup>
-							<VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
-						</PropertyGroup>
-					</Project>"
-			});
 
 			AndroidManifest = default_android_manifest;
 			LayoutMain = default_layout_main;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -23,6 +23,13 @@ namespace Xamarin.ProjectTools
 	public abstract class XamarinAndroidProject : DotNetXamarinProject
 	{
 		/// <summary>
+		/// Override to provide additional MSBuild XML content inside the auto-generated Directory.Build.targets file.
+		/// The returned string is inserted as-is inside the root &lt;Project&gt; element, before the
+		/// <c>_ClearResolvedCodeAnalysisRuleSet</c> target.
+		/// </summary>
+		protected virtual string ExtraDirectoryBuildTargetsContent => "";
+
+		/// <summary>
 		/// Initializes a new instance of the XamarinAndroidProject class with the specified configuration names.
 		/// Sets the default language to C# and output type to Library.
 		/// </summary>
@@ -35,6 +42,24 @@ namespace Xamarin.ProjectTools
 		{
 			Language = XamarinAndroidProjectLanguage.CSharp;
 			SetProperty (KnownProperties.OutputType, "Library");
+
+			// Prevent CI Guardian SDL analysis from breaking CoreCompile incrementality.
+			// Guardian's MergeGuardianDotnetAnalyzersRuleSets target regenerates a merged
+			// ruleset file on every build (new timestamp), which is in CoreCompile's Inputs
+			// via $(ResolvedCodeAnalysisRuleSet). Clearing this property ensures CoreCompile
+			// is properly incremental when source files haven't changed.
+			Imports.Add (new Import (() => "Directory.Build.targets") {
+				TextContent = () => $"""
+					<Project>
+						{ExtraDirectoryBuildTargetsContent}
+						<Target Name="_ClearResolvedCodeAnalysisRuleSet" BeforeTargets="CoreCompile" AfterTargets="ResolveCodeAnalysisRuleSet;MergeGuardianDotnetAnalyzersRuleSets">
+							<PropertyGroup>
+								<ResolvedCodeAnalysisRuleSet />
+							</PropertyGroup>
+						</Target>
+					</Project>
+				""",
+			});
 		}
 
 		/// <summary>


### PR DESCRIPTION
## Summary

Backports the CI fixes identified while investigating [Azure DevOps build 15189356](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_build/results?buildId=15189356):

- [`f708e85e5`](https://github.com/dotnet/android/commit/f708e85e529816727993b26c42e608635c4c8f2e) / #10900 — clear `ResolvedCodeAnalysisRuleSet` in generated test projects so Guardian does not break `CoreCompile` incrementality
- [`52c36b4d8`](https://github.com/dotnet/android/commit/52c36b4d8c15932ac28056d0ea7a2e26a0743b73) / #10926 — ignore Guardian-generated `*.gdn.sarif` files
- [`9595ae339`](https://github.com/dotnet/android/commit/9595ae339ad0ac0a9d1d9b5880e61f95a609b73d) / #10927 — ignore submodule working trees in the fail-on-dirty-tree check

For the MAUI integration failure, both pipeline checkouts are pinned to the latest stable [.NET MAUI 10.0.100 service release](https://github.com/dotnet/maui/releases/tag/10.0.100). This provides an immutable .NET 10-compatible source revision instead of following a moving branch.

The macOS Debug APK failure is not included because the logs indicated a transient test-runner failure and all Release variants passed.

## Testing

- `git diff --check`
- Verified MAUI `10.0.100` is a stable release and uses .NET SDK `10.0.108`
- Local MSBuild tests were not run because this checkout does not contain a prepared .NET for Android build