### PR TITLE
[generator] Remove class_ref compatibility getters

### DIFF
--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
@@ -1,11 +1,7 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass {
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
-
-	internal static IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
 
 	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
@@ -15,7 +15,7 @@ public abstract class MyInterface : Java.Lang.Object {
 		}
 	}
 
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
 
 }
 
@@ -77,10 +77,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-	static IntPtr java_class_ref {
-		get { return _members_java_code_IMyInterface.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -99,7 +95,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		get { return _members_java_code_IMyInterface.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	private static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
@@ -1,11 +1,7 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='com.example']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("com/example/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass : Java.Lang.Object {
-	static readonly JniPeerMembers _members = new XAPeerMembers ("com/example/MyClass", typeof (MyClass));
-
-	internal static new IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("com/example/MyClass", typeof (MyClass));
 
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteObjectField.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteObjectField.txt
@@ -23,11 +23,7 @@ public partial class MyClass {
 		}
 	}
 
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
-
-	internal static IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
 
 	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/ObsoleteInterfaceAlternativeClass.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/ObsoleteInterfaceAlternativeClass.txt
@@ -54,7 +54,7 @@ public abstract class Parent : Java.Lang.Object {
 		}
 	}
 
-	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent", typeof (Parent));
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent", typeof (Parent));
 
 }
 
