### PR TITLE
[Java.Interop] Lazily allocate peer member caches

### DIFF
--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Java.Interop
 {
@@ -15,20 +16,30 @@ namespace Java.Interop
 
 		readonly JniPeerMembers                             Members;
 
-		readonly ConcurrentDictionary<string, JniFieldInfo> InstanceFields = new ConcurrentDictionary<string, JniFieldInfo> (1, 3, StringComparer.Ordinal);
+		ConcurrentDictionary<string, JniFieldInfo>? InstanceFields;
 
 		internal void Dispose ()
 		{
-			InstanceFields.Clear ();
+			Interlocked.Exchange (ref InstanceFields, null)?.Clear ();
 		}
 
 		public JniFieldInfo GetFieldInfo (string encodedMember)
 		{
-			return InstanceFields.GetOrAdd (encodedMember, static (member, fields) => {
+			return GetInstanceFields ().GetOrAdd (encodedMember, static (member, fields) => {
 				string field, signature;
 				JniPeerMembers.GetNameAndSignature (member, out field, out signature);
 				return fields.Members.JniPeerType.GetInstanceField (field, signature);
 			}, this);
+		}
+
+		ConcurrentDictionary<string, JniFieldInfo> GetInstanceFields ()
+		{
+			var fields = Volatile.Read (ref InstanceFields);
+			if (fields != null)
+				return fields;
+
+			var candidate = new ConcurrentDictionary<string, JniFieldInfo> (1, 3, StringComparer.Ordinal);
+			return Interlocked.CompareExchange (ref InstanceFields, candidate, null) ?? candidate;
 		}
 	}}
 }

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
@@ -15,16 +15,18 @@ namespace Java.Interop
 
 		readonly JniPeerMembers                             Members;
 
