### PR TITLE
[release/10.0.1xx] Backport selective R8 obfuscation and optimization

### DIFF
--- a/Documentation/docs-mobile/TOC.yml
+++ b/Documentation/docs-mobile/TOC.yml
@@ -274,6 +274,8 @@
         href: messages/xa1037.md
       - name: XA1038
         href: messages/xa1038.md
+      - name: XA1050
+        href: messages/xa1050.md
     - name: "XA2xxx: Linker"
       items:
       - name: "XA2xxx: Linker"

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -1119,6 +1119,22 @@ r8 dex-compiler and shrinker. The default value is a path into the
 .NET for Android workload installation. For further information see our
 documentation on [D8 and R8][d8-r8].
 
+## AndroidR8ObfuscationMode
+
+An enum-style property that specifies how `r8` obfuscates Java names when
+[`$(AndroidLinkTool)`](#androidlinktool) is `r8`. Supported values are:
+
+- `private-members` preserves Java class and interface names and public or
+  protected member names. Private and package-private members can be
+  obfuscated, and R8 optimization is enabled.
+- `disabled` disables obfuscation, preserves all Java names, and uses the
+  non-optimizing Android R8 defaults.
+
+This property does not disable R8 code shrinking.
+
+This property was introduced in a .NET 10 servicing release and defaults to
+`disabled` in .NET 10.
+
 ## AndroidResgenExtraArgs
 
 Specifies

--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -150,6 +150,7 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 + [XA1039](xa1039.md): The Android Support libraries are not supported in .NET 9 and later, please migrate to AndroidX. See https://aka.ms/xamarin/androidx for more details.
 + [XA1040](xa1040.md): The CoreCLR runtime on Android is an experimental feature and not yet suitable for production use. File issues at: https://github.com/dotnet/android/issues
 + [XA1041](xa1041.md): The MSBuild property 'MonoAndroidAssetPrefix' has an invalid value of 'c:\Foo\Assets'. The value is expected to be a directory path representing the relative location of your Assets or Resources
++ [XA1050](xa1050.md): The 'AndroidR8ObfuscationMode' MSBuild property has an invalid value.
 
 ## XA2xxx: Linker
 

--- a/Documentation/docs-mobile/messages/xa1050.md
+++ b/Documentation/docs-mobile/messages/xa1050.md
@@ -1,0 +1,34 @@
+---
+title: .NET for Android error XA1050
+description: XA1050 error code
+ms.date: 09/10/2026
+f1_keywords:
+  - "XA1050"
+---
+
+# .NET for Android error XA1050
+
+## Example messages
+
+```dotnetcli
+error XA1050: The 'AndroidR8ObfuscationMode' MSBuild property has an invalid value of 'private-member'. Valid values are 'disabled' and 'private-members'.
+```
+
+## Issue
+
+The [`$(AndroidR8ObfuscationMode)`](../building-apps/build-properties.md#androidr8obfuscationmode)
+MSBuild property contains an unsupported value. This property is validated when
+R8 runs.
+
+## Solution
+
+Set `$(AndroidR8ObfuscationMode)` to one of the supported values:
+
+```xml
+<PropertyGroup>
+  <AndroidR8ObfuscationMode>private-members</AndroidR8ObfuscationMode>
+</PropertyGroup>
+```
+
+Use `disabled` to preserve all Java names and use the legacy non-optimizing
+Android R8 configuration.

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -136,6 +136,7 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_clr.dex" ExcludeFromLegacy="true" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)java_runtime_fastdev_clr.dex" ExcludeFromLegacy="true" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)manifestmerger.jar" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)proguard-android-optimize.txt" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)proguard-android.txt" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)protobuf-net.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)System.CodeDom.dll" />

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -903,6 +903,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;AndroidR8ObfuscationMode&apos; MSBuild property has an invalid value of &apos;{0}&apos;. Valid values are &apos;disabled&apos; and &apos;private-members&apos;..
+        /// </summary>
+        public static string XA1050 {
+            get {
+                return ResourceManager.GetString("XA1050", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 and higher will only support a single AppDomain, so this API will no longer be available in .NET for Android once .NET 6 is released..
         /// </summary>
         public static string XA2000 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1009,6 +1009,11 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - The current value of the property
 </comment>
   </data>
+  <data name="XA1050" xml:space="preserve">
+    <value>The 'AndroidR8ObfuscationMode' MSBuild property has an invalid value of '{0}'. Valid values are 'disabled' and 'private-members'.</value>
+    <comment>The following are literal names and should not be translated: AndroidR8ObfuscationMode, MSBuild, disabled, private-members.
+{0} - The invalid value of the AndroidR8ObfuscationMode MSBuild property.</comment>
+  </data>
   <data name="XA4241" xml:space="preserve">
     <value>Java dependency '{0}' is not satisfied.</value>
     <comment>The following are literal names and should not be translated: Java.

--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
@@ -1,7 +1,5 @@
 # This is Xamarin-specific (and enhanced) configuration.
 
--dontobfuscate
-
 -keep class android.support.multidex.MultiDexApplication { <init>(); }
 -keep class net.dot.jni.** { *; <init>(); }
 -keep class mono.MonoRuntimeProvider* { *; <init>(...); }
@@ -22,6 +20,8 @@
 -keepclassmembers class md52ce486a14f4bcd95899665e9d932190b.** { *; <init>(...); }
 
 # .NET runtime
+# Loaded by name from managed code.
+-keep class net.dot.android.ApplicationRegistration { *; }
 -keep class net.dot.android.crypto.** { *; <init>(...); }
 
 # Android's template misses fluent setters...

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Android.Tasks
 		public string? ProguardMappingFileOutput { get; set; }
 		public string? BuildMetadataFileOutput { get; set; }
 		public string []? ProguardConfigurationFiles { get; set; }
+		public string ObfuscationMode { get; set; } = "disabled";
 
 		protected override string MainClass => "com.android.tools.r8.R8";
 
@@ -116,6 +117,9 @@ namespace Xamarin.Android.Tasks
 				}
 				if (!ProguardCommonXamarinConfiguration.IsNullOrWhiteSpace ()) {
 					using (var xamcfg = File.CreateText (ProguardCommonXamarinConfiguration)) {
+						WriteObfuscationRules (xamcfg, ObfuscationMode);
+						xamcfg.WriteLine ();
+						xamcfg.Flush ();
 						GetType ().Assembly.GetManifestResourceStream ("proguard_xamarin.cfg").CopyTo (xamcfg.BaseStream);
 						if (IgnoreWarnings) {
 							xamcfg.WriteLine ("-ignorewarnings");
@@ -163,6 +167,27 @@ namespace Xamarin.Android.Tasks
 			}
 
 			return responseFile;
+		}
+
+		internal static void WriteObfuscationRules (TextWriter writer, string obfuscationMode)
+		{
+			if (string.Equals (obfuscationMode, "disabled", StringComparison.OrdinalIgnoreCase)) {
+				writer.WriteLine ("-dontobfuscate");
+				return;
+			}
+			if (!string.Equals (obfuscationMode, "private-members", StringComparison.OrdinalIgnoreCase)) {
+				throw new ArgumentException ($"Unsupported R8 obfuscation mode '{obfuscationMode}'.", nameof (obfuscationMode));
+			}
+
+			writer.WriteLine ("-keep,allowshrinking,allowoptimization class **");
+			writer.WriteLine ("-keepclassmembers,allowshrinking,allowoptimization class ** {");
+			writer.WriteLine ("   public protected *;");
+			writer.WriteLine ("}");
+			// Managed interface proxy selection observes Class.getInterfaces(), which R8 cannot infer.
+			writer.WriteLine ("-keep,allowoptimization interface ** {");
+			writer.WriteLine ("   public protected *;");
+			writer.WriteLine ("}");
+			writer.WriteLine ("-keep,allowshrinking class * implements **");
 		}
 
 		// Note: We do not want to call the base.LogEventsFromTextOutput as it will incorrectly identify

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Xamarin.ProjectTools;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Collections.Generic;
 using System.Xml.Linq;
 using Xamarin.Tools.Zip;
@@ -17,12 +18,18 @@ namespace Xamarin.Android.Build.Tests
 	public class PackagingTest : BaseTest
 	{
 		[Test]
-		public void CheckR8MetadataFilesExist ()
+		[TestCase (null, false)]
+		[TestCase ("disabled", false)]
+		[TestCase ("private-members", true)]
+		public void CheckR8MetadataFilesExist (string obfuscationMode, bool optimizationsEnabled)
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
 			};
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidLinkTool, "r8");
+			if (obfuscationMode != null) {
+				proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidR8ObfuscationMode, obfuscationMode);
+			}
 			// Projects must set $(AndroidCreateProguardMappingFile) to true to opt in
 			proj.SetProperty (proj.ReleaseProperties, "AndroidCreateProguardMappingFile", true);
 			proj.SetProperty ("AndroidPackageFormat", "aab");
@@ -35,13 +42,57 @@ namespace Xamarin.Android.Build.Tests
 				FileAssert.Exists (aab, $"'{aab}' should have been generated.");
 				using (var zip = ZipHelper.OpenZip (aab)) {
 					Assert.IsTrue (zip.Any (e => e.FullName == "BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map"), $"AAB file `{aab}` should contain the ProGuard mapping.");
-					Assert.IsTrue (zip.Any (e => e.FullName == "BUNDLE-METADATA/com.android.tools/r8.json"), $"AAB file `{aab}` should contain the R8 build metadata.");
+					var metadata = zip.SingleOrDefault (e => e.FullName == "BUNDLE-METADATA/com.android.tools/r8.json");
+					Assert.IsNotNull (metadata, $"AAB file `{aab}` should contain the R8 build metadata.");
+					using var stream = new MemoryStream ();
+					metadata.Extract (stream);
+					stream.Position = 0;
+					using var document = JsonDocument.Parse (stream);
+					var options = document.RootElement.GetProperty ("options");
+					Assert.AreEqual (optimizationsEnabled, options.GetProperty ("isOptimizationsEnabled").GetBoolean ());
 				}
 
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
 				foreach (var target in new [] { "_CompileToDalvik", "_BuildApkEmbed" }) {
 					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
 				}
+			}
+		}
+
+		[Test]
+		public void InvalidR8ObfuscationModeFailsBuild ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidLinkTool, "r8");
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidR8ObfuscationMode, "private-member");
+
+			using var builder = CreateApkBuilder ();
+			builder.ThrowOnBuildFailure = false;
+			Assert.IsFalse (builder.Build (proj), "Build should reject an invalid AndroidR8ObfuscationMode.");
+			StringAssertEx.Contains ("error XA1050", builder.LastBuildOutput);
+			StringAssertEx.Contains ("'private-member'", builder.LastBuildOutput);
+		}
+
+		[TestCase ("", true)]
+		[TestCase ("r8", false)]
+		public void InvalidR8ObfuscationModeIsValidatedOnlyForR8 (string linkTool, bool expectedResult)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidLinkTool, linkTool);
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidR8ObfuscationMode, "private-member");
+
+			using var builder = CreateApkBuilder ();
+			builder.Target = "_ValidateAndroidR8ObfuscationMode";
+			builder.ThrowOnBuildFailure = false;
+			builder.AutomaticNuGetRestore = false;
+			Assert.AreEqual (expectedResult, builder.Build (proj), "Validation result should depend on whether R8 is enabled.");
+			if (!expectedResult) {
+				StringAssertEx.Contains ("error XA1050", builder.LastBuildOutput);
+				StringAssertEx.Contains ("'private-member'", builder.LastBuildOutput);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/R8Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/R8Tests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class R8Tests
+	{
+		[Test]
+		public void WritePrivateMemberObfuscationRules ()
+		{
+			using var writer = new StringWriter ();
+			R8.WriteObfuscationRules (writer, "private-members");
+
+			var expected = """
+				-keep,allowshrinking,allowoptimization class **
+				-keepclassmembers,allowshrinking,allowoptimization class ** {
+				   public protected *;
+				}
+				-keep,allowoptimization interface ** {
+				   public protected *;
+				}
+				-keep,allowshrinking class * implements **
+
+				""";
+			Assert.AreEqual (expected.ReplaceLineEndings (Environment.NewLine), writer.ToString ());
+		}
+
+		[Test]
+		public void WriteDisabledObfuscationRules ()
+		{
+			using var writer = new StringWriter ();
+			R8.WriteObfuscationRules (writer, "disabled");
+
+			Assert.AreEqual ("-dontobfuscate" + Environment.NewLine, writer.ToString ());
+		}
+
+		[Test]
+		public void WriteInvalidObfuscationModeThrows ()
+		{
+			using var writer = new StringWriter ();
+
+			Assert.Throws<ArgumentException> (() => R8.WriteObfuscationRules (writer, "private-member"));
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -25,6 +25,7 @@ namespace Xamarin.ProjectTools
 		public const string AndroidEnableDesugar = "AndroidEnableDesugar";
 		public const string AndroidManifestMerger = "AndroidManifestMerger";
 		public const string AndroidLinkTool = "AndroidLinkTool";
+		public const string AndroidR8ObfuscationMode = "AndroidR8ObfuscationMode";
 		public const string UseJackAndJill = "UseJackAndJill";
 		public const string AotAssemblies = "AotAssemblies";
 		public const string AndroidEnableProfiledAot = "AndroidEnableProfiledAot";

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -252,6 +252,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' ">False</AndroidEnableDesugar>
 	<AndroidD8IgnoreWarnings    Condition=" '$(AndroidD8IgnoreWarnings)' == '' ">True</AndroidD8IgnoreWarnings>
 	<AndroidR8IgnoreWarnings    Condition=" '$(AndroidR8IgnoreWarnings)' == '' ">True</AndroidR8IgnoreWarnings>
+	<AndroidR8ObfuscationMode   Condition=" '$(AndroidR8ObfuscationMode)' == '' ">disabled</AndroidR8ObfuscationMode>
 	<AndroidCreateProguardMappingFile Condition="'$(AndroidCreateProguardMappingFile)' == '' And '$(AndroidLinkTool)' == 'r8'">True</AndroidCreateProguardMappingFile>
 
 	<!-- Figure out which is the main packaging format we want-->
@@ -968,6 +969,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidEnableProfiledAot=$(AndroidEnableProfiledAot)" />
 		<_PropertyCacheItems Include="AndroidDexTool=$(AndroidDexTool)" />
 		<_PropertyCacheItems Include="AndroidLinkTool=$(AndroidLinkTool)" />
+		<_PropertyCacheItems Include="AndroidR8ObfuscationMode=$(AndroidR8ObfuscationMode)" />
 		<_PropertyCacheItems Include="AndroidLinkResources=$(AndroidLinkResources)" />
 		<_PropertyCacheItems Include="AndroidPackageFormat=$(AndroidPackageFormat)" />
 		<_PropertyCacheItems Include="EmbedAssembliesIntoApk=$(EmbedAssembliesIntoApk)" />
@@ -2115,7 +2117,8 @@ because xbuild doesn't support framework reference assemblies.
     <_ProguardConfiguration Include="$(ProguardConfigFiles)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(ProguardConfigFiles)' == '' ">
-    <_ProguardConfiguration Include="$(MSBuildThisFileDirectory)proguard-android.txt" />
+    <_ProguardConfiguration Include="$(MSBuildThisFileDirectory)proguard-android.txt"          Condition=" '$(AndroidR8ObfuscationMode)' == 'disabled' " />
+    <_ProguardConfiguration Include="$(MSBuildThisFileDirectory)proguard-android-optimize.txt" Condition=" '$(AndroidR8ObfuscationMode)' == 'private-members' " />
     <_ProguardConfiguration Include="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"         Condition=" '$(AndroidLinkTool)' != '' " />
     <_ProguardConfiguration Include="$(_ProguardProjectConfiguration)"                               Condition=" '$(AndroidLinkTool)' != '' " />
     <_ProguardConfiguration Include="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg" Condition=" '$(AndroidLinkTool)' != '' " />
@@ -3078,6 +3081,15 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="Dependencies" ItemName="AndroidDependency" />
     <Output TaskParameter="JavaDependencies" ItemName="JavaDependency" />
   </CalculateProjectDependencies>
+</Target>
+
+<Target Name="_ValidateAndroidR8ObfuscationMode"
+    BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+    Condition=" '$(AndroidLinkTool)' == 'r8' ">
+  <AndroidError Code="XA1050"
+      ResourceName="XA1050"
+      FormatArguments="$(AndroidR8ObfuscationMode)"
+      Condition=" '$(AndroidR8ObfuscationMode)' != 'disabled' And '$(AndroidR8ObfuscationMode)' != 'private-members' " />
 </Target>
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -75,6 +75,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         ProguardMappingFileOutput="$(AndroidProguardMappingFile)"
         BuildMetadataFileOutput="$(_AndroidR8BuildMetadataFile)"
         ProguardConfigurationFiles="@(_ProguardConfiguration)"
+        ObfuscationMode="$(AndroidR8ObfuscationMode)"
         EnableShrinking="$(_R8EnableShrinking)"
         EnableMultiDex="$(AndroidEnableMultiDex)"
         MultiDexMainDexListFile="$(_AndroidMainDexListFile)"

--- a/src/proguard-android/proguard-android.targets
+++ b/src/proguard-android/proguard-android.targets
@@ -1,29 +1,35 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_Destination>$(MicrosoftAndroidSdkOutDir)proguard-android.txt</_Destination>
+    <_OptimizeDestination>$(MicrosoftAndroidSdkOutDir)proguard-android-optimize.txt</_OptimizeDestination>
   </PropertyGroup>
 
   <Target Name="_GenerateProGuardRules"
       BeforeTargets="Build"
       Inputs="$(MSBuildThisFile);build.gradle;settings.gradle"
-      Outputs="$(_Destination)">
+      Outputs="$(_Destination);$(_OptimizeDestination)">
     <Exec
         Command="&quot;$(GradleWPath)&quot; extractProguardFiles $(GradleArgs)"
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <ItemGroup>
-      <_ProguardRules Include="$(MSBuildThisFileDirectory)build\intermediates\default_proguard_files\global\proguard-android.txt-*" />
+      <_ProguardRules Include="$(MSBuildThisFileDirectory)build\intermediates\default_proguard_files\global\proguard-android.txt-*">
+        <Destination>$(_Destination)</Destination>
+      </_ProguardRules>
+      <_ProguardRules Include="$(MSBuildThisFileDirectory)build\intermediates\default_proguard_files\global\proguard-android-optimize.txt-*">
+        <Destination>$(_OptimizeDestination)</Destination>
+      </_ProguardRules>
     </ItemGroup>
     <Copy
         SourceFiles="@(_ProguardRules)"
-        DestinationFiles="$(_Destination)"
+        DestinationFiles="@(_ProguardRules->'%(Destination)')"
     />
-    <Touch Files="$(_Destination)" />
+    <Touch Files="$(_Destination);$(_OptimizeDestination)" />
   </Target>
 
   <Target Name="_CleanProguardRules" BeforeTargets="Clean">
-    <Delete Files="$(_Destination)" />
+    <Delete Files="$(_Destination);$(_OptimizeDestination)" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"

--- a/tests/MSBuildDeviceIntegration/Tests/R8ObfuscationTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/R8ObfuscationTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	[Category ("UsesDevice")]
+	public class R8ObfuscationTests : DeviceTest
+	{
+		const string SuccessMarker = "# R8_SELECTIVE_OBFUSCATION_RESULT 21";
+		const string JavaClassName = "example/ObfuscationProbe";
+		const string JavaMappingClassName = "example.ObfuscationProbe";
+
+		[TestCase (AndroidRuntime.MonoVM)]
+		[TestCase (AndroidRuntime.CoreCLR)]
+		public void PrivateJavaMembersAreObfuscated (AndroidRuntime runtime)
+		{
+			var packageName = $"com.xamarin.r8obfuscation.{runtime.ToString ().ToLowerInvariant ()}";
+			var proj = new XamarinAndroidApplicationProject (packageName: packageName) {
+				IsRelease = true,
+				OtherBuildItems = {
+					new AndroidItem.AndroidJavaSource ("ObfuscationProbe.java") {
+						Encoding = new UTF8Encoding (encoderShouldEmitUTF8Identifier: false),
+						TextContent = () => """
+							package example;
+
+							public class ObfuscationProbe {
+								public static int publicEntry (int value) {
+									return protectedEntry (value) + packagePrivateEntry (value) + privateEntry (value);
+								}
+
+								protected static int protectedEntry (int value) {
+									return value + 1;
+								}
+
+								static int packagePrivateEntry (int value) {
+									return value + 2;
+								}
+
+								private static int privateEntry (int value) {
+									return value + 3;
+								}
+							}
+							""",
+						Metadata = {
+							{ "Bind", "False" },
+						},
+					},
+					new BuildItem (AndroidBuildActions.ProguardConfiguration, "proguard.cfg") {
+						TextContent = () => """
+							-keep,allowobfuscation class example.ObfuscationProbe {
+							   <methods>;
+							   <fields>;
+							}
+							""",
+					},
+				},
+			};
+			proj.SetRuntime (runtime);
+			proj.SetRuntimeIdentifiers (new [] { DeviceAbi });
+			proj.SetProperty ("AndroidLinkTool", "r8");
+			proj.SetProperty ("AndroidR8ObfuscationMode", "private-members");
+			proj.SetProperty ("AndroidCreateProguardMappingFile", "true");
+			proj.SetDefaultTargetDevice ();
+			proj.MainActivity = proj.DefaultMainActivity.Replace (
+				"//${AFTER_ONCREATE}",
+				"""
+				using var probeClass = Java.Lang.Class.ForName (
+					"example.ObfuscationProbe",
+					initialize: true,
+					Android.App.Application.Context.ClassLoader);
+				IntPtr publicEntry = Android.Runtime.JNIEnv.GetStaticMethodID (probeClass.Handle, "publicEntry", "(I)I");
+				int result = Android.Runtime.JNIEnv.CallStaticIntMethod (probeClass.Handle, publicEntry, new Android.Runtime.JValue (5));
+				Console.WriteLine ($"# R8_SELECTIVE_OBFUSCATION_RESULT {result}");
+				if (result != 21) {
+					throw new InvalidOperationException ($"Unexpected R8 obfuscation probe result: {result}");
+				}
+				""");
+
+			using var builder = CreateApkBuilder ();
+			bool installed = false;
+			try {
+				installed = builder.Install (proj);
+				Assert.IsTrue (installed, "Project should have installed.");
+
+				var projectDirectory = Path.Combine (Root, builder.ProjectDirectory);
+				var mappingFiles = Directory.GetFiles (
+					Path.Combine (projectDirectory, proj.OutputPath),
+					"mapping.txt",
+					SearchOption.AllDirectories);
+				Assert.AreEqual (1, mappingFiles.Length, "The R8 build should produce one mapping file.");
+				string mapping = File.ReadAllText (mappingFiles [0]);
+
+				StringAssert.Contains ($"{JavaMappingClassName} -> {JavaMappingClassName}:", mapping,
+					"Java class names should remain unchanged.");
+				string mappedPackagePrivateMethod = GetRenamedMethod (mapping, "packagePrivateEntry");
+				string mappedPrivateMethod = GetRenamedMethod (mapping, "privateEntry");
+
+				var dexFiles = Directory.GetFiles (
+					Path.Combine (projectDirectory, proj.IntermediateOutputPath),
+					"classes*.dex",
+					SearchOption.AllDirectories);
+				Assert.IsNotEmpty (dexFiles, "R8 should produce at least one DEX file.");
+				AssertDexContainsMethod (dexFiles, "publicEntry");
+				AssertDexContainsMethod (dexFiles, "protectedEntry");
+				AssertDexContainsMethod (dexFiles, mappedPackagePrivateMethod);
+				AssertDexContainsMethod (dexFiles, mappedPrivateMethod);
+				AssertDexDoesNotContainMethod (dexFiles, "packagePrivateEntry");
+				AssertDexDoesNotContainMethod (dexFiles, "privateEntry");
+
+				ClearAdbLogcat ();
+				RunProjectAndAssert (proj, builder, doNotCleanupOnUpdate: true);
+				Assert.IsTrue (WaitForActivityToStart (proj.PackageName, "MainActivity",
+					Path.Combine (projectDirectory, "logcat.log"), 30), "Activity should have started.");
+				Assert.IsTrue (MonitorAdbLogcat (line => line.Contains (SuccessMarker),
+					Path.Combine (projectDirectory, "startup-logcat.log"), 45), $"Output did not contain {SuccessMarker}.");
+			} finally {
+				if (installed) {
+					try {
+						builder.ThrowOnBuildFailure = false;
+						if (!builder.Uninstall (proj)) {
+							TestContext.Error.WriteLine ($"Failed to uninstall '{proj.PackageName}' during test cleanup.");
+						}
+					} catch (Exception ex) {
+						TestContext.Error.WriteLine ($"Failed to uninstall '{proj.PackageName}' during test cleanup: {ex}");
+					}
+				}
+			}
+		}
+
+		static string GetRenamedMethod (string mapping, string methodName)
+		{
+			var match = Regex.Match (
+				mapping,
+				$@"(?m)^\s*(?:\d+:\d+:)?int {Regex.Escape (methodName)}\(int\)(?::\d+:\d+)?\s+->\s+(?<name>\S+)\s*$");
+			Assert.IsTrue (match.Success, $"R8 mapping should contain {methodName}(int).");
+			string mappedMethodName = match.Groups ["name"].Value;
+			Assert.AreNotEqual (methodName, mappedMethodName, $"{methodName}(int) should be renamed.");
+			return mappedMethodName;
+		}
+
+		void AssertDexContainsMethod (string [] dexFiles, string methodName)
+		{
+			Assert.IsTrue (dexFiles.Any (dex => DexUtils.ContainsClassWithMethod (
+				$"L{JavaClassName};", methodName, "(I)I", dex, AndroidSdkPath)),
+				$"DEX should contain {JavaClassName}.{methodName}(int).");
+		}
+
+		void AssertDexDoesNotContainMethod (string [] dexFiles, string methodName)
+		{
+			Assert.IsFalse (dexFiles.Any (dex => DexUtils.ContainsClassWithMethod (
+				$"L{JavaClassName};", methodName, "(I)I", dex, AndroidSdkPath)),
+				$"DEX should not contain {JavaClassName}.{methodName}(int).");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Backports the complete relevant selective R8 obfuscation/optimization work from #12668 to .NET 10 servicing and incorporates the follow-up validation changes from #12753.

- keeps `$(AndroidR8ObfuscationMode)` defaulted to `disabled` on .NET 10, preserving existing behavior
- makes `private-members` available as an explicit opt-in, enabling R8 optimization while preserving Java class/interface and public/protected member names
- adds `XA1050` validation, English resources, documentation, and message documentation for unsupported values
- gates mode validation on `$(AndroidLinkTool) == r8`, so unrelated builds are unaffected
- adds task, packaging, incremental-build, invalid-mode, R8-only validation, and device coverage
- installs both Android default R8 configuration variants

## Release-branch adaptations

The release branch predates main's NativeAOT `R8Mapping` and user-Java-source rooting infrastructure. Device coverage is therefore adapted to MonoVM and CoreCLR, reads `mapping.txt` directly, and supplies the explicit keep rule needed for the Java probe. The release task's existing `string[]` configuration-file shape is retained.

No `.apkdesc` baselines are changed: unlike main, the .NET 10 servicing default remains `disabled`, and measured targeted packaging/device coverage did not require release baseline updates. No unrelated Java.Interop version changes are included.

## Validation

- built `Xamarin.Android.sln` and configured the repository local Android workload
- built `Xamarin.Android.Build.Tests` and `MSBuildDeviceIntegration`
- R8 task and packaging matrix: 9/9 passed, covering default, explicit `disabled`, explicit `private-members`, incremental builds, metadata/optimization state, invalid-mode `XA1050`, and validation with R8 enabled/disabled
- physical-device R8 coverage: 2/2 passed on MonoVM and CoreCLR
- changed XML files parse successfully
- `git diff --check` passes
- final review reported no findings

Backport of #12668; includes #12753.