### PR TITLE
[tests] Fix duplicate MockBuildEngine constructor

### DIFF
--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/MockBuildEngine.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/MockBuildEngine.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests;
 /// <summary>
 /// Minimal IBuildEngine implementation for use with TaskLoggingHelper in tests.
 /// </summary>
-sealed class MockBuildEngine (IList<BuildWarningEventArgs>? warnings = null) : IBuildEngine
+sealed class MockBuildEngine : IBuildEngine
 {
 	readonly IList<BuildWarningEventArgs>? warnings;
 


### PR DESCRIPTION
Remove the primary-constructor parameter list from the integration tests' `MockBuildEngine`, fixing CS0111 on `main`.

#12724 (`ecef743e91614754e6e1ab0ed7ed1834ecdedf5c`) added that signature after #12736 had introduced an explicit constructor with the same optional warning-list parameter. The merged combination left both constructors in place. This one-line repair keeps the explicit constructor and warning collection unchanged, including the existing no-XA4326 assertions; it does not change the production generator.

The failure appears in the Linux and macOS builds of [Azure DevOps build 1588988](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1588988):

    MockBuildEngine.cs(15,9): error CS0111: Type 'MockBuildEngine' already defines a member called 'MockBuildEngine' with the same parameter types.

Based directly on current `main` (`d907cd735615d5d17616cbba9e1a4aeef99ab61d`), independently of #12722. Rechecked live main and open PRs before editing and immediately before opening this PR; no equivalent fix was found.

### Validation

- Compiled the actual `MockBuildEngine.cs` using an isolated .NET SDK `11.0.100-rc.1.26431.118`, its net11.0 reference assemblies, and its real `Microsoft.Build.Framework.dll`. The same command reproduced CS0111 before the fix and succeeded without diagnostics after it.
- An artifacts-only host driver compiled together with the fixed source passed default construction, explicit `null`, and supplied-list cases. Logging with default/null was harmless; successive warnings appended to the supplied list with object identity preserved.
- The fixed file is byte-for-byte identical to its last working main version, immediately before #12724.

<details>
<summary>Direct compiler command</summary>

`SDK` points to the private SDK copy and `OUT` to the session artifact directory; run from the repository root:

```bash
refs=()
for ref in "$SDK"/packs/Microsoft.NETCore.App.Ref/*/ref/net11.0/*.dll; do
    refs+=("-r:$ref")
done
"$SDK/dotnet" exec \
    "$SDK/sdk/11.0.100-rc.1.26431.118/Roslyn/bincore/csc.dll" \
    -nologo -target:library -nullable:enable -langversion:latest \
    "-out:$OUT/MockBuildEngine.dll" "${refs[@]}" \
    "-r:$SDK/sdk/11.0.100-rc.1.26431.118/Microsoft.Build.Framework.dll" \
    tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/MockBuildEngine.cs
```

</details>

**Integration-test limit:** Attempted `dotnet test tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests.csproj --no-restore -p:BuildProjectReferences=false --filter 'FullyQualifiedName~JniAssemblyRewriterTests|FullyQualifiedName~GeneratedTypeMapRewriterTests' -v minimal`, but no tests executed in the unprepared worktree. A subsequent `dotnet build` of the same project with `--no-restore -p:BuildProjectReferences=false -v minimal` confirmed NETSDK1004 (missing `project.assets.json`). The local Android build outputs are also absent. No full bootstrap or device tests were run, and older installed generator binaries were not substituted for current-main integration validation.