### PR TITLE
[typemap] Reduce generator allocations with modern .NET APIs

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -111,9 +111,12 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)net\Microsoft.Android.Build.BaseTasks.pdb" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)net\Java.Interop.Localization.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)net\Java.Interop.Localization.pdb" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)net\Xamarin.Android.Tools.AndroidSdk.dll" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)net\Xamarin.Android.Tools.AndroidSdk.pdb" />
     <_MSBuildFiles Include="@(_LocalizationLanguages->'$(MicrosoftAndroidSdkOutDir)net\%(Identity)\Microsoft.Android.Build.BaseTasks.resources.dll')" />
     <_MSBuildFiles Include="@(_LocalizationLanguages->'$(MicrosoftAndroidSdkOutDir)net\%(Identity)\Microsoft.Android.Build.Tasks.resources.dll')" />
     <_MSBuildFiles Include="@(_LocalizationLanguages->'$(MicrosoftAndroidSdkOutDir)net\%(Identity)\Java.Interop.Localization.resources.dll')" />
+    <_MSBuildFiles Include="@(_LocalizationLanguages->'$(MicrosoftAndroidSdkOutDir)net\%(Identity)\Xamarin.Android.Tools.AndroidSdk.resources.dll')" />
     <_MSBuildFiles Include="@(_LocalizationLanguages->'$(MicrosoftAndroidSdkOutDir)%(Identity)\Microsoft.Android.Build.BaseTasks.resources.dll')" />
     <_MSBuildFiles Include="@(_LocalizationLanguages->'$(MicrosoftAndroidSdkOutDir)%(Identity)\Xamarin.Android.Build.Tasks.resources.dll')" />
     <_MSBuildFiles Include="@(_LocalizationLanguages->'$(MicrosoftAndroidSdkOutDir)%(Identity)\Xamarin.Android.Tools.AndroidSdk.resources.dll')" />

--- a/src/Microsoft.Android.Build.Tasks/Microsoft.Android.Build.Tasks.csproj
+++ b/src/Microsoft.Android.Build.Tasks/Microsoft.Android.Build.Tasks.csproj
@@ -45,12 +45,14 @@
     <Compile Remove="Tests\**" />
     <ProjectReference Include="..\Microsoft.Android.Build.BaseTasks\Microsoft.Android.Build.BaseTasks.csproj" />
     <ProjectReference Include="..\Microsoft.Android.Sdk.TrimmableTypeMap\Microsoft.Android.Sdk.TrimmableTypeMap.csproj" />
+    <ProjectReference Include="..\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj" />
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Localization\Java.Interop.Localization.csproj" />
     <InternalsVisibleTo Include="Microsoft.Android.Build.Tasks.Tests" Key="0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\Xamarin.Android.Build.Tasks\Utilities\NullableExtensions.cs" Link="Utilities\NullableExtensions.cs" />
+    <Compile Include="..\Xamarin.Android.Build.Tasks\Utilities\ManifestPlaceholderResolver.cs" Link="Utilities\ManifestPlaceholderResolver.cs" />
   </ItemGroup>
 
   <!--

--- a/src/Microsoft.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
+++ b/src/Microsoft.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
@@ -26,14 +26,15 @@
 #nullable enable
 using System;
 using System.IO;
-using System.Linq;
 using System.Xml;
 using Microsoft.Build.Framework;
 using Microsoft.Android.Sdk.TrimmableTypeMap;
 using Xamarin.Android.Tools;
 using Microsoft.Android.Build.Tasks;
+using Xamarin.Android.Tasks;
+using Properties = Xamarin.Android.Tasks.Properties;
 