@@ -113,10 +113,6 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-	static IntPtr java_class_ref {
-		get { return _members_com_xamarin_android_Parent.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -135,7 +131,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 		get { return _members_com_xamarin_android_Parent.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_com_xamarin_android_Parent = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
+	private static readonly JniPeerMembers _members_com_xamarin_android_Parent = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	public IParentInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -1,11 +1,7 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass {
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
-
-	internal static IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
 
 	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteConstSugarInterfaceFields.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteConstSugarInterfaceFields.txt
@@ -42,7 +42,7 @@ public abstract class MyInterface : Java.Lang.Object {
 		}
 	}
 
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
 
 }
 

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -42,10 +42,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-	static IntPtr java_class_ref {
-		get { return _members_java_code_IMyInterface.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -64,7 +60,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		get { return _members_java_code_IMyInterface.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	private static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
@@ -13,10 +13,6 @@ public partial interface AnimatorListener : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/AnimatorListener", DoNotGenerateAcw=true)]
 internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, AnimatorListener {
-	static IntPtr java_class_ref {
-		get { return _members_java_code_AnimatorListener.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -35,7 +31,7 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 		get { return _members_java_code_AnimatorListener.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_java_code_AnimatorListener = new XAPeerMembers ("java/code/AnimatorListener", typeof (AnimatorListenerInvoker));
+	private static readonly JniPeerMembers _members_java_code_AnimatorListener = new XAPeerMembers ("java/code/AnimatorListener", typeof (AnimatorListenerInvoker));
 
 	public AnimatorListenerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -15,7 +15,7 @@ public abstract class MyInterface : Java.Lang.Object {
 		}
 	}
 
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
 
 }
 
@@ -77,10 +77,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-	static IntPtr java_class_ref {
-		get { return _members_java_code_IMyInterface.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -99,7 +95,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		get { return _members_java_code_IMyInterface.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	private static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -38,10 +38,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-	static IntPtr java_class_ref {
-		get { return _members_java_code_IMyInterface.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -60,7 +56,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		get { return _members_java_code_IMyInterface.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	private static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -71,10 +71,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-	static IntPtr java_class_ref {
-		get { return _members_java_code_IMyInterface.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -93,7 +89,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		get { return _members_java_code_IMyInterface.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	private static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -40,10 +40,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-	static IntPtr java_class_ref {
-		get { return _members_java_code_IMyInterface.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -62,7 +58,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		get { return _members_java_code_IMyInterface.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	private static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceFieldAsDimProperty.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceFieldAsDimProperty.txt
@@ -28,7 +28,7 @@ public abstract class MyInterface : Java.Lang.Object {
 		}
 	}
 
-	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/MyInterface", typeof (MyInterface));
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/MyInterface", typeof (MyInterface));
 
 }
 
@@ -70,10 +70,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("com/xamarin/android/MyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-	static IntPtr java_class_ref {
-		get { return _members_com_xamarin_android_MyInterface.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -92,7 +88,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		get { return _members_com_xamarin_android_MyInterface.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_com_xamarin_android_MyInterface = new XAPeerMembers ("com/xamarin/android/MyInterface", typeof (IMyInterfaceInvoker));
+	private static readonly JniPeerMembers _members_com_xamarin_android_MyInterface = new XAPeerMembers ("com/xamarin/android/MyInterface", typeof (IMyInterfaceInvoker));
 
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -9,10 +9,6 @@ public partial interface IMyInterface2 : java.code.IMyInterface {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface2", DoNotGenerateAcw=true)]
 internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInterface2 {
-	static IntPtr java_class_ref {
-		get { return _members_java_code_IMyInterface2.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -31,9 +27,9 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 		get { return _members_java_code_IMyInterface2.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface2Invoker));
+	private static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface2Invoker));
 
-	static readonly JniPeerMembers _members_java_code_IMyInterface2 = new XAPeerMembers ("java/code/IMyInterface2", typeof (IMyInterface2Invoker));
+	private static readonly JniPeerMembers _members_java_code_IMyInterface2 = new XAPeerMembers ("java/code/IMyInterface2", typeof (IMyInterface2Invoker));
 
 	public IMyInterface2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteKotlinUnsignedArrayTypeMethodsClass.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteKotlinUnsignedArrayTypeMethodsClass.txt
@@ -1,11 +1,7 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass {
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
-
-	internal static IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
 
 	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteKotlinUnsignedArrayTypePropertiesClass.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteKotlinUnsignedArrayTypePropertiesClass.txt
@@ -1,11 +1,7 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass {
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
-
-	internal static IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
 
 	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteKotlinUnsignedTypeMethodsClass.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteKotlinUnsignedTypeMethodsClass.txt
@@ -1,11 +1,7 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass {
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
-
-	internal static IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
 
 	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteKotlinUnsignedTypePropertiesClass.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteKotlinUnsignedTypePropertiesClass.txt
@@ -1,11 +1,7 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass {
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
-
-	internal static IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
 
 	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
@@ -1,11 +1,7 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='com.example']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("com/example/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass : Java.Lang.Object {
-	static readonly JniPeerMembers _members = new XAPeerMembers ("com/example/MyClass", typeof (MyClass));
-
-	internal static new IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("com/example/MyClass", typeof (MyClass));
 
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
@@ -10,11 +10,7 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 	// Metadata.xml XPath class reference: path="/api/package[@name='com.xamarin.android']/class[@name='Parent.Child']"
 	[global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
 	public partial class Child : Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (Child));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (Child));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -44,10 +40,6 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-	static IntPtr java_class_ref {
-		get { return _members_com_xamarin_android_Parent.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -66,7 +58,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 		get { return _members_com_xamarin_android_Parent.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_com_xamarin_android_Parent = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
+	private static readonly JniPeerMembers _members_com_xamarin_android_Parent = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	public IParentInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
@@ -20,10 +20,6 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 	[global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
 	internal partial class IChildInvoker : global::Java.Lang.Object, IChild {
-		static IntPtr java_class_ref {
-			get { return _members_com_xamarin_android_Parent_Child.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -42,7 +38,7 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 			get { return _members_com_xamarin_android_Parent_Child.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_com_xamarin_android_Parent_Child = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (IChildInvoker));
+		private static readonly JniPeerMembers _members_com_xamarin_android_Parent_Child = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (IChildInvoker));
 
 		public IChildInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{
@@ -85,10 +81,6 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-	static IntPtr java_class_ref {
-		get { return _members_com_xamarin_android_Parent.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -107,7 +99,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 		get { return _members_com_xamarin_android_Parent.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_com_xamarin_android_Parent = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
+	private static readonly JniPeerMembers _members_com_xamarin_android_Parent = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	public IParentInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteObjectField.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteObjectField.txt
@@ -23,11 +23,7 @@ public partial class MyClass {
 		}
 	}
 
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
-
-	internal static IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
 
 	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
@@ -15,7 +15,7 @@ public abstract class MyInterface : Java.Lang.Object {
 		}
 	}
 
-	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
 
 }
 
@@ -48,10 +48,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-	static IntPtr java_class_ref {
-		get { return _members_java_code_IMyInterface.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -70,7 +66,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		get { return _members_java_code_IMyInterface.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	private static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceProperty.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceProperty.txt
@@ -31,10 +31,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-	static IntPtr java_class_ref {
-		get { return _members_java_code_IMyInterface.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -53,7 +49,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		get { return _members_java_code_IMyInterface.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	private static readonly JniPeerMembers _members_java_code_IMyInterface = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -11,10 +11,6 @@ public partial interface IParentChild : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
 internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentChild {
-	static IntPtr java_class_ref {
-		get { return _members_com_xamarin_android_Parent_Child.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -33,7 +29,7 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 		get { return _members_com_xamarin_android_Parent_Child.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_com_xamarin_android_Parent_Child = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (IParentChildInvoker));
+	private static readonly JniPeerMembers _members_com_xamarin_android_Parent_Child = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (IParentChildInvoker));
 
 	public IParentChildInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{
@@ -85,10 +81,6 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-	static IntPtr java_class_ref {
-		get { return _members_com_xamarin_android_Parent.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -107,7 +99,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 		get { return _members_com_xamarin_android_Parent.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members_com_xamarin_android_Parent = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
+	private static readonly JniPeerMembers _members_com_xamarin_android_Parent = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	public IParentInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1373,12 +1373,8 @@ namespace generatortests
 		protected override CodeGenerationTarget Target => CodeGenerationTarget.XAJavaInterop1;
 
 		[Test]
-		public void WriteClassExternalBase ()
+		public void WriteClassPeerMembers ()
 		{
-			// Tests the case where a class inherits from a class that is not in the same assembly.
-			// Specifically, the internal class_ref field does NOT need the new modifier.
-			//  - This prevents a CS0109 warning from being generated.
-
 			options.SymbolTable.AddType (new TestClass (null, "Java.Lang.Object"));
 
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options, "Java.Lang.Object");
@@ -1389,33 +1385,26 @@ namespace generatortests
 			generator.Context.ContextTypes.Pop ();
 
 			var result = writer.ToString ().NormalizeLineEndings ();
-			Assert.True (result.Contains ("internal static IntPtr class_ref".NormalizeLineEndings ()));
-			Assert.False (result.Contains ("internal static new IntPtr class_ref".NormalizeLineEndings ()));
+			Assert.True (result.Contains ("private static readonly JniPeerMembers _members".NormalizeLineEndings ()));
+			Assert.False (result.Contains ("class_ref".NormalizeLineEndings ()));
 		}
 
 		[Test]
-		public void WriteClassInternalBase ()
+		public void WriteFinalClassPeerMembers ()
 		{
-			// Tests the case where a class inherits from Java.Lang.Object and is in the same assembly.
-			// Specifically, the internal class_ref field does need the new modifier.
-			// - This prevents a CS0108 warning from being generated.
-
 			options.SymbolTable.AddType (new TestClass (null, "Java.Lang.Object"));
 
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options, "Java.Lang.Object");
+			@class.IsFinal = true;
 			@class.Validate (options, new GenericParameterDefinitionList (), generator.Context);
-
-			// FromXml is set to true when a class is set to true when the api.xml contains an entry for the class.
-			// Therefore, if a class's base has FromXml set to true, the class and its base will be in the same C# assembly.
-			@class.BaseGen.FromXml = true;
 
 			generator.Context.ContextTypes.Push (@class);
 			generator.WriteType (@class, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
 			generator.Context.ContextTypes.Pop ();
 
 			var result = writer.ToString ().NormalizeLineEndings ();
-			Assert.True (result.Contains ("internal static new IntPtr class_ref".NormalizeLineEndings ()));
-			Assert.False (result.Contains ("internal static IntPtr class_ref".NormalizeLineEndings ()));
+			Assert.True (result.Contains ("private static readonly JniPeerMembers _members".NormalizeLineEndings ()));
+			Assert.False (result.Contains ("class_ref".NormalizeLineEndings ()));
 		}
 
 		[Test]

--- a/external/Java.Interop/tests/generator-Tests/Unit-Tests/SourceWriters/PeerMembersFieldTests.cs
+++ b/external/Java.Interop/tests/generator-Tests/Unit-Tests/SourceWriters/PeerMembersFieldTests.cs
@@ -11,9 +11,9 @@ namespace generatortests.SourceWriters
 		[Test]
 		public void PeerMembersField_Class ()
 		{
-			var field = new PeerMembersField (new CodeGenerationOptions { CodeGenerationTarget = CodeGenerationTarget.JavaInterop1 }, "B", "MyJavaType", false);
+			var field = new PeerMembersField (new CodeGenerationOptions { CodeGenerationTarget = CodeGenerationTarget.XAJavaInterop1 }, "B", "MyJavaType", false);
 
-			Assert.AreEqual ("static readonly JniPeerMembers _members = new JniPeerMembers (\"B\", typeof (MyJavaType));", GetOutput (field).Trim ());
+			Assert.AreEqual ("private static readonly JniPeerMembers _members = new XAPeerMembers (\"B\", typeof (MyJavaType));", GetOutput (field).Trim ());
 		}
 
 		[Test]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='BasePublicClass']"
 	[global::Android.Runtime.Register ("xamarin/test/BasePublicClass", DoNotGenerateAcw=true)]
 	public partial class BasePublicClass : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/BasePublicClass", typeof (BasePublicClass));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/BasePublicClass", typeof (BasePublicClass));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='ExtendPublicClass']"
 	[global::Android.Runtime.Register ("xamarin/test/ExtendPublicClass", DoNotGenerateAcw=true)]
 	public partial class ExtendPublicClass : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/ExtendPublicClass", typeof (ExtendPublicClass));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/ExtendPublicClass", typeof (ExtendPublicClass));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
@@ -20,10 +20,6 @@ namespace Xamarin.Test {
 
 	[global::Android.Runtime.Register ("xamarin/test/ExtendedInterface", DoNotGenerateAcw=true)]
 	internal partial class IExtendedInterfaceInvoker : global::Java.Lang.Object, IExtendedInterface {
-		static IntPtr java_class_ref {
-			get { return _members_xamarin_test_ExtendedInterface.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -42,9 +38,9 @@ namespace Xamarin.Test {
 			get { return _members_xamarin_test_ExtendedInterface.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_xamarin_test_BaseInterface = new XAPeerMembers ("xamarin/test/BaseInterface", typeof (IExtendedInterfaceInvoker));
+		private static readonly JniPeerMembers _members_xamarin_test_BaseInterface = new XAPeerMembers ("xamarin/test/BaseInterface", typeof (IExtendedInterfaceInvoker));
 
-		static readonly JniPeerMembers _members_xamarin_test_ExtendedInterface = new XAPeerMembers ("xamarin/test/ExtendedInterface", typeof (IExtendedInterfaceInvoker));
+		private static readonly JniPeerMembers _members_xamarin_test_ExtendedInterface = new XAPeerMembers ("xamarin/test/ExtendedInterface", typeof (IExtendedInterfaceInvoker));
 
 		public IExtendedInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -29,10 +29,6 @@ namespace Xamarin.Test {
 
 		[global::Android.Runtime.Register ("xamarin/test/PublicClass$ProtectedInterface", DoNotGenerateAcw=true)]
 		internal partial class IProtectedInterfaceInvoker : global::Java.Lang.Object, IProtectedInterface {
-			static IntPtr java_class_ref {
-				get { return _members_xamarin_test_PublicClass_ProtectedInterface.JniPeerType.PeerReference.Handle; }
-			}
-
 			[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 			[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -51,7 +47,7 @@ namespace Xamarin.Test {
 				get { return _members_xamarin_test_PublicClass_ProtectedInterface.ManagedPeerType; }
 			}
 
-			static readonly JniPeerMembers _members_xamarin_test_PublicClass_ProtectedInterface = new XAPeerMembers ("xamarin/test/PublicClass$ProtectedInterface", typeof (IProtectedInterfaceInvoker));
+			private static readonly JniPeerMembers _members_xamarin_test_PublicClass_ProtectedInterface = new XAPeerMembers ("xamarin/test/PublicClass$ProtectedInterface", typeof (IProtectedInterfaceInvoker));
 
 			public IProtectedInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 			{
@@ -88,11 +84,7 @@ namespace Xamarin.Test {
 
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/PublicClass", typeof (PublicClass));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/PublicClass", typeof (PublicClass));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='PublicFinalClass']"
 	[global::Android.Runtime.Register ("xamarin/test/PublicFinalClass", DoNotGenerateAcw=true)]
 	public sealed partial class PublicFinalClass : global::Xamarin.Test.BasePublicClass {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/PublicFinalClass", typeof (PublicFinalClass));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/PublicFinalClass", typeof (PublicFinalClass));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='TestClass']"
 	[global::Android.Runtime.Register ("xamarin/test/TestClass", DoNotGenerateAcw=true)]
 	public partial class TestClass : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/TestClass", typeof (TestClass));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/TestClass", typeof (TestClass));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='AbsSpinner']"
 	[global::Android.Runtime.Register ("xamarin/test/AbsSpinner", DoNotGenerateAcw=true)]
 	public abstract partial class AbsSpinner : Xamarin.Test.AdapterView<Xamarin.Test.ISpinnerAdapter> {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinner));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinner));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -120,7 +116,7 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinnerInvoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinnerInvoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
@@ -19,11 +19,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/AdapterView", DoNotGenerateAcw=true)]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.Adapter"})]
 	public abstract partial class AdapterView : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/AdapterView", typeof (AdapterView));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/AdapterView", typeof (AdapterView));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -106,7 +102,7 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/AdapterView", typeof (AdapterViewInvoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/AdapterView", typeof (AdapterViewInvoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='GenericReturnObject']"
 	[global::Android.Runtime.Register ("xamarin/test/GenericReturnObject", DoNotGenerateAcw=true)]
 	public partial class GenericReturnObject : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/GenericReturnObject", typeof (GenericReturnObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/GenericReturnObject", typeof (GenericReturnObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.IAdapter.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.IAdapter.cs
@@ -12,10 +12,6 @@ namespace Xamarin.Test {
 
 	[global::Android.Runtime.Register ("xamarin/test/Adapter", DoNotGenerateAcw=true)]
 	internal partial class IAdapterInvoker : global::Java.Lang.Object, IAdapter {
-		static IntPtr java_class_ref {
-			get { return _members_xamarin_test_Adapter.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -34,7 +30,7 @@ namespace Xamarin.Test {
 			get { return _members_xamarin_test_Adapter.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_xamarin_test_Adapter = new XAPeerMembers ("xamarin/test/Adapter", typeof (IAdapterInvoker));
+		private static readonly JniPeerMembers _members_xamarin_test_Adapter = new XAPeerMembers ("xamarin/test/Adapter", typeof (IAdapterInvoker));
 
 		public IAdapterInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -12,10 +12,6 @@ namespace Xamarin.Test {
 
 	[global::Android.Runtime.Register ("xamarin/test/SpinnerAdapter", DoNotGenerateAcw=true)]
 	internal partial class ISpinnerAdapterInvoker : global::Java.Lang.Object, ISpinnerAdapter {
-		static IntPtr java_class_ref {
-			get { return _members_xamarin_test_SpinnerAdapter.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -34,9 +30,9 @@ namespace Xamarin.Test {
 			get { return _members_xamarin_test_SpinnerAdapter.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_xamarin_test_Adapter = new XAPeerMembers ("xamarin/test/Adapter", typeof (ISpinnerAdapterInvoker));
+		private static readonly JniPeerMembers _members_xamarin_test_Adapter = new XAPeerMembers ("xamarin/test/Adapter", typeof (ISpinnerAdapterInvoker));
 
-		static readonly JniPeerMembers _members_xamarin_test_SpinnerAdapter = new XAPeerMembers ("xamarin/test/SpinnerAdapter", typeof (ISpinnerAdapterInvoker));
+		private static readonly JniPeerMembers _members_xamarin_test_SpinnerAdapter = new XAPeerMembers ("xamarin/test/SpinnerAdapter", typeof (ISpinnerAdapterInvoker));
 
 		public ISpinnerAdapterInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -38,11 +38,7 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -125,7 +121,7 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Arrays/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Arrays/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Arrays/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Arrays/Xamarin.Test.SomeObject.cs
@@ -172,11 +172,7 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Throwable']"
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
 	public partial class Throwable {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Throwable", typeof (Throwable));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Throwable", typeof (Throwable));
 
 		static Delegate cb_getMessage_GetMessage_Ljava_lang_String_;
 #pragma warning disable 0169

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='CSharpKeywords']"
 	[global::Android.Runtime.Register ("xamarin/test/CSharpKeywords", DoNotGenerateAcw=true)]
 	public partial class CSharpKeywords : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/CSharpKeywords", typeof (CSharpKeywords));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/CSharpKeywords", typeof (CSharpKeywords));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Constructors/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Constructors/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Constructors/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Constructors/Xamarin.Test.SomeObject.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Constructors/Xamarin.Test.SomeObject2.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Constructors/Xamarin.Test.SomeObject2.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject2']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
 	public sealed partial class SomeObject2 : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_ClassParse/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_ClassParse/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_ClassParse/Java.Lang.String.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_ClassParse/Java.Lang.String.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='String']"
 	[global::Android.Runtime.Register ("java/lang/String", DoNotGenerateAcw=true)]
 	public partial class String : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/String", typeof (String));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/String", typeof (String));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_ClassParse/Xamarin.Google.Composable.MyClass.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_ClassParse/Xamarin.Google.Composable.MyClass.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Google.Composable {
 	// Metadata.xml XPath class reference: path="/api/package[@name='com.com.google.compose']/class[@name='MyClass']"
 	[global::Android.Runtime.Register ("com/com/google/compose/MyClass", DoNotGenerateAcw=true)]
 	public partial class MyClass : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("com/com/google/compose/MyClass", typeof (MyClass));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("com/com/google/compose/MyClass", typeof (MyClass));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_ClassParse/Xamarin.Test.Invalidnames.In.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_ClassParse/Xamarin.Test.Invalidnames.In.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test.Invalidnames {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test.invalidnames']/class[@name='in']"
 	[global::Android.Runtime.Register ("xamarin/test/invalidnames/in", DoNotGenerateAcw=true)]
 	public partial class In : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/invalidnames/in", typeof (In));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/invalidnames/in", typeof (In));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_ClassParse/Xamarin.Test.Invalidnames.InvalidNameMembers.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_ClassParse/Xamarin.Test.Invalidnames.InvalidNameMembers.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test.Invalidnames {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test.invalidnames']/class[@name='InvalidNameMembers']"
 	[global::Android.Runtime.Register ("xamarin/test/invalidnames/InvalidNameMembers", DoNotGenerateAcw=true)]
 	public partial class InvalidNameMembers : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/invalidnames/InvalidNameMembers", typeof (InvalidNameMembers));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/invalidnames/InvalidNameMembers", typeof (InvalidNameMembers));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
@@ -12,10 +12,6 @@ namespace Android.Text {
 
 	[global::Android.Runtime.Register ("android/text/Spannable", DoNotGenerateAcw=true)]
 	internal partial class ISpannableInvoker : global::Java.Lang.Object, ISpannable {
-		static IntPtr java_class_ref {
-			get { return _members_android_text_Spannable.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -34,9 +30,9 @@ namespace Android.Text {
 			get { return _members_android_text_Spannable.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_android_text_Spannable = new XAPeerMembers ("android/text/Spannable", typeof (ISpannableInvoker));
+		private static readonly JniPeerMembers _members_android_text_Spannable = new XAPeerMembers ("android/text/Spannable", typeof (ISpannableInvoker));
 
-		static readonly JniPeerMembers _members_android_text_Spanned = new XAPeerMembers ("android/text/Spanned", typeof (ISpannableInvoker));
+		private static readonly JniPeerMembers _members_android_text_Spanned = new XAPeerMembers ("android/text/Spanned", typeof (ISpannableInvoker));
 
 		public ISpannableInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
@@ -17,10 +17,6 @@ namespace Android.Text {
 
 	[global::Android.Runtime.Register ("android/text/Spanned", DoNotGenerateAcw=true)]
 	internal partial class ISpannedInvoker : global::Java.Lang.Object, ISpanned {
-		static IntPtr java_class_ref {
-			get { return _members_android_text_Spanned.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -39,7 +35,7 @@ namespace Android.Text {
 			get { return _members_android_text_Spanned.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_android_text_Spanned = new XAPeerMembers ("android/text/Spanned", typeof (ISpannedInvoker));
+		private static readonly JniPeerMembers _members_android_text_Spanned = new XAPeerMembers ("android/text/Spanned", typeof (ISpannedInvoker));
 
 		public ISpannedInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
@@ -18,11 +18,7 @@ namespace Android.Text {
 	// Metadata.xml XPath class reference: path="/api/package[@name='android.text']/class[@name='SpannableString']"
 	[global::Android.Runtime.Register ("android/text/SpannableString", DoNotGenerateAcw=true)]
 	public partial class SpannableString : global::Android.Text.SpannableStringInternal, global::Android.Text.ISpannable {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("android/text/SpannableString", typeof (SpannableString));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("android/text/SpannableString", typeof (SpannableString));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
@@ -18,11 +18,7 @@ namespace Android.Text {
 	// Metadata.xml XPath class reference: path="/api/package[@name='android.text']/class[@name='SpannableStringInternal']"
 	[global::Android.Runtime.Register ("android/text/SpannableStringInternal", DoNotGenerateAcw=true)]
 	public abstract partial class SpannableStringInternal : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternal));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternal));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -92,7 +88,7 @@ namespace Android.Text {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternalInvoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternalInvoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
@@ -29,10 +29,6 @@ namespace Android.Views {
 
 		[global::Android.Runtime.Register ("android/view/View$OnClickListener", DoNotGenerateAcw=true)]
 		internal partial class IOnClickListenerInvoker : global::Java.Lang.Object, IOnClickListener {
-			static IntPtr java_class_ref {
-				get { return _members_android_view_View_OnClickListener.JniPeerType.PeerReference.Handle; }
-			}
-
 			[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 			[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -51,7 +47,7 @@ namespace Android.Views {
 				get { return _members_android_view_View_OnClickListener.ManagedPeerType; }
 			}
 
-			static readonly JniPeerMembers _members_android_view_View_OnClickListener = new XAPeerMembers ("android/view/View$OnClickListener", typeof (IOnClickListenerInvoker));
+			private static readonly JniPeerMembers _members_android_view_View_OnClickListener = new XAPeerMembers ("android/view/View$OnClickListener", typeof (IOnClickListenerInvoker));
 
 			public IOnClickListenerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 			{
@@ -122,11 +118,7 @@ namespace Android.Views {
 
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("android/view/View", typeof (View));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("android/view/View", typeof (View));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaCrypto.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaCrypto.cs
@@ -18,11 +18,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	// Metadata.xml XPath class reference: path="/api/package[@name='com.google.android.exoplayer.drm']/class[@name='FrameworkMediaCrypto']"
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/FrameworkMediaCrypto", DoNotGenerateAcw=true)]
 	public sealed partial class FrameworkMediaCrypto : global::Java.Lang.Object, global::Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaCrypto", typeof (FrameworkMediaCrypto));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaCrypto", typeof (FrameworkMediaCrypto));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
@@ -18,11 +18,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	// Metadata.xml XPath class reference: path="/api/package[@name='com.google.android.exoplayer.drm']/class[@name='FrameworkMediaDrm']"
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/FrameworkMediaDrm", DoNotGenerateAcw=true)]
 	public sealed partial class FrameworkMediaDrm : global::Java.Lang.Object, global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaDrm", typeof (FrameworkMediaDrm));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaDrm", typeof (FrameworkMediaDrm));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
@@ -16,10 +16,6 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaCrypto", DoNotGenerateAcw=true)]
 	internal partial class IExoMediaCryptoInvoker : global::Java.Lang.Object, IExoMediaCrypto {
-		static IntPtr java_class_ref {
-			get { return _members_com_google_android_exoplayer_drm_ExoMediaCrypto.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -38,7 +34,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return _members_com_google_android_exoplayer_drm_ExoMediaCrypto.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_com_google_android_exoplayer_drm_ExoMediaCrypto = new XAPeerMembers ("com/google/android/exoplayer/drm/ExoMediaCrypto", typeof (IExoMediaCryptoInvoker));
+		private static readonly JniPeerMembers _members_com_google_android_exoplayer_drm_ExoMediaCrypto = new XAPeerMembers ("com/google/android/exoplayer/drm/ExoMediaCrypto", typeof (IExoMediaCryptoInvoker));
 
 		public IExoMediaCryptoInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -17,10 +17,6 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", DoNotGenerateAcw=true)]
 	internal partial class IExoMediaDrmOnEventListenerInvoker : global::Java.Lang.Object, IExoMediaDrmOnEventListener {
-		static IntPtr java_class_ref {
-			get { return _members_com_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -39,7 +35,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return _members_com_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_com_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener = new XAPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", typeof (IExoMediaDrmOnEventListenerInvoker));
+		private static readonly JniPeerMembers _members_com_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener = new XAPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", typeof (IExoMediaDrmOnEventListenerInvoker));
 
 		public IExoMediaDrmOnEventListenerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{
@@ -191,10 +187,6 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm", DoNotGenerateAcw=true)]
 	internal partial class IExoMediaDrmInvoker : global::Java.Lang.Object, IExoMediaDrm {
-		static IntPtr java_class_ref {
-			get { return _members_com_google_android_exoplayer_drm_ExoMediaDrm.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -213,7 +205,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return _members_com_google_android_exoplayer_drm_ExoMediaDrm.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_com_google_android_exoplayer_drm_ExoMediaDrm = new XAPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm", typeof (IExoMediaDrmInvoker));
+		private static readonly JniPeerMembers _members_com_google_android_exoplayer_drm_ExoMediaDrm = new XAPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm", typeof (IExoMediaDrmInvoker));
 
 		public IExoMediaDrmInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/GenericArguments/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/GenericArguments/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -16,10 +16,6 @@ namespace Xamarin.Test {
 
 	[global::Android.Runtime.Register ("xamarin/test/I1", DoNotGenerateAcw=true)]
 	internal partial class II1Invoker : global::Java.Lang.Object, II1 {
-		static IntPtr java_class_ref {
-			get { return _members_xamarin_test_I1.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -38,7 +34,7 @@ namespace Xamarin.Test {
 			get { return _members_xamarin_test_I1.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_xamarin_test_I1 = new XAPeerMembers ("xamarin/test/I1", typeof (II1Invoker));
+		private static readonly JniPeerMembers _members_xamarin_test_I1 = new XAPeerMembers ("xamarin/test/I1", typeof (II1Invoker));
 
 		public II1Invoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -16,10 +16,6 @@ namespace Xamarin.Test {
 
 	[global::Android.Runtime.Register ("xamarin/test/I2", DoNotGenerateAcw=true)]
 	internal partial class II2Invoker : global::Java.Lang.Object, II2 {
-		static IntPtr java_class_ref {
-			get { return _members_xamarin_test_I2.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -38,7 +34,7 @@ namespace Xamarin.Test {
 			get { return _members_xamarin_test_I2.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_xamarin_test_I2 = new XAPeerMembers ("xamarin/test/I2", typeof (II2Invoker));
+		private static readonly JniPeerMembers _members_xamarin_test_I2 = new XAPeerMembers ("xamarin/test/I2", typeof (II2Invoker));
 
 		public II2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject2']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject2 : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -109,7 +105,7 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2Invoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2Invoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NestedTypes/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NestedTypes/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -32,10 +32,6 @@ namespace Xamarin.Test {
 
 			[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$Action$Factory", DoNotGenerateAcw=true)]
 			internal partial class IFactoryInvoker : global::Java.Lang.Object, IFactory {
-				static IntPtr java_class_ref {
-					get { return _members_xamarin_test_NotificationCompatBase_Action_Factory.JniPeerType.PeerReference.Handle; }
-				}
-
 				[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 				[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 				public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -54,7 +50,7 @@ namespace Xamarin.Test {
 					get { return _members_xamarin_test_NotificationCompatBase_Action_Factory.ManagedPeerType; }
 				}
 
-				static readonly JniPeerMembers _members_xamarin_test_NotificationCompatBase_Action_Factory = new XAPeerMembers ("xamarin/test/NotificationCompatBase$Action$Factory", typeof (IFactoryInvoker));
+				private static readonly JniPeerMembers _members_xamarin_test_NotificationCompatBase_Action_Factory = new XAPeerMembers ("xamarin/test/NotificationCompatBase$Action$Factory", typeof (IFactoryInvoker));
 
 				public IFactoryInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 				{
@@ -94,11 +90,7 @@ namespace Xamarin.Test {
 
 			}
 
-			static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (Action));
-
-			internal static new IntPtr class_ref {
-				get { return _members.JniPeerType.PeerReference.Handle; }
-			}
+			private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (Action));
 
 			[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 			[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -130,7 +122,7 @@ namespace Xamarin.Test {
 			{
 			}
 
-			static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (ActionInvoker));
+			private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (ActionInvoker));
 
 			[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 			[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -149,11 +141,7 @@ namespace Xamarin.Test {
 		// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='NotificationCompatBase.InstanceInner']"
 		[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$InstanceInner", DoNotGenerateAcw=true)]
 		public abstract partial class InstanceInner : global::Java.Lang.Object {
-			static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInner));
-
-			internal static new IntPtr class_ref {
-				get { return _members.JniPeerType.PeerReference.Handle; }
-			}
+			private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInner));
 
 			[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 			[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -205,7 +193,7 @@ namespace Xamarin.Test {
 			{
 			}
 
-			static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInnerInvoker));
+			private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInnerInvoker));
 
 			[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 			[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -221,11 +209,7 @@ namespace Xamarin.Test {
 
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/NotificationCompatBase", typeof (NotificationCompatBase));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/NotificationCompatBase", typeof (NotificationCompatBase));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NonStaticFields/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NonStaticFields/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -78,11 +78,7 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Java.Lang.Class.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Java.Lang.Class.cs
@@ -19,11 +19,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Class", DoNotGenerateAcw=true)]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
 	public partial class Class : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Class", typeof (Class));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Class", typeof (Class));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Java.Lang.Integer.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Java.Lang.Integer.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Integer']"
 	[global::Android.Runtime.Register ("java/lang/Integer", DoNotGenerateAcw=true)]
 	public partial class Integer : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Integer", typeof (Integer));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Integer", typeof (Integer));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Java.Lang.Throwable.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Java.Lang.Throwable.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Throwable']"
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
 	public partial class Throwable {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Throwable", typeof (Throwable));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Throwable", typeof (Throwable));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
@@ -22,11 +22,7 @@ namespace Xamarin.Test {
 		[global::Android.Runtime.Register ("xamarin/test/A$B", DoNotGenerateAcw=true)]
 		[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.A.B"})]
 		public partial class B : global::Java.Lang.Object {
-			static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/A$B", typeof (B));
-
-			internal static new IntPtr class_ref {
-				get { return _members.JniPeerType.PeerReference.Handle; }
-			}
+			private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/A$B", typeof (B));
 
 			[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 			[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -86,11 +82,7 @@ namespace Xamarin.Test {
 
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/A", typeof (A));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/A", typeof (A));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
@@ -19,11 +19,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/C", DoNotGenerateAcw=true)]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.C"})]
 	public partial class C : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/C", typeof (C));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/C", typeof (C));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalProperties/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalProperties/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -206,7 +202,7 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/ParameterXPath/Java.Lang.Integer.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/ParameterXPath/Java.Lang.Integer.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Integer']"
 	[global::Android.Runtime.Register ("java/lang/Integer", DoNotGenerateAcw=true)]
 	public partial class Integer : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Integer", typeof (Integer));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Integer", typeof (Integer));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/ParameterXPath/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/ParameterXPath/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/ParameterXPath/Java.Util.IList.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/ParameterXPath/Java.Util.IList.cs
@@ -13,10 +13,6 @@ namespace Java.Util {
 
 	[global::Android.Runtime.Register ("java/util/List", DoNotGenerateAcw=true)]
 	internal partial class IListInvoker : global::Java.Lang.Object, IList {
-		static IntPtr java_class_ref {
-			get { return _members_java_util_List.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -35,7 +31,7 @@ namespace Java.Util {
 			get { return _members_java_util_List.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_java_util_List = new XAPeerMembers ("java/util/List", typeof (IListInvoker));
+		private static readonly JniPeerMembers _members_java_util_List = new XAPeerMembers ("java/util/List", typeof (IListInvoker));
 
 		public IListInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
@@ -19,11 +19,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/A", DoNotGenerateAcw=true)]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends java.lang.Object"})]
 	public partial class A : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/A", typeof (A));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/A", typeof (A));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticFields/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticFields/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticFields/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticFields/Xamarin.Test.SomeObject.cs
@@ -90,11 +90,7 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticMethods/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticMethods/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticMethods/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticMethods/Xamarin.Test.SomeObject.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticProperties/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticProperties/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -18,11 +18,7 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
@@ -18,11 +18,7 @@ namespace Java.IO {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.io']/class[@name='FilterOutputStream']"
 	[global::Android.Runtime.Register ("java/io/FilterOutputStream", DoNotGenerateAcw=true)]
 	public partial class FilterOutputStream : global::Java.IO.OutputStream {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/FilterOutputStream", typeof (FilterOutputStream));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/FilterOutputStream", typeof (FilterOutputStream));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
@@ -18,11 +18,7 @@ namespace Java.IO {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.io']/class[@name='IOException']"
 	[global::Android.Runtime.Register ("java/io/IOException", DoNotGenerateAcw=true)]
 	public abstract partial class IOException : global::Java.Lang.Throwable {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/IOException", typeof (IOException));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/IOException", typeof (IOException));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -85,7 +81,7 @@ namespace Java.IO {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/IOException", typeof (IOExceptionInvoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/IOException", typeof (IOExceptionInvoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
@@ -18,11 +18,7 @@ namespace Java.IO {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.io']/class[@name='InputStream']"
 	[global::Android.Runtime.Register ("java/io/InputStream", DoNotGenerateAcw=true)]
 	public abstract partial class InputStream : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/InputStream", typeof (InputStream));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/InputStream", typeof (InputStream));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -378,7 +374,7 @@ namespace Java.IO {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/InputStream", typeof (InputStreamInvoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/InputStream", typeof (InputStreamInvoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
@@ -18,11 +18,7 @@ namespace Java.IO {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.io']/class[@name='OutputStream']"
 	[global::Android.Runtime.Register ("java/io/OutputStream", DoNotGenerateAcw=true)]
 	public abstract partial class OutputStream : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/OutputStream", typeof (OutputStream));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/OutputStream", typeof (OutputStream));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -243,7 +239,7 @@ namespace Java.IO {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/OutputStream", typeof (OutputStreamInvoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/io/OutputStream", typeof (OutputStreamInvoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Throwable']"
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
 	public partial class Throwable {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Throwable", typeof (Throwable));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Throwable", typeof (Throwable));
 
 		static Delegate cb_getMessage_GetMessage_Ljava_lang_String_;
 #pragma warning disable 0169

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
@@ -16,11 +16,7 @@ using Java.Interop;
 // Metadata.xml XPath class reference: path="/api/package[@name='']/class[@name='ClassWithoutNamespace']"
 [global::Android.Runtime.Register ("ClassWithoutNamespace", DoNotGenerateAcw=true)]
 public abstract partial class ClassWithoutNamespace : global::Java.Lang.Object, IInterfaceWithoutNamespace {
-	static readonly JniPeerMembers _members = new XAPeerMembers ("ClassWithoutNamespace", typeof (ClassWithoutNamespace));
-
-	internal static new IntPtr class_ref {
-		get { return _members.JniPeerType.PeerReference.Handle; }
-	}
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("ClassWithoutNamespace", typeof (ClassWithoutNamespace));
 
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -93,7 +89,7 @@ internal partial class ClassWithoutNamespaceInvoker : ClassWithoutNamespace {
 	{
 	}
 
-	static readonly JniPeerMembers _members = new XAPeerMembers ("ClassWithoutNamespace", typeof (ClassWithoutNamespaceInvoker));
+	private static readonly JniPeerMembers _members = new XAPeerMembers ("ClassWithoutNamespace", typeof (ClassWithoutNamespaceInvoker));
 
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
@@ -14,10 +14,6 @@ public partial interface IInterfaceWithoutNamespace : IJavaObject, IJavaPeerable
 
 [global::Android.Runtime.Register ("InterfaceWithoutNamespace", DoNotGenerateAcw=true)]
 internal partial class IInterfaceWithoutNamespaceInvoker : global::Java.Lang.Object, IInterfaceWithoutNamespace {
-	static IntPtr java_class_ref {
-		get { return _members__InterfaceWithoutNamespace.JniPeerType.PeerReference.Handle; }
-	}
-
 	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -36,7 +32,7 @@ internal partial class IInterfaceWithoutNamespaceInvoker : global::Java.Lang.Obj
 		get { return _members__InterfaceWithoutNamespace.ManagedPeerType; }
 	}
 
-	static readonly JniPeerMembers _members__InterfaceWithoutNamespace = new XAPeerMembers ("InterfaceWithoutNamespace", typeof (IInterfaceWithoutNamespaceInvoker));
+	private static readonly JniPeerMembers _members__InterfaceWithoutNamespace = new XAPeerMembers ("InterfaceWithoutNamespace", typeof (IInterfaceWithoutNamespaceInvoker));
 
 	public IInterfaceWithoutNamespaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 	{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Java.Lang.String.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Java.Lang.String.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='String']"
 	[global::Android.Runtime.Register ("java/lang/String", DoNotGenerateAcw=true)]
 	public sealed partial class String : global::Java.Lang.Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/String", typeof (String));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/String", typeof (String));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
@@ -21,10 +21,6 @@ namespace Java.Util {
 
 	[global::Android.Runtime.Register ("java/util/Collection", DoNotGenerateAcw=true)]
 	internal partial class ICollectionInvoker : global::Java.Lang.Object, ICollection {
-		static IntPtr java_class_ref {
-			get { return _members_java_util_Collection.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -43,7 +39,7 @@ namespace Java.Util {
 			get { return _members_java_util_Collection.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_java_util_Collection = new XAPeerMembers ("java/util/Collection", typeof (ICollectionInvoker));
+		private static readonly JniPeerMembers _members_java_util_Collection = new XAPeerMembers ("java/util/Collection", typeof (ICollectionInvoker));
 
 		public ICollectionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
@@ -17,10 +17,6 @@ namespace Java.Util {
 
 	[global::Android.Runtime.Register ("java/util/Deque", DoNotGenerateAcw=true)]
 	internal partial class IDequeInvoker : global::Java.Lang.Object, IDeque {
-		static IntPtr java_class_ref {
-			get { return _members_java_util_Deque.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -39,11 +35,11 @@ namespace Java.Util {
 			get { return _members_java_util_Deque.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_java_util_Collection = new XAPeerMembers ("java/util/Collection", typeof (IDequeInvoker));
+		private static readonly JniPeerMembers _members_java_util_Collection = new XAPeerMembers ("java/util/Collection", typeof (IDequeInvoker));
 
-		static readonly JniPeerMembers _members_java_util_Deque = new XAPeerMembers ("java/util/Deque", typeof (IDequeInvoker));
+		private static readonly JniPeerMembers _members_java_util_Deque = new XAPeerMembers ("java/util/Deque", typeof (IDequeInvoker));
 
-		static readonly JniPeerMembers _members_java_util_Queue = new XAPeerMembers ("java/util/Queue", typeof (IDequeInvoker));
+		private static readonly JniPeerMembers _members_java_util_Queue = new XAPeerMembers ("java/util/Queue", typeof (IDequeInvoker));
 
 		public IDequeInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
@@ -17,10 +17,6 @@ namespace Java.Util {
 
 	[global::Android.Runtime.Register ("java/util/Queue", DoNotGenerateAcw=true)]
 	internal partial class IQueueInvoker : global::Java.Lang.Object, IQueue {
-		static IntPtr java_class_ref {
-			get { return _members_java_util_Queue.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -39,9 +35,9 @@ namespace Java.Util {
 			get { return _members_java_util_Queue.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_java_util_Collection = new XAPeerMembers ("java/util/Collection", typeof (IQueueInvoker));
+		private static readonly JniPeerMembers _members_java_util_Collection = new XAPeerMembers ("java/util/Collection", typeof (IQueueInvoker));
 
-		static readonly JniPeerMembers _members_java_util_Queue = new XAPeerMembers ("java/util/Queue", typeof (IQueueInvoker));
+		private static readonly JniPeerMembers _members_java_util_Queue = new XAPeerMembers ("java/util/Queue", typeof (IQueueInvoker));
 
 		public IQueueInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
@@ -18,11 +18,7 @@ namespace Test.ME {
 	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericImplementation']"
 	[global::Android.Runtime.Register ("test/me/GenericImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/GenericImplementation", typeof (GenericImplementation));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/GenericImplementation", typeof (GenericImplementation));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -18,11 +18,7 @@ namespace Test.ME {
 	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']"
 	[global::Android.Runtime.Register ("test/me/GenericObjectPropertyImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericObjectPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/GenericObjectPropertyImplementation", typeof (GenericObjectPropertyImplementation));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/GenericObjectPropertyImplementation", typeof (GenericObjectPropertyImplementation));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -18,11 +18,7 @@ namespace Test.ME {
 	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericStringImplementation']"
 	[global::Android.Runtime.Register ("test/me/GenericStringImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericStringImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/GenericStringImplementation", typeof (GenericStringImplementation));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/GenericStringImplementation", typeof (GenericStringImplementation));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -18,11 +18,7 @@ namespace Test.ME {
 	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']"
 	[global::Android.Runtime.Register ("test/me/GenericStringPropertyImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericStringPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/GenericStringPropertyImplementation", typeof (GenericStringPropertyImplementation));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/GenericStringPropertyImplementation", typeof (GenericStringPropertyImplementation));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
@@ -17,10 +17,6 @@ namespace Test.ME {
 
 	[global::Android.Runtime.Register ("test/me/GenericInterface", DoNotGenerateAcw=true)]
 	internal partial class IGenericInterfaceInvoker : global::Java.Lang.Object, IGenericInterface {
-		static IntPtr java_class_ref {
-			get { return _members_test_me_GenericInterface.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -39,7 +35,7 @@ namespace Test.ME {
 			get { return _members_test_me_GenericInterface.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_test_me_GenericInterface = new XAPeerMembers ("test/me/GenericInterface", typeof (IGenericInterfaceInvoker));
+		private static readonly JniPeerMembers _members_test_me_GenericInterface = new XAPeerMembers ("test/me/GenericInterface", typeof (IGenericInterfaceInvoker));
 
 		public IGenericInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -23,10 +23,6 @@ namespace Test.ME {
 
 	[global::Android.Runtime.Register ("test/me/GenericPropertyInterface", DoNotGenerateAcw=true)]
 	internal partial class IGenericPropertyInterfaceInvoker : global::Java.Lang.Object, IGenericPropertyInterface {
-		static IntPtr java_class_ref {
-			get { return _members_test_me_GenericPropertyInterface.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -45,7 +41,7 @@ namespace Test.ME {
 			get { return _members_test_me_GenericPropertyInterface.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_test_me_GenericPropertyInterface = new XAPeerMembers ("test/me/GenericPropertyInterface", typeof (IGenericPropertyInterfaceInvoker));
+		private static readonly JniPeerMembers _members_test_me_GenericPropertyInterface = new XAPeerMembers ("test/me/GenericPropertyInterface", typeof (IGenericPropertyInterfaceInvoker));
 
 		public IGenericPropertyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
@@ -27,7 +27,7 @@ namespace Test.ME {
 			}
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/TestInterface", typeof (TestInterface));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/TestInterface", typeof (TestInterface));
 
 	}
 
@@ -78,10 +78,6 @@ namespace Test.ME {
 
 	[global::Android.Runtime.Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
 	internal partial class ITestInterfaceInvoker : global::Java.Lang.Object, ITestInterface {
-		static IntPtr java_class_ref {
-			get { return _members_test_me_TestInterface.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -100,7 +96,7 @@ namespace Test.ME {
 			get { return _members_test_me_TestInterface.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_test_me_TestInterface = new XAPeerMembers ("test/me/TestInterface", typeof (ITestInterfaceInvoker));
+		private static readonly JniPeerMembers _members_test_me_TestInterface = new XAPeerMembers ("test/me/TestInterface", typeof (ITestInterfaceInvoker));
 
 		public ITestInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -39,11 +39,7 @@ namespace Test.ME {
 
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementation));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementation));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -185,7 +181,7 @@ namespace Test.ME {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementationInvoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementationInvoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.Enum.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.Enum.cs
@@ -19,11 +19,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Enum", DoNotGenerateAcw=true)]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"E extends java.lang.Enum<E>"})]
 	public abstract partial class Enum : global::Java.Lang.Object, global::Java.Lang.IComparable {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Enum", typeof (Enum));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Enum", typeof (Enum));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -72,7 +68,7 @@ namespace Java.Lang {
 		{
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Enum", typeof (EnumInvoker));
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Enum", typeof (EnumInvoker));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -17,10 +17,6 @@ namespace Java.Lang {
 
 	[global::Android.Runtime.Register ("java/lang/Comparable", DoNotGenerateAcw=true)]
 	internal partial class IComparableInvoker : global::Java.Lang.Object, IComparable {
-		static IntPtr java_class_ref {
-			get { return _members_java_lang_Comparable.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -39,7 +35,7 @@ namespace Java.Lang {
 			get { return _members_java_lang_Comparable.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_java_lang_Comparable = new XAPeerMembers ("java/lang/Comparable", typeof (IComparableInvoker));
+		private static readonly JniPeerMembers _members_java_lang_Comparable = new XAPeerMembers ("java/lang/Comparable", typeof (IComparableInvoker));
 
 		public IComparableInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.State.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.State.cs
@@ -90,11 +90,7 @@ namespace Java.Lang {
 			}
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/State", typeof (State));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/State", typeof (State));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/java.lang.Object/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/java.lang.Object/Java.Lang.Object.cs
@@ -8,11 +8,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/java.util.List/Java.Lang.Object.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/java.util.List/Java.Lang.Object.cs
@@ -18,11 +18,7 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object {
-		static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
-
-		internal static IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("java/lang/Object", typeof (Object));
 
 	}
 }

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/java.util.List/Java.Util.IList.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/java.util.List/Java.Util.IList.cs
@@ -13,10 +13,6 @@ namespace Java.Util {
 
 	[global::Android.Runtime.Register ("java/util/List", DoNotGenerateAcw=true)]
 	internal partial class IListInvoker : global::Java.Lang.Object, IList {
-		static IntPtr java_class_ref {
-			get { return _members_java_util_List.JniPeerType.PeerReference.Handle; }
-		}
-
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -35,7 +31,7 @@ namespace Java.Util {
 			get { return _members_java_util_List.ManagedPeerType; }
 		}
 
-		static readonly JniPeerMembers _members_java_util_List = new XAPeerMembers ("java/util/List", typeof (IListInvoker));
+		private static readonly JniPeerMembers _members_java_util_List = new XAPeerMembers ("java/util/List", typeof (IListInvoker));
 
 		public IListInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
 		{

--- a/external/Java.Interop/tests/generator-Tests/expected.xaji/java.util.List/Xamarin.Test.SomeObject.cs
+++ b/external/Java.Interop/tests/generator-Tests/expected.xaji/java.util.List/Xamarin.Test.SomeObject.cs
@@ -172,11 +172,7 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-
-		internal static new IntPtr class_ref {
-			get { return _members.JniPeerType.PeerReference.Handle; }
-		}
+		private static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/external/Java.Interop/tools/generator/SourceWriters/BoundClass.cs
+++ b/external/Java.Interop/tools/generator/SourceWriters/BoundClass.cs
@@ -105,17 +105,7 @@ namespace generator.SourceWriters
 
 		void AddBindingInfrastructure (ClassGen klass, CodeGenerationOptions opt)
 		{
-			// @class.InheritsObject is true unless @class refers to java.lang.Object or java.lang.Throwable. (see ClassGen constructor)
-			// If @class's base class is defined in the same api.xml file, then it requires the new keyword to overshadow the internal
-			// members of its baseclass since the two classes will be defined in the same assembly. If the base class is not from the
-			// same api.xml file, the new keyword is not needed because the internal access modifier already prevents it from being seen.
-			var baseFromSameAssembly = klass?.BaseGen?.FromXml ?? false;
-			var requireNew = klass.InheritsObject && baseFromSameAssembly;
-
 			Fields.Add (new PeerMembersField (opt, klass.RawJniName, klass.Name, false));
-			if (opt.CodeGenerationTarget != CodeGenerationTarget.JavaInterop1) {
-				Properties.Add (new ClassHandleGetter (requireNew));
-			}
 
 			if (klass.BaseGen != null && klass.InheritsObject) {
 				Properties.Add (new JniPeerMembersGetter ());

--- a/external/Java.Interop/tools/generator/SourceWriters/ClassInvokers.cs
+++ b/external/Java.Interop/tools/generator/SourceWriters/ClassInvokers.cs
@@ -7,42 +7,6 @@ using Xamarin.SourceWriter;
 
 namespace generator.SourceWriters
 {
-	public class ClassHandleGetter : PropertyWriter
-	{
-		// internal static new IntPtr class_ref {
-		//   get { return _members.JniPeerType.PeerReference.Handle; }
-		// }
-		public ClassHandleGetter (bool requireNew)
-		{
-			Name = "class_ref";
-			PropertyType = TypeReferenceWriter.IntPtr;
-
-			IsInternal = true;
-			IsStatic = true;
-			IsShadow = requireNew;
-
-			HasGet = true;
-			GetBody.Add ("return _members.JniPeerType.PeerReference.Handle;");
-		}
-	}
-
-	public class InterfaceHandleGetter : PropertyWriter
-	{
-		// static IntPtr java_class_ref {
-		//   get { return _members.JniPeerType.PeerReference.Handle; }
-		// }
-		public InterfaceHandleGetter (string members)
-		{
-			Name = "java_class_ref";
-			PropertyType = TypeReferenceWriter.IntPtr;
-
-			IsStatic = true;
-
-			HasGet = true;
-			GetBody.Add ($"return {members}.JniPeerType.PeerReference.Handle;");
-		}
-	}
-
 	public class JniPeerMembersGetter : PropertyWriter
 	{
 		// [DebuggerBrowsable (DebuggerBrowsableState.Never)]
@@ -94,7 +58,7 @@ namespace generator.SourceWriters
 		// [DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		// [EditorBrowsable (EditorBrowsableState.Never)]
 		// protected override IntPtr ThresholdClass {
-		// 	get { return class_ref; }
+		// 	get { return _members.JniPeerType.PeerReference.Handle; }
 		// }
 		public InterfaceThresholdClassGetter (string getExpression)
 		{

--- a/external/Java.Interop/tools/generator/SourceWriters/InterfaceInvokerClass.cs
+++ b/external/Java.Interop/tools/generator/SourceWriters/InterfaceInvokerClass.cs
@@ -36,10 +36,6 @@ namespace generator.SourceWriters
 
 			string members = $"_members_{iface.JavaFullNameId}";
 
-			if (!ji) {
-				Properties.Add (new InterfaceHandleGetter (members));
-			}
-
 			Properties.Add (new JniPeerMembersGetter (members));
 
 			if (!ji) {

--- a/external/Java.Interop/tools/generator/SourceWriters/InterfaceMemberAlternativeClass.cs
+++ b/external/Java.Interop/tools/generator/SourceWriters/InterfaceMemberAlternativeClass.cs
@@ -47,10 +47,10 @@ namespace generator.SourceWriters
 
 			Constructors.Add (new ConstructorWriter { Name = Name, IsInternal = true });
 
-			var needs_class_ref = AddFields (iface, should_obsolete, opt, context);
+			var needs_peer_members = AddFields (iface, should_obsolete, opt, context);
 			AddMethods (iface, should_obsolete, opt);
 
-			if (needs_class_ref || iface.Methods.Where (m => m.IsStatic).Any ())
+			if (needs_peer_members || iface.Methods.Where (m => m.IsStatic).Any ())
 				Fields.Add (new PeerMembersField (opt, iface.RawJniName, Name, false));
 
 			if (!iface.HasManagedName && !opt.SupportInterfaceConstants)
@@ -85,18 +85,18 @@ namespace generator.SourceWriters
 			var seen = new HashSet<string> ();
 
 			var original_fields = DeprecateFields (iface, shouldObsolete);
-			var needs_class_ref = AddInterfaceFields (iface, iface.Fields, seen, opt, context);
+			var needs_peer_members = AddInterfaceFields (iface, iface.Fields, seen, opt, context);
 			RestoreDeprecatedFields (original_fields);
 
 			foreach (var i in iface.GetAllImplementedInterfaces ().OfType<InterfaceGen> ()) {
 				AddInlineComment ($"// The following are fields from: {i.JavaName}");
 
 				original_fields = DeprecateFields (i, shouldObsolete);
-				needs_class_ref = AddInterfaceFields (i, i.Fields, seen, opt, context) || needs_class_ref;
+				needs_peer_members = AddInterfaceFields (i, i.Fields, seen, opt, context) || needs_peer_members;
 				RestoreDeprecatedFields (original_fields);
 			}
 
-			return needs_class_ref;
+			return needs_peer_members;
 		}
 
 		bool AddInterfaceFields (InterfaceGen iface, List<Field> fields, HashSet<string> seen, CodeGenerationOptions opt, CodeGeneratorContext context)

--- a/external/Java.Interop/tools/generator/SourceWriters/PeerMembersField.cs
+++ b/external/Java.Interop/tools/generator/SourceWriters/PeerMembersField.cs
@@ -16,7 +16,7 @@ namespace generator.SourceWriters
 			Name = name;
 			Type = new TypeReferenceWriter ("JniPeerMembers");
 
-			IsPrivate = isInterface;
+			IsPrivate = isInterface || opt.CodeGenerationTarget == Xamarin.Android.Binder.CodeGenerationTarget.XAJavaInterop1;
 			IsStatic = true;
 			IsReadonly = true;
 

--- a/src/Mono.Android/Android.App/Notification.cs
+++ b/src/Mono.Android/Android.App/Notification.cs
@@ -16,12 +16,12 @@ namespace Android.App {
 		public long[] Vibrate {
 			get {
 				if (vibrate_jfieldId == IntPtr.Zero)
-					vibrate_jfieldId = JNIEnv.GetFieldID (class_ref, "vibrate", "[J");
+					vibrate_jfieldId = JNIEnv.GetFieldID (_members.JniPeerType.PeerReference.Handle, "vibrate", "[J");
 				return (long[]) JNIEnv.GetArray (JNIEnv.GetObjectField (Handle, vibrate_jfieldId), JniHandleOwnership.TransferLocalRef, typeof (long))!;
 			}
 			set {
 				if (vibrate_jfieldId == IntPtr.Zero)
-					vibrate_jfieldId = JNIEnv.GetFieldID (class_ref, "vibrate", "[J");
+					vibrate_jfieldId = JNIEnv.GetFieldID (_members.JniPeerType.PeerReference.Handle, "vibrate", "[J");
 				IntPtr native_pattern = JNIEnv.NewArray (value);
 				JNIEnv.SetField (Handle, vibrate_jfieldId, native_pattern);
 				JNIEnv.DeleteLocalRef (native_pattern);
@@ -29,5 +29,4 @@ namespace Android.App {
 		}
 	}
 }
-
 

--- a/src/Mono.Android/Android.Content/ContentValues.cs
+++ b/src/Mono.Android/Android.Content/ContentValues.cs
@@ -10,7 +10,7 @@ namespace Android.Content {
 		public bool GetAsBoolean (string key)
 		{
 			if (id_getAsBoolean_Ljava_lang_String_ == IntPtr.Zero)
-				id_getAsBoolean_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "getAsBoolean", "(Ljava/lang/String;)Ljava/lang/Boolean;");
+				id_getAsBoolean_Ljava_lang_String_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "getAsBoolean", "(Ljava/lang/String;)Ljava/lang/Boolean;");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var ret = new Java.Lang.Boolean (JNIEnv.CallObjectMethod (Handle, id_getAsBoolean_Ljava_lang_String_, new JValue (jkey)),
@@ -26,7 +26,7 @@ namespace Android.Content {
 		public sbyte GetAsByte (string key)
 		{
 			if (id_getAsByte_Ljava_lang_String_ == IntPtr.Zero)
-				id_getAsByte_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "getAsByte", "(Ljava/lang/String;)Ljava/lang/Byte;");
+				id_getAsByte_Ljava_lang_String_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "getAsByte", "(Ljava/lang/String;)Ljava/lang/Byte;");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var ret = new Java.Lang.Byte (JNIEnv.CallObjectMethod (Handle, id_getAsByte_Ljava_lang_String_, new JValue (jkey)),
@@ -42,7 +42,7 @@ namespace Android.Content {
 		public double GetAsDouble (string key)
 		{
 			if (id_getAsDouble_Ljava_lang_String_ == IntPtr.Zero)
-				id_getAsDouble_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "getAsDouble", "(Ljava/lang/String;)Ljava/lang/Double;");
+				id_getAsDouble_Ljava_lang_String_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "getAsDouble", "(Ljava/lang/String;)Ljava/lang/Double;");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var ret = new Java.Lang.Double (JNIEnv.CallObjectMethod (Handle, id_getAsDouble_Ljava_lang_String_, new JValue (jkey)),
@@ -58,7 +58,7 @@ namespace Android.Content {
 		public float GetAsFloat (string key)
 		{
 			if (id_getAsFloat_Ljava_lang_String_ == IntPtr.Zero)
-				id_getAsFloat_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "getAsFloat", "(Ljava/lang/String;)Ljava/lang/Float;");
+				id_getAsFloat_Ljava_lang_String_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "getAsFloat", "(Ljava/lang/String;)Ljava/lang/Float;");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var ret = new Java.Lang.Float (JNIEnv.CallObjectMethod (Handle, id_getAsFloat_Ljava_lang_String_, new JValue (jkey)),
@@ -74,7 +74,7 @@ namespace Android.Content {
 		public int GetAsInteger (string key)
 		{
 			if (id_getAsInteger_Ljava_lang_String_ == IntPtr.Zero)
-				id_getAsInteger_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "getAsInteger", "(Ljava/lang/String;)Ljava/lang/Integer;");
+				id_getAsInteger_Ljava_lang_String_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "getAsInteger", "(Ljava/lang/String;)Ljava/lang/Integer;");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var ret = new Java.Lang.Integer (JNIEnv.CallObjectMethod (Handle, id_getAsInteger_Ljava_lang_String_, new JValue (jkey)),
@@ -90,7 +90,7 @@ namespace Android.Content {
 		public long GetAsLong (string key)
 		{
 			if (id_getAsLong_Ljava_lang_String_ == IntPtr.Zero)
-				id_getAsLong_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "getAsLong", "(Ljava/lang/String;)Ljava/lang/Long;");
+				id_getAsLong_Ljava_lang_String_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "getAsLong", "(Ljava/lang/String;)Ljava/lang/Long;");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var ret = new Java.Lang.Long (JNIEnv.CallObjectMethod (Handle, id_getAsLong_Ljava_lang_String_, new JValue (jkey)),
@@ -106,7 +106,7 @@ namespace Android.Content {
 		public short GetAsShort (string key)
 		{
 			if (id_getAsShort_Ljava_lang_String_ == IntPtr.Zero)
-				id_getAsShort_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "getAsShort", "(Ljava/lang/String;)Ljava/lang/Short;");
+				id_getAsShort_Ljava_lang_String_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "getAsShort", "(Ljava/lang/String;)Ljava/lang/Short;");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var ret = new Java.Lang.Short (JNIEnv.CallObjectMethod (Handle, id_getAsShort_Ljava_lang_String_, new JValue (jkey)),
@@ -123,7 +123,7 @@ namespace Android.Content {
 		public void Put (string key, bool value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Boolean_ == IntPtr.Zero)
-				id_put_Ljava_lang_String_Ljava_lang_Boolean_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Boolean;)V");
+				id_put_Ljava_lang_String_Ljava_lang_Boolean_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "put", "(Ljava/lang/String;Ljava/lang/Boolean;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var val = new Java.Lang.Boolean (value))
@@ -139,7 +139,7 @@ namespace Android.Content {
 		public void Put (string key, sbyte value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Byte_ == IntPtr.Zero)
-				id_put_Ljava_lang_String_Ljava_lang_Byte_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Byte;)V");
+				id_put_Ljava_lang_String_Ljava_lang_Byte_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "put", "(Ljava/lang/String;Ljava/lang/Byte;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var val = new Java.Lang.Byte (value))
@@ -155,7 +155,7 @@ namespace Android.Content {
 		public void Put (string key, short value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Short_ == IntPtr.Zero)
-				id_put_Ljava_lang_String_Ljava_lang_Short_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Short;)V");
+				id_put_Ljava_lang_String_Ljava_lang_Short_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "put", "(Ljava/lang/String;Ljava/lang/Short;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var val = new Java.Lang.Short (value))
@@ -171,7 +171,7 @@ namespace Android.Content {
 		public void Put (string key, int value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Integer_ == IntPtr.Zero)
-				id_put_Ljava_lang_String_Ljava_lang_Integer_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Integer;)V");
+				id_put_Ljava_lang_String_Ljava_lang_Integer_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "put", "(Ljava/lang/String;Ljava/lang/Integer;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var val = new Java.Lang.Integer (value))
@@ -187,7 +187,7 @@ namespace Android.Content {
 		public void Put (string key, long value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Long_ == IntPtr.Zero)
-				id_put_Ljava_lang_String_Ljava_lang_Long_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Long;)V");
+				id_put_Ljava_lang_String_Ljava_lang_Long_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "put", "(Ljava/lang/String;Ljava/lang/Long;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var val = new Java.Lang.Long (value))
@@ -203,7 +203,7 @@ namespace Android.Content {
 		public void Put (string key, float value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Float_ == IntPtr.Zero)
-				id_put_Ljava_lang_String_Ljava_lang_Float_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Float;)V");
+				id_put_Ljava_lang_String_Ljava_lang_Float_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "put", "(Ljava/lang/String;Ljava/lang/Float;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var val = new Java.Lang.Float (value))
@@ -219,7 +219,7 @@ namespace Android.Content {
 		public void Put (string key, double value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Double_ == IntPtr.Zero)
-				id_put_Ljava_lang_String_Ljava_lang_Double_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Double;)V");
+				id_put_Ljava_lang_String_Ljava_lang_Double_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "put", "(Ljava/lang/String;Ljava/lang/Double;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
 				using (var val = new Java.Lang.Double (value))

--- a/src/Mono.Android/Android.Content/CursorLoader.cs
+++ b/src/Mono.Android/Android.Content/CursorLoader.cs
@@ -11,7 +11,7 @@ namespace Android.Content
                 public override Java.Lang.Object? LoadInBackground ()
                 {
                         if (id_loadInBackground == IntPtr.Zero)
-                                id_loadInBackground = JNIEnv.GetMethodID (class_ref, "loadInBackground", "()Landroid/database/Cursor;");
+                                id_loadInBackground = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "loadInBackground", "()Landroid/database/Cursor;");
 
                         if (GetType () == ThresholdType)
                                 return (Java.Lang.Object?) Java.Lang.Object.GetObject<Android.Database.ICursor> (JNIEnv.CallObjectMethod  (Handle, id_loadInBackground), JniHandleOwnership.TransferLocalRef);

--- a/src/Mono.Android/Android.OS/AsyncTask.cs
+++ b/src/Mono.Android/Android.OS/AsyncTask.cs
@@ -20,10 +20,10 @@ namespace Android.OS {
 	> : AsyncTask {
 
 		[UnsafeAccessor (UnsafeAccessorKind.StaticField, Name = "_members")]
-		static extern ref JniPeerMembers GetPeerMembers (AsyncTask? _);
+		static extern ref readonly JniPeerMembers GetPeerMembers (AsyncTask? _);
 
 		protected override IntPtr ThresholdClass {
-		get { return GetPeerMembers (null).JniPeerType.PeerReference.Handle; }
+			get { return GetPeerMembers (null).JniPeerType.PeerReference.Handle; }
 		}
 
 		protected override global::System.Type ThresholdType {

--- a/src/Mono.Android/Android.OS/AsyncTask.cs
+++ b/src/Mono.Android/Android.OS/AsyncTask.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Android.Runtime;
 
 using Java.Interop;
@@ -18,15 +19,11 @@ namespace Android.OS {
 			TResult
 	> : AsyncTask {
 
-		static IntPtr java_class_handle;
-		internal static new IntPtr class_ref {
-			get {
-				return JNIEnv.FindClass ("android/os/AsyncTask", ref java_class_handle);
-			}
-		}
+		[UnsafeAccessor (UnsafeAccessorKind.StaticField, Name = "_members")]
+		static extern ref JniPeerMembers GetPeerMembers (AsyncTask? _);
 
 		protected override IntPtr ThresholdClass {
-			get { return class_ref; }
+		get { return GetPeerMembers (null).JniPeerType.PeerReference.Handle; }
 		}
 
 		protected override global::System.Type ThresholdType {
@@ -55,11 +52,11 @@ namespace Android.OS {
 			}
 
 			if (id_ctor == IntPtr.Zero)
-				id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				id_ctor = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "()V");
 			SetHandle (
-					JNIEnv.StartCreateInstance (class_ref, id_ctor),
+					JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor),
 					JniHandleOwnership.TransferLocalRef);
-			JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor);
+			JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor);
 		}
 
 		protected override Java.Lang.Object? DoInBackground (params Java.Lang.Object[]? native_parms)
@@ -80,7 +77,7 @@ namespace Android.OS {
 		public Android.OS.AsyncTask<TParams, TProgress, TResult>? Execute (params TParams[] @params)
 		{
 			if (id_execute_arrayLjava_lang_Object_ == IntPtr.Zero)
-				id_execute_arrayLjava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "execute", "([Ljava/lang/Object;)Landroid/os/AsyncTask;");
+				id_execute_arrayLjava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "execute", "([Ljava/lang/Object;)Landroid/os/AsyncTask;");
 			IntPtr native__params = JNIEnv.NewObjectArray<TParams> (@params);
 			try {
 				var __ret = Java.Lang.Object.GetObject<Android.OS.AsyncTask<TParams, TProgress, TResult>> (JNIEnv.CallObjectMethod  (Handle, id_execute_arrayLjava_lang_Object_, new JValue (native__params)), JniHandleOwnership.TransferLocalRef);
@@ -99,7 +96,7 @@ namespace Android.OS {
 		public TResult? GetResult ()
 		{
 			if (id_get == IntPtr.Zero)
-				id_get = JNIEnv.GetMethodID (class_ref, "get", "()Ljava/lang/Object;");
+				id_get = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "get", "()Ljava/lang/Object;");
 			return JavaConvert.FromJniHandle<TResult>(JNIEnv.CallObjectMethod  (Handle, id_get), JniHandleOwnership.TransferLocalRef);
 		}
 

--- a/src/Mono.Android/Android.Util/SparseArray.cs
+++ b/src/Mono.Android/Android.Util/SparseArray.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 using Android.Runtime;
 
@@ -13,6 +14,9 @@ namespace Android.Util
 			E
 	> : SparseArray
 	{
+		[UnsafeAccessor (UnsafeAccessorKind.StaticField, Name = "_members")]
+		static extern ref JniPeerMembers GetPeerMembers (SparseArray? _);
+
 		public SparseArray ()
 		{
 		}
@@ -27,9 +31,9 @@ namespace Android.Util
 		public virtual void Append (int key, E value)
 		{
 			if (id_append_ILjava_lang_Object_ == IntPtr.Zero)
-				id_append_ILjava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "put", "(ILjava/lang/Object;)V");
+				id_append_ILjava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "put", "(ILjava/lang/Object;)V");
 			JavaConvert.WithLocalJniHandle (value, lref => {
-					JNIEnv.CallNonvirtualVoidMethod (Handle, class_ref, id_append_ILjava_lang_Object_, new JValue (key), new JValue (lref));
+					JNIEnv.CallNonvirtualVoidMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_append_ILjava_lang_Object_, new JValue (key), new JValue (lref));
 					return IntPtr.Zero;
 			});
 		}
@@ -39,8 +43,8 @@ namespace Android.Util
 		public new virtual E Get (int key)
 		{
 			if (id_get_I == IntPtr.Zero)
-				id_get_I = JNIEnv.GetMethodID (class_ref, "get", "(I)Ljava/lang/Object;");
-			return JavaConvert.FromJniHandle<E>(JNIEnv.CallNonvirtualObjectMethod (Handle, class_ref, id_get_I, new JValue (key)), JniHandleOwnership.TransferLocalRef)!;
+				id_get_I = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "get", "(I)Ljava/lang/Object;");
+			return JavaConvert.FromJniHandle<E>(JNIEnv.CallNonvirtualObjectMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_get_I, new JValue (key)), JniHandleOwnership.TransferLocalRef)!;
 		}
 
 		static IntPtr id_get_ILjava_lang_Object_;
@@ -48,9 +52,9 @@ namespace Android.Util
 		public virtual E Get (int key, E valueIfKeyNotFound)
 		{
 			if (id_get_ILjava_lang_Object_ == IntPtr.Zero)
-				id_get_ILjava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "get", "(ILjava/lang/Object;)Ljava/lang/Object;");
+				id_get_ILjava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "get", "(ILjava/lang/Object;)Ljava/lang/Object;");
 			IntPtr value = JavaConvert.WithLocalJniHandle (valueIfKeyNotFound,
-					lref => JNIEnv.CallNonvirtualObjectMethod (Handle, class_ref, id_get_ILjava_lang_Object_, new JValue (key), new JValue (lref)));
+					lref => JNIEnv.CallNonvirtualObjectMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_get_ILjava_lang_Object_, new JValue (key), new JValue (lref)));
 			return JavaConvert.FromJniHandle<E> (value, JniHandleOwnership.TransferLocalRef)!;
 		}
 
@@ -59,9 +63,9 @@ namespace Android.Util
 		public virtual int IndexOfValue (E value)
 		{
 			if (id_indexOfValue_Ljava_lang_Object_ == IntPtr.Zero)
-				id_indexOfValue_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "indexOfValue", "(Ljava/lang/Object;)I");
+				id_indexOfValue_Ljava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "indexOfValue", "(Ljava/lang/Object;)I");
 			return JavaConvert.WithLocalJniHandle (value,
-					lref => JNIEnv.CallNonvirtualIntMethod (Handle, class_ref, id_indexOfValue_Ljava_lang_Object_, new JValue (lref)));
+					lref => JNIEnv.CallNonvirtualIntMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_indexOfValue_Ljava_lang_Object_, new JValue (lref)));
 		}
 
 		static IntPtr id_put_ILjava_lang_Object_;
@@ -69,9 +73,9 @@ namespace Android.Util
 		public virtual void Put (int key, E value)
 		{
 			if (id_put_ILjava_lang_Object_ == IntPtr.Zero)
-				id_put_ILjava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "put", "(ILjava/lang/Object;)V");
+				id_put_ILjava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "put", "(ILjava/lang/Object;)V");
 			JavaConvert.WithLocalJniHandle (value, lref => {
-					JNIEnv.CallNonvirtualVoidMethod (Handle, class_ref, id_put_ILjava_lang_Object_, new JValue (key), new JValue (lref));
+					JNIEnv.CallNonvirtualVoidMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_put_ILjava_lang_Object_, new JValue (key), new JValue (lref));
 					return IntPtr.Zero;
 			});
 		}
@@ -81,9 +85,9 @@ namespace Android.Util
 		public virtual void SetValueAt (int index, E value)
 		{
 			if (id_setValueAt_ILjava_lang_Object_ == IntPtr.Zero)
-				id_setValueAt_ILjava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "setValueAt", "(ILjava/lang/Object;)V");
+				id_setValueAt_ILjava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "setValueAt", "(ILjava/lang/Object;)V");
 			JavaConvert.WithLocalJniHandle (value, lref => {
-					JNIEnv.CallNonvirtualVoidMethod (Handle, class_ref, id_setValueAt_ILjava_lang_Object_, new JValue (index), new JValue (lref));
+					JNIEnv.CallNonvirtualVoidMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_setValueAt_ILjava_lang_Object_, new JValue (index), new JValue (lref));
 					return IntPtr.Zero;
 			});
 		}
@@ -93,9 +97,9 @@ namespace Android.Util
 		public new virtual E ValueAt (int index)
 		{
 			if (id_valueAt_I == IntPtr.Zero)
-				id_valueAt_I = JNIEnv.GetMethodID (class_ref, "valueAt", "(I)Ljava/lang/Object;");
+				id_valueAt_I = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "valueAt", "(I)Ljava/lang/Object;");
 			return JavaConvert.FromJniHandle<E> (
-					JNIEnv.CallNonvirtualObjectMethod (Handle, class_ref, id_valueAt_I, new JValue (index)),
+					JNIEnv.CallNonvirtualObjectMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_valueAt_I, new JValue (index)),
 					JniHandleOwnership.TransferLocalRef)!;
 		}
 	}

--- a/src/Mono.Android/Android.Util/SparseArray.cs
+++ b/src/Mono.Android/Android.Util/SparseArray.cs
@@ -15,7 +15,7 @@ namespace Android.Util
 	> : SparseArray
 	{
 		[UnsafeAccessor (UnsafeAccessorKind.StaticField, Name = "_members")]
-		static extern ref JniPeerMembers GetPeerMembers (SparseArray? _);
+		static extern ref readonly JniPeerMembers GetPeerMembers (SparseArray? _);
 
 		public SparseArray ()
 		{
@@ -40,22 +40,24 @@ namespace Android.Util
 		
 		static IntPtr id_get_I;
 		[Register ("get", "(I)Ljava/lang/Object;", "")]
+		[return: MaybeNull]
 		public new virtual E Get (int key)
 		{
 			if (id_get_I == IntPtr.Zero)
 				id_get_I = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "get", "(I)Ljava/lang/Object;");
-			return JavaConvert.FromJniHandle<E>(JNIEnv.CallNonvirtualObjectMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_get_I, new JValue (key)), JniHandleOwnership.TransferLocalRef)!;
+			return JavaConvert.FromJniHandle<E>(JNIEnv.CallNonvirtualObjectMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_get_I, new JValue (key)), JniHandleOwnership.TransferLocalRef);
 		}
 
 		static IntPtr id_get_ILjava_lang_Object_;
 		[Register ("get", "(ILjava/lang/Object;)Ljava/lang/Object;", "")]
+		[return: MaybeNull]
 		public virtual E Get (int key, E valueIfKeyNotFound)
 		{
 			if (id_get_ILjava_lang_Object_ == IntPtr.Zero)
 				id_get_ILjava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "get", "(ILjava/lang/Object;)Ljava/lang/Object;");
 			IntPtr value = JavaConvert.WithLocalJniHandle (valueIfKeyNotFound,
 					lref => JNIEnv.CallNonvirtualObjectMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_get_ILjava_lang_Object_, new JValue (key), new JValue (lref)));
-			return JavaConvert.FromJniHandle<E> (value, JniHandleOwnership.TransferLocalRef)!;
+			return JavaConvert.FromJniHandle<E> (value, JniHandleOwnership.TransferLocalRef);
 		}
 
 		static IntPtr id_indexOfValue_Ljava_lang_Object_;
@@ -94,13 +96,14 @@ namespace Android.Util
 		
 		static IntPtr id_valueAt_I;
 		[Register ("valueAt", "(I)Ljava/lang/Object;", "")]
+		[return: MaybeNull]
 		public new virtual E ValueAt (int index)
 		{
 			if (id_valueAt_I == IntPtr.Zero)
 				id_valueAt_I = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "valueAt", "(I)Ljava/lang/Object;");
 			return JavaConvert.FromJniHandle<E> (
 					JNIEnv.CallNonvirtualObjectMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_valueAt_I, new JValue (index)),
-					JniHandleOwnership.TransferLocalRef)!;
+					JniHandleOwnership.TransferLocalRef);
 		}
 	}
 }

--- a/src/Mono.Android/Android.Widget/AbsListView.cs
+++ b/src/Mono.Android/Android.Widget/AbsListView.cs
@@ -73,7 +73,7 @@ namespace Android.Widget {
 		public virtual void SetAdapter (Android.Widget.IListAdapter adapter)
 		{
 			if (id_setAdapter_Landroid_widget_ListAdapter_ == IntPtr.Zero)
-				id_setAdapter_Landroid_widget_ListAdapter_ = JNIEnv.GetMethodID (class_ref, "setAdapter", "(Landroid/widget/ListAdapter;)V");
+				id_setAdapter_Landroid_widget_ListAdapter_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "setAdapter", "(Landroid/widget/ListAdapter;)V");
 
 			if (GetType () == ThresholdType)
 				JNIEnv.CallVoidMethod  (Handle, id_setAdapter_Landroid_widget_ListAdapter_, new JValue (adapter));
@@ -95,7 +95,7 @@ namespace Android.Widget {
 				value = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null).Handle;
 #else   // !JAVA_INTEROP
 				if (id_getAdapter == IntPtr.Zero)
-					id_getAdapter = JNIEnv.GetMethodID (class_ref, "getAdapter", "()Landroid/widget/Adapter;");
+					id_getAdapter = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "getAdapter", "()Landroid/widget/Adapter;");
 				value = JNIEnv.CallObjectMethod (Handle, id_getAdapter);
 #endif	// !JAVA_INTEROP
 				return Java.Lang.Object.GetObject<IListAdapter> (value, JniHandleOwnership.TransferLocalRef);
@@ -113,7 +113,7 @@ namespace Android.Widget {
 				}
 #else   // !JAVA_INTEROP
 				if (id_setAdapter_Landroid_widget_Adapter_ == IntPtr.Zero)
-					id_setAdapter_Landroid_widget_Adapter_ = JNIEnv.GetMethodID (class_ref, "setAdapter", "(Landroid/widget/ListAdapter;)V");
+					id_setAdapter_Landroid_widget_Adapter_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "setAdapter", "(Landroid/widget/ListAdapter;)V");
 				JNIEnv.CallVoidMethod (Handle, id_setAdapter_Landroid_widget_Adapter_, new JValue (JNIEnv.ToJniHandle (value)));
 #endif	// !JAVA_INTEROP
 			}

--- a/src/Mono.Android/Android.Widget/AdapterView.cs
+++ b/src/Mono.Android/Android.Widget/AdapterView.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Android.Views;
 using JLO = Java.Lang.Object;
 
@@ -55,6 +56,9 @@ namespace Android.Widget {
 			T
 	> : AdapterView  where T : IAdapter {
 
+		[UnsafeAccessor (UnsafeAccessorKind.StaticField, Name = "_members")]
+		static extern ref JniPeerMembers GetPeerMembers (AdapterView? _);
+
 		public AdapterView (IntPtr handle, JniHandleOwnership transfer)
 			: base (handle, transfer)
 		{
@@ -70,11 +74,11 @@ namespace Android.Widget {
 
 			if (GetType () == typeof (AdapterView<T>)) {
 				if (id_ctor_Landroid_content_Context_ == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_ = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;)V");
+					id_ctor_Landroid_content_Context_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;)V");
 				SetHandle (
-						JNIEnv.StartCreateInstance (class_ref, id_ctor_Landroid_content_Context_, new JValue (context)),
+						JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_, new JValue (context)),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Landroid_content_Context_, new JValue (context));
+				JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_, new JValue (context));
 			} else {
 				SetHandle (
 						JNIEnv.StartCreateInstance (GetType (), "(Landroid/content/Context;)V", new JValue (context)),
@@ -94,11 +98,11 @@ namespace Android.Widget {
 
 			if (GetType () == typeof (AdapterView<T>)) {
 				if (id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_ == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_ = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;Landroid/util/AttributeSet;)V");
+					id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;Landroid/util/AttributeSet;)V");
 				SetHandle (
-						JNIEnv.StartCreateInstance (class_ref, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_, new JValue (context), new JValue (attrs)),
+						JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_, new JValue (context), new JValue (attrs)),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_, new JValue (context), new JValue (attrs));
+				JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_, new JValue (context), new JValue (attrs));
 			} else {
 				SetHandle (
 						JNIEnv.StartCreateInstance (GetType (), "(Landroid/content/Context;Landroid/util/AttributeSet;)V", new JValue (context), new JValue (attrs)),
@@ -119,11 +123,11 @@ namespace Android.Widget {
 
 			if (GetType () == typeof (AdapterView<T>)) {
 				if (id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;Landroid/util/AttributeSet;I)V");
+					id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;Landroid/util/AttributeSet;I)V");
 				SetHandle (
-						JNIEnv.StartCreateInstance (class_ref, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I, new JValue (context), new JValue (attrs), new JValue (defStyle)),
+						JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I, new JValue (context), new JValue (attrs), new JValue (defStyle)),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I, new JValue (context), new JValue (attrs), new JValue (defStyle));
+				JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I, new JValue (context), new JValue (attrs), new JValue (defStyle));
 			} else {
 				SetHandle (
 						JNIEnv.StartCreateInstance (GetType (), "(Landroid/content/Context;Landroid/util/AttributeSet;I)V", new JValue (context), new JValue (attrs), new JValue (defStyle)),

--- a/src/Mono.Android/Android.Widget/AdapterView.cs
+++ b/src/Mono.Android/Android.Widget/AdapterView.cs
@@ -57,7 +57,7 @@ namespace Android.Widget {
 	> : AdapterView  where T : IAdapter {
 
 		[UnsafeAccessor (UnsafeAccessorKind.StaticField, Name = "_members")]
-		static extern ref JniPeerMembers GetPeerMembers (AdapterView? _);
+		static extern ref readonly JniPeerMembers GetPeerMembers (AdapterView? _);
 
 		public AdapterView (IntPtr handle, JniHandleOwnership transfer)
 			: base (handle, transfer)

--- a/src/Mono.Android/Android.Widget/AdapterViewAnimator.cs
+++ b/src/Mono.Android/Android.Widget/AdapterViewAnimator.cs
@@ -26,9 +26,9 @@ namespace Android.Widget {
 		{
 			if (GetType () == typeof (AdapterViewAnimator<T>)) {
 				if (id_ctor_Landroid_content_Context_ == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_ = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;)V");
+					id_ctor_Landroid_content_Context_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;)V");
 				SetHandle (
-						JNIEnv.NewObject (class_ref, id_ctor_Landroid_content_Context_, new JValue (context)),
+						JNIEnv.NewObject (_members.JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_, new JValue (context)),
 						JniHandleOwnership.TransferLocalRef);
 			} else {
 				SetHandle (
@@ -44,9 +44,9 @@ namespace Android.Widget {
 		{
 			if (GetType () == typeof (AdapterViewAnimator<T>)) {
 				if (id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_ == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_ = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;Landroid/util/AttributeSet;)V");
+					id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;Landroid/util/AttributeSet;)V");
 				SetHandle (
-						JNIEnv.NewObject (class_ref, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_, new JValue (context), new JValue (attrs)),
+						JNIEnv.NewObject (_members.JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_, new JValue (context), new JValue (attrs)),
 						JniHandleOwnership.TransferLocalRef);
 			} else {
 				SetHandle (
@@ -62,9 +62,9 @@ namespace Android.Widget {
 		{
 			if (GetType () == typeof (AdapterViewAnimator<T>)) {
 				if (id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;Landroid/util/AttributeSet;I)V");
+					id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;Landroid/util/AttributeSet;I)V");
 				SetHandle (
-						JNIEnv.NewObject (class_ref, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I, new JValue (context), new JValue (attrs), new JValue (defStyle)),
+						JNIEnv.NewObject (_members.JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_Landroid_util_AttributeSet_I, new JValue (context), new JValue (attrs), new JValue (defStyle)),
 						JniHandleOwnership.TransferLocalRef);
 			} else {
 				SetHandle (
@@ -85,7 +85,7 @@ namespace Android.Widget {
                         [Register ("getAdapter", "()Landroid/widget/Adapter;", "GetGetAdapterHandler")]
                         get {
                                 if (id_getAdapter == IntPtr.Zero)
-                                        id_getAdapter = JNIEnv.GetMethodID (class_ref, "getAdapter", "()Landroid/widget/Adapter;");
+                                        id_getAdapter = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "getAdapter", "()Landroid/widget/Adapter;");
                                 Android.Widget.IAdapter? result;
                                 if (GetType () == ThresholdType)
                                         result = Java.Lang.Object.GetObject<Android.Widget.IAdapter> (JNIEnv.CallObjectMethod  (Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
@@ -101,7 +101,7 @@ namespace Android.Widget {
                         }
                         set {
                                 if (id_setAdapter_Landroid_widget_Adapter_ == IntPtr.Zero)
-                                        id_setAdapter_Landroid_widget_Adapter_ = JNIEnv.GetMethodID (class_ref, "setAdapter", "(Landroid/widget/Adapter;)V");
+                                        id_setAdapter_Landroid_widget_Adapter_ = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "setAdapter", "(Landroid/widget/Adapter;)V");
 
                                 if (GetType () == ThresholdType)
                                         JNIEnv.CallVoidMethod  (Handle, id_setAdapter_Landroid_widget_Adapter_, new JValue (JNIEnv.ToJniHandle (value)));

--- a/src/Mono.Android/Android.Widget/ArrayAdapter.cs
+++ b/src/Mono.Android/Android.Widget/ArrayAdapter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Android.Runtime;
 
 using Java.Interop;
@@ -12,6 +13,9 @@ namespace Android.Widget {
 			[DynamicallyAccessedMembers (Constructors)]
 			T
 	> : ArrayAdapter {
+
+		[UnsafeAccessor (UnsafeAccessorKind.StaticField, Name = "_members")]
+		static extern ref JniPeerMembers GetPeerMembers (ArrayAdapter? _);
 
 		public ArrayAdapter (IntPtr handle, JniHandleOwnership transfer)
 			: base (handle, transfer)
@@ -28,11 +32,11 @@ namespace Android.Widget {
 
 			if (GetType () == typeof (ArrayAdapter<T>)) {
 				if (id_ctor_Landroid_content_Context_I == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_I = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;I)V");
+					id_ctor_Landroid_content_Context_I = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;I)V");
 				SetHandle (
-						JNIEnv.StartCreateInstance (class_ref, id_ctor_Landroid_content_Context_I, new JValue (context), new JValue (textViewResourceId)),
+						JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_I, new JValue (context), new JValue (textViewResourceId)),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Landroid_content_Context_I, new JValue (context), new JValue (textViewResourceId));
+				JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_I, new JValue (context), new JValue (textViewResourceId));
 			} else {
 				SetHandle (
 						JNIEnv.StartCreateInstance (GetType (), "(Landroid/content/Context;I)V", new JValue (context), new JValue (textViewResourceId)),
@@ -52,11 +56,11 @@ namespace Android.Widget {
 
 			if (GetType () == typeof (ArrayAdapter<T>)) {
 				if (id_ctor_Landroid_content_Context_II == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_II = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;II)V");
+					id_ctor_Landroid_content_Context_II = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;II)V");
 				SetHandle (
-						JNIEnv.StartCreateInstance (class_ref, id_ctor_Landroid_content_Context_II, new JValue (context), new JValue (resource), new JValue (textViewResourceId)),
+						JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_II, new JValue (context), new JValue (resource), new JValue (textViewResourceId)),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Landroid_content_Context_II, new JValue (context), new JValue (resource), new JValue (textViewResourceId));
+				JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_II, new JValue (context), new JValue (resource), new JValue (textViewResourceId));
 			} else {
 				SetHandle (
 						JNIEnv.StartCreateInstance (GetType (), "(Landroid/content/Context;II)V", new JValue (context), new JValue (resource), new JValue (textViewResourceId)),
@@ -77,11 +81,11 @@ namespace Android.Widget {
 			IntPtr native_objects = JNIEnv.NewObjectArray (objects);
 			if (GetType () == typeof (ArrayAdapter<T>)) {
 				if (id_ctor_Landroid_content_Context_IarrayLjava_lang_Object_ == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_IarrayLjava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;I[Ljava/lang/Object;)V");
+					id_ctor_Landroid_content_Context_IarrayLjava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;I[Ljava/lang/Object;)V");
 				SetHandle (
-						JNIEnv.StartCreateInstance (class_ref, id_ctor_Landroid_content_Context_IarrayLjava_lang_Object_, new JValue (context), new JValue (textViewResourceId), new JValue (native_objects)),
+						JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_IarrayLjava_lang_Object_, new JValue (context), new JValue (textViewResourceId), new JValue (native_objects)),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Landroid_content_Context_IarrayLjava_lang_Object_, new JValue (context), new JValue (textViewResourceId), new JValue (native_objects));
+				JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_IarrayLjava_lang_Object_, new JValue (context), new JValue (textViewResourceId), new JValue (native_objects));
 			} else {
 				SetHandle (
 						JNIEnv.StartCreateInstance (GetType (), "(Landroid/content/Context;I[Ljava/lang/Object;)V", new JValue (context), new JValue (textViewResourceId), new JValue (native_objects)),
@@ -103,11 +107,11 @@ namespace Android.Widget {
 			IntPtr native_objects = JNIEnv.NewObjectArray<T> (objects);;
 			if (GetType () == typeof (ArrayAdapter<T>)) {
 				if (id_ctor_Landroid_content_Context_IIarrayLjava_lang_Object_ == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_IIarrayLjava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;II[Ljava/lang/Object;)V");
+					id_ctor_Landroid_content_Context_IIarrayLjava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;II[Ljava/lang/Object;)V");
 				SetHandle (
-						JNIEnv.StartCreateInstance (class_ref, id_ctor_Landroid_content_Context_IIarrayLjava_lang_Object_, new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (native_objects)),
+						JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_IIarrayLjava_lang_Object_, new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (native_objects)),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Landroid_content_Context_IIarrayLjava_lang_Object_, new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (native_objects));
+				JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_IIarrayLjava_lang_Object_, new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (native_objects));
 			} else {
 				SetHandle (
 						JNIEnv.StartCreateInstance (GetType (), "(Landroid/content/Context;II[Ljava/lang/Object;)V", new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (native_objects)),
@@ -129,11 +133,11 @@ namespace Android.Widget {
 			IntPtr lrefObjects = JavaList<T>.ToLocalJniHandle (objects);
 			if (GetType () == typeof (ArrayAdapter<T>)) {
 				if (id_ctor_Landroid_content_Context_ILjava_util_List_ == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_ILjava_util_List_ = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;ILjava/util/List;)V");
+					id_ctor_Landroid_content_Context_ILjava_util_List_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;ILjava/util/List;)V");
 				SetHandle (
-						JNIEnv.StartCreateInstance (class_ref, id_ctor_Landroid_content_Context_ILjava_util_List_, new JValue (context), new JValue (textViewResourceId), new JValue (lrefObjects)),
+						JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_ILjava_util_List_, new JValue (context), new JValue (textViewResourceId), new JValue (lrefObjects)),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Landroid_content_Context_ILjava_util_List_, new JValue (context), new JValue (textViewResourceId), new JValue (lrefObjects));
+				JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_ILjava_util_List_, new JValue (context), new JValue (textViewResourceId), new JValue (lrefObjects));
 			} else {
 				SetHandle (
 						JNIEnv.StartCreateInstance (GetType (), "(Landroid/content/Context;ILjava/util/List;)V", new JValue (context), new JValue (textViewResourceId), new JValue (lrefObjects)),
@@ -155,11 +159,11 @@ namespace Android.Widget {
 			IntPtr lrefObjects = JavaList<T>.ToLocalJniHandle (objects);
 			if (GetType () == typeof (ArrayAdapter<T>)) {
 				if (id_ctor_Landroid_content_Context_IILjava_util_List_ == IntPtr.Zero)
-					id_ctor_Landroid_content_Context_IILjava_util_List_ = JNIEnv.GetMethodID (class_ref, "<init>", "(Landroid/content/Context;IILjava/util/List;)V");
+					id_ctor_Landroid_content_Context_IILjava_util_List_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "(Landroid/content/Context;IILjava/util/List;)V");
 				SetHandle (
-						JNIEnv.StartCreateInstance (class_ref, id_ctor_Landroid_content_Context_IILjava_util_List_, new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (lrefObjects)),
+						JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_IILjava_util_List_, new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (lrefObjects)),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Landroid_content_Context_IILjava_util_List_, new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (lrefObjects));
+				JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor_Landroid_content_Context_IILjava_util_List_, new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (lrefObjects));
 			} else {
 				SetHandle (
 						JNIEnv.StartCreateInstance (GetType (), "(Landroid/content/Context;IILjava/util/List;)V", new JValue (context), new JValue (resource), new JValue (textViewResourceId), new JValue (lrefObjects)),
@@ -175,9 +179,9 @@ namespace Android.Widget {
 		public void Add (T @object)
 		{
 			if (id_add_Ljava_lang_Object_ == IntPtr.Zero)
-				id_add_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "add", "(Ljava/lang/Object;)V");
+				id_add_Ljava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "add", "(Ljava/lang/Object;)V");
 			JavaConvert.WithLocalJniHandle (@object, lref => {
-					JNIEnv.CallNonvirtualVoidMethod (Handle, class_ref, id_add_Ljava_lang_Object_, new JValue (lref));
+					JNIEnv.CallNonvirtualVoidMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_add_Ljava_lang_Object_, new JValue (lref));
 					return IntPtr.Zero;
 			});
 		}
@@ -187,9 +191,9 @@ namespace Android.Widget {
 		public new static Android.Widget.ArrayAdapter<Java.Lang.ICharSequence> CreateFromResource (Android.Content.Context context, int textArrayResId, int textViewResId)
 		{
 			if (id_createFromResource_Landroid_content_Context_II == IntPtr.Zero)
-				id_createFromResource_Landroid_content_Context_II = JNIEnv.GetStaticMethodID (class_ref, "createFromResource", "(Landroid/content/Context;II)Landroid/widget/ArrayAdapter;");
+				id_createFromResource_Landroid_content_Context_II = JNIEnv.GetStaticMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "createFromResource", "(Landroid/content/Context;II)Landroid/widget/ArrayAdapter;");
 			var result = JavaConvert.FromJniHandle<ArrayAdapter<Java.Lang.ICharSequence>> (
-					JNIEnv.CallStaticObjectMethod (class_ref, id_createFromResource_Landroid_content_Context_II, new JValue (context), new JValue (textArrayResId), new JValue (textViewResId)),
+					JNIEnv.CallStaticObjectMethod (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_createFromResource_Landroid_content_Context_II, new JValue (context), new JValue (textArrayResId), new JValue (textViewResId)),
 						JniHandleOwnership.TransferLocalRef);
 			GC.KeepAlive (context);
 			return result ?? throw new InvalidOperationException ("Unable to marshal the return value to an Android.Widget.ArrayAdapter instance.");
@@ -200,9 +204,9 @@ namespace Android.Widget {
 		public new T? GetItem (int position)
 		{
 			if (id_getItem_I == IntPtr.Zero)
-				id_getItem_I = JNIEnv.GetMethodID (class_ref, "getItem", "(I)Ljava/lang/Object;");
+				id_getItem_I = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "getItem", "(I)Ljava/lang/Object;");
 			return JavaConvert.FromJniHandle<T>(
-					JNIEnv.CallNonvirtualObjectMethod (Handle, class_ref, id_getItem_I, new JValue (position)),
+					JNIEnv.CallNonvirtualObjectMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_getItem_I, new JValue (position)),
 					JniHandleOwnership.TransferLocalRef);
 		}
 
@@ -211,9 +215,9 @@ namespace Android.Widget {
 		public int GetPosition (T item)
 		{
 			if (id_getPosition_Ljava_lang_Object_ == IntPtr.Zero)
-				id_getPosition_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getPosition", "(Ljava/lang/Object;)I");
+				id_getPosition_Ljava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "getPosition", "(Ljava/lang/Object;)I");
 			return JavaConvert.WithLocalJniHandle (item,
-					lref => JNIEnv.CallNonvirtualIntMethod (Handle, class_ref, id_getPosition_Ljava_lang_Object_, new JValue (lref)));
+					lref => JNIEnv.CallNonvirtualIntMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_getPosition_Ljava_lang_Object_, new JValue (lref)));
 		}
 
 		static IntPtr id_insert_Ljava_lang_Object_I;
@@ -221,9 +225,9 @@ namespace Android.Widget {
 		public void Insert (T @object, int index)
 		{
 			if (id_insert_Ljava_lang_Object_I == IntPtr.Zero)
-				id_insert_Ljava_lang_Object_I = JNIEnv.GetMethodID (class_ref, "insert", "(Ljava/lang/Object;I)V");
+				id_insert_Ljava_lang_Object_I = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "insert", "(Ljava/lang/Object;I)V");
 			JavaConvert.WithLocalJniHandle (@object, lref => {
-					JNIEnv.CallNonvirtualVoidMethod (Handle, class_ref, id_insert_Ljava_lang_Object_I, new JValue (lref), new JValue (index));
+					JNIEnv.CallNonvirtualVoidMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_insert_Ljava_lang_Object_I, new JValue (lref), new JValue (index));
 					return IntPtr.Zero;
 			});
 		}
@@ -233,9 +237,9 @@ namespace Android.Widget {
 		public void Remove (T @object)
 		{
 			if (id_remove_Ljava_lang_Object_ == IntPtr.Zero)
-				id_remove_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "remove", "(Ljava/lang/Object;)V");
+				id_remove_Ljava_lang_Object_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "remove", "(Ljava/lang/Object;)V");
 			JavaConvert.WithLocalJniHandle (@object, lref => {
-					JNIEnv.CallNonvirtualVoidMethod (Handle, class_ref, id_remove_Ljava_lang_Object_, new JValue (lref));
+					JNIEnv.CallNonvirtualVoidMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_remove_Ljava_lang_Object_, new JValue (lref));
 					return IntPtr.Zero;
 			});
 		}
@@ -245,8 +249,8 @@ namespace Android.Widget {
 		public new void Sort (Java.Util.IComparator comparator)
 		{
 			if (id_sort_Ljava_util_Comparator_ == IntPtr.Zero)
-				id_sort_Ljava_util_Comparator_ = JNIEnv.GetMethodID (class_ref, "sort", "(Ljava/util/Comparator;)V");
-			JNIEnv.CallNonvirtualVoidMethod (Handle, class_ref, id_sort_Ljava_util_Comparator_, new JValue (comparator));
+				id_sort_Ljava_util_Comparator_ = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "sort", "(Ljava/util/Comparator;)V");
+			JNIEnv.CallNonvirtualVoidMethod (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_sort_Ljava_util_Comparator_, new JValue (comparator));
 			GC.KeepAlive (comparator);
 			GC.KeepAlive (this);
 		}

--- a/src/Mono.Android/Android.Widget/ArrayAdapter.cs
+++ b/src/Mono.Android/Android.Widget/ArrayAdapter.cs
@@ -15,7 +15,7 @@ namespace Android.Widget {
 	> : ArrayAdapter {
 
 		[UnsafeAccessor (UnsafeAccessorKind.StaticField, Name = "_members")]
-		static extern ref JniPeerMembers GetPeerMembers (ArrayAdapter? _);
+		static extern ref readonly JniPeerMembers GetPeerMembers (ArrayAdapter? _);
 
 		public ArrayAdapter (IntPtr handle, JniHandleOwnership transfer)
 			: base (handle, transfer)

--- a/src/Mono.Android/Android.Widget/BaseAdapter.cs
+++ b/src/Mono.Android/Android.Widget/BaseAdapter.cs
@@ -1,20 +1,16 @@
 using System;
+using System.Runtime.CompilerServices;
 
 using Android.Runtime;
 
 using Java.Interop;
-
 namespace Android.Widget {
 
 	[Register ("android/widget/BaseAdapter", DoNotGenerateAcw=true)]
 	public abstract partial class BaseAdapter<T> : BaseAdapter {
 
-		static IntPtr java_class_handle;
-		static new IntPtr class_ref {
-			get {
-				return JNIEnv.FindClass ("android/widget/BaseAdapter", ref java_class_handle);
-			}
-		}
+		[UnsafeAccessor (UnsafeAccessorKind.StaticField, Name = "_members")]
+		static extern ref JniPeerMembers GetPeerMembers (BaseAdapter? _);
 
 		public BaseAdapter (IntPtr handle, JniHandleOwnership transfer)
 			: base (handle, transfer)
@@ -38,11 +34,11 @@ namespace Android.Widget {
 			}
 
 			if (id_ctor == IntPtr.Zero)
-				id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				id_ctor = JNIEnv.GetMethodID (GetPeerMembers (null).JniPeerType.PeerReference.Handle, "<init>", "()V");
 			SetHandle (
-					JNIEnv.StartCreateInstance (class_ref, id_ctor),
+					JNIEnv.StartCreateInstance (GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor),
 					JniHandleOwnership.TransferLocalRef);
-			JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor);
+			JNIEnv.FinishCreateInstance (Handle, GetPeerMembers (null).JniPeerType.PeerReference.Handle, id_ctor);
 		}
 
 		public override Java.Lang.Object? GetItem (int position)
@@ -54,4 +50,3 @@ namespace Android.Widget {
 
 	}
 }
-

--- a/src/Mono.Android/Android.Widget/BaseAdapter.cs
+++ b/src/Mono.Android/Android.Widget/BaseAdapter.cs
@@ -10,7 +10,7 @@ namespace Android.Widget {
 	public abstract partial class BaseAdapter<T> : BaseAdapter {
 
 		[UnsafeAccessor (UnsafeAccessorKind.StaticField, Name = "_members")]
-		static extern ref JniPeerMembers GetPeerMembers (BaseAdapter? _);
+		static extern ref readonly JniPeerMembers GetPeerMembers (BaseAdapter? _);
 
 		public BaseAdapter (IntPtr handle, JniHandleOwnership transfer)
 			: base (handle, transfer)

--- a/src/Mono.Android/Android.Widget/TextView.cs
+++ b/src/Mono.Android/Android.Widget/TextView.cs
@@ -11,7 +11,7 @@ namespace Android.Widget {
 		void AddTextChangedListener (TextWatcherImplementor watcher)
 		{
 			if (id_addTextChangedListener == IntPtr.Zero)
-				id_addTextChangedListener = JNIEnv.GetMethodID (class_ref, "addTextChangedListener", "(Landroid/text/TextWatcher;)V");
+				id_addTextChangedListener = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "addTextChangedListener", "(Landroid/text/TextWatcher;)V");
 			JNIEnv.CallVoidMethod (Handle, id_addTextChangedListener, new JValue (watcher));
 			GC.KeepAlive (watcher);
 			GC.KeepAlive (this);

--- a/src/Mono.Android/Java.Lang/Throwable.cs
+++ b/src/Mono.Android/Java.Lang/Throwable.cs
@@ -66,7 +66,7 @@ namespace Java.Lang {
 		[DebuggerBrowsable (DebuggerBrowsableState.Never)]
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		protected virtual IntPtr ThresholdClass {
-			get { return class_ref; }
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		[DebuggerBrowsable (DebuggerBrowsableState.Never)]

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
@@ -98,7 +98,7 @@ namespace Xamarin.Android.JcwGenTests {
 		public void JavaSideActivation ()
 		{
 			using (var i = new ConstructorTest ()) {
-				// To ensure that CallMethodFromCtor.class_ref is initialized
+				// Ensure the Java class handle is initialized.
 			}
 			using (var c = Java.Lang.Class.FromType (typeof (ConstructorTest))) {
 				int initGref = Java.Interop.Runtime.GlobalReferenceCount;
@@ -367,7 +367,7 @@ namespace Xamarin.Android.JcwGenTests {
 		{
 			DefaultConstructorInvoked = true;
 
-			// Ensure that CallMethodFromCtor.class_ref is initialized
+			// Ensure the Java class handle is initialized.
 			var ignore  = ThresholdClass;
 			ignore      = ignore;
 		}
@@ -391,4 +391,3 @@ namespace Xamarin.Android.JcwGenTests {
 		}
 	}
 }
-

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Timing.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Timing.cs
@@ -21,7 +21,7 @@ namespace Com.Xamarin.Android {
 		public virtual unsafe void VirtualVoidMethod_Timing_Traditional ()
 		{
 			if (jonp_id_VirtualVoidMethod == IntPtr.Zero)
-				jonp_id_VirtualVoidMethod = JNIEnv.GetMethodID (class_ref, "VirtualVoidMethod", "()V");
+				jonp_id_VirtualVoidMethod = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "VirtualVoidMethod", "()V");
 
 			if (GetType () == ThresholdType)
 				JNIEnv.CallVoidMethod  (Handle, jonp_id_VirtualVoidMethod);
@@ -34,7 +34,7 @@ namespace Com.Xamarin.Android {
 		public virtual unsafe void VirtualVoidMethod_Timing_TraditionalWithCaching ()
 		{
 			if (jonp_id_VirtualVoidMethod == IntPtr.Zero)
-				jonp_id_VirtualVoidMethod = JNIEnv.GetMethodID (class_ref, "VirtualVoidMethod", "()V");
+				jonp_id_VirtualVoidMethod = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "VirtualVoidMethod", "()V");
 
 			if (GetType () == ThresholdType)
 				JNIEnv.CallVoidMethod  (Handle, jonp_id_VirtualVoidMethod);
@@ -50,7 +50,7 @@ namespace Com.Xamarin.Android {
 
 		public unsafe void VirtualVoidMethod_Timing_NoCache ()
 		{
-			var m = JNIEnv.GetMethodID (class_ref, "VirtualVoidMethod", "()V");
+			var m = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "VirtualVoidMethod", "()V");
 
 			if (GetType () == ThresholdType)
 				JNIEnv.CallVoidMethod  (Handle, m);
@@ -65,7 +65,7 @@ namespace Com.Xamarin.Android {
 			IntPtr m;
 			lock (dictInstanceMethods) {
 				if (!dictInstanceMethods.TryGetValue (id, out m))
-					dictInstanceMethods.Add (id, m = JNIEnv.GetMethodID (class_ref, "VirtualVoidMethod", "()V"));
+					dictInstanceMethods.Add (id, m = JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "VirtualVoidMethod", "()V"));
 			}
 
 			if (GetType () == ThresholdType)
@@ -80,8 +80,8 @@ namespace Com.Xamarin.Android {
 			const string id = "VirtualVoidMethod.()V";
 
 			var m = concurrentInstanceMethods.AddOrUpdate (id,
-				s => JNIEnv.GetMethodID (class_ref, "VirtualVoidMethod", "()V"),
-				(s, c) => c != IntPtr.Zero ? c : JNIEnv.GetMethodID (class_ref, "VirtualVoidMethod", "()V"));
+				s => JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "VirtualVoidMethod", "()V"),
+				(s, c) => c != IntPtr.Zero ? c : JNIEnv.GetMethodID (_members.JniPeerType.PeerReference.Handle, "VirtualVoidMethod", "()V"));
 
 			if (GetType () == ThresholdType)
 				JNIEnv.CallVoidMethod  (Handle, m);

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Content/ContentValuesTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Content/ContentValuesTests.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+
+using Android.Content;
+
+namespace Android.ContentTests {
+
+	[TestFixture]
+	public class ContentValuesTests {
+
+		[Test]
+		public void PrimitiveValueRoundTrips ()
+		{
+			using var values = new ContentValues ();
+
+			values.Put ("answer", 42);
+
+			Assert.AreEqual (42, values.GetAsInteger ("answer"));
+		}
+	}
+}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Util/SparseArrayTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Util/SparseArrayTests.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+
+using Android.Util;
+
+namespace Android.UtilTests {
+
+	[TestFixture]
+	public class SparseArrayTests {
+
+		[Test]
+		public void GenericSparseArrayUsesSparseArrayClass ()
+		{
+			using var values = new SparseArray<string> ();
+
+			values.Put (1, "one");
+
+			Assert.AreEqual ("one", values.Get (1));
+		}
+	}
+}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/AdapterTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/AdapterTests.cs
@@ -59,6 +59,16 @@ namespace Android.WidgetTests {
 			var adapter = view.Adapter;
 			view.Adapter = adapter;
 		}
+
+		[Test]
+		public void GenericArrayAdapterUsesArrayAdapterClass ()
+		{
+			using var adapter = new ArrayAdapter<string> (Application.Context, Android.Resource.Layout.SimpleListItem1);
+
+			adapter.Add ("first");
+
+			Assert.AreEqual ("first", adapter.GetItem (0));
+		}
 	}
 
 	public class CanOverrideAbsListView_Adapter : AbsListView {


### PR DESCRIPTION
## Summary

- stop emitting unused `class_ref` and `java_class_ref` compatibility properties
- keep generated `JniPeerMembers` fields private and migrate handwritten consumers to direct access
- use colocated `UnsafeAccessor` methods for the three generic wrappers that need their non-generic base type's private `_members`
- remove unreachable exact-type constructor paths from the abstract `AsyncTask<T...>`, `AdapterView<T>`, and `BaseAdapter<T>` wrappers
- update generator expectations and add generic `AsyncTask<T...>`, `ArrayAdapter<T>`, `SparseArray<T>`, and `ContentValues` runtime coverage

## Size

API 37 Release `Mono.Android.dll` is 41,366,016 bytes, 513,024 bytes smaller than the recorded 41,879,040-byte baseline. The generator removes 6,778 `MethodDef`, `Property`, and `MethodSemantics` rows.

## Validation

- Java.Interop generator tests: 497 passed
- API 37 Debug and Release framework builds
- MonoVM device suite: 1,007 passed, 75 skipped
- CoreCLR + trimmable typemap device suite: 718 passed, 12 skipped

Fixes #12680