### PR TITLE
[NativeAOT] Let the SDK select runtime packs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
@@ -10,7 +10,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup>
     <AndroidNETSdkVersion>@ANDROID_PACK_VERSION_LONG@</AndroidNETSdkVersion>
     <XamarinAndroidVersion>@ANDROID_PACK_VERSION_LONG@</XamarinAndroidVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>@MICROSOFT_NETCORE_APP_REF_PACKAGE_VERSION@</MicrosoftNETCoreAppRefPackageVersion>
     <_AndroidLatestStableApiLevel>@ANDROID_LATEST_STABLE_API_LEVEL@</_AndroidLatestStableApiLevel>
     <_AndroidLatestUnstableApiLevel>@ANDROID_LATEST_UNSTABLE_API_LEVEL@</_AndroidLatestUnstableApiLevel>
     <_AndroidSupportedApiLevels>,@ANDROID_API_LEVELS@,</_AndroidSupportedApiLevels>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -34,16 +34,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
     <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
   </PropertyGroup>
 
-  <!-- Outer restores use RuntimeIdentifiers; RuntimeIdentifier is only set in per-RID inner builds. -->
-  <ItemGroup>
-    <_AndroidNetCoreAppNativeAotKnownRuntimePack Include="@(KnownRuntimePack->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('RuntimePackLabels', 'NativeAOT'))" />
-    <KnownRuntimePack Remove="@(_AndroidNetCoreAppNativeAotKnownRuntimePack)" />
-    <KnownRuntimePack Include="@(_AndroidNetCoreAppNativeAotKnownRuntimePack)">
-      <LatestRuntimeFrameworkVersion>$(MicrosoftNETCoreAppRefPackageVersion)</LatestRuntimeFrameworkVersion>
-      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);android-arm</RuntimePackRuntimeIdentifiers>
-    </KnownRuntimePack>
-  </ItemGroup>
-
   <!-- Default property values for NativeAOT Debug configuration -->
   <PropertyGroup Condition="'$(DebugSymbols)' == 'true'">
     <NativeDebugSymbols>true</NativeDebugSymbols>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
+using System.Text.Json;
 
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
@@ -119,17 +119,25 @@ namespace Xamarin.Android.Build.Tests
 			);
 
 			var intermediate = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath);