-namespace Xamarin.Android.Tasks
+namespace Microsoft.Android.Tasks
 {
 	public class GetAndroidPackageName : AndroidTask
 	{
@@ -57,7 +58,7 @@ namespace Xamarin.Android.Tasks
 				if (reader.MoveToContent () == XmlNodeType.Element) {
 					var package = reader.GetAttribute ("package");
 					if (!package.IsNullOrEmpty ()) {
-						PackageName = ManifestDocument.ReplacePlaceholders (ManifestPlaceholders, package);
+						PackageName = ManifestPlaceholderResolver.Replace (ManifestPlaceholders, package);
 					}
 				}
 			}
@@ -72,7 +73,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			if (JavaNameValidator.TryGetInvalidPackageSegment (PackageName, '.', out var invalidIdentifier)) {
-				Log.LogCodedError ("XA4258", Properties.Resources.XA4258, PackageName, invalidIdentifier);
+				Log.LogCodedError ("XA4258", Properties.Resources.XA4258, PackageName, invalidIdentifier.ToString ());
 			}
 
 			Log.LogDebugMessage ($"  PackageName: {PackageName}");

--- a/src/Microsoft.Android.Build.Tasks/Tests/Microsoft.Android.Build.Tasks.Tests/GetAndroidPackageNameTests.cs
+++ b/src/Microsoft.Android.Build.Tasks/Tests/Microsoft.Android.Build.Tasks.Tests/GetAndroidPackageNameTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using NUnit.Framework;
-using Xamarin.Android.Tasks;
+using Microsoft.Android.Tasks;
 
 namespace Xamarin.Android.Build.Tests {
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -27,6 +28,8 @@ enum JniParamKind
 /// </summary>
 static class JniSignatureHelper
 {
+	static readonly SearchValues<char> JavaSourceNameSeparators = SearchValues.Create ("/$");
+
 	/// <summary>
 	/// Parses the parameter types from a JNI method signature like "(Landroid/os/Bundle;)V".
 	/// </summary>
@@ -234,7 +237,11 @@ static class JniSignatureHelper
 	/// </summary>
 	internal static string JniNameToJavaName (string jniName)
 	{
-		return jniName.Replace ('/', '.').Replace ('$', '.');
+		if (jniName.AsSpan ().IndexOfAny (JavaSourceNameSeparators) < 0) {
+			return jniName;
+		}
+		return string.Create (jniName.Length, jniName, static (destination, name) =>
+			name.AsSpan ().ReplaceAny (destination, JavaSourceNameSeparators, '.'));
 	}
 
 	/// <summary>
@@ -259,7 +266,8 @@ static class JniSignatureHelper
 		if (lastSlash < 0) {
 			return null;
 		}
-		return jniName.Substring (0, lastSlash).Replace ('/', '.');
+		return string.Create (lastSlash, jniName, static (destination, name) =>
+			name.AsSpan (0, destination.Length).Replace (destination, '/', '.'));
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/MetadataHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/MetadataHelper.cs
@@ -22,7 +22,7 @@ static class MetadataHelper
 		int byteCount = checked (nameByteCount + contentBytes.Length);
 		byte []? rented = null;
 		Span<byte> input = byteCount <= stackallocThresholdBytes
-			? stackalloc byte [stackallocThresholdBytes]
+			? stackalloc byte [byteCount]
 			: (rented = ArrayPool<byte>.Shared.Rent (byteCount));
 		try {
 			Encoding.UTF8.GetBytes (moduleName.AsSpan (), input [..nameByteCount]);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/MetadataHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/MetadataHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
@@ -16,15 +17,24 @@ static class MetadataHelper
 	/// </summary>
 	public static Guid DeterministicMvid (string moduleName, ReadOnlySpan<byte> contentBytes = default)
 	{
-		using var sha = SHA256.Create ();
-		byte [] nameBytes = Encoding.UTF8.GetBytes (moduleName);
-		byte [] input = new byte [nameBytes.Length + contentBytes.Length];
-		nameBytes.CopyTo (input, 0);
-		contentBytes.CopyTo (input.AsSpan (nameBytes.Length));
-		byte [] hash = sha.ComputeHash (input);
-		byte [] guidBytes = new byte [16];
-		Array.Copy (hash, guidBytes, 16);
-		return new Guid (guidBytes);
+		const int stackallocThresholdBytes = 256;
+		int nameByteCount = Encoding.UTF8.GetByteCount (moduleName);
+		int byteCount = checked (nameByteCount + contentBytes.Length);
+		byte []? rented = null;
+		Span<byte> input = byteCount <= stackallocThresholdBytes
+			? stackalloc byte [stackallocThresholdBytes]
+			: (rented = ArrayPool<byte>.Shared.Rent (byteCount));
+		try {
+			Encoding.UTF8.GetBytes (moduleName.AsSpan (), input [..nameByteCount]);
+			contentBytes.CopyTo (input [nameByteCount..]);
+			Span<byte> hash = stackalloc byte [SHA256.HashSizeInBytes];
+			SHA256.HashData (input [..byteCount], hash);
+			return new Guid (hash [..16]);
+		} finally {
+			if (rented is not null) {
+				ArrayPool<byte>.Shared.Return (rented);
+			}
+		}
 	}
 
 	/// <summary>
@@ -32,7 +42,6 @@ static class MetadataHelper
 	/// </summary>
 	public static byte [] ComputeContentFingerprint (TypeMapAssemblyData data)
 	{
-		using var sha = SHA256.Create ();
 		using var stream = new MemoryStream ();
 		using var writer = new BinaryWriter (stream, Encoding.UTF8);
 		foreach (var entry in data.Entries) {
@@ -66,7 +75,7 @@ static class MetadataHelper
 			writer.Write (assoc.AliasProxyTypeReference);
 		}
 		writer.Flush ();
-		return sha.ComputeHash (stream.GetBuffer (), 0, checked ((int) stream.Length));
+		return SHA256.HashData (stream.GetBuffer ().AsSpan (0, checked ((int) stream.Length)));
 	}
 
 	/// <summary>
@@ -76,7 +85,6 @@ static class MetadataHelper
 	/// </summary>
 	public static byte [] ComputeIncrementalFingerprint (TypeMapAssemblyData data, Version systemRuntimeVersion, bool useSharedTypemapUniverse)
 	{
-		using var sha = SHA256.Create ();
 		using var stream = new MemoryStream ();
 		using var writer = new BinaryWriter (stream, Encoding.UTF8);
 		writer.Write (GeneratorModuleVersionId.ToByteArray ());
@@ -137,7 +145,7 @@ static class MetadataHelper
 			writer.Write (assemblyName);
 		}
 		writer.Flush ();
-		return sha.ComputeHash (stream.GetBuffer (), 0, checked ((int) stream.Length));
+		return SHA256.HashData (stream.GetBuffer ().AsSpan (0, checked ((int) stream.Length)));
 	}
 
 	/// <summary>
@@ -148,7 +156,6 @@ static class MetadataHelper
 		Version systemRuntimeVersion,
 		bool useSharedTypemapUniverse)
 	{
-		using var sha = SHA256.Create ();
 		using var stream = new MemoryStream ();
 		using var writer = new BinaryWriter (stream, Encoding.UTF8);
 		writer.Write (GeneratorModuleVersionId.ToByteArray ());
@@ -159,7 +166,7 @@ static class MetadataHelper
 			writer.Write (assemblyName);
 		}
 		writer.Flush ();
-		return sha.ComputeHash (stream.GetBuffer (), 0, checked ((int) stream.Length));
+		return SHA256.HashData (stream.GetBuffer ().AsSpan (0, checked ((int) stream.Length)));
 	}
 
 	static void WriteTypeRef (this BinaryWriter writer, TypeRefData type)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -1,8 +1,8 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
@@ -15,6 +15,10 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 static class ModelBuilder
 {
 	const string ProxyTypeSuffix = "_Proxy";
+	const string AliasHolderTypeSuffix = "_Aliases";
+
+	static readonly SearchValues<char> ManagedTypeNameSeparators = SearchValues.Create (".+`");
+	static readonly SearchValues<char> JniNameSeparators = SearchValues.Create ("/$");
 
 	static readonly HashSet<string> EssentialRuntimeTypes = new (StringComparer.Ordinal) {
 		"java/lang/Object",
@@ -162,7 +166,7 @@ static class ModelBuilder
 		// Alias group: generate an alias holder and indexed entries for each peer.
 		// The base JNI name maps to the alias holder; each peer gets "[0]", "[1]", etc.
 		var aliasKeys = new List<string> ();
-		string holderTypeName = jniName.Replace ('/', '_').Replace ('$', '_') + "_Aliases";
+		string holderTypeName = JniNameToAliasHolderTypeName (jniName);
 		var holderNamespace = "_TypeMap.Aliases";
 		string holderRef = AssemblyQualify ($"{holderNamespace}.{holderTypeName}", assemblyName);
 
@@ -252,18 +256,18 @@ static class ModelBuilder
 
 	static string ManagedTypeNameToProxyTypeName (string managedTypeName)
 	{
-		var builder = new StringBuilder (managedTypeName.Length + ProxyTypeSuffix.Length);
-		AppendSafeManagedTypeName (builder, managedTypeName);
-		builder.Append (ProxyTypeSuffix);
-		return builder.ToString ();
+		return string.Create (managedTypeName.Length + ProxyTypeSuffix.Length, managedTypeName, static (destination, name) => {
+			name.AsSpan ().ReplaceAny (destination, ManagedTypeNameSeparators, '_');
+			ProxyTypeSuffix.AsSpan ().CopyTo (destination [name.Length..]);
+		});
 	}
 
-	static void AppendSafeManagedTypeName (StringBuilder builder, string managedTypeName)
+	static string JniNameToAliasHolderTypeName (string jniName)
 	{
-		for (int i = 0; i < managedTypeName.Length; i++) {
-			char c = managedTypeName [i];
-			builder.Append (c == '.' || c == '+' || c == '`' ? '_' : c);
-		}
+		return string.Create (jniName.Length + AliasHolderTypeSuffix.Length, jniName, static (destination, name) => {
+			name.AsSpan ().ReplaceAny (destination, JniNameSeparators, '_');
+			AliasHolderTypeSuffix.AsSpan ().CopyTo (destination [name.Length..]);
+		});
 	}
 
 	static JavaPeerProxyData BuildProxyType (JavaPeerInfo peer, string jniName, HashSet<string> usedProxyNames, bool isAcw)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
@@ -33,18 +33,18 @@ internal static class JavaNameValidator
 		"permits", "record", "sealed", "var", "yield",
 	};
 
-	internal static bool IsInvalidIdentifier (string identifier, bool isTypeName) =>
+	internal static bool IsInvalidIdentifier (ReadOnlySpan<char> identifier, bool isTypeName) =>
 		!IsSupportedIdentifier (identifier, isPackageSegment: false) ||
-		JavaKeywords.Contains (identifier) ||
-		isTypeName && RestrictedTypeIdentifiers.Contains (identifier);
+		JavaKeywords.GetAlternateLookup<ReadOnlySpan<char>> ().Contains (identifier) ||
+		isTypeName && RestrictedTypeIdentifiers.GetAlternateLookup<ReadOnlySpan<char>> ().Contains (identifier);
 
-	static bool IsInvalidPackageIdentifier (string identifier) =>
+	static bool IsInvalidPackageIdentifier (ReadOnlySpan<char> identifier) =>
 		!IsSupportedIdentifier (identifier, isPackageSegment: true) ||
-		JavaKeywords.Contains (identifier);
+		JavaKeywords.GetAlternateLookup<ReadOnlySpan<char>> ().Contains (identifier);
 
 	// JLS 3.8 permits combining, format, and supplementary characters, but generated JCWs also need
 	// stable source paths and class names throughout javac, AAPT, DEX, and the Android runtime.
-	static bool IsSupportedIdentifier (string identifier, bool isPackageSegment)
+	static bool IsSupportedIdentifier (ReadOnlySpan<char> identifier, bool isPackageSegment)
 	{
 		if (identifier.Length == 0) {
 			return false;
@@ -88,11 +88,12 @@ internal static class JavaNameValidator
 			? value <= char.MaxValue && JavaIdentifierData.IsPackageIdentifierPart ((char) value)
 			: JavaIdentifierData.IsSupportedIdentifierPart (value);
 
-	internal static bool TryGetInvalidPackageSegment (string packageName, char separator, out string invalidSegment)
+	internal static bool TryGetInvalidPackageSegment (ReadOnlySpan<char> packageName, char separator, out string invalidSegment)
 	{
-		foreach (var segment in packageName.Split (separator)) {
+		foreach (var range in packageName.Split (separator)) {
+			var segment = packageName [range];
 			if (IsInvalidPackageIdentifier (segment)) {
-				invalidSegment = segment;
+				invalidSegment = segment.ToString ();
 				return true;
 			}
 		}
@@ -101,19 +102,16 @@ internal static class JavaNameValidator
 		return false;
 	}
 
-	internal static bool TryGetInvalidJniNameSegment (string jniName, out string invalidSegment)
+	internal static bool TryGetInvalidJniNameSegment (ReadOnlySpan<char> jniName, out string invalidSegment)
 	{
-		var segments = jniName.Split ('/');
-		for (int i = 0; i < segments.Length - 1; i++) {
-			if (IsInvalidPackageIdentifier (segments [i])) {
-				invalidSegment = segments [i];
-				return true;
-			}
+		int lastSlash = jniName.LastIndexOf ('/');
+		if (lastSlash >= 0 && TryGetInvalidPackageSegment (jniName [..lastSlash], '/', out invalidSegment)) {
+			return true;
 		}
 
-		string typeName = segments [segments.Length - 1];
+		var typeName = jniName [(lastSlash + 1)..];
 		if (IsInvalidIdentifier (typeName, isTypeName: true)) {
-			invalidSegment = typeName;
+			invalidSegment = typeName.ToString ();
 			return true;
 		}
 
@@ -121,14 +119,14 @@ internal static class JavaNameValidator
 		return false;
 	}
 
-	internal static bool TryGetInvalidJniManifestNameSegment (string jniName, out string invalidSegment)
+	internal static bool TryGetInvalidJniManifestNameSegment (ReadOnlySpan<char> jniName, out string invalidSegment)
 	{
-		var segments = jniName.Split ('/');
-		for (int i = 0; i < segments.Length; i++) {
-			bool isTypeName = i == segments.Length - 1;
-			if (IsInvalidPackageIdentifier (segments [i]) ||
-					isTypeName && RestrictedTypeIdentifiers.Contains (segments [i])) {
-				invalidSegment = segments [i];
+		foreach (var range in jniName.Split ('/')) {
+			var segment = jniName [range];
+			bool isTypeName = range.End.Value == jniName.Length;
+			if (IsInvalidPackageIdentifier (segment) ||
+					isTypeName && RestrictedTypeIdentifiers.GetAlternateLookup<ReadOnlySpan<char>> ().Contains (segment)) {
+				invalidSegment = segment.ToString ();
 				return true;
 			}
 		}
@@ -137,17 +135,18 @@ internal static class JavaNameValidator
 		return false;
 	}
 
-	internal static bool TryGetInvalidJniSourceTypeSegment (string jniName, out string invalidSegment)
+	internal static bool TryGetInvalidJniSourceTypeSegment (ReadOnlySpan<char> jniName, out string invalidSegment)
 	{
 		if (TryGetInvalidJniNameSegment (jniName, out invalidSegment)) {
 			return true;
 		}
 
 		// '$' becomes '.' when a JNI binary name is emitted as a Java source type reference.
-		string typeName = jniName.Substring (jniName.LastIndexOf ('/') + 1);
-		foreach (var segment in typeName.Split ('$')) {
+		var typeName = jniName [(jniName.LastIndexOf ('/') + 1)..];
+		foreach (var range in typeName.Split ('$')) {
+			var segment = typeName [range];
 			if (IsInvalidIdentifier (segment, isTypeName: true)) {
-				invalidSegment = segment;
+				invalidSegment = segment.ToString ();
 				return true;
 			}
 		}
@@ -155,7 +154,7 @@ internal static class JavaNameValidator
 		return false;
 	}
 
-	internal static bool TryGetInvalidJniTypeSegment (string jniType, out string typeName, out string invalidSegment)
+	internal static bool TryGetInvalidJniTypeSegment (ReadOnlySpan<char> jniType, out string typeName, out string invalidSegment)
 	{
 		int typeStart = 0;
 		while (typeStart < jniType.Length && jniType [typeStart] == '[') {
@@ -163,7 +162,7 @@ internal static class JavaNameValidator
 		}
 
 		if (typeStart < jniType.Length - 1 && jniType [typeStart] == 'L' && jniType [jniType.Length - 1] == ';') {
-			typeName = jniType.Substring (typeStart + 1, jniType.Length - typeStart - 2);
+			typeName = jniType [(typeStart + 1)..^1].ToString ();
 			return TryGetInvalidJniSourceTypeSegment (typeName, out invalidSegment);
 		}
 
@@ -172,24 +171,24 @@ internal static class JavaNameValidator
 		return false;
 	}
 
-	internal static bool TryGetInvalidJavaSourceTypeSegment (string javaType, out string invalidSegment)
+	internal static bool TryGetInvalidJavaSourceTypeSegment (ReadOnlySpan<char> javaType, out string invalidSegment)
 	{
-		string typeName = javaType;
+		var typeName = javaType;
 		while (typeName.EndsWith ("[]", StringComparison.Ordinal)) {
-			typeName = typeName.Substring (0, typeName.Length - 2);
+			typeName = typeName [..^2];
 		}
 		if (typeName is "boolean" or "byte" or "char" or "short" or "int" or "long" or "float" or "double" or "void") {
 			invalidSegment = "";
 			return false;
 		}
 
-		var segments = typeName.Split ('.');
-		for (int i = 0; i < segments.Length; i++) {
-			var nestedSegments = segments [i].Split ('$');
-			for (int nestedIndex = 0; nestedIndex < nestedSegments.Length; nestedIndex++) {
-				bool isTypeName = i == segments.Length - 1 || nestedIndex > 0;
-				if (IsInvalidIdentifier (nestedSegments [nestedIndex], isTypeName)) {
-					invalidSegment = nestedSegments [nestedIndex];
+		foreach (var range in typeName.Split ('.')) {
+			var segment = typeName [range];
+			foreach (var nestedRange in segment.Split ('$')) {
+				var nestedSegment = segment [nestedRange];
+				bool isTypeName = range.End.Value == typeName.Length || nestedRange.Start.Value > 0;
+				if (IsInvalidIdentifier (nestedSegment, isTypeName)) {
+					invalidSegment = nestedSegment.ToString ();
 					return true;
 				}
 			}
@@ -199,14 +198,14 @@ internal static class JavaNameValidator
 		return false;
 	}
 
-	internal static bool TryGetInvalidJavaManifestTypeSegment (string javaType, out string invalidSegment)
+	internal static bool TryGetInvalidJavaManifestTypeSegment (ReadOnlySpan<char> javaType, out string invalidSegment)
 	{
-		var segments = javaType.Split ('.');
-		for (int i = 0; i < segments.Length; i++) {
-			bool isTypeName = i == segments.Length - 1;
-			if (IsInvalidPackageIdentifier (segments [i]) ||
-					isTypeName && RestrictedTypeIdentifiers.Contains (segments [i])) {
-				invalidSegment = segments [i];
+		foreach (var range in javaType.Split ('.')) {
+			var segment = javaType [range];
+			bool isTypeName = range.End.Value == javaType.Length;
+			if (IsInvalidPackageIdentifier (segment) ||
+					isTypeName && RestrictedTypeIdentifiers.GetAlternateLookup<ReadOnlySpan<char>> ().Contains (segment)) {
+				invalidSegment = segment.ToString ();
 				return true;
 			}
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/JavaNameValidator.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
-internal static class JavaNameValidator
+public static class JavaNameValidator
 {
 	// Java SE 21 reserved keywords and literals:
 	// https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-3.9
@@ -88,21 +88,21 @@ internal static class JavaNameValidator
 			? value <= char.MaxValue && JavaIdentifierData.IsPackageIdentifierPart ((char) value)
 			: JavaIdentifierData.IsSupportedIdentifierPart (value);
 
-	internal static bool TryGetInvalidPackageSegment (ReadOnlySpan<char> packageName, char separator, out string invalidSegment)
+	public static bool TryGetInvalidPackageSegment (ReadOnlySpan<char> packageName, char separator, out ReadOnlySpan<char> invalidSegment)
 	{
 		foreach (var range in packageName.Split (separator)) {
 			var segment = packageName [range];
 			if (IsInvalidPackageIdentifier (segment)) {
-				invalidSegment = segment.ToString ();
+				invalidSegment = segment;
 				return true;
 			}
 		}
 
-		invalidSegment = "";
+		invalidSegment = default;
 		return false;
 	}
 
-	internal static bool TryGetInvalidJniNameSegment (ReadOnlySpan<char> jniName, out string invalidSegment)
+	internal static bool TryGetInvalidJniNameSegment (ReadOnlySpan<char> jniName, out ReadOnlySpan<char> invalidSegment)
 	{
 		int lastSlash = jniName.LastIndexOf ('/');
 		if (lastSlash >= 0 && TryGetInvalidPackageSegment (jniName [..lastSlash], '/', out invalidSegment)) {
@@ -111,31 +111,31 @@ internal static class JavaNameValidator
 
 		var typeName = jniName [(lastSlash + 1)..];
 		if (IsInvalidIdentifier (typeName, isTypeName: true)) {
-			invalidSegment = typeName.ToString ();
+			invalidSegment = typeName;
 			return true;
 		}
 
-		invalidSegment = "";
+		invalidSegment = default;
 		return false;
 	}
 
-	internal static bool TryGetInvalidJniManifestNameSegment (ReadOnlySpan<char> jniName, out string invalidSegment)
+	internal static bool TryGetInvalidJniManifestNameSegment (ReadOnlySpan<char> jniName, out ReadOnlySpan<char> invalidSegment)
 	{
 		foreach (var range in jniName.Split ('/')) {
 			var segment = jniName [range];
 			bool isTypeName = range.End.Value == jniName.Length;
 			if (IsInvalidPackageIdentifier (segment) ||
 					isTypeName && RestrictedTypeIdentifiers.GetAlternateLookup<ReadOnlySpan<char>> ().Contains (segment)) {
-				invalidSegment = segment.ToString ();
+				invalidSegment = segment;
 				return true;
 			}
 		}
 
-		invalidSegment = "";
+		invalidSegment = default;
 		return false;
 	}
 
-	internal static bool TryGetInvalidJniSourceTypeSegment (ReadOnlySpan<char> jniName, out string invalidSegment)
+	internal static bool TryGetInvalidJniSourceTypeSegment (ReadOnlySpan<char> jniName, out ReadOnlySpan<char> invalidSegment)
 	{
 		if (TryGetInvalidJniNameSegment (jniName, out invalidSegment)) {
 			return true;
@@ -146,7 +146,7 @@ internal static class JavaNameValidator
 		foreach (var range in typeName.Split ('$')) {
 			var segment = typeName [range];
 			if (IsInvalidIdentifier (segment, isTypeName: true)) {
-				invalidSegment = segment.ToString ();
+				invalidSegment = segment;
 				return true;
 			}
 		}
@@ -154,7 +154,7 @@ internal static class JavaNameValidator
 		return false;
 	}
 
-	internal static bool TryGetInvalidJniTypeSegment (ReadOnlySpan<char> jniType, out string typeName, out string invalidSegment)
+	internal static bool TryGetInvalidJniTypeSegment (ReadOnlySpan<char> jniType, out ReadOnlySpan<char> typeName, out ReadOnlySpan<char> invalidSegment)
 	{
 		int typeStart = 0;
 		while (typeStart < jniType.Length && jniType [typeStart] == '[') {
@@ -162,23 +162,23 @@ internal static class JavaNameValidator
 		}
 
 		if (typeStart < jniType.Length - 1 && jniType [typeStart] == 'L' && jniType [jniType.Length - 1] == ';') {
-			typeName = jniType [(typeStart + 1)..^1].ToString ();
+			typeName = jniType [(typeStart + 1)..^1];
 			return TryGetInvalidJniSourceTypeSegment (typeName, out invalidSegment);
 		}
 
-		typeName = "";
-		invalidSegment = "";
+		typeName = default;
+		invalidSegment = default;
 		return false;
 	}
 
-	internal static bool TryGetInvalidJavaSourceTypeSegment (ReadOnlySpan<char> javaType, out string invalidSegment)
+	internal static bool TryGetInvalidJavaSourceTypeSegment (ReadOnlySpan<char> javaType, out ReadOnlySpan<char> invalidSegment)
 	{
 		var typeName = javaType;
 		while (typeName.EndsWith ("[]", StringComparison.Ordinal)) {
 			typeName = typeName [..^2];
 		}
 		if (typeName is "boolean" or "byte" or "char" or "short" or "int" or "long" or "float" or "double" or "void") {
-			invalidSegment = "";
+			invalidSegment = default;
 			return false;
 		}
 
@@ -188,29 +188,29 @@ internal static class JavaNameValidator
 				var nestedSegment = segment [nestedRange];
 				bool isTypeName = range.End.Value == typeName.Length || nestedRange.Start.Value > 0;
 				if (IsInvalidIdentifier (nestedSegment, isTypeName)) {
-					invalidSegment = nestedSegment.ToString ();
+					invalidSegment = nestedSegment;
 					return true;
 				}
 			}
 		}
 
-		invalidSegment = "";
+		invalidSegment = default;
 		return false;
 	}
 
-	internal static bool TryGetInvalidJavaManifestTypeSegment (ReadOnlySpan<char> javaType, out string invalidSegment)
+	internal static bool TryGetInvalidJavaManifestTypeSegment (ReadOnlySpan<char> javaType, out ReadOnlySpan<char> invalidSegment)
 	{
 		foreach (var range in javaType.Split ('.')) {
 			var segment = javaType [range];
 			bool isTypeName = range.End.Value == javaType.Length;
 			if (IsInvalidPackageIdentifier (segment) ||
 					isTypeName && RestrictedTypeIdentifiers.GetAlternateLookup<ReadOnlySpan<char>> ().Contains (segment)) {
-				invalidSegment = segment.ToString ();
+				invalidSegment = segment;
 				return true;
 			}
 		}
 
-		invalidSegment = "";
+		invalidSegment = default;
 		return false;
 	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
@@ -186,4 +186,5 @@ builds), the generator runs exactly once per outer build.
 | `Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets` | CoreCLR specifics, incl. the post-trim `linked-java` regeneration. |
 | `Microsoft.Android.Sdk.TypeMap.Trimmable.NativeAOT.targets` | NativeAOT specifics (ILC inputs, proguard). |
 | `../Microsoft.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs` | The net11.0 MSBuild task front-end for the generator. |
+| `../Microsoft.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs` | The net11.0 package-name task; shares Java identifier validation with the generator. |
 | `Microsoft.Android.Sdk.TrimmableTypeMap/**` | The net11.0 generator/scanner library invoked by the task. |

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -2305,7 +2305,7 @@ public sealed class JavaPeerScanner : IDisposable
 		return descriptor.Length > 0;
 	}
 
-	bool IsSpecialManagedType (TypeRefData managedType, string managedTypeName, params string [] assemblyNames)
+	bool IsSpecialManagedType (TypeRefData managedType, string managedTypeName, params ReadOnlySpan<string> assemblyNames)
 	{
 		if (!string.Equals (managedType.ManagedTypeName, managedTypeName, StringComparison.Ordinal)) {
 			return false;

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -1288,10 +1288,10 @@ public sealed class JavaPeerScanner : IDisposable
 	/// Looks up an unqualified managed type name across loaded assemblies.
 	/// Used only by legacy-compatible constructor signature discovery.
 	/// </summary>
-	string? TryResolveJniObjectDescriptor (string managedType)
+	string? TryResolveJniObjectDescriptor (ReadOnlySpan<char> managedType)
 	{
 		foreach (var index in assemblyCache.Values) {
-			if (index.TypesByFullName.TryGetValue (managedType, out var handle)) {
+			if (index.TypesByFullName.GetAlternateLookup<ReadOnlySpan<char>> ().TryGetValue (managedType, out var handle)) {
 				return GetJniObjectDescriptor (handle, index);
 			}
 		}
@@ -1323,7 +1323,8 @@ public sealed class JavaPeerScanner : IDisposable
 	string? ResolveTypeOfArgumentToJniName (string assemblyQualifiedName)
 	{
 		var commaIdx = assemblyQualifiedName.IndexOf (',');
-		var typeName = (commaIdx >= 0 ? assemblyQualifiedName.Substring (0, commaIdx) : assemblyQualifiedName).Trim ();
+		var qualifiedName = assemblyQualifiedName.AsSpan ();
+		var typeName = (commaIdx >= 0 ? qualifiedName [..commaIdx] : qualifiedName).Trim ();
 		var descriptor = TryResolveJniObjectDescriptor (typeName);
 		if (descriptor is null || descriptor.Length < 3) {
 			return null;
@@ -2487,19 +2488,23 @@ public sealed class JavaPeerScanner : IDisposable
 	{
 		var commaIndex = value.IndexOf (',');
 		if (commaIndex < 0) {
-			return NormalizeConnectorManagedTypeName (value);
+			return value.Trim ().Replace ('/', '+');
 		}
 
-		var typeName = NormalizeConnectorManagedTypeName (value.Substring (0, commaIndex));
-		var remainder = value.Substring (commaIndex + 1).Trim ();
+		var qualifiedName = value.AsSpan ();
+		var remainder = qualifiedName [(commaIndex + 1)..].Trim ();
 		var nextCommaIndex = remainder.IndexOf (',');
-		var assemblyName = nextCommaIndex < 0 ? remainder : remainder.Substring (0, nextCommaIndex).Trim ();
-		return string.Equals (assemblyName, defaultAssemblyName, StringComparison.Ordinal) ? typeName : null;
+		var assemblyName = nextCommaIndex < 0 ? remainder : remainder [..nextCommaIndex].Trim ();
+		return assemblyName.Equals (defaultAssemblyName, StringComparison.Ordinal)
+			? NormalizeConnectorManagedTypeName (qualifiedName [..commaIndex])
+			: null;
 	}
 
-	static string NormalizeConnectorManagedTypeName (string managedTypeName)
+	static string NormalizeConnectorManagedTypeName (ReadOnlySpan<char> managedTypeName)
 	{
-		return managedTypeName.Trim ().Replace ('/', '+');
+		var typeName = managedTypeName.Trim ();
+		return string.Create (typeName.Length, typeName, static (destination, name) =>
+			name.Replace (destination, '/', '+'));
 	}
 
 	/// <summary>
@@ -2752,11 +2757,11 @@ public sealed class JavaPeerScanner : IDisposable
 		if (connector is not null) {
 			// Strip the optional type qualifier after ':'
 			int colonIndex = connector.IndexOf (':');
-			string handlerName = colonIndex >= 0 ? connector.Substring (0, colonIndex) : connector;
+			var handlerName = colonIndex >= 0 ? connector.AsSpan (0, colonIndex) : connector.AsSpan ();
 
 			if (handlerName.StartsWith ("Get", StringComparison.Ordinal)
 				&& handlerName.EndsWith ("Handler", StringComparison.Ordinal)) {
-				return "n_" + handlerName.Substring (3, handlerName.Length - 3 - "Handler".Length);
+				return string.Concat ("n_".AsSpan (), handlerName.Slice ("Get".Length, handlerName.Length - "Get".Length - "Handler".Length));
 			}
 		}
 
@@ -2786,7 +2791,7 @@ public sealed class JavaPeerScanner : IDisposable
 
 		// After ':' is typically "TypeName, AssemblyName, Version=…" (assembly-qualified name),
 		// but some connectors only provide "TypeName" without an assembly.
-		string typeQualified = connector.Substring (colonIndex + 1);
+		var typeQualified = connector.AsSpan (colonIndex + 1);
 		int commaIndex = typeQualified.IndexOf (',');
 
 		if (commaIndex < 0) {
@@ -2795,10 +2800,10 @@ public sealed class JavaPeerScanner : IDisposable
 			return;
 		}
 
-		declaringTypeName = NormalizeConnectorManagedTypeName (typeQualified.Substring (0, commaIndex));
-		string rest = typeQualified.Substring (commaIndex + 1).Trim ();
+		declaringTypeName = NormalizeConnectorManagedTypeName (typeQualified [..commaIndex]);
+		var rest = typeQualified [(commaIndex + 1)..].Trim ();
 		int nextComma = rest.IndexOf (',');
-		declaringAssemblyName = nextComma >= 0 ? rest.Substring (0, nextComma).Trim () : rest.Trim ();
+		declaringAssemblyName = (nextComma >= 0 ? rest [..nextComma].Trim () : rest).ToString ();
 	}
 
 	string GetHashedPackageName (string ns, string assemblyName)
@@ -2833,9 +2838,9 @@ public sealed class JavaPeerScanner : IDisposable
 	{
 		// Strip nested type suffix (e.g., "My.Namespace.Outer+Inner" → "My.Namespace.Outer")
 		int plusIndex = fullName.IndexOf ('+');
-		var nameForNamespace = plusIndex >= 0 ? fullName.Substring (0, plusIndex) : fullName;
+		var nameForNamespace = plusIndex >= 0 ? fullName.AsSpan (0, plusIndex) : fullName.AsSpan ();
 		int lastDot = nameForNamespace.LastIndexOf ('.');
-		return lastDot >= 0 ? nameForNamespace.Substring (0, lastDot) : "";
+		return lastDot >= 0 ? nameForNamespace [..lastDot].ToString () : "";
 	}
 
 	static string ExtractShortName (string fullName)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -234,7 +234,7 @@ public class TrimmableTypeMapGenerator
 			ReportInvalidJniType (JniSignatureHelper.ParseReturnTypeString (jniSignature));
 		}
 
-		static bool TryGetInvalidThrownNameSegment (string thrownName, out string invalidIdentifier) =>
+		static bool TryGetInvalidThrownNameSegment (string thrownName, out ReadOnlySpan<char> invalidIdentifier) =>
 			thrownName.IndexOf ('/') >= 0
 				? JavaNameValidator.TryGetInvalidJniSourceTypeSegment (thrownName, out invalidIdentifier)
 				: JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (thrownName, out invalidIdentifier);
@@ -289,14 +289,14 @@ public class TrimmableTypeMapGenerator
 		void ReportInvalidJniType (string jniType)
 		{
 			if (JavaNameValidator.TryGetInvalidJniTypeSegment (jniType, out var typeName, out var invalidIdentifier)) {
-				ReportInvalidName (typeName, invalidIdentifier);
+				ReportInvalidName (typeName.ToString (), invalidIdentifier);
 			}
 		}
 
-		void ReportInvalidName (string name, string invalidIdentifier)
+		void ReportInvalidName (string name, ReadOnlySpan<char> invalidIdentifier)
 		{
 			if (reportedNames.Add (name)) {
-				logger.LogInvalidJavaNameError (name, invalidIdentifier);
+				logger.LogInvalidJavaNameError (name, invalidIdentifier.ToString ());
 				valid = false;
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/JniRemapping/JniAssemblyRewriterTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/JniRemapping/JniAssemblyRewriterTests.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using Microsoft.Android.Sdk.TrimmableTypeMap;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
@@ -889,85 +888,6 @@ namespace Xamarin.Android.Build.Tests
 				"acme.orig.P2 -> a.b.P2:\n" +
 				"    void go() -> q\n")));
 			StringAssert.Contains ("shared", exception.Message.ToLowerInvariant ());
-		}
-
-		[Test]
-		public void RewritesGeneratedTypeMapWithOwnerSpecificMethodNames ()
-		{
-			byte [] source = GenerateTypeMapWithSharedMethodName ();
-			var warnings = new List<BuildWarningEventArgs> ();
-
-			JniRewriteResult result = Rewrite (source, Mapping (
-				"test.First -> a.b.First:\n" +
-				"    void n_Run() -> a\n" +
-				"test.Second -> a.b.Second:\n" +
-				"    void n_Run() -> b\n"), warnings);
-
-			CollectionAssert.AreEquivalent (new [] { "a", "b", "()V" }, ReadUtf8Values (result.Image));
-			CollectionAssert.DoesNotContain (warnings.Select (warning => warning.Code).ToArray (), "XA4326");
-		}
-
-		[Test]
-		public void RewritesGeneratedTypeMapWithMappedAndUnmappedMethodNames ()
-		{
-			byte [] source = GenerateTypeMapWithSharedMethodName ();
-			var warnings = new List<BuildWarningEventArgs> ();
-
-			JniRewriteResult result = Rewrite (source, Mapping (
-				"test.First -> a.b.First:\n" +
-				"    void n_Run() -> a\n" +
-				"test.Second -> test.Second:\n"), warnings);
-
-			CollectionAssert.AreEquivalent (new [] { "a", "n_Run", "()V" }, ReadUtf8Values (result.Image));
-			CollectionAssert.DoesNotContain (warnings.Select (warning => warning.Code).ToArray (), "XA4326");
-		}
-
-		static byte [] GenerateTypeMapWithSharedMethodName ()
-		{
-			var peers = new [] {
-				CreatePeer ("test/First", "Test.First"),
-				CreatePeer ("test/Second", "Test.Second"),
-			};
-			using var stream = new MemoryStream ();
-			new TypeMapAssemblyGenerator (new Version (11, 0, 0, 0)).Generate (peers, stream, "OwnerSpecificNames");
-			return stream.ToArray ();
-
-			static JavaPeerInfo CreatePeer (string javaName, string managedName)
-			{
-				int separator = managedName.LastIndexOf ('.');
-				return new JavaPeerInfo {
-					JavaName = javaName,
-					CompatJniName = javaName,
-					ManagedTypeName = managedName,
-					ManagedTypeNamespace = managedName.Substring (0, separator),
-					ManagedTypeShortName = managedName.Substring (separator + 1),
-					AssemblyName = "TestAsm",
-					DoNotGenerateAcw = false,
-					ActivationCtor = new ActivationCtorInfo {
-						DeclaringTypeName = managedName,
-						DeclaringAssemblyName = "TestAsm",
-						Style = ActivationCtorStyle.XamarinAndroid,
-					},
-					MarshalMethods = [
-						new MarshalMethodInfo {
-							JniName = "run",
-							NativeCallbackName = "n_Run",
-							JniSignature = "()V",
-							ManagedMethodName = "Run",
-						},
-					],
-				};
-			}
-		}
-
-		static string [] ReadUtf8Values (byte [] image)
-		{
-			using var peReader = new PEReader (ImmutableArray.Create (image));
-			MetadataReader reader = peReader.GetMetadataReader ();
-			return FieldRvaTable.Read (peReader, reader).Entries
-				.Select (entry => entry.Utf8Value)
-				.OfType<string> ()
-				.ToArray ();
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -1066,18 +1066,7 @@ namespace Xamarin.Android.Tasks {
 
 		internal static string ReplacePlaceholders (string [] placeholders, string text, Action<string, string> logCodedWarning = null)
 		{
-			string result = text;
-			if (placeholders == null)
-				return result;
-			foreach (var entry in placeholders.Select (e => e.Split (new char [] {'='}, 2, StringSplitOptions.None))) {
-				if (entry.Length == 2)
-					result = result.Replace ("${" + entry [0] + "}", entry [1]);
-				else {
-					if (logCodedWarning != null)
-						logCodedWarning ("XA1010", string.Format (Properties.Resources.XA1010, string.Join (";", placeholders)));
-				}
-			}
-			return result;
+			return ManifestPlaceholderResolver.Replace (placeholders, text, logCodedWarning);
 		}
 
 		public void SetAbi (string abi)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestPlaceholderResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestPlaceholderResolver.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace Xamarin.Android.Tasks;
+
+static class ManifestPlaceholderResolver
+{
+	internal static string Replace (string []? placeholders, string text, Action<string, string>? logCodedWarning = null)
+	{
+		string result = text;
+		if (placeholders is null) {
+			return result;
+		}
+		foreach (var entry in placeholders.Select (e => e.Split (new char [] { '=' }, 2, StringSplitOptions.None))) {
+			if (entry.Length == 2) {
+				result = result.Replace ("${" + entry [0] + "}", entry [1]);
+			} else if (logCodedWarning is not null) {
+				logCodedWarning ("XA1010", string.Format (CultureInfo.CurrentCulture, Properties.Resources.XA1010, string.Join (";", placeholders)));
+			}
+		}
+		return result;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -111,12 +111,6 @@
     <Compile Include="..\..\external\Java.Interop\src\utils\NullableAttributes.cs">
       <Link>Utilities\NullableAttributes.cs</Link>
     </Compile>
-    <Compile Include="..\Microsoft.Android.Sdk.TrimmableTypeMap\JavaNameValidator.cs">
-      <Link>Utilities\JavaNameValidator.cs</Link>
-    </Compile>
-    <Compile Include="..\Microsoft.Android.Sdk.TrimmableTypeMap\JavaIdentifierData.cs">
-      <Link>Utilities\JavaIdentifierData.cs</Link>
-    </Compile>
     <Compile Include="..\Mono.Android\\Android.App\UsesLibraryAttribute.cs">
       <Link>Mono.Android\UsesLibraryAttribute.cs</Link>
     </Compile>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -28,7 +28,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidApkSigner" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AppendCustomMetadataToItemGroup" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AssemblyModifierPipeline" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.GetAndroidPackageName" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Microsoft.Android.Tasks.GetAndroidPackageName" AssemblyFile="$(_MicrosoftAndroidBuildTasksAssembly)" Runtime="NET" TaskFactory="TaskHostFactory" Condition=" '$(MSBuildRuntimeType)' == 'Full' " />
+<UsingTask TaskName="Microsoft.Android.Tasks.GetAndroidPackageName" AssemblyFile="$(_MicrosoftAndroidBuildTasksAssembly)" Runtime="NET" Condition=" '$(MSBuildRuntimeType)' == 'Core' " />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aot" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.BuildArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.BuildAppBundle" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/GeneratedTypeMapRewriterTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/GeneratedTypeMapRewriterTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Xamarin.Android.Tasks.JniRemapping;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests;
+
+public class GeneratedTypeMapRewriterTests
+{
+	[Fact]
+	public void RewritesGeneratedTypeMapWithOwnerSpecificMethodNames ()
+	{
+		byte [] source = GenerateTypeMapWithSharedMethodName ();
+		var warnings = new List<BuildWarningEventArgs> ();
+
+		JniRewriteResult result = Rewrite (source, """
+			test.First -> a.b.First:
+			    void n_Run() -> a
+			test.Second -> a.b.Second:
+			    void n_Run() -> b
+			""", warnings);
+
+		Assert.Equal (new [] { "()V", "a", "b" }, ReadUtf8Values (result.Image).OrderBy (value => value, StringComparer.Ordinal));
+		Assert.DoesNotContain (warnings, warning => warning.Code == "XA4326");
+	}
+
+	[Fact]
+	public void RewritesGeneratedTypeMapWithMappedAndUnmappedMethodNames ()
+	{
+		byte [] source = GenerateTypeMapWithSharedMethodName ();
+		var warnings = new List<BuildWarningEventArgs> ();
+
+		JniRewriteResult result = Rewrite (source, """
+			test.First -> a.b.First:
+			    void n_Run() -> a
+			test.Second -> test.Second:
+			""", warnings);
+
+		Assert.Equal (new [] { "()V", "a", "n_Run" }, ReadUtf8Values (result.Image).OrderBy (value => value, StringComparer.Ordinal));
+		Assert.DoesNotContain (warnings, warning => warning.Code == "XA4326");
+	}
+
+	static JniRewriteResult Rewrite (byte [] sourceImage, string mappingText, IList<BuildWarningEventArgs> warnings)
+	{
+		using var reader = new StringReader (mappingText);
+		var log = new TaskLoggingHelper (new MockBuildEngine (warnings), nameof (GeneratedTypeMapRewriterTests));
+		return JniAssemblyRewriter.Rewrite (sourceImage, R8Mapping.Parse (reader), log);
+	}
+
+	static byte [] GenerateTypeMapWithSharedMethodName ()
+	{
+		var peers = new [] {
+			CreatePeer ("test/First", "Test.First"),
+			CreatePeer ("test/Second", "Test.Second"),
+		};
+		using var stream = new MemoryStream ();
+		new TypeMapAssemblyGenerator (new Version (11, 0, 0, 0)).Generate (peers, stream, "OwnerSpecificNames");
+		return stream.ToArray ();
+
+		static JavaPeerInfo CreatePeer (string javaName, string managedName)
+		{
+			int separator = managedName.LastIndexOf ('.');
+			return new JavaPeerInfo {
+				JavaName = javaName,
+				CompatJniName = javaName,
+				ManagedTypeName = managedName,
+				ManagedTypeNamespace = managedName.Substring (0, separator),
+				ManagedTypeShortName = managedName.Substring (separator + 1),
+				AssemblyName = "TestAsm",
+				DoNotGenerateAcw = false,
+				ActivationCtor = new ActivationCtorInfo {
+					DeclaringTypeName = managedName,
+					DeclaringAssemblyName = "TestAsm",
+					Style = ActivationCtorStyle.XamarinAndroid,
+				},
+				MarshalMethods = [
+					new MarshalMethodInfo {
+						JniName = "run",
+						NativeCallbackName = "n_Run",
+						JniSignature = "()V",
+						ManagedMethodName = "Run",
+					},
+				],
+			};
+		}
+	}
+
+	static string [] ReadUtf8Values (byte [] image)
+	{
+		using var peReader = new PEReader (ImmutableArray.Create (image));
+		MetadataReader reader = peReader.GetMetadataReader ();
+		return FieldRvaTable.Read (peReader, reader).Entries
+			.Select (entry => entry.Utf8Value)
+			.OfType<string> ()
+			.ToArray ();
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/MockBuildEngine.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/MockBuildEngine.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests;
@@ -7,7 +8,7 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests;
 /// <summary>
 /// Minimal IBuildEngine implementation for use with TaskLoggingHelper in tests.
 /// </summary>
-sealed class MockBuildEngine : IBuildEngine
+sealed class MockBuildEngine (IList<BuildWarningEventArgs>? warnings = null) : IBuildEngine
 {
 	public bool ContinueOnError => false;
 	public int LineNumberOfTaskNode => 0;
@@ -18,5 +19,5 @@ sealed class MockBuildEngine : IBuildEngine
 	public void LogCustomEvent (CustomBuildEventArgs e) { }
 	public void LogErrorEvent (BuildErrorEventArgs e) { }
 	public void LogMessageEvent (BuildMessageEventArgs e) { }
-	public void LogWarningEvent (BuildWarningEventArgs e) { }
+	public void LogWarningEvent (BuildWarningEventArgs e) => warnings?.Add (e);
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JavaNameValidatorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JavaNameValidatorTests.cs
@@ -49,7 +49,7 @@ public class JavaNameValidatorTests
 	public void TryGetInvalidPackageSegment_ReservedIdentifier_ReturnsTrue (string identifier)
 	{
 		Assert.True (JavaNameValidator.TryGetInvalidPackageSegment ($"com.{identifier}.example", '.', out var actual));
-		Assert.Equal (identifier, actual);
+		Assert.Equal (identifier, actual.ToString ());
 	}
 
 	[Theory]
@@ -57,7 +57,7 @@ public class JavaNameValidatorTests
 	public void TryGetInvalidJniNameSegment_ReservedPackageIdentifier_ReturnsTrue (string identifier)
 	{
 		Assert.True (JavaNameValidator.TryGetInvalidJniNameSegment ($"com/{identifier}/Example", out var actual));
-		Assert.Equal (identifier, actual);
+		Assert.Equal (identifier, actual.ToString ());
 	}
 
 	[Theory]
@@ -65,7 +65,7 @@ public class JavaNameValidatorTests
 	public void TryGetInvalidJniNameSegment_ReservedTypeIdentifier_ReturnsTrue (string identifier)
 	{
 		Assert.True (JavaNameValidator.TryGetInvalidJniNameSegment ($"com/example/{identifier}", out var actual));
-		Assert.Equal (identifier, actual);
+		Assert.Equal (identifier, actual.ToString ());
 	}
 
 	[Theory]
@@ -76,7 +76,7 @@ public class JavaNameValidatorTests
 	{
 		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment (jniName, out _));
 		Assert.True (JavaNameValidator.TryGetInvalidJniSourceTypeSegment (jniName, out var actual));
-		Assert.Equal (expected, actual);
+		Assert.Equal (expected, actual.ToString ());
 	}
 
 	[Theory]
@@ -84,11 +84,11 @@ public class JavaNameValidatorTests
 	public void RestrictedTypeIdentifier_IsValidInPackageButInvalidAsType (string identifier)
 	{
 		Assert.False (JavaNameValidator.TryGetInvalidPackageSegment ($"com.example.{identifier}", '.', out var packageIdentifier));
-		Assert.Equal ("", packageIdentifier);
+		Assert.True (packageIdentifier.IsEmpty);
 		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ($"com/{identifier}/Example", out var jniPackageIdentifier));
-		Assert.Equal ("", jniPackageIdentifier);
+		Assert.True (jniPackageIdentifier.IsEmpty);
 		Assert.True (JavaNameValidator.TryGetInvalidJniNameSegment ($"com/example/{identifier}", out var typeIdentifier));
-		Assert.Equal (identifier, typeIdentifier);
+		Assert.Equal (identifier, typeIdentifier.ToString ());
 	}
 
 	[Theory]
@@ -113,13 +113,13 @@ public class JavaNameValidatorTests
 	public void ValidNames_ReturnFalseAndEmptyIdentifier ()
 	{
 		Assert.False (JavaNameValidator.TryGetInvalidPackageSegment ("com.example.app", '.', out var packageIdentifier));
-		Assert.Equal ("", packageIdentifier);
+		Assert.True (packageIdentifier.IsEmpty);
 		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ("com/example/MainActivity", out var jniIdentifier));
-		Assert.Equal ("", jniIdentifier);
+		Assert.True (jniIdentifier.IsEmpty);
 		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment ("com/example/Outer$Inner", out var nestedIdentifier));
-		Assert.Equal ("", nestedIdentifier);
+		Assert.True (nestedIdentifier.IsEmpty);
 		Assert.False (JavaNameValidator.TryGetInvalidJniSourceTypeSegment ("com/example/Outer$Inner", out nestedIdentifier));
-		Assert.Equal ("", nestedIdentifier);
+		Assert.True (nestedIdentifier.IsEmpty);
 	}
 
 	[Theory]
@@ -130,7 +130,7 @@ public class JavaNameValidatorTests
 	public void UnicodeIdentifiers_AreValid (string jniName)
 	{
 		Assert.False (JavaNameValidator.TryGetInvalidJniNameSegment (jniName, out var invalidIdentifier));
-		Assert.Equal ("", invalidIdentifier);
+		Assert.True (invalidIdentifier.IsEmpty);
 	}
 
 	[Theory]
@@ -210,7 +210,7 @@ public class JavaNameValidatorTests
 	public void InvalidOrUnsupportedIdentifier_ReturnsSegment (string jniName, string expected)
 	{
 		Assert.True (JavaNameValidator.TryGetInvalidJniNameSegment (jniName, out var invalidIdentifier));
-		Assert.Equal (expected, invalidIdentifier);
+		Assert.Equal (expected, invalidIdentifier.ToString ());
 	}
 
 	[Theory]
@@ -221,14 +221,14 @@ public class JavaNameValidatorTests
 	public void JavaTypeOnlyIdentifiers_AreInvalidPackageSegments (string packageName, string expected)
 	{
 		Assert.True (JavaNameValidator.TryGetInvalidPackageSegment (packageName, '.', out var invalidIdentifier));
-		Assert.Equal (expected, invalidIdentifier);
+		Assert.Equal (expected, invalidIdentifier.ToString ());
 		Assert.True (
 			JavaNameValidator.TryGetInvalidJniNameSegment (
 				packageName.Replace ('.', '/') + "/Peer",
 				out invalidIdentifier
 			)
 		);
-		Assert.Equal (expected, invalidIdentifier);
+		Assert.Equal (expected, invalidIdentifier.ToString ());
 	}
 
 	[Fact]
@@ -252,8 +252,8 @@ public class JavaNameValidatorTests
 	public void TryGetInvalidJniTypeSegment_ReservedTypeIdentifier_ReturnsTrue (string jniType, string expectedTypeName, string expectedIdentifier)
 	{
 		Assert.True (JavaNameValidator.TryGetInvalidJniTypeSegment (jniType, out var typeName, out var invalidIdentifier));
-		Assert.Equal (expectedTypeName, typeName);
-		Assert.Equal (expectedIdentifier, invalidIdentifier);
+		Assert.Equal (expectedTypeName, typeName.ToString ());
+		Assert.Equal (expectedIdentifier, invalidIdentifier.ToString ());
 	}
 
 	[Theory]
@@ -266,6 +266,6 @@ public class JavaNameValidatorTests
 	{
 		bool invalid = JavaNameValidator.TryGetInvalidJavaSourceTypeSegment (javaType, out var invalidIdentifier);
 		Assert.Equal (expectedIdentifier is not null, invalid);
-		Assert.Equal (expectedIdentifier ?? "", invalidIdentifier);
+		Assert.Equal (expectedIdentifier ?? "", invalidIdentifier.ToString ());
 	}
 }


### PR DESCRIPTION
Follow-up to #12678, using the generator's new .NET 11 target to reduce temporary allocations.

Five focused optimizations:
- Validate Java names with spans, alternate keyword lookups, and span NFC checks.
- Construct proxy, alias, and Java names with `string.Create` and span replacements.
- Replace scanner `params` arrays with `ReadOnlySpan<string>`.
- Parse connector and assembly-qualified names with spans and use alternate type-name lookups.
- Use span-based UTF-8 encoding and `SHA256.HashData` for deterministic metadata hashing.

Preserves Java 21 identifier rules, generated names, resolution order, and hash serialization. Larger structural optimizations are left for follow-up PRs.

Review follow-up: move `GetAndroidPackageName` and its existing coverage into the net11.0 task project, remove the validator/identifier-data source links from the netstandard2.0 assembly, and package the task's Android SDK helper dependency. Validation results now remain spans until the diagnostic boundary; no compatibility implementation of the validator is retained.

### Allocation measurements

Compared `386608ea08` (before these optimizations) with `8026fb78ec`, using identically configured Release generator builds and the same probe binary on macOS Arm64, .NET 11 preview 7, workstation GC. These measurements precede the package-task migration and span-output follow-up.

The workload uses the installed Android API 37 preview 7 reference assemblies plus a small app: 9,087 peers, 5,759 marshal methods, and 332 generated Java sources. Full generation emits four typemap assemblies totaling 5,406,720 bytes. It uses per-assembly typemap universes and `collectMarshalMethodsForNonAcw=false`, matching the Debug task path. The fingerprint-hit case still scans, models, fingerprints, and generates Java/manifest content, but its callback skips typemap DLL emission; it is not an MSBuild no-op build.

Five alternating baseline/current samples per case, each with 10 warm-up invocations and 30 measured invocations. Values below are medians; MB is decimal.

| Path | Allocated bytes/invocation before | After | Reduction | Gen 0 collections per 30 invocations |
| --- | ---: | ---: | ---: | ---: |
| Full generation | 135.21 MB | 128.13 MB | **5.23%** | 373 → 351 |
| Fingerprint hit / skip DLL emission | 87.14 MB | 80.25 MB | **7.91%** | 277 → 253 |

Allocation counters use `GC.GetTotalAllocatedBytes(precise: true)` around the measured loop; startup, input-file reading, and warm-up are excluded. Separate `dotnet-trace collect --profile gc-verbose` captures corroborate the reduction, with measurement-window markers and zero lost events in all four traces. Sampled allocations show fewer temporary strings, `char[]`, `string[]`, and `StringBuilder` objects. Generated DLL/Java/manifest checksums match between variants in each case.

This establishes lower managed allocation volume and fewer Gen 0 collections, not a general latency improvement. Gen 1/2 counts were roughly flat or slightly higher. Median total GC pause time per sample was 1,098.6 → 1,006.2 ms for full generation and 839.3 → 843.0 ms for the fingerprint-hit case. Untraced median time per invocation was 131.1 → 131.2 ms and 99.0 → 108.0 ms respectively; ranges overlapped, and traced timings changed the ordering. No end-to-end build-speed claim is made. This profiles the standalone net11.0 generator, not end-to-end MSBuild execution.