### PR TITLE
[Java.Interop] Optimize peer identity hash lookup

### DIFF
--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniEnvironment.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniEnvironment.cs
@@ -226,7 +226,18 @@ namespace Java.Interop {
 
 		internal    JniEnvironmentInfo (IntPtr environmentPointer, JniRuntime runtime)
 		{
-			EnvironmentPointer  = environmentPointer;
+			if (environmentPointer == IntPtr.Zero)
+				throw new ArgumentException ("JNIEnv* must not be null.", nameof (environmentPointer));
+			if (runtime == null)
+				throw new ArgumentNullException (nameof (runtime));
+
+			int r = JniEnvironment.References.GetJavaVM (environmentPointer, out IntPtr vm);
+			if (r < 0)
+				throw new InvalidOperationException ("JNIEnv::GetJavaVM() returned: " + r.ToString ());
+			if (vm != runtime.InvocationPointer)
+				throw new ArgumentException ("JNIEnv* does not belong to the specified JniRuntime.", nameof (environmentPointer));
+
+			this.environmentPointer = environmentPointer;
 			Runtime             = runtime;
 		}
 

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -168,6 +168,8 @@ namespace Java.Interop
 		bool                                            DestroyRuntimeOnDispose;
 
 		internal    JniObjectReference                  ClassLoader;
+		internal    IntPtr                              SystemClass;
+		internal    IntPtr                              SystemIdentityHashCode;
 
 		public  IntPtr                                  InvocationPointer   {get; private set;}
 
@@ -203,14 +205,6 @@ namespace Java.Interop
 			ObjectReferenceManager      = SetRuntime (options.ObjectReferenceManager ?? throw new NotSupportedException ($"Please set {nameof (CreationOptions)}.{nameof (options.ObjectReferenceManager)}!"));
 			TypeManager                 = SetRuntime (options.TypeManager ?? throw new NotSupportedException ($"Please set {nameof (CreationOptions)}.{nameof (options.TypeManager)}!"));
 
-			if (Interlocked.CompareExchange (ref current, this, null) != null) {
-				Debug.WriteLine ("WARNING: More than one JniRuntime instance created. This is DOOMED TO FAIL.");
-			}
-
-			lock (Runtimes) {
-				Runtimes [InvocationPointer] = this;
-			}
-
 			var envp    = options.EnvironmentPointer;
 			if (envp == IntPtr.Zero &&
 					Invoker.GetEnv (InvocationPointer, out envp, (int) JniVersion) != JNI_OK &&
@@ -220,6 +214,13 @@ namespace Java.Interop
 			}
 			var env     = new JniEnvironmentInfo (envp, this);
 			JniEnvironment.SetEnvironmentInfo (env);
+
+			// java/lang/System is a bootstrap class, so it can be resolved before
+			// initializing the application ClassLoader.
+			var systemType = new JniType ("java/lang/System"u8);
+			systemType.RegisterWithRuntime ();
+			SystemClass = systemType.PeerReference.Handle;
+			SystemIdentityHashCode = systemType.GetStaticMethod ("identityHashCode"u8, "(Ljava/lang/Object;)I"u8).ID;
 
 			ClassLoader = options.ClassLoader;
 			if (ClassLoader.IsValid) {
@@ -245,6 +246,14 @@ namespace Java.Interop
 				ManagedPeer.Init ();
 			}
 #endif  // !XA_JI_EXCLUDE
+
+			lock (Runtimes) {
+				Runtimes [InvocationPointer] = this;
+			}
+
+			if (Interlocked.CompareExchange (ref current, this, null) != null) {
+				Debug.WriteLine ("WARNING: More than one JniRuntime instance created. This is DOOMED TO FAIL.");
+			}
 		}
 
 		static unsafe IntPtr GetInvocationPointerFromEnvironmentPointer (IntPtr envp)

