### PR TITLE
[native] Preserve borrowed NativeAOT JNI references

### DIFF
--- a/src/native/nativeaot/host/host-jni.cc
+++ b/src/native/nativeaot/host/host-jni.cc
@@ -37,7 +37,8 @@ void XA_Host_NativeAOT_OnInit (jstring language, jstring filesDir, jstring cache
 {
 	JNIEnv *env = OSBridge::ensure_jnienv ();
 
-	// Host::OnInit takes ownership of its JNI string references.
+	// JNI method arguments are borrowed and must remain valid after Host::OnInit returns.
+	// Pass duplicates because Host::OnInit takes ownership of the references it receives.
 	jstring language_ref = duplicate_local_reference (env, language);
 	jstring files_dir_ref = duplicate_local_reference (env, filesDir);
 	jstring cache_dir_ref = duplicate_local_reference (env, cacheDir);

--- a/src/native/nativeaot/host/host-jni.cc
+++ b/src/native/nativeaot/host/host-jni.cc
@@ -2,9 +2,31 @@
 
 #include <host/host-jni.hh>
 #include <host/host-nativeaot.hh>
+#include <host/os-bridge.hh>
 #include <runtime-base/logger.hh>
+#include <shared/helpers.hh>
 
 using namespace xamarin::android;
+
+namespace {
+	jstring duplicate_local_reference (JNIEnv *env, jstring value) noexcept
+	{
+		if (value == nullptr) {
+			return nullptr;
+		}
+
+		auto local_ref = reinterpret_cast<jstring> (env->NewLocalRef (value));
+		if (local_ref != nullptr) [[likely]] {
+			return local_ref;
+		}
+
+		if (env->ExceptionCheck ()) {
+			env->ExceptionDescribe ();
+			env->ExceptionClear ();
+		}
+		Helpers::abort_application ("Failed to duplicate a JNI string reference for NativeAOT initialization");
+	}
+}
 
 auto XA_Host_NativeAOT_JNI_OnLoad (JavaVM *vm, void *reserved) -> int
 {
@@ -13,5 +35,11 @@ auto XA_Host_NativeAOT_JNI_OnLoad (JavaVM *vm, void *reserved) -> int
 
 void XA_Host_NativeAOT_OnInit (jstring language, jstring filesDir, jstring cacheDir, JnienvInitializeArgs *initArgs)
 {
-	Host::OnInit (language, filesDir, cacheDir, initArgs);
+	JNIEnv *env = OSBridge::ensure_jnienv ();
+
+	// Host::OnInit takes ownership of its JNI string references.
+	jstring language_ref = duplicate_local_reference (env, language);
+	jstring files_dir_ref = duplicate_local_reference (env, filesDir);
+	jstring cache_dir_ref = duplicate_local_reference (env, cacheDir);
+	Host::OnInit (language_ref, files_dir_ref, cache_dir_ref, initArgs);
 }

--- a/src/native/nativeaot/host/host-jni.cc
+++ b/src/native/nativeaot/host/host-jni.cc
@@ -3,21 +3,22 @@
 #include <host/host-jni.hh>
 #include <host/host-nativeaot.hh>
 #include <host/os-bridge.hh>
+#include <runtime-base/jni-wrappers.hh>
 #include <runtime-base/logger.hh>
 #include <shared/helpers.hh>
 
 using namespace xamarin::android;
 
 namespace {
-	jstring duplicate_local_reference (JNIEnv *env, jstring value) noexcept
+	jstring_wrapper duplicate_local_reference (JNIEnv *env, jstring value) noexcept
 	{
 		if (value == nullptr) {
-			return nullptr;
+			return jstring_wrapper (env);
 		}
 
 		auto local_ref = reinterpret_cast<jstring> (env->NewLocalRef (value));
 		if (local_ref != nullptr) [[likely]] {
-			return local_ref;
+			return jstring_wrapper (env, local_ref);
 		}
 
 		if (env->ExceptionCheck ()) {
@@ -37,10 +38,9 @@ void XA_Host_NativeAOT_OnInit (jstring language, jstring filesDir, jstring cache
 {
 	JNIEnv *env = OSBridge::ensure_jnienv ();
 
-	// JNI method arguments are borrowed and must remain valid after Host::OnInit returns.
-	// Pass duplicates because Host::OnInit takes ownership of the references it receives.
-	jstring language_ref = duplicate_local_reference (env, language);
-	jstring files_dir_ref = duplicate_local_reference (env, filesDir);
-	jstring cache_dir_ref = duplicate_local_reference (env, cacheDir);
-	Host::OnInit (language_ref, files_dir_ref, cache_dir_ref, initArgs);
+	// Give the wrappers their own references; the caller still needs its borrowed arguments.
+	auto language_js = duplicate_local_reference (env, language);
+	auto files_dir = duplicate_local_reference (env, filesDir);
+	auto cache_dir = duplicate_local_reference (env, cacheDir);
+	Host::OnInit (language_js, files_dir, cache_dir, initArgs);
 }

--- a/src/native/nativeaot/host/host.cc
+++ b/src/native/nativeaot/host/host.cc
@@ -47,18 +47,15 @@ auto HostCommon::Java_JNI_OnLoad (JavaVM *vm, void *reserved) noexcept -> jint
 
 // Be VERY careful with what we do here - the managed runtime is not fully initialized
 // at the point this method is called.
-void Host::OnInit (jstring language, jstring filesDir, jstring cacheDir, JnienvInitializeArgs *initArgs) noexcept
+void Host::OnInit (jstring_wrapper &language, jstring_wrapper &files_dir, jstring_wrapper &cache_dir, JnienvInitializeArgs *initArgs) noexcept
 {
 	abort_if_invalid_pointer_argument (initArgs, "initArgs");
 
 	JNIEnv *env = OSBridge::ensure_jnienv ();
 	jclass runtimeClass = env->FindClass ("mono/android/Runtime");
 
-	jstring_wrapper language_js (env, language);
-	jstring_wrapper files_dir (env, filesDir);
-	jstring_wrapper cache_dir (env, cacheDir);
 	AndroidSystem::set_primary_override_dir (files_dir);
-	HostEnvironment::setup_environment (language_js, files_dir, cache_dir);
+	HostEnvironment::setup_environment (language, files_dir, cache_dir);
 	Logger::init_reference_logging (AndroidSystem::get_primary_override_dir ());
 
 	OSBridge::initialize_on_runtime_init (env, runtimeClass);

--- a/src/native/nativeaot/include/host/host-nativeaot.hh
+++ b/src/native/nativeaot/include/host/host-nativeaot.hh
@@ -6,9 +6,11 @@
 #include "managed-interface.hh"
 
 namespace xamarin::android {
+	class jstring_wrapper;
+
 	class Host : public HostCommon
 	{
 	public:
-		static void OnInit (jstring language, jstring filesDir, jstring cacheDir, JnienvInitializeArgs *initArgs) noexcept;
+		static void OnInit (jstring_wrapper &language, jstring_wrapper &files_dir, jstring_wrapper &cache_dir, JnienvInitializeArgs *initArgs) noexcept;
 	};
 }


### PR DESCRIPTION
## Why this change is necessary

`Java_net_dot_jni_nativeaot_JavaInteropRuntime_init` receives borrowed JNI local references. The native `Host::OnInit()` path wrapped its three string arguments in owning `jstring_wrapper` instances, deleting the original references on return. Managed initialization later reused `filesDir` to set `AppContext.BaseDirectory`, which CheckJNI reported as `Bad global or local ref passed to JNI`.

## What changed

Duplicate `language`, `filesDir`, and `cacheDir` with `NewLocalRef()` at the NativeAOT native boundary. `Host::OnInit()` retains its documented owning behavior while deleting only the duplicates, leaving the JNI method arguments valid for their remaining managed use. Null arguments remain null; allocation failure reports and clears a pending Java exception before aborting.

## Issues fixed

N/A.

## Tests

- `dotnet build src/native/native-nativeaot.csproj -c Debug --no-restore -p:AndroidSupportedTargetJitAbis=arm64-v8a -p:AndroidSupportedTargetAotAbis=arm64`
- Isolated JVM `-Xcheck:jni` reproduction: deleting the borrowed reference fails with `Bad global or local ref passed to JNI`; deleting a `NewLocalRef()` duplicate leaves the original reference valid.