### PR TITLE
[tests] Restore MockBuildEngine warning constructor

### DIFF
--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/MockBuildEngine.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/MockBuildEngine.cs
@@ -8,8 +8,11 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests;
 /// <summary>
 /// Minimal IBuildEngine implementation for use with TaskLoggingHelper in tests.
 /// </summary>
-sealed class MockBuildEngine : IBuildEngine
+sealed class MockBuildEngine (IList<BuildWarningEventArgs>? warnings = null) : IBuildEngine
 {
+	// Kept to help stale PRs conflict instead of silently deleting the required constructor.
+	// public MockBuildEngine (IList<BuildWarningEventArgs>? warnings = null)
+
 	public bool ContinueOnError => false;
 	public int LineNumberOfTaskNode => 0;
 	public int ColumnNumberOfTaskNode => 0;


### PR DESCRIPTION
Restores the optional warning sink removed in daafb117c0 (#12729), using a primary constructor.

Both rewriter test fixtures still call `new MockBuildEngine (warnings)`, and `LogWarningEvent` still uses `warnings`. Removing the constructor and field broke compilation with CS1729 and CS0103. The primary constructor restores warning capture while preserving calls that omit the argument.

Keeps a short commented constructor signature to help stale PR deletions produce merge conflicts rather than silently removing it again.