--- a/external/Java.Interop/src/Java.Interop/Java.Interop/JniSystem.cs
+++ b/external/Java.Interop/src/Java.Interop/Java.Interop/JniSystem.cs
@@ -5,19 +5,20 @@ using System;
 namespace Java.Interop
 {
 	static class JniSystem {
-		static JniType? _typeRef;
-		static JniType TypeRef {
-			get {return JniType.GetCachedJniType (ref _typeRef, "java/lang/System");}
-		}
-
-		static JniMethodInfo? _identityHashCode;
 		internal static unsafe int IdentityHashCode (JniObjectReference value)
 		{
 			var args = stackalloc JniArgumentValue [1];
 			args [0] = new JniArgumentValue (value);
-			TypeRef.GetCachedStaticMethod (ref _identityHashCode, "identityHashCode", "(Ljava/lang/Object;)I");
-			return JniEnvironment.StaticMethods.CallStaticIntMethod (TypeRef.PeerReference, _identityHashCode, args);
+			var info = JniEnvironment.CurrentInfo;
+			var runtime = info.Runtime;
+			var hashCode = JniNativeMethods.CallStaticIntMethodA (
+				info.EnvironmentPointer,
+				runtime.SystemClass,
+				runtime.SystemIdentityHashCode,
+				(IntPtr) args);
+			// System.identityHashCode() accepts null and does not throw, so avoid the
+			// generic method wrapper's second JNI call to ExceptionOccurred().
+			return hashCode;
 		}
 	}
 }
-

--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniEnvironmentTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniEnvironmentTests.cs
@@ -56,6 +56,13 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		public void References_GetIdentityHashCode_Null ()
+		{
+			Assert.AreEqual (0, JniEnvironment.References.GetIdentityHashCode (default));
+			Assert.IsFalse (JniEnvironment.Exceptions.ExceptionCheck ());
+		}
+
+		[Test]
 		public void References_CreatedReference_InvalidRef ()
 		{
 			var c = JniEnvironment.LocalReferenceCount;
@@ -144,4 +151,3 @@ namespace Java.InteropTests
 		}
 	}
 }
-

--- a/tests/Android.Benchmarks/BenchmarkInstrumentation.cs
+++ b/tests/Android.Benchmarks/BenchmarkInstrumentation.cs
@@ -40,6 +40,10 @@ public class BenchmarkInstrumentation : Instrumentation
 					.WithId ("Android"))
 				.AddLogger (ConsoleLogger.Default)
 				.AddColumnProvider (DefaultColumnProviders.Instance)
+				.AddColumn (
+					StatisticColumn.P50,
+					StatisticColumn.Max,
+					StatisticColumn.OperationsPerSecond)
 				.AddExporter (CsvExporter.Default, MarkdownExporter.GitHub)
 				.WithArtifactsPath (artifactsPath)
 				.WithOptions (ConfigOptions.DisableOptimizationsValidator);
@@ -48,7 +52,11 @@ public class BenchmarkInstrumentation : Instrumentation
 
 			var summaries = BenchmarkRunner.Run (GetType ().Assembly, config);
 			var reportCount = summaries.Sum (summary => summary.Reports.Length);
-			var hasErrors = summaries.Any (summary => summary.HasCriticalValidationErrors);
+			var hasErrors =
+				reportCount == 0 ||
+				summaries.Any (summary =>
+					summary.HasCriticalValidationErrors ||
+					summary.Reports.Any (report => !report.Success));
 
 			results.PutInt ("reports", reportCount);
 			results.PutString ("artifactsPath", artifactsPath);

--- a/tests/Android.Benchmarks/ExportRoundtripBenchmarks.cs
+++ b/tests/Android.Benchmarks/ExportRoundtripBenchmarks.cs
@@ -6,6 +6,8 @@ using Java.Interop;
 namespace Xamarin.Android.Benchmarks;
 
 [MemoryDiagnoser]
+[WarmupCount (5)]
+[IterationCount (15)]
 public unsafe class ExportRoundtripBenchmarks
 {
 	const int Value = 42;
@@ -30,7 +32,7 @@ public unsafe class ExportRoundtripBenchmarks
 			JNIEnv.DeleteLocalRef (peerClass);
 		}
 
