### PR TITLE
[android-tools] Move SM02729 suppression to reported line

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
@@ -122,7 +122,7 @@ namespace Xamarin.Android.Tools
 				if (string.IsNullOrEmpty (entry.Name))
 					continue;
 
-				var destinationFile = Path.GetFullPath (Path.Combine (fullExtractRoot, entry.FullName));
+				var destinationFile = Path.GetFullPath (Path.Combine (fullExtractRoot, entry.FullName)); // CodeQL [SM02729] IsUnderDirectory canonicalizes both paths and enforces ordinal directory-boundary containment.
 
 				// Zip Slip protection
 				if (!FileUtil.IsUnderDirectory (destinationFile, fullExtractRoot)) {
@@ -133,7 +133,7 @@ namespace Xamarin.Android.Tools
 				if (!string.IsNullOrEmpty (entryDir))
 					Directory.CreateDirectory (entryDir);
 
-				entry.ExtractToFile (destinationFile, overwrite: true); // codeql[SM02729] IsUnderDirectory canonicalizes both paths and enforces ordinal directory-boundary containment.
+				entry.ExtractToFile (destinationFile, overwrite: true);
 			}
 		}
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/DownloadUtils.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Android.Tools
 				if (!string.IsNullOrEmpty (entryDir))
 					Directory.CreateDirectory (entryDir);
 
-				entry.ExtractToFile (destinationFile, overwrite: true); // CodeQL [SM02729] IsUnderDirectory canonicalizes both paths and enforces ordinal directory-boundary containment.
+				entry.ExtractToFile (destinationFile, overwrite: true); // codeql[SM02729] IsUnderDirectory canonicalizes both paths and enforces ordinal directory-boundary containment.
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Move the SM02729 suppression from the extraction call to `entry.FullName`, the line CodeQL reports.
- Keep the existing canonical path-containment check unchanged.

CodeQL associates the suppression with the reported line rather than the downstream extraction call.

## Validation

`DownloadUtilsTests`: 27 passed.