-			var assets = File.ReadAllText (Path.Combine (intermediate, "..", "project.assets.json"));
-			var runtimePackMatch = Regex.Match (assets, "\"Microsoft\\.NETCore\\.App\\.Runtime\\.NativeAOT\\.[a-z0-9.-]+/([^\"]+)\"");
-			Assert.IsTrue (
-				runtimePackMatch.Success,
+			using var assets = JsonDocument.Parse (File.ReadAllText (Path.Combine (intermediate, "..", "project.assets.json")));
+			var runtimePacks = assets.RootElement
+				.GetProperty ("project")
+				.GetProperty ("frameworks")
+				.EnumerateObject ()
+				.SelectMany (framework => framework.Value.GetProperty ("downloadDependencies").EnumerateArray ())
+				.Where (dependency => dependency.GetProperty ("name").GetString ()?.StartsWith ("Microsoft.NETCore.App.Runtime.NativeAOT.", StringComparison.Ordinal) == true)
+				.ToArray ();
+			Assert.IsNotEmpty (
+				runtimePacks,
 				"Restore should select a NativeAOT runtime pack."
 			);
-			Assert.AreNotEqual (
-				"0.0.0",
-				runtimePackMatch.Groups [1].Value,
-				"Restore should ignore MicrosoftNETCoreAppRefPackageVersion and use the SDK-selected NativeAOT runtime pack version."
-			);
+			foreach (var runtimePack in runtimePacks) {
+				Assert.AreNotEqual (
+					"[0.0.0, 0.0.0]",
+					runtimePack.GetProperty ("version").GetString (),
+					"Restore should ignore MicrosoftNETCoreAppRefPackageVersion and use the SDK-selected NativeAOT runtime pack version."
+				);
+			}
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
@@ -98,6 +99,36 @@ namespace Xamarin.Android.Build.Tests
 				"\"Microsoft.NETCore.App.Runtime.NativeAOT.linux-bionic-arm\"",
 				assets,
 				"Restore should not fall back to the linux-bionic-arm NativeAOT runtime pack."
+			);
+		}
+
+		[Test]
+		public void RestoreNativeAot_UsesSdkRuntimePackVersion ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.NativeAOT);
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (
+				builder.RunTarget (proj, "Restore", parameters: [
+					"MicrosoftNETCoreAppRefPackageVersion=0.0.0",
+				]),
+				"Restore should use the .NET SDK's NativeAOT runtime pack version."
+			);
+
+			var intermediate = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath);
+			var assets = File.ReadAllText (Path.Combine (intermediate, "..", "project.assets.json"));
+			var runtimePackMatch = Regex.Match (assets, "\"Microsoft\\.NETCore\\.App\\.Runtime\\.NativeAOT\\.[a-z0-9.-]+/([^\"]+)\"");
+			Assert.IsTrue (
+				runtimePackMatch.Success,
+				"Restore should select a NativeAOT runtime pack."
+			);
+			Assert.AreNotEqual (
+				"0.0.0",
+				runtimePackMatch.Groups [1].Value,
+				"Restore should ignore MicrosoftNETCoreAppRefPackageVersion and use the SDK-selected NativeAOT runtime pack version."
 			);
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -281,7 +281,6 @@
       <_BundledVersionsCacheLines Include="AndroidBuildApiLevel=$(_AndroidBuildApiLevels)" />
       <_BundledVersionsCacheLines Include="DotNetTargetFramework=$(DotNetTargetFramework)" />
       <_BundledVersionsCacheLines Include="DotNetTargetFrameworkVersion=$(DotNetTargetFrameworkVersion)" />
-      <_BundledVersionsCacheLines Include="MicrosoftNETCoreAppRefPackageVersion=$(MicrosoftNETCoreAppRefPackageVersion)" />
     </ItemGroup>
     <WriteLinesToFile
         File="$(IntermediateOutputPath)_GenerateBundledVersions.cache"
@@ -304,7 +303,6 @@
       <_BundledVersionsReplacement Include="@ANDROID_LATEST_UNSTABLE_API_LEVEL@=$(AndroidLatestUnstableApiLevel)" />
       <_BundledVersionsReplacement Include="@ANDROID_API_LEVELS@=$(_AndroidBuildApiLevels)" />
       <_BundledVersionsReplacement Include="@DOTNET_TARGET_FRAMEWORK@=$(DotNetTargetFramework)" />
-      <_BundledVersionsReplacement Include="@MICROSOFT_NETCORE_APP_REF_PACKAGE_VERSION@=$(MicrosoftNETCoreAppRefPackageVersion)" />
     </ItemGroup>
     <ReplaceFileContents
         SourceFile="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\in\Microsoft.Android.Sdk.BundledVersions.in.targets"


### PR DESCRIPTION
The Android RC1 workload stamped its build-time `MicrosoftNETCoreAppRefPackageVersion` into customer projects and used it to rewrite the .NET SDK's NativeAOT `KnownRuntimePack` metadata. When the workload was built against `11.0.0-rc.1.26428.117` but installed with the `11.0.100-rc.1.26425.128` SDK, `dotnet publish -p:PublishAot=true` requested runtime-pack versions that were not available on NuGet.org.

- Remove the Android-side `KnownRuntimePack` rewrite now that the .NET SDK advertises `android-arm` itself.
- Stop exporting `MicrosoftNETCoreAppRefPackageVersion` from the Android workload's bundled-version targets.
- Add restore coverage proving an invalid workload dependency version cannot affect the SDK-selected NativeAOT runtime-pack version.

This keeps runtime-pack and ILCompiler selection owned by the installed .NET SDK and avoids mismatches between independently built SDK and Android workload releases.

Fixes #12362