-		ConcurrentDictionary<string, JniFieldInfo>? InstanceFields;
+		ConcurrentDictionary<string, JniFieldInfo>? instanceFields;
+
+		ConcurrentDictionary<string, JniFieldInfo> InstanceFields => GetOrCreate (ref instanceFields, 3);
 
 		internal void Dispose ()
 		{
-			Clear (ref InstanceFields);
+			Clear (ref instanceFields);
 		}
 
 		public JniFieldInfo GetFieldInfo (string encodedMember)
 		{
-			return GetOrCreate (ref InstanceFields, 3).GetOrAdd (encodedMember, static (member, fields) => {
+			return InstanceFields.GetOrAdd (encodedMember, static (member, fields) => {
 				string field, signature;
 				JniPeerMembers.GetNameAndSignature (member, out field, out signature);
 				return fields.Members.JniPeerType.GetInstanceField (field, signature);

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Threading;
 
 namespace Java.Interop
 {
@@ -20,7 +19,7 @@ namespace Java.Interop
 
 		internal void Dispose ()
 		{
-			Interlocked.Exchange (ref InstanceFields, null)?.Clear ();
+			Clear (ref InstanceFields);
 		}
 
 		public JniFieldInfo GetFieldInfo (string encodedMember)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
@@ -25,21 +25,11 @@ namespace Java.Interop
 
 		public JniFieldInfo GetFieldInfo (string encodedMember)
 		{
-			return GetInstanceFields ().GetOrAdd (encodedMember, static (member, fields) => {
+			return GetOrCreate (ref InstanceFields, 3).GetOrAdd (encodedMember, static (member, fields) => {
 				string field, signature;
 				JniPeerMembers.GetNameAndSignature (member, out field, out signature);
 				return fields.Members.JniPeerType.GetInstanceField (field, signature);
 			}, this);
-		}
-
-		ConcurrentDictionary<string, JniFieldInfo> GetInstanceFields ()
-		{
-			var fields = Volatile.Read (ref InstanceFields);
-			if (fields != null)
-				return fields;
-
-			var candidate = new ConcurrentDictionary<string, JniFieldInfo> (1, 3, StringComparer.Ordinal);
-			return Interlocked.CompareExchange (ref InstanceFields, candidate, null) ?? candidate;
 		}
 	}}
 }

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Threading;
 
 namespace Java.Interop
 {
@@ -46,12 +45,7 @@ namespace Java.Interop
 		internal void Dispose ()
 		{
 			Clear (ref InstanceMethods);
-			var constructors = Interlocked.Exchange (ref SubclassConstructors, null);
-			if (constructors != null) {
-				foreach (var p in constructors.Values)
-					p.Dispose ();
-				constructors.Clear ();
-			}
+			Clear (ref SubclassConstructors, static value => value.Dispose ());
 
 			if (jniPeerType != null)
 				jniPeerType.Dispose ();

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
@@ -39,13 +39,16 @@ namespace Java.Interop
 
 		readonly Type                                       DeclaringType;
 
-		ConcurrentDictionary<string, JniMethodInfo>?             InstanceMethods;
-		ConcurrentDictionary<Type, JniInstanceMethods>?          SubclassConstructors;
+		ConcurrentDictionary<string, JniMethodInfo>?             instanceMethods;
+		ConcurrentDictionary<Type, JniInstanceMethods>?          subclassConstructors;
+
+		ConcurrentDictionary<string, JniMethodInfo>               InstanceMethods      => GetOrCreate (ref instanceMethods, 3);
+		ConcurrentDictionary<Type, JniInstanceMethods>            SubclassConstructors => GetOrCreate (ref subclassConstructors, 1);
 
 		internal void Dispose ()
 		{
-			Clear (ref InstanceMethods);
-			Clear (ref SubclassConstructors, static value => value.Dispose ());
+			Clear (ref instanceMethods);
+			Clear (ref subclassConstructors, static value => value.Dispose ());
 
 			if (jniPeerType != null)
 				jniPeerType.Dispose ();
@@ -56,7 +59,7 @@ namespace Java.Interop
 		{
 			if (signature == null)
 				throw new ArgumentNullException (nameof (signature));
-			return GetOrCreate (ref InstanceMethods, 3).GetOrAdd (signature, static (member, methods) =>
+			return InstanceMethods.GetOrAdd (signature, static (member, methods) =>
 					methods.JniPeerType.GetConstructor (member), this);
 		}
 
@@ -87,12 +90,12 @@ namespace Java.Interop
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods..ctor(Type declaringType) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 27
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods.GetConstructorsForType(Type declaringType) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 77
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods.StartCreateInstance(String constructorSignature, Type declaringType, JniArgumentValue* parameters) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 146
-			return GetOrCreate (ref SubclassConstructors, 1).GetOrAdd (declaringType, static type => new JniInstanceMethods (type));
+			return SubclassConstructors.GetOrAdd (declaringType, static type => new JniInstanceMethods (type));
 		}
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)
 		{
-			return GetOrCreate (ref InstanceMethods, 3).GetOrAdd (encodedMember, static (member, methods) => {
+			return InstanceMethods.GetOrAdd (encodedMember, static (member, methods) => {
 				string method, signature;
 				JniPeerMembers.GetNameAndSignature (member, out method, out signature);
 				return methods.GetMethodInfo (method, signature);

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
@@ -45,7 +45,7 @@ namespace Java.Interop
 
 		internal void Dispose ()
 		{
-			Interlocked.Exchange (ref InstanceMethods, null)?.Clear ();
+			Clear (ref InstanceMethods);
 			var constructors = Interlocked.Exchange (ref SubclassConstructors, null);
 			if (constructors != null) {
 				foreach (var p in constructors.Values)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
@@ -41,14 +41,17 @@ namespace Java.Interop
 		readonly Type                                       DeclaringType;
 
 		ConcurrentDictionary<string, JniMethodInfo>?             InstanceMethods;
-		readonly ConcurrentDictionary<Type, JniInstanceMethods> SubclassConstructors = new ConcurrentDictionary<Type, JniInstanceMethods> (1, 1);
+		ConcurrentDictionary<Type, JniInstanceMethods>?          SubclassConstructors;
 
 		internal void Dispose ()
 		{
 			Interlocked.Exchange (ref InstanceMethods, null)?.Clear ();
-			foreach (var p in SubclassConstructors.Values)
-				p.Dispose ();
-			SubclassConstructors.Clear ();
+			var constructors = Interlocked.Exchange (ref SubclassConstructors, null);
+			if (constructors != null) {
+				foreach (var p in constructors.Values)
+					p.Dispose ();
+				constructors.Clear ();
+			}
 
 			if (jniPeerType != null)
 				jniPeerType.Dispose ();
@@ -90,7 +93,7 @@ namespace Java.Interop
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods..ctor(Type declaringType) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 27
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods.GetConstructorsForType(Type declaringType) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 77
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods.StartCreateInstance(String constructorSignature, Type declaringType, JniArgumentValue* parameters) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 146
-			return SubclassConstructors.GetOrAdd (declaringType, static type => new JniInstanceMethods (type));
+			return GetSubclassConstructors ().GetOrAdd (declaringType, static type => new JniInstanceMethods (type));
 		}
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)
@@ -110,6 +113,16 @@ namespace Java.Interop
 
 			var candidate = new ConcurrentDictionary<string, JniMethodInfo> (1, 3, StringComparer.Ordinal);
 			return Interlocked.CompareExchange (ref InstanceMethods, candidate, null) ?? candidate;
+		}
+
+		ConcurrentDictionary<Type, JniInstanceMethods> GetSubclassConstructors ()
+		{
+			var constructors = Volatile.Read (ref SubclassConstructors);
+			if (constructors != null)
+				return constructors;
+
+			var candidate = new ConcurrentDictionary<Type, JniInstanceMethods> (1, 1);
+			return Interlocked.CompareExchange (ref SubclassConstructors, candidate, null) ?? candidate;
 		}
 
 		JniMethodInfo GetMethodInfo (string method, string signature)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
@@ -62,7 +62,7 @@ namespace Java.Interop
 		{
 			if (signature == null)
 				throw new ArgumentNullException (nameof (signature));
-			return GetInstanceMethods ().GetOrAdd (signature, static (member, methods) =>
+			return GetOrCreate (ref InstanceMethods, 3).GetOrAdd (signature, static (member, methods) =>
 					methods.JniPeerType.GetConstructor (member), this);
 		}
 
@@ -93,36 +93,16 @@ namespace Java.Interop
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods..ctor(Type declaringType) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 27
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods.GetConstructorsForType(Type declaringType) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 77
 			//    at Java.Interop.JniPeerMembers.JniInstanceMethods.StartCreateInstance(String constructorSignature, Type declaringType, JniArgumentValue* parameters) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 146
-			return GetSubclassConstructors ().GetOrAdd (declaringType, static type => new JniInstanceMethods (type));
+			return GetOrCreate (ref SubclassConstructors, 1).GetOrAdd (declaringType, static type => new JniInstanceMethods (type));
 		}
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)
 		{
-			return GetInstanceMethods ().GetOrAdd (encodedMember, static (member, methods) => {
+			return GetOrCreate (ref InstanceMethods, 3).GetOrAdd (encodedMember, static (member, methods) => {
 				string method, signature;
 				JniPeerMembers.GetNameAndSignature (member, out method, out signature);
 				return methods.GetMethodInfo (method, signature);
 			}, this);
-		}
-
-		ConcurrentDictionary<string, JniMethodInfo> GetInstanceMethods ()
-		{
-			var methods = Volatile.Read (ref InstanceMethods);
-			if (methods != null)
-				return methods;
-
-			var candidate = new ConcurrentDictionary<string, JniMethodInfo> (1, 3, StringComparer.Ordinal);
-			return Interlocked.CompareExchange (ref InstanceMethods, candidate, null) ?? candidate;
-		}
-
-		ConcurrentDictionary<Type, JniInstanceMethods> GetSubclassConstructors ()
-		{
-			var constructors = Volatile.Read (ref SubclassConstructors);
-			if (constructors != null)
-				return constructors;
-
-			var candidate = new ConcurrentDictionary<Type, JniInstanceMethods> (1, 1);
-			return Interlocked.CompareExchange (ref SubclassConstructors, candidate, null) ?? candidate;
 		}
 
 		JniMethodInfo GetMethodInfo (string method, string signature)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Java.Interop
 {
@@ -39,12 +40,12 @@ namespace Java.Interop
 
 		readonly Type                                       DeclaringType;
 
-		readonly ConcurrentDictionary<string, JniMethodInfo>    InstanceMethods      = new ConcurrentDictionary<string, JniMethodInfo> (1, 3, StringComparer.Ordinal);
+		ConcurrentDictionary<string, JniMethodInfo>?             InstanceMethods;
 		readonly ConcurrentDictionary<Type, JniInstanceMethods> SubclassConstructors = new ConcurrentDictionary<Type, JniInstanceMethods> (1, 1);
 
 		internal void Dispose ()
 		{
-			InstanceMethods.Clear ();
+			Interlocked.Exchange (ref InstanceMethods, null)?.Clear ();
 			foreach (var p in SubclassConstructors.Values)
 				p.Dispose ();
 			SubclassConstructors.Clear ();
@@ -58,7 +59,7 @@ namespace Java.Interop
 		{
 			if (signature == null)
 				throw new ArgumentNullException (nameof (signature));
-			return InstanceMethods.GetOrAdd (signature, static (member, methods) =>
+			return GetInstanceMethods ().GetOrAdd (signature, static (member, methods) =>
 					methods.JniPeerType.GetConstructor (member), this);
 		}
 
@@ -94,11 +95,21 @@ namespace Java.Interop
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)
 		{
-			return InstanceMethods.GetOrAdd (encodedMember, static (member, methods) => {
+			return GetInstanceMethods ().GetOrAdd (encodedMember, static (member, methods) => {
 				string method, signature;
 				JniPeerMembers.GetNameAndSignature (member, out method, out signature);
 				return methods.GetMethodInfo (method, signature);
 			}, this);
+		}
+
+		ConcurrentDictionary<string, JniMethodInfo> GetInstanceMethods ()
+		{
+			var methods = Volatile.Read (ref InstanceMethods);
+			if (methods != null)
+				return methods;
+
+			var candidate = new ConcurrentDictionary<string, JniMethodInfo> (1, 3, StringComparer.Ordinal);
+			return Interlocked.CompareExchange (ref InstanceMethods, candidate, null) ?? candidate;
 		}
 
 		JniMethodInfo GetMethodInfo (string method, string signature)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
@@ -20,7 +20,7 @@ namespace Java.Interop
 
 		public JniFieldInfo GetFieldInfo (string encodedMember)
 		{
-			return GetStaticFields ().GetOrAdd (encodedMember, static (member, fields) => {
+			return GetOrCreate (ref StaticFields, 3).GetOrAdd (encodedMember, static (member, fields) => {
 				string field, signature;
 				JniPeerMembers.GetNameAndSignature (member, out field, out signature);
 				return fields.Members.JniPeerType.GetStaticField (field, signature);
@@ -30,16 +30,6 @@ namespace Java.Interop
 		internal void Dispose ()
 		{
 			Interlocked.Exchange (ref StaticFields, null)?.Clear ();
-		}
-
-		ConcurrentDictionary<string, JniFieldInfo> GetStaticFields ()
-		{
-			var fields = Volatile.Read (ref StaticFields);
-			if (fields != null)
-				return fields;
-
-			var candidate = new ConcurrentDictionary<string, JniFieldInfo> (1, 3, StringComparer.Ordinal);
-			return Interlocked.CompareExchange (ref StaticFields, candidate, null) ?? candidate;
 		}
 	}}
 }

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Threading;
 
 namespace Java.Interop
 {
@@ -29,7 +28,7 @@ namespace Java.Interop
 
 		internal void Dispose ()
 		{
-			Interlocked.Exchange (ref StaticFields, null)?.Clear ();
+			Clear (ref StaticFields);
 		}
 	}}
 }

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
@@ -15,11 +15,13 @@ namespace Java.Interop
 
 		readonly JniPeerMembers                             Members;
 
-		ConcurrentDictionary<string, JniFieldInfo>? StaticFields;
+		ConcurrentDictionary<string, JniFieldInfo>? staticFields;
+
+		ConcurrentDictionary<string, JniFieldInfo> StaticFields => GetOrCreate (ref staticFields, 3);
 
 		public JniFieldInfo GetFieldInfo (string encodedMember)
 		{
-			return GetOrCreate (ref StaticFields, 3).GetOrAdd (encodedMember, static (member, fields) => {
+			return StaticFields.GetOrAdd (encodedMember, static (member, fields) => {
 				string field, signature;
 				JniPeerMembers.GetNameAndSignature (member, out field, out signature);
 				return fields.Members.JniPeerType.GetStaticField (field, signature);
@@ -28,7 +30,7 @@ namespace Java.Interop
 
 		internal void Dispose ()
 		{
-			Clear (ref StaticFields);
+			Clear (ref staticFields);
 		}
 	}}
 }

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Java.Interop
 {
@@ -15,11 +16,11 @@ namespace Java.Interop
 
 		readonly JniPeerMembers                             Members;
 
-		readonly ConcurrentDictionary<string, JniFieldInfo> StaticFields = new ConcurrentDictionary<string, JniFieldInfo> (1, 3, StringComparer.Ordinal);
+		ConcurrentDictionary<string, JniFieldInfo>? StaticFields;
 
 		public JniFieldInfo GetFieldInfo (string encodedMember)
 		{
-			return StaticFields.GetOrAdd (encodedMember, static (member, fields) => {
+			return GetStaticFields ().GetOrAdd (encodedMember, static (member, fields) => {
 				string field, signature;
 				JniPeerMembers.GetNameAndSignature (member, out field, out signature);
 				return fields.Members.JniPeerType.GetStaticField (field, signature);
@@ -28,7 +29,17 @@ namespace Java.Interop
 
 		internal void Dispose ()
 		{
-			StaticFields.Clear ();
+			Interlocked.Exchange (ref StaticFields, null)?.Clear ();
+		}
+
+		ConcurrentDictionary<string, JniFieldInfo> GetStaticFields ()
+		{
+			var fields = Volatile.Read (ref StaticFields);
+			if (fields != null)
+				return fields;
+
+			var candidate = new ConcurrentDictionary<string, JniFieldInfo> (1, 3, StringComparer.Ordinal);
+			return Interlocked.CompareExchange (ref StaticFields, candidate, null) ?? candidate;
 		}
 	}}
 }

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Java.Interop
 {
@@ -15,20 +16,30 @@ namespace Java.Interop
 
 		internal    readonly    JniPeerMembers              Members;
 
-		readonly ConcurrentDictionary<string, JniMethodInfo> StaticMethods = new ConcurrentDictionary<string, JniMethodInfo> (1, 3, StringComparer.Ordinal);
+		ConcurrentDictionary<string, JniMethodInfo>? StaticMethods;
 
 		internal void Dispose ()
 		{
-			StaticMethods.Clear ();
+			Interlocked.Exchange (ref StaticMethods, null)?.Clear ();
 		}
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)
 		{
-			return StaticMethods.GetOrAdd (encodedMember, static (member, methods) => {
+			return GetStaticMethods ().GetOrAdd (encodedMember, static (member, methods) => {
 				string method, signature;
 				JniPeerMembers.GetNameAndSignature (member, out method, out signature);
 				return methods.GetMethodInfo (method, signature);
 			}, this);
+		}
+
+		ConcurrentDictionary<string, JniMethodInfo> GetStaticMethods ()
+		{
+			var methods = Volatile.Read (ref StaticMethods);
+			if (methods != null)
+				return methods;
+
+			var candidate = new ConcurrentDictionary<string, JniMethodInfo> (1, 3, StringComparer.Ordinal);
+			return Interlocked.CompareExchange (ref StaticMethods, candidate, null) ?? candidate;
 		}
 
 		JniMethodInfo GetMethodInfo (string method, string signature)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Threading;
 
 namespace Java.Interop
 {
@@ -20,7 +19,7 @@ namespace Java.Interop
 
 		internal void Dispose ()
 		{
-			Interlocked.Exchange (ref StaticMethods, null)?.Clear ();
+			Clear (ref StaticMethods);
 		}
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
@@ -15,16 +15,18 @@ namespace Java.Interop
 
 		internal    readonly    JniPeerMembers              Members;
 
-		ConcurrentDictionary<string, JniMethodInfo>? StaticMethods;
+		ConcurrentDictionary<string, JniMethodInfo>? staticMethods;
+
+		ConcurrentDictionary<string, JniMethodInfo> StaticMethods => GetOrCreate (ref staticMethods, 3);
 
 		internal void Dispose ()
 		{
-			Clear (ref StaticMethods);
+			Clear (ref staticMethods);
 		}
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)
 		{
-			return GetOrCreate (ref StaticMethods, 3).GetOrAdd (encodedMember, static (member, methods) => {
+			return StaticMethods.GetOrAdd (encodedMember, static (member, methods) => {
 				string method, signature;
 				JniPeerMembers.GetNameAndSignature (member, out method, out signature);
 				return methods.GetMethodInfo (method, signature);

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
@@ -25,21 +25,11 @@ namespace Java.Interop
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)
 		{
-			return GetStaticMethods ().GetOrAdd (encodedMember, static (member, methods) => {
+			return GetOrCreate (ref StaticMethods, 3).GetOrAdd (encodedMember, static (member, methods) => {
 				string method, signature;
 				JniPeerMembers.GetNameAndSignature (member, out method, out signature);
 				return methods.GetMethodInfo (method, signature);
 			}, this);
-		}
-
-		ConcurrentDictionary<string, JniMethodInfo> GetStaticMethods ()
-		{
-			var methods = Volatile.Read (ref StaticMethods);
-			if (methods != null)
-				return methods;
-
-			var candidate = new ConcurrentDictionary<string, JniMethodInfo> (1, 3, StringComparer.Ordinal);
-			return Interlocked.CompareExchange (ref StaticMethods, candidate, null) ?? candidate;
 		}
 
 		JniMethodInfo GetMethodInfo (string method, string signature)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.cs
@@ -1,9 +1,11 @@
 ﻿#nullable enable
 
 using System;
-using System.Diagnostics;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
+using System.Threading;
 
 namespace Java.Interop {
 
@@ -106,6 +108,17 @@ namespace Java.Interop {
 			if (value == null)
 				throw new ObjectDisposedException (nameof (JniPeerMembers));
 			return value;
+		}
+
+		static ConcurrentDictionary<TKey, TValue> GetOrCreate<TKey, TValue> (ref ConcurrentDictionary<TKey, TValue>? dictionary, int capacity)
+			where TKey : notnull
+		{
+			var value = Volatile.Read (ref dictionary);
+			if (value != null)
+				return value;
+
+			var candidate = new ConcurrentDictionary<TKey, TValue> (1, capacity);
+			return Interlocked.CompareExchange (ref dictionary, candidate, null) ?? candidate;
 		}
 
 		protected virtual void Dispose (bool disposing)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.cs
@@ -121,10 +121,17 @@ namespace Java.Interop {
 			return Interlocked.CompareExchange (ref dictionary, candidate, null) ?? candidate;
 		}
 
-		static void Clear<TKey, TValue> (ref ConcurrentDictionary<TKey, TValue>? dictionary)
+		static void Clear<TKey, TValue> (ref ConcurrentDictionary<TKey, TValue>? dictionary, Action<TValue>? dispose = null)
 			where TKey : notnull
 		{
-			Interlocked.Exchange (ref dictionary, null)?.Clear ();
+			var values = Interlocked.Exchange (ref dictionary, null);
+			if (values == null)
+				return;
+			if (dispose != null) {
+				foreach (var value in values.Values)
+					dispose (value);
+			}
+			values.Clear ();
 		}
 
 		protected virtual void Dispose (bool disposing)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.cs
@@ -121,6 +121,12 @@ namespace Java.Interop {
 			return Interlocked.CompareExchange (ref dictionary, candidate, null) ?? candidate;
 		}
 
+		static void Clear<TKey, TValue> (ref ConcurrentDictionary<TKey, TValue>? dictionary)
+			where TKey : notnull
+		{
+			Interlocked.Exchange (ref dictionary, null)?.Clear ();
+		}
+
 		protected virtual void Dispose (bool disposing)
 		{
 			if (!disposing || jniPeerType == null)

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Threading.Tasks;
 
 using Java.Interop;
 using NUnit.Framework;
@@ -21,13 +22,33 @@ namespace Java.InteropTests
 		[Category ("TrimmableTypeMapUnsupported")]
 		public void VirtualInvokeOnBaseInvokesMostDerivedJavaMethod ()
 		{
-			var registered  = GetInstanceMethods (MyString._members.InstanceMethods);
-			Assert.AreEqual (0, registered.Count);
+			Assert.IsNull (GetInstanceMethods (MyString._members.InstanceMethods));
 			using (var s = new MyString ("hello!")) {
+				var registered = GetInstanceMethods (MyString._members.InstanceMethods);
 				Assert.AreEqual (1, registered.Count);  // for the constructor
 				Assert.AreEqual ("hello!", s.ToString ());
 				Assert.AreEqual (1, registered.Count);
 			}
+		}
+
+		[Test]
+		[Category ("TrimmableTypeMapUnsupported")]
+		public void ConcurrentFirstUsePublishesSingleInstanceMethodCache ()
+		{
+			var members = new JniPeerMembers (MyString.JniTypeName, typeof (MyString));
+			var methods = members.InstanceMethods;
+			var constructors = new JniMethodInfo [16];
+
+			Assert.IsNull (GetInstanceMethods (methods));
+			Parallel.For (0, constructors.Length, i => constructors [i] = methods.GetConstructor ("()V"));
+
+			var registered = GetInstanceMethods (methods);
+			Assert.AreEqual (1, registered.Count);
+			foreach (var constructor in constructors)
+				Assert.AreSame (constructors [0], constructor);
+			Assert.AreSame (registered ["()V"], constructors [0]);
+
+			JniPeerMembers.Dispose (members);
 		}
 
 		static ConcurrentDictionary<string, JniMethodInfo> GetInstanceMethods (JniPeerMembers.JniInstanceMethods methods)

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
@@ -118,31 +118,31 @@ namespace Java.InteropTests
 
 		static ConcurrentDictionary<string, JniFieldInfo> GetInstanceFields (JniPeerMembers.JniInstanceFields fields)
 		{
-			var field = typeof (JniPeerMembers.JniInstanceFields).GetField ("InstanceFields", BindingFlags.NonPublic | BindingFlags.Instance);
+			var field = typeof (JniPeerMembers.JniInstanceFields).GetField ("instanceFields", BindingFlags.NonPublic | BindingFlags.Instance);
 			return GetCache<string, JniFieldInfo> (field, fields);
 		}
 
 		static ConcurrentDictionary<string, JniMethodInfo> GetInstanceMethods (JniPeerMembers.JniInstanceMethods methods)
 		{
-			var field = typeof (JniPeerMembers.JniInstanceMethods).GetField ("InstanceMethods", BindingFlags.NonPublic | BindingFlags.Instance);
+			var field = typeof (JniPeerMembers.JniInstanceMethods).GetField ("instanceMethods", BindingFlags.NonPublic | BindingFlags.Instance);
 			return GetCache<string, JniMethodInfo> (field, methods);
 		}
 
 		static ConcurrentDictionary<Type, JniPeerMembers.JniInstanceMethods> GetSubclassConstructors (JniPeerMembers.JniInstanceMethods methods)
 		{
-			var field = typeof (JniPeerMembers.JniInstanceMethods).GetField ("SubclassConstructors", BindingFlags.NonPublic | BindingFlags.Instance);
+			var field = typeof (JniPeerMembers.JniInstanceMethods).GetField ("subclassConstructors", BindingFlags.NonPublic | BindingFlags.Instance);
 			return GetCache<Type, JniPeerMembers.JniInstanceMethods> (field, methods);
 		}
 
 		static ConcurrentDictionary<string, JniFieldInfo> GetStaticFields (JniPeerMembers.JniStaticFields fields)
 		{
-			var field = typeof (JniPeerMembers.JniStaticFields).GetField ("StaticFields", BindingFlags.NonPublic | BindingFlags.Instance);
+			var field = typeof (JniPeerMembers.JniStaticFields).GetField ("staticFields", BindingFlags.NonPublic | BindingFlags.Instance);
 			return GetCache<string, JniFieldInfo> (field, fields);
 		}
 
 		static ConcurrentDictionary<string, JniMethodInfo> GetStaticMethods (JniPeerMembers.JniStaticMethods methods)
 		{
-			var field = typeof (JniPeerMembers.JniStaticMethods).GetField ("StaticMethods", BindingFlags.NonPublic | BindingFlags.Instance);
+			var field = typeof (JniPeerMembers.JniStaticMethods).GetField ("staticMethods", BindingFlags.NonPublic | BindingFlags.Instance);
 			return GetCache<string, JniMethodInfo> (field, methods);
 		}
 

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
@@ -36,75 +36,90 @@ namespace Java.InteropTests
 		public void ConcurrentFirstUsePublishesSingleInstanceMethodCache ()
 		{
 			var members = new JniPeerMembers (MyString.JniTypeName, typeof (MyString));
-			var methods = members.InstanceMethods;
-			var constructors = new JniMethodInfo [16];
+			try {
+				var methods = members.InstanceMethods;
+				var constructors = new JniMethodInfo [16];
 
-			Assert.IsNull (GetInstanceMethods (methods));
-			Parallel.For (0, constructors.Length, i => constructors [i] = methods.GetConstructor ("()V"));
+				Assert.IsNull (GetInstanceMethods (methods));
+				Parallel.For (0, constructors.Length, i => constructors [i] = methods.GetConstructor ("()V"));
 
-			var registered = GetInstanceMethods (methods);
-			Assert.AreEqual (1, registered.Count);
-			foreach (var constructor in constructors)
-				Assert.AreSame (constructors [0], constructor);
-			Assert.AreSame (registered ["()V"], constructors [0]);
-
-			JniPeerMembers.Dispose (members);
+				var registered = GetInstanceMethods (methods);
+				Assert.AreEqual (1, registered.Count);
+				foreach (var constructor in constructors)
+					Assert.AreSame (constructors [0], constructor);
+				Assert.AreSame (registered ["()V"], constructors [0]);
+			} finally {
+				JniPeerMembers.Dispose (members);
+			}
 		}
 
 		[Test]
 		public void PeerMemberCachesAreInitiallyNull ()
 		{
 			var members = new JniPeerMembers (CallVirtualFromConstructorBase.JniTypeName, typeof (CallVirtualFromConstructorBase));
-
-			Assert.IsNull (GetInstanceFields (members.InstanceFields));
-			Assert.IsNull (GetInstanceMethods (members.InstanceMethods));
-			Assert.IsNull (GetSubclassConstructors (members.InstanceMethods));
-			Assert.IsNull (GetStaticFields (members.StaticFields));
-			Assert.IsNull (GetStaticMethods (members.StaticMethods));
+			try {
+				Assert.IsNull (GetInstanceFields (members.InstanceFields));
+				Assert.IsNull (GetInstanceMethods (members.InstanceMethods));
+				Assert.IsNull (GetSubclassConstructors (members.InstanceMethods));
+				Assert.IsNull (GetStaticFields (members.StaticFields));
+				Assert.IsNull (GetStaticMethods (members.StaticMethods));
+			} finally {
+				JniPeerMembers.Dispose (members);
+			}
 		}
 
 		[Test]
 		public void ConstructorTypeCacheIsAllocatedOnlyForManagedSubclasses ()
 		{
 			var members = new JniPeerMembers (CallVirtualFromConstructorBase.JniTypeName, typeof (CallVirtualFromConstructorBase));
-			var methods = members.InstanceMethods;
+			try {
+				var methods = members.InstanceMethods;
 
-			Assert.AreSame (methods, methods.GetConstructorsForType (typeof (CallVirtualFromConstructorBase)));
-			Assert.IsNull (GetSubclassConstructors (methods));
+				Assert.AreSame (methods, methods.GetConstructorsForType (typeof (CallVirtualFromConstructorBase)));
+				Assert.IsNull (GetSubclassConstructors (methods));
 
-			var derivedMethods = methods.GetConstructorsForType (typeof (CallVirtualFromConstructorDerived));
-			var constructors = GetSubclassConstructors (methods);
-			Assert.AreEqual (1, constructors.Count);
-			Assert.AreSame (derivedMethods, constructors [typeof (CallVirtualFromConstructorDerived)]);
+				var derivedMethods = methods.GetConstructorsForType (typeof (CallVirtualFromConstructorDerived));
+				var constructors = GetSubclassConstructors (methods);
+				Assert.AreEqual (1, constructors.Count);
+				Assert.AreSame (derivedMethods, constructors [typeof (CallVirtualFromConstructorDerived)]);
 
-			methods.Dispose ();
-			Assert.IsNull (GetSubclassConstructors (methods));
-			Assert.Throws<InvalidOperationException> (() => {
-				var type = derivedMethods.JniPeerType;
-			});
+				methods.Dispose ();
+				Assert.IsNull (GetSubclassConstructors (methods));
+				Assert.Throws<InvalidOperationException> (() => {
+					var type = derivedMethods.JniPeerType;
+				});
+			} finally {
+				JniPeerMembers.Dispose (members);
+			}
 		}
 
 		[Test]
 		public void ConcurrentFirstUsePublishesSingleFieldAndStaticMethodCaches ()
 		{
 			var instanceMembers = new JniPeerMembers (CallNonvirtualBase.JniTypeName, typeof (CallNonvirtualBase));
-			var instanceFields = new JniFieldInfo [16];
-			Assert.IsNull (GetInstanceFields (instanceMembers.InstanceFields));
-			Parallel.For (0, instanceFields.Length, i => instanceFields [i] = instanceMembers.InstanceFields.GetFieldInfo ("methodInvoked.Z"));
-			AssertSingleCachedValue (GetInstanceFields (instanceMembers.InstanceFields), "methodInvoked.Z", instanceFields);
-			JniPeerMembers.Dispose (instanceMembers);
+			try {
+				var instanceFields = new JniFieldInfo [16];
+				Assert.IsNull (GetInstanceFields (instanceMembers.InstanceFields));
+				Parallel.For (0, instanceFields.Length, i => instanceFields [i] = instanceMembers.InstanceFields.GetFieldInfo ("methodInvoked.Z"));
+				AssertSingleCachedValue (GetInstanceFields (instanceMembers.InstanceFields), "methodInvoked.Z", instanceFields);
+			} finally {
+				JniPeerMembers.Dispose (instanceMembers);
+			}
 
 			var staticMembers = new JniPeerMembers (JavaLangSystemTestObject.JniTypeName, typeof (JavaLangSystemTestObject));
-			var staticFields = new JniFieldInfo [16];
-			Assert.IsNull (GetStaticFields (staticMembers.StaticFields));
-			Parallel.For (0, staticFields.Length, i => staticFields [i] = staticMembers.StaticFields.GetFieldInfo ("in.Ljava/io/InputStream;"));
-			AssertSingleCachedValue (GetStaticFields (staticMembers.StaticFields), "in.Ljava/io/InputStream;", staticFields);
+			try {
+				var staticFields = new JniFieldInfo [16];
+				Assert.IsNull (GetStaticFields (staticMembers.StaticFields));
+				Parallel.For (0, staticFields.Length, i => staticFields [i] = staticMembers.StaticFields.GetFieldInfo ("in.Ljava/io/InputStream;"));
+				AssertSingleCachedValue (GetStaticFields (staticMembers.StaticFields), "in.Ljava/io/InputStream;", staticFields);
 
-			var staticMethods = new JniMethodInfo [16];
-			Assert.IsNull (GetStaticMethods (staticMembers.StaticMethods));
-			Parallel.For (0, staticMethods.Length, i => staticMethods [i] = staticMembers.StaticMethods.GetMethodInfo ("currentTimeMillis.()J"));
-			AssertSingleCachedValue (GetStaticMethods (staticMembers.StaticMethods), "currentTimeMillis.()J", staticMethods);
-			JniPeerMembers.Dispose (staticMembers);
+				var staticMethods = new JniMethodInfo [16];
+				Assert.IsNull (GetStaticMethods (staticMembers.StaticMethods));
+				Parallel.For (0, staticMethods.Length, i => staticMethods [i] = staticMembers.StaticMethods.GetMethodInfo ("currentTimeMillis.()J"));
+				AssertSingleCachedValue (GetStaticMethods (staticMembers.StaticMethods), "currentTimeMillis.()J", staticMethods);
+			} finally {
+				JniPeerMembers.Dispose (staticMembers);
+			}
 		}
 
 		static void AssertSingleCachedValue<T> (ConcurrentDictionary<string, T> cache, string key, T [] values)

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
@@ -56,7 +56,7 @@ namespace Java.InteropTests
 		[Test]
 		public void PeerMemberCachesAreInitiallyNull ()
 		{
-			var members = new JniPeerMembers (CallVirtualFromConstructorBase.JniTypeName, typeof (CallVirtualFromConstructorBase));
+			var members = new JniPeerMembers (CallNonvirtualBase.JniTypeName, typeof (CallNonvirtualBase));
 			try {
 				Assert.IsNull (GetInstanceFields (members.InstanceFields));
 				Assert.IsNull (GetInstanceMethods (members.InstanceMethods));
@@ -71,17 +71,17 @@ namespace Java.InteropTests
 		[Test]
 		public void ConstructorTypeCacheIsAllocatedOnlyForManagedSubclasses ()
 		{
-			var members = new JniPeerMembers (CallVirtualFromConstructorBase.JniTypeName, typeof (CallVirtualFromConstructorBase));
+			var members = new JniPeerMembers (CallNonvirtualBase.JniTypeName, typeof (CallNonvirtualBase));
 			try {
 				var methods = members.InstanceMethods;
 
-				Assert.AreSame (methods, methods.GetConstructorsForType (typeof (CallVirtualFromConstructorBase)));
+				Assert.AreSame (methods, methods.GetConstructorsForType (typeof (CallNonvirtualBase)));
 				Assert.IsNull (GetSubclassConstructors (methods));
 
-				var derivedMethods = methods.GetConstructorsForType (typeof (CallVirtualFromConstructorDerived));
+				var derivedMethods = methods.GetConstructorsForType (typeof (CallNonvirtualDerived));
 				var constructors = GetSubclassConstructors (methods);
 				Assert.AreEqual (1, constructors.Count);
-				Assert.AreSame (derivedMethods, constructors [typeof (CallVirtualFromConstructorDerived)]);
+				Assert.AreSame (derivedMethods, constructors [typeof (CallNonvirtualDerived)]);
 
 				methods.Dispose ();
 				Assert.IsNull (GetSubclassConstructors (methods));

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
@@ -78,6 +78,10 @@ namespace Java.InteropTests
 			Assert.AreSame (derivedMethods, constructors [typeof (CallVirtualFromConstructorDerived)]);
 
 			methods.Dispose ();
+			Assert.IsNull (GetSubclassConstructors (methods));
+			Assert.Throws<InvalidOperationException> (() => {
+				var type = derivedMethods.JniPeerType;
+			});
 		}
 
 		[Test]

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
@@ -51,10 +51,100 @@ namespace Java.InteropTests
 			JniPeerMembers.Dispose (members);
 		}
 
+		[Test]
+		public void PeerMemberCachesAreInitiallyNull ()
+		{
+			var members = new JniPeerMembers (CallVirtualFromConstructorBase.JniTypeName, typeof (CallVirtualFromConstructorBase));
+
+			Assert.IsNull (GetInstanceFields (members.InstanceFields));
+			Assert.IsNull (GetInstanceMethods (members.InstanceMethods));
+			Assert.IsNull (GetSubclassConstructors (members.InstanceMethods));
+			Assert.IsNull (GetStaticFields (members.StaticFields));
+			Assert.IsNull (GetStaticMethods (members.StaticMethods));
+		}
+
+		[Test]
+		public void ConstructorTypeCacheIsAllocatedOnlyForManagedSubclasses ()
+		{
+			var members = new JniPeerMembers (CallVirtualFromConstructorBase.JniTypeName, typeof (CallVirtualFromConstructorBase));
+			var methods = members.InstanceMethods;
+
+			Assert.AreSame (methods, methods.GetConstructorsForType (typeof (CallVirtualFromConstructorBase)));
+			Assert.IsNull (GetSubclassConstructors (methods));
+
+			var derivedMethods = methods.GetConstructorsForType (typeof (CallVirtualFromConstructorDerived));
+			var constructors = GetSubclassConstructors (methods);
+			Assert.AreEqual (1, constructors.Count);
+			Assert.AreSame (derivedMethods, constructors [typeof (CallVirtualFromConstructorDerived)]);
+
+			methods.Dispose ();
+		}
+
+		[Test]
+		public void ConcurrentFirstUsePublishesSingleFieldAndStaticMethodCaches ()
+		{
+			var instanceMembers = new JniPeerMembers (CallNonvirtualBase.JniTypeName, typeof (CallNonvirtualBase));
+			var instanceFields = new JniFieldInfo [16];
+			Assert.IsNull (GetInstanceFields (instanceMembers.InstanceFields));
+			Parallel.For (0, instanceFields.Length, i => instanceFields [i] = instanceMembers.InstanceFields.GetFieldInfo ("methodInvoked.Z"));
+			AssertSingleCachedValue (GetInstanceFields (instanceMembers.InstanceFields), "methodInvoked.Z", instanceFields);
+			JniPeerMembers.Dispose (instanceMembers);
+
+			var staticMembers = new JniPeerMembers (JavaLangSystemTestObject.JniTypeName, typeof (JavaLangSystemTestObject));
+			var staticFields = new JniFieldInfo [16];
+			Assert.IsNull (GetStaticFields (staticMembers.StaticFields));
+			Parallel.For (0, staticFields.Length, i => staticFields [i] = staticMembers.StaticFields.GetFieldInfo ("in.Ljava/io/InputStream;"));
+			AssertSingleCachedValue (GetStaticFields (staticMembers.StaticFields), "in.Ljava/io/InputStream;", staticFields);
+
+			var staticMethods = new JniMethodInfo [16];
+			Assert.IsNull (GetStaticMethods (staticMembers.StaticMethods));
+			Parallel.For (0, staticMethods.Length, i => staticMethods [i] = staticMembers.StaticMethods.GetMethodInfo ("currentTimeMillis.()J"));
+			AssertSingleCachedValue (GetStaticMethods (staticMembers.StaticMethods), "currentTimeMillis.()J", staticMethods);
+			JniPeerMembers.Dispose (staticMembers);
+		}
+
+		static void AssertSingleCachedValue<T> (ConcurrentDictionary<string, T> cache, string key, T [] values)
+			where T : class
+		{
+			Assert.AreEqual (1, cache.Count);
+			foreach (var value in values)
+				Assert.AreSame (values [0], value);
+			Assert.AreSame (cache [key], values [0]);
+		}
+
+		static ConcurrentDictionary<string, JniFieldInfo> GetInstanceFields (JniPeerMembers.JniInstanceFields fields)
+		{
+			var field = typeof (JniPeerMembers.JniInstanceFields).GetField ("InstanceFields", BindingFlags.NonPublic | BindingFlags.Instance);
+			return GetCache<string, JniFieldInfo> (field, fields);
+		}
+
 		static ConcurrentDictionary<string, JniMethodInfo> GetInstanceMethods (JniPeerMembers.JniInstanceMethods methods)
 		{
-			var f   = typeof (JniPeerMembers.JniInstanceMethods).GetField ("InstanceMethods", BindingFlags.NonPublic | BindingFlags.Instance);
-			return (ConcurrentDictionary<string, JniMethodInfo>) f.GetValue (methods);
+			var field = typeof (JniPeerMembers.JniInstanceMethods).GetField ("InstanceMethods", BindingFlags.NonPublic | BindingFlags.Instance);
+			return GetCache<string, JniMethodInfo> (field, methods);
+		}
+
+		static ConcurrentDictionary<Type, JniPeerMembers.JniInstanceMethods> GetSubclassConstructors (JniPeerMembers.JniInstanceMethods methods)
+		{
+			var field = typeof (JniPeerMembers.JniInstanceMethods).GetField ("SubclassConstructors", BindingFlags.NonPublic | BindingFlags.Instance);
+			return GetCache<Type, JniPeerMembers.JniInstanceMethods> (field, methods);
+		}
+
+		static ConcurrentDictionary<string, JniFieldInfo> GetStaticFields (JniPeerMembers.JniStaticFields fields)
+		{
+			var field = typeof (JniPeerMembers.JniStaticFields).GetField ("StaticFields", BindingFlags.NonPublic | BindingFlags.Instance);
+			return GetCache<string, JniFieldInfo> (field, fields);
+		}
+
+		static ConcurrentDictionary<string, JniMethodInfo> GetStaticMethods (JniPeerMembers.JniStaticMethods methods)
+		{
+			var field = typeof (JniPeerMembers.JniStaticMethods).GetField ("StaticMethods", BindingFlags.NonPublic | BindingFlags.Instance);
+			return GetCache<string, JniMethodInfo> (field, methods);
+		}
+
+		static ConcurrentDictionary<TKey, TValue> GetCache<TKey, TValue> (FieldInfo field, object owner)
+		{
+			return (ConcurrentDictionary<TKey, TValue>) field.GetValue (owner);
 		}
 
 		[Test]
@@ -187,6 +277,11 @@ namespace Java.InteropTests
 			var s = IAndroidInterface.getClassName ();
 			Assert.AreEqual ("DesugarAndroidInterface$-CC", s);
 		}
+	}
+
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
+	abstract class JavaLangSystemTestObject : JavaObject {
+		internal const string JniTypeName = "java/lang/System";
 	}
 
 	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]


### PR DESCRIPTION
## Summary

- allocate instance/static method and field caches only on first use
- allocate the managed-subclass constructor cache only when a derived constructor path is needed
- share lock-free cache publication through a generic `GetOrCreate<TKey, TValue>()` helper
- atomically detach and clear allocated caches during disposal
- cover deferred allocation and concurrent first use

## Analysis

Across Mono.Android for API 37, the types in our bindings have the following numbers of methods and fields:

Category | 0 | 1 | 2–4 | >4 | Mean
-- | -- | -- | -- | -- | --
Instance methods + constructors | 5.9% | 15.2% | 31.9% | 47.1% | 8.09
Instance fields | 95.5% | 1.2% | 2.2% | 1.1% | 0.18
Static methods | 82.6% | 5.4% | 7.8% | 4.2% | 0.95
Static fields | 81.6% | 13.6% | 3.1% | 1.7% | 0.61

This means that for most types, we should not be allocating a heavy `ConcurrentDictionary` for instance fields, static methods, and static fields. It's also possible that for some binding types we won't call even a single of their methods even though their static constructor runs. It makes sense to reduce allocations and reduce gc pressure here.

## Results

A Release trimmed CoreCLR arm64 app created from `dotnet new maui --sample-content` was measured through first window focus on a Samsung A16.

Current `main` eagerly allocates approximately 1,347 peer cache dictionaries (~274 KiB at the measured 208 B per empty dictionary). With this change, first launch allocated 273 dictionaries (~55 KiB), avoiding about 1,074 dictionary allocations / **218 KiB gross managed allocation**.

Repeated process-cold launches allocated 271–273 dictionaries (average 272):

| Cache | Current `main` (eager) | This PR (lazy) |
|---|---:|---:|
| Instance methods | 265–267 | 198–199 |
| Subclass constructors | 265–267 | 33 |
| Instance fields | 264–266 | 10 |
| Static methods | 264–266 | 22 |
| Static fields | 264–266 | 8–9 |
| **Total** | **1,322–1,332** | **271–273** |

The eager counts differ by one because one managed-subclass constructor path creates an additional `JniInstanceMethods` helper; only primary `JniPeerMembers` instances own the field/static caches.

The earlier instance-method-only version avoided about 67 dictionaries (~14 KiB); most savings come from deferring the other four caches.

### Startup timing

A final all-cache A/B used 64 paired process-cold launches in four package-ID crossover blocks on the Samsung A16 (Release trimmed CoreCLR arm64, speed-compiled packages, animations disabled, alternating order, 27.6–28.0 °C):

| Variant | Mean | Median |
|---|---:|---:|
| Current `main` (`47eabaf`) | 2,232.13 ms | 2,220.5 ms |
| This PR | 2,220.58 ms | 2,212.5 ms |

The paired delta was **−11.55 ms (−0.52%)**, favoring this PR, but was not statistically significant: 95% t interval **[−28.06, +4.97] ms**, bootstrap interval **[−27.98, +4.16] ms**, with 36/64 wins and one tie.

The honest conclusion is **no measurable startup regression or improvement**. Reduced managed allocation and retained heap are the demonstrated benefits.

Concurrent `Dispose()` and cache access remains unsupported, as before. `Interlocked.Exchange()` atomically detaches each cache visible to disposal but is not a disposed-state guard for stale references.

## Retained startup heap

Two startup GC dumps per revision were collected after first window focus from the same Release trimmed CoreCLR arm64 `dotnet new maui --sample-content` app on Samsung A16. `dotnet-gcdump collect` induced a Gen2 GC, so values are live retained objects.

| Run | Current main | This PR | Delta |
|---|---:|---:|---:|
| Clean first launch | 4,568,463 B / 65,446 objects | 4,390,711 B / 61,096 objects | -177,752 B / -4,350 objects |
| Process-cold repeat | 4,487,244 B / 64,667 objects | 4,312,748 B / 60,382 objects | -174,496 B / -4,285 objects |
| **Mean** | **4,527,854 B / 65,057 objects** | **4,351,730 B / 60,739 objects** | **-176,124 B (-3.89%) / -4,318 (-6.64%)** |

The targeted cache dictionary counts were 1,141/1,126 on current main versus 276/274 with this PR, avoiding 865/852 retained dictionaries. The entire retained `ConcurrentDictionary` delta is exactly these Java.Interop caches.

Useful cache contents were unchanged: `JniMethodInfo` counts were 818/815 for both revisions, `JniFieldInfo` was 36 for both, and method, field, and subclass node counts were unchanged. The dumps show removal of empty containers only.

## Tests

- Java.Interop Debug build: 0 warnings, 0 errors
- focused `JniPeerMembersTests`: 12 passed, 1 skipped
- full `Java.Interop-Tests`: 711 passed, 6 skipped, 0 failed