### PR TITLE
[flaky-ci] Pin test slicer to repo-local runtime

### DIFF
--- a/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
@@ -7,6 +7,7 @@ parameters:
   condition: succeeded()  # Condition to run tests
 
 steps:
+# The tool apphost does not locate its runtime from PATH, so use the SDK installed during test setup.
 - ${{if parameters.testFilter}}:
   - pwsh: >-
       $(Agent.ToolsDirectory)/dotnet-test-slicer slice
@@ -18,6 +19,8 @@ steps:
     displayName: Slice unit tests with filter
     failOnStderr: true
     condition: ${{ parameters.condition }}
+    env:
+      DOTNET_ROOT: ${{ parameters.xaSourcePath }}/bin/$(XA.Build.Configuration)/dotnet
 - ${{ else }}:
   - pwsh: >-
       $(Agent.ToolsDirectory)/dotnet-test-slicer slice
@@ -28,6 +31,8 @@ steps:
     displayName: Slice unit tests
     failOnStderr: true
     condition: ${{ parameters.condition }}
+    env:
+      DOTNET_ROOT: ${{ parameters.xaSourcePath }}/bin/$(XA.Build.Configuration)/dotnet
 
 - ${{ if eq(parameters.retryFailedTests, 'false') }}:
   # If we aren't using auto-retry logic, then this is just a simple template call
@@ -63,6 +68,8 @@ steps:
     displayName: Look for failed tests
     workingDirectory: ${{ parameters.xaSourcePath }}
     condition: ${{ parameters.condition }}
+    env:
+      DOTNET_ROOT: ${{ parameters.xaSourcePath }}/bin/$(XA.Build.Configuration)/dotnet
 
     # dotnet-test-slicer removed the failed tests from our results file, so it's safe to publish it now
   - task: PublishTestResults@2

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -66,6 +66,7 @@ stages:
         testAssembly: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
         testFilter: $(ExcludedNightlyNUnitCategories)
         testRunTitle: MSBuildDeviceIntegration On Device - macOS
+        xaSourcePath: ${{ parameters.xaSourcePath }}
 
     - ${{ if ne(parameters.usesCleanImages, true) }}:
       - template: start-stop-emulator.yaml


### PR DESCRIPTION
## Why

Hosted macOS builds [1574631](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1574631) and [1574989](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1574989) installed `dotnet-test-slicer` successfully, then failed before running tests because its native apphost could not locate .NET. The tool was invoked by absolute path, so adding its directory to `PATH` did not help runtime discovery; both `DOTNET_ROOT_X64` and `DOTNET_ROOT` were unset.

The pinned slicer package targets `net8.0` with `rollForward: LatestMajor`, while test setup already installs the repository-pinned compatible SDK under `bin/$(XA.Build.Configuration)/dotnet`.

Tracked by https://github.com/dotnet/android/issues/12704.

## What changed

- Set `DOTNET_ROOT` to the repo-local SDK for every initial and retry slicer invocation.
- Forward `xaSourcePath` through the emulator-stage template so custom checkout paths resolve the same SDK installed during setup.

## Validation

- Parsed both changed YAML templates and checked parameter substitution for a custom source root.
- Confirmed all three slicer invocations receive the expanded repo-local `DOTNET_ROOT`.
- Launched `dotnet-test-slicer` 0.1.0-alpha7 successfully against a .NET 11-only runtime root, exercising its configured major-version roll-forward.