-		long expected = DirectManagedCall ();
+		long expected = DirectStringCall ();
 		long primitiveResult = JniPrimitiveRoundtrip ();
 		long stringResult = JniStringRoundtrip ();
 		if (primitiveResult != State + Value)
@@ -46,7 +48,14 @@ public unsafe class ExportRoundtripBenchmarks
 		peer.Dispose ();
 	}
 
-	long DirectManagedCall ()
+	[Benchmark (Baseline = true)]
+	public long DirectPrimitiveCall ()
+	{
+		return peer.PrimitiveRoundtrip (Value, State);
+	}
+
+	[Benchmark]
+	public long DirectStringCall ()
 	{
 		return peer.Roundtrip (Value, State, TextValue);
 	}

--- a/tests/Android.Benchmarks/PeerActivationComponentBenchmarks.cs
+++ b/tests/Android.Benchmarks/PeerActivationComponentBenchmarks.cs
@@ -5,10 +5,18 @@ using Java.Interop;
 namespace Xamarin.Android.Benchmarks;
 
 [MemoryDiagnoser]
+[WarmupCount (5)]
+[IterationCount (15)]
 public class PeerActivationComponentBenchmarks
 {
+	IntPtr equivalentReference;
+	IntPtr identityHashCodeMethod;
 	IntPtr objectClass;
 	IntPtr reference;
+	JniObjectReference systemClass;
+	JniMethodInfo? identityHashCodeMethodInfo;
+	Java.Lang.String? peer;
+	WeakReference<Java.Lang.String>? weakPeer;
 
 	[GlobalSetup]
 	public void Setup ()
@@ -26,11 +34,29 @@ public class PeerActivationComponentBenchmarks
 		} finally {
 			JNIEnv.DeleteLocalRef (localClass);
 		}
+
+		equivalentReference = JNIEnv.NewGlobalRef (reference);
+		systemClass = JniEnvironment.Types.FindClass ("java/lang/System");
+		identityHashCodeMethod = JNIEnv.GetStaticMethodID (
+			systemClass.Handle,
+			"identityHashCode",
+			"(Ljava/lang/Object;)I");
+		identityHashCodeMethodInfo = new JniMethodInfo (identityHashCodeMethod, isStatic: true);
+		peer = Java.Lang.Object.GetObject<Java.Lang.String> (reference, JniHandleOwnership.DoNotTransfer);
+		if (peer == null)
+			throw new InvalidOperationException ("Could not create the Java string peer.");
+		weakPeer = new WeakReference<Java.Lang.String> (peer);
 	}
 
 	[GlobalCleanup]
 	public void Cleanup ()
 	{
+		weakPeer = null;
+		peer?.Dispose ();
+		peer = null;
+		identityHashCodeMethodInfo = null;
+		JniObjectReference.Dispose (ref systemClass);
+		DeleteGlobalReference (ref equivalentReference);
 		DeleteGlobalReference (ref objectClass);
 		DeleteGlobalReference (ref reference);
 	}
@@ -67,6 +93,70 @@ public class PeerActivationComponentBenchmarks
 	public int GetIdentityHashCode ()
 	{
 		return JniEnvironment.References.GetIdentityHashCode (new JniObjectReference (reference));
+	}
+
+	[Benchmark]
+	public unsafe int GetIdentityHashCodeWithExceptionCheck ()
+	{
+		var method = identityHashCodeMethodInfo ??
+			throw new InvalidOperationException ("The identity hash code method is unavailable.");
+		var args = stackalloc JniArgumentValue [1];
+		args [0] = new JniArgumentValue (new JniObjectReference (reference));
+		return JniEnvironment.StaticMethods.CallStaticIntMethod (systemClass, method, args);
+	}
+
+	[Benchmark]
+	public int GetIdentityHashCodeWithPrecachedMethod ()
+	{
+		return JNIEnv.CallStaticIntMethod (
+			systemClass.Handle,
+			identityHashCodeMethod,
+			new JValue (reference));
+	}
+
+	[Benchmark]
+	public bool ExceptionCheck ()
+	{
+		return JniEnvironment.Exceptions.ExceptionCheck ();
+	}
+
+	[Benchmark]
+	public bool ExceptionOccurred ()
+	{
+		var exception = JniEnvironment.Exceptions.ExceptionOccurred ();
+		if (!exception.IsValid)
+			return false;
+
+		JniObjectReference.Dispose (ref exception);
+		throw new InvalidOperationException ("No Java exception should be pending during the benchmark.");
+	}
+
+	[Benchmark]
+	public bool IsSameObject ()
+	{
+		return JniEnvironment.Types.IsSameObject (
+			new JniObjectReference (reference),
+			new JniObjectReference (equivalentReference));
+	}
+
+	[Benchmark]
+	public int WeakReferenceTryGetTarget ()
+	{
+		var reference = weakPeer;
+		if (reference != null && reference.TryGetTarget (out var target))
+			return target.JniIdentityHashCode;
+		return 0;
+	}
+
+	[Benchmark]
+	public bool WeakReferenceIsSameObject ()
+	{
+		var reference = weakPeer;
+		return reference != null &&
+			reference.TryGetTarget (out var target) &&
+			JniEnvironment.Types.IsSameObject (
+				new JniObjectReference (this.reference),
+				target.PeerReference);
 	}
 
 	[Benchmark]

--- a/tests/Android.Benchmarks/PeerLookupBenchmarks.cs
+++ b/tests/Android.Benchmarks/PeerLookupBenchmarks.cs
@@ -1,10 +1,13 @@
 using Android.Runtime;
 using BenchmarkDotNet.Attributes;
+using Java.Interop;
 
 namespace Xamarin.Android.Benchmarks;
 
 [MemoryDiagnoser]
 [InvocationCount (OperationsPerIteration)]
+[WarmupCount (5)]
+[IterationCount (15)]
 public class PeerLookupBenchmarks
 {
 	const int OperationsPerIteration = 4096;
@@ -104,6 +107,122 @@ public class PeerLookupBenchmarks
 	static IntPtr CreateGlobalString ()
 	{
 		IntPtr localReference = JNIEnv.NewString ("benchmark");
+		try {
+			return JNIEnv.NewGlobalRef (localReference);
+		} finally {
+			JNIEnv.DeleteLocalRef (localReference);
+		}
+	}
+
+	static void DeleteGlobalReference (ref IntPtr reference)
+	{
+		if (reference == IntPtr.Zero)
+			return;
+		JNIEnv.DeleteGlobalRef (reference);
+		reference = IntPtr.Zero;
+	}
+}
+
+[MemoryDiagnoser]
+[WarmupCount (5)]
+[IterationCount (15)]
+public class PeerLookupLocalityBenchmarks
+{
+	const int OperationsPerIteration = 4096;
+
+	IntPtr [] references = [];
+	Java.Lang.String? [] peers = [];
+	WeakReference<Java.Lang.String>? recentPeer;
+	int operationIndex;
+
+	[Params (1, 2, 8, 64)]
+	public int WorkingSetSize { get; set; }
+
+	[Params (1, 8)]
+	public int ConsecutiveLookups { get; set; }
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		references = new IntPtr [WorkingSetSize];
+		peers = new Java.Lang.String? [WorkingSetSize];
+		for (int i = 0; i < references.Length; i++) {
+			references [i] = CreateGlobalString (i);
+			var peer = Java.Lang.Object.GetObject<Java.Lang.String> (
+				references [i],
+				JniHandleOwnership.DoNotTransfer);
+			if (peer == null)
+				throw new InvalidOperationException ($"Could not create Java string peer {i}.");
+			peers [i] = peer;
+		}
+
+		var firstPeer = peers [0];
+		if (firstPeer == null)
+			throw new InvalidOperationException ("The first Java string peer is unavailable.");
+		recentPeer = new WeakReference<Java.Lang.String> (firstPeer);
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		recentPeer = null;
+		for (int i = 0; i < references.Length; i++) {
+			peers [i]?.Dispose ();
+			peers [i] = null;
+			DeleteGlobalReference (ref references [i]);
+		}
+	}
+
+	[Benchmark (Baseline = true, OperationsPerInvoke = OperationsPerIteration)]
+	public Java.Lang.String? CurrentRegistryLookup ()
+	{
+		Java.Lang.String? peer = null;
+		for (int i = 0; i < OperationsPerIteration; i++) {
+			peer = Java.Lang.Object.GetObject<Java.Lang.String> (
+				GetNextReference (),
+				JniHandleOwnership.DoNotTransfer);
+		}
+		return peer;
+	}
+
+	[Benchmark (OperationsPerInvoke = OperationsPerIteration)]
+	public Java.Lang.String? RecentPeerIsSameObjectFastPath ()
+	{
+		Java.Lang.String? peer = null;
+		for (int i = 0; i < OperationsPerIteration; i++) {
+			IntPtr reference = GetNextReference ();
+			var recent = recentPeer;
+			if (recent != null &&
+					recent.TryGetTarget (out peer) &&
+					JniEnvironment.Types.IsSameObject (
+						new JniObjectReference (reference),
+						peer.PeerReference)) {
+				continue;
+			}
+
+			peer = Java.Lang.Object.GetObject<Java.Lang.String> (
+				reference,
+				JniHandleOwnership.DoNotTransfer);
+			if (peer != null) {
+				if (recent == null) {
+					recentPeer = new WeakReference<Java.Lang.String> (peer);
+				} else {
+					recent.SetTarget (peer);
+				}
+			}
+		}
+		return peer;
+	}
+
+	IntPtr GetNextReference ()
+	{
+		int index = (operationIndex++ / ConsecutiveLookups) % WorkingSetSize;
+		return references [index];
+	}
+
+	static IntPtr CreateGlobalString (int index)
+	{
+		IntPtr localReference = JNIEnv.NewString ($"benchmark-{index}");
 		try {
 			return JNIEnv.NewGlobalRef (localReference);
 		} finally {

--- a/tests/Android.Benchmarks/PeerLookupGcBridgeBenchmarks.cs
+++ b/tests/Android.Benchmarks/PeerLookupGcBridgeBenchmarks.cs
@@ -1,0 +1,151 @@
+using System.Diagnostics;
+using Android.Runtime;
+using BenchmarkDotNet.Attributes;
+using Perfolizer.Mathematics.OutlierDetection;
+
+namespace Xamarin.Android.Benchmarks;
+
+[WarmupCount (3)]
+[IterationCount (30)]
+[Outliers (OutlierMode.DontRemove)]
+public class PeerLookupGcBridgeBenchmarks
+{
+	const int OperationsPerInvoke = 65_536;
+
+	Java.Lang.String? [] peers = [];
+	IntPtr reference;
+	Thread? gcThread;
+	Exception? gcThreadException;
+	ManualResetEventSlim? gcThreadReady;
+	bool stopGcThread;
+	int completedCollections;
+
+	[Params (false, true)]
+	public bool BridgePressure { get; set; }
+
+	[Params (64, 512)]
+	public int RegisteredPeerCount { get; set; }
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		peers = new Java.Lang.String? [RegisteredPeerCount];
+		for (int i = 0; i < peers.Length; i++)
+			peers [i] = new Java.Lang.String ($"peer-{i}");
+
+		var firstPeer = peers [0];
+		if (firstPeer == null)
+			throw new InvalidOperationException ("The first Java string peer is unavailable.");
+		reference = JNIEnv.NewGlobalRef (firstPeer.Handle);
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		StopGcThread ();
+		DeleteGlobalReference (ref reference);
+		for (int i = 0; i < peers.Length; i++) {
+			peers [i]?.Dispose ();
+			peers [i] = null;
+		}
+	}
+
+	[IterationSetup]
+	public void StartGcThread ()
+	{
+		if (!BridgePressure)
+			return;
+
+		stopGcThread = false;
+		gcThreadException = null;
+		var ready = new ManualResetEventSlim ();
+		gcThreadReady = ready;
+		completedCollections = 0;
+		var thread = new Thread (() => {
+			try {
+				while (!Volatile.Read (ref stopGcThread)) {
+					GC.Collect (GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: false);
+					Interlocked.Increment (ref completedCollections);
+					ready.Set ();
+					Thread.Sleep (1);
+				}
+			} catch (Exception e) {
+				gcThreadException = e;
+			}
+		}) {
+			IsBackground = true,
+			Name = "Peer lookup GC pressure",
+		};
+		gcThread = thread;
+		thread.Start ();
+		if (!ready.Wait (TimeSpan.FromSeconds (30))) {
+			Volatile.Write (ref stopGcThread, true);
+			thread.Join (TimeSpan.FromSeconds (30));
+			gcThread = null;
+			gcThreadReady = null;
+			ready.Dispose ();
+			throw new TimeoutException ("The GC pressure thread did not complete a collection within 30 seconds.");
+		}
+	}
+
+	[IterationCleanup]
+	public void StopGcThread ()
+	{
+		var thread = gcThread;
+		if (thread == null)
+			return;
+
+		Volatile.Write (ref stopGcThread, true);
+		if (!thread.Join (TimeSpan.FromSeconds (30)))
+			throw new TimeoutException ("The GC pressure thread did not stop within 30 seconds.");
+		gcThread = null;
+		gcThreadReady?.Dispose ();
+		gcThreadReady = null;
+
+		var exception = gcThreadException;
+		gcThreadException = null;
+		if (exception != null)
+			throw new InvalidOperationException ("The GC pressure thread failed.", exception);
+	}
+
+	[Benchmark (OperationsPerInvoke = OperationsPerInvoke)]
+	public Java.Lang.String? GetObjectCached ()
+	{
+		int collectionsBefore = Volatile.Read (ref completedCollections);
+		Java.Lang.String? peer = null;
+		for (int i = 0; i < OperationsPerInvoke; i++) {
+			peer = Java.Lang.Object.GetObject<Java.Lang.String> (
+				reference,
+				JniHandleOwnership.DoNotTransfer);
+		}
+		WaitForCollection (collectionsBefore);
+		return peer;
+	}
+
+	void WaitForCollection (int collectionsBefore)
+	{
+		if (!BridgePressure)
+			return;
+
+		long timeout = Stopwatch.GetTimestamp () + (30 * Stopwatch.Frequency);
+		while (Volatile.Read (ref completedCollections) <= collectionsBefore) {
+			if (Volatile.Read (ref gcThreadException) != null) {
+				StopGcThread ();
+				throw new InvalidOperationException ("The GC pressure thread failed.");
+			}
+			if (Stopwatch.GetTimestamp () >= timeout) {
+				StopGcThread ();
+				throw new TimeoutException ("No forced collection completed during the measured lookup batch.");
+			}
+			Thread.SpinWait (64);
+		}
+	}
+
+	static void DeleteGlobalReference (ref IntPtr value)
+	{
+		if (value == IntPtr.Zero)
+			return;
+		JNIEnv.DeleteGlobalRef (value);
+		value = IntPtr.Zero;
+	}
+}

--- a/tests/Android.Benchmarks/README.md
+++ b/tests/Android.Benchmarks/README.md
@@ -9,11 +9,41 @@ Run every benchmark:
 ./dotnet-local.sh run --project tests/Android.Benchmarks/Android.Benchmarks.csproj -c Release
 ```
 
-Filter benchmarks by passing BenchmarkDotNet's `--filter` argument:
+To filter benchmarks, install the app on a specific device and pass the filter
+as an instrumentation argument:
 
 ```sh
-./dotnet-local.sh run --project tests/Android.Benchmarks/Android.Benchmarks.csproj -c Release -- --filter '*JniMethodInfoBenchmarks*'
+./dotnet-local.sh build tests/Android.Benchmarks/Android.Benchmarks.csproj \
+    -c Release -t:Install -p:Device=DEVICE_SERIAL
+adb -s DEVICE_SERIAL shell am instrument -w \
+    -e filter '*JniMethodInfoBenchmarks*' \
+    net.dot.android.benchmarks/.BenchmarkInstrumentation
 ```
+
+Peer lookup investigation benchmark groups can be run with:
+
+```sh
+adb -s DEVICE_SERIAL shell am instrument -w \
+    -e filter '*Peer*' \
+    net.dot.android.benchmarks/.BenchmarkInstrumentation
+adb -s DEVICE_SERIAL shell am instrument -w \
+    -e filter '*ExportRoundtrip*' \
+    net.dot.android.benchmarks/.BenchmarkInstrumentation
+```
+
+`PeerLookupGcBridgeBenchmarks` deliberately runs collections on a background
+thread. Treat it as a stress comparison that includes GC suspension and
+scheduling effects, rather than a steady-state microbenchmark or a direct
+measurement of GC-bridge code. It uses more measurement iterations than the
+other benchmark groups and reports median and maximum iteration time; these
+statistics still describe iteration-level throughput rather than individual
+lookup latency. Each measured lookup batch waits for the benchmark's GC worker
+to complete a forced collection, so the pressure result also includes any
+remaining collection wait at the end of the batch.
+
+The recent-peer lookup benchmark keeps its peers alive. It measures the normal
+live-peer hit and locality tradeoff, including the added cost when consecutive
+lookups target different peers; it does not model stale weak references.
 
 The instrumentation result reports the on-device artifacts directory. Results
 are also streamed through logcat by `dotnet run`.


### PR DESCRIPTION
## Context

Relates to #12764.

The startup investigation in #12764 identifies `JavaMarshalRegisteredPeers.PeekPeer()` as part of the .NET MAUI startup hot path, especially while MAUI creates and binds native item views during initial layout. Every registered-peer lookup currently calls Java `System.identityHashCode()` through the generic JNI method wrapper, which then performs a second JNI call to `ExceptionOccurred()`.

`System.identityHashCode(Object)` does not throw and explicitly returns zero for `null`, so the generic exception lookup is unnecessary on this path.

## Changes

- Cache the `java/lang/System` class and `identityHashCode` method handles per `JniRuntime` during runtime initialization.
- Invoke `CallStaticIntMethodA` directly from `JniSystem.IdentityHashCode()` without the generic `ExceptionOccurred()` roundtrip.
- Use UTF-8 class/member/signature lookups.
- Preserve runtime ownership and recreation semantics by keeping the raw handles on their owning `JniRuntime`.
- Validate that an explicitly supplied `JNIEnv*` belongs to the supplied runtime before installing thread-local environment state.
- Add regression coverage for `identityHashCode(null) == 0` with no pending exception.
- Expand the on-device BenchmarkDotNet suite to cover identity lookup components, registered-peer locality, JNI callback overhead, and forced GC pressure.

## Galaxy S23 results

Release, CoreCLR, trimmable type map, Android 16/API 36:

| Benchmark | Before | After | Change | Allocation |
|---|---:|---:|---:|---:|
| `GetIdentityHashCode` | 98.11 ns | 63.71 ns | **35% faster** | 0 B |
| Repeated cached peer lookup | ~191 ns | ~158 ns | **17% faster** | 0 B |

Additional component results:

- `ExceptionOccurred()`: 51.27 ns, 0 B
- `IsSameObject()`: 48.64 ns, 0 B
- Benchmark-only recent-peer hit: ~41 ns, 0 B

The recent-peer experiment remains workload-dependent and is not included as a runtime behavior change in this PR.

## Validation

- Java.Interop JVM tests: 713 passed, 6 skipped
- Android BenchmarkDotNet project: Release build succeeded
- On-device Galaxy S23 benchmark runs for peer components and lookup locality

----

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [x] Unit tests