### PR TITLE
Bump System.CodeDom from 10.0.11 to 10.0.12

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,7 +7,7 @@
   <!-- NuGet Package Versions -->
   <ItemGroup>
     <PackageReference Update="Microsoft.Win32.Registry"                     Version="5.0.0" />
-    <PackageReference Update="System.CodeDom"                               Version="10.0.11" />
+    <PackageReference Update="System.CodeDom"                               Version="10.0.12" />
     <PackageReference Update="Irony"                                        Version="1.5.3" />
   </ItemGroup>
 


### PR DESCRIPTION
----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed
- [x] Unit tests

Ports #12757 to `main` so the current development branch uses System.CodeDom 10.0.12.

Related: #12757

Tests: XML parsing and `git diff --check`.