### PR TITLE
[Java.Interop] Keep JNI reference owners alive during calls

### DIFF
--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JavaPeerableExtensions.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JavaPeerableExtensions.cs
@@ -12,7 +12,10 @@ namespace Java.Interop {
 		public static string? GetJniTypeName (this IJavaPeerable self)
 		{
 			JniPeerMembers.AssertSelf (self);
-			return JniEnvironment.Types.GetJniTypeNameFromInstance (self.PeerReference);
+			var name = JniEnvironment.Types.GetJniTypeNameFromInstance (self.PeerReference);
+			// PeerReference is borrowed and does not keep its managed owner alive.
+			GC.KeepAlive (self);
+			return name;
 		}
 
 		/// <include file="../Documentation/Java.Interop/JavaPeerableExtensions.xml" path="/docs/member[@name='M:TryJavaCast']/*" />
@@ -42,10 +45,12 @@ namespace Java.Interop {
 			}
 
 			var r = self.PeerReference;
-			return JniEnvironment.Runtime.ValueManager.CreatePeer (
+			var peer = JniEnvironment.Runtime.ValueManager.CreatePeer (
 					ref r, JniObjectReferenceOptions.Copy,
 					targetType: typeof (TResult))
 				as TResult;
+			GC.KeepAlive (self);
+			return peer;
 		}
 	}
 }

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniEnvironment.Errors.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniEnvironment.Errors.cs
@@ -39,6 +39,7 @@ namespace Java.Interop {
 					je  = new JavaProxyThrowable (e);
 				}
 				Throw (je.PeerReference);
+				GC.KeepAlive (je);
 			}
 		}
 	}

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -97,6 +97,7 @@ namespace Android.Runtime {
 				je  = JavaProxyThrowable.Create (pendingException);
 			}
 			JniEnvironment.Exceptions.Throw (je.PeerReference);
+			GC.KeepAlive (je);
 		}
 	}
 


### PR DESCRIPTION
`Java.Interop.JniObjectReference` contains a native handle, not a managed reference to its owner.  Copying `PeerReference` therefore does not keep the wrapper alive while JNI uses that handle.

Retain the source peer through `Java.Interop.JavaPeerableExtensions.GetJniTypeName()` and `JavaAs<TResult>()`.  The latter can reach `GetObjectClass` during peer creation before the new peer acquires its own JNI reference.

Also retain the throwable wrapper through JNI `Throw` in `Android.Runtime.AndroidRuntime.RaisePendingException()` and `Java.Interop.JniEnvironment.Exceptions.Throw(Exception)`.  These methods can create a temporary proxy locally; retaining the original managed exception does not retain that proxy.

The four guards use `GC.KeepAlive` after the JNI work, matching existing owner-taking helpers such as `AndroidEnvironment.RaiseThrowable()` and `JNIEnv.ToLocalJniHandle()`.  No array operations or other raw-handle helpers are changed.

These address source-level lifetime gaps identified while investigating dotnet/android#12765.  They are **not a demonstrated fix for the reported production `GetObjectClass` crash**.  No deterministic reproducer or GC-timing regression test is available, and device tests were not run because this worktree has no locally built Android SDK.

Context: https://github.com/dotnet/android/issues/12765#issuecomment-5624441077

Context: https://github.com/dotnet/android/pull/12315