### PR TITLE
Bump System.IO.Hashing to 10.0.12

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-rc.2.26455.110</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <MicrosoftDotNetCecilPackageVersion>0.11.5-preview.26455.110</MicrosoftDotNetCecilPackageVersion>
     <MSTestPackageVersion>4.5.0-preview.26455.2</MSTestPackageVersion>
-    <SystemIOHashingPackageVersion>10.0.11</SystemIOHashingPackageVersion>
+    <SystemIOHashingPackageVersion>10.0.12</SystemIOHashingPackageVersion>
     <SystemReflectionMetadataPackageVersion>11.0.0-preview.1.26104.118</SystemReflectionMetadataPackageVersion>
     <!-- Previous .NET Android version -->
     <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.69</MicrosoftNETSdkAndroidManifest100100PackageVersion>


### PR DESCRIPTION
Manually ports #12758 from `release/10.0.1xx` to `main` so the current development branch uses the latest servicing release of `System.IO.Hashing`.

Updates the central package version from 10.0.11 to 10.